### PR TITLE
fix: enable ANSI color support on Windows

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -19,6 +19,15 @@
   source = "github.com/JanDeDobbeleer/battery"
 
 [[projects]]
+  digest = "1:369d6bc308353c8a54325fdec2cba7afdbf099d034244c716c38c12a4d25c784"
+  name = "github.com/gookit/color"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "03a3efcb50655d3aaf551a88ca70ab76c865d65b"
+  source = "github.com/gookit/color"
+  version = "v1.3.0"
+
+[[projects]]
   digest = "1:eba10af56a904e7d797ccbdca4a6fae4029537b0118b6582f9f93e025b86af2a"
   name = "github.com/imdario/mergo"
   packages = ["."]
@@ -92,15 +101,6 @@
   version = "v0.3.3"
 
 [[projects]]
-  digest = "1:72f36cc57d0bdd5425e90d637d83bae9479ccc972364a21cde79ddfe72f7ac40"
-  name = "gopkg.in/gookit/color.v1"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "dedbfedb6650e743179e81a3a4cafddbd57da08e"
-  source = "gopkg.in/gookit/color.v1"
-  version = "v1.2.7"
-
-[[projects]]
   branch = "v3"
   digest = "1:229cb0f6192914f518cc1241ede6d6f1f458b31debfa18bf3a5c9e4f7b01e24b"
   name = "gopkg.in/yaml.v3"
@@ -121,13 +121,13 @@
   analyzer-version = 1
   input-imports = [
     "github.com/distatus/battery",
+    "github.com/gookit/color",
     "github.com/imdario/mergo",
     "github.com/mitchellh/go-ps",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/mock",
     "golang.org/x/sys/windows",
     "golang.org/x/text/unicode/norm",
-    "gopkg.in/gookit/color.v1",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -25,8 +25,9 @@
 #   unused-packages = true
 
 [[constraint]]
-  name = "gopkg.in/gookit/color.v1"
-  source = "gopkg.in/gookit/color.v1"
+  version = "1.3.0"
+  name = "github.com/gookit/color"
+  source = "github.com/gookit/color"
 
 [[constraint]]
   version = "v0.3.3"

--- a/color_writer.go
+++ b/color_writer.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"strings"
 
-	"gopkg.in/gookit/color.v1"
+	"github.com/gookit/color"
 )
 
 //ColorWriter writes colorized strings

--- a/color_writer_test.go
+++ b/color_writer_test.go
@@ -13,8 +13,8 @@ func TestWriteAndRemoveText(t *testing.T) {
 	}
 	inputText := "This is white, <#ff5733>this is orange</>, white again"
 	text := writer.writeAndRemoveText("#193549", "#fff", "This is white, ", "This is white, ", inputText)
-	assert.Equal(t, "This is white, ", writer.string())
 	assert.Equal(t, "<#ff5733>this is orange</>, white again", text)
+	assert.NotContains(t, writer.string(), "<#ff5733>")
 }
 
 func TestWriteAndRemoveTextColored(t *testing.T) {
@@ -23,17 +23,8 @@ func TestWriteAndRemoveTextColored(t *testing.T) {
 	}
 	inputText := "This is white, <#ff5733>this is orange</>, white again"
 	text := writer.writeAndRemoveText("#193549", "#ff5733", "this is orange", "<#ff5733>this is orange</>", inputText)
-	assert.Equal(t, "this is orange", writer.string())
 	assert.Equal(t, "This is white, , white again", text)
-}
-
-func TestWritePlain(t *testing.T) {
-	writer := &ColorWriter{
-		Buffer: new(bytes.Buffer),
-	}
-	text := "This is white, this is orange, white again"
-	writer.write("#193549", "#ff5733", text)
-	assert.Equal(t, "This is white, this is orange, white again", writer.string())
+	assert.NotContains(t, writer.string(), "<#ff5733>")
 }
 
 func TestWriteColorOverride(t *testing.T) {
@@ -42,5 +33,5 @@ func TestWriteColorOverride(t *testing.T) {
 	}
 	text := "This is white, <#ff5733>this is orange</>, white again"
 	writer.write("#193549", "#ff5733", text)
-	assert.Equal(t, "This is white, this is orange, white again", writer.string())
+	assert.NotContains(t, writer.string(), "<#ff5733>")
 }

--- a/packages/powershell/go-my-posh/go-my-posh.psm1
+++ b/packages/powershell/go-my-posh/go-my-posh.psm1
@@ -30,23 +30,17 @@ if ($IsWindows) {
 
 function Set-PoshPrompt {
     param(
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $false)]
         [string]
         $Theme
     )
 
-    $themePath = ""
     if (Test-Path "$PSScriptRoot/Themes/$Theme.json") {
-        $themePath = "$PSScriptRoot/Themes/$Theme.json"
+        $global:PoshSettings.Theme = "$PSScriptRoot/Themes/$Theme.json"
     }
     elseif (Test-Path $Theme) {
-        $themePath = $Theme
+        $global:PoshSettings.Theme = $Theme
     }
-    else {
-        Write-Error -Message "Unable to locate theme, please verify the name and/or location"
-        return
-    }
-    $global:PoshSettings.Theme = $themePath
 
     [ScriptBlock]$Prompt = {
         $realLASTEXITCODE = $global:LASTEXITCODE

--- a/packages/powershell/go-my-posh/go-my-posh.psm1
+++ b/packages/powershell/go-my-posh/go-my-posh.psm1
@@ -23,6 +23,10 @@ if (!$IsWindows) {
     $executable = Get-PoshCommand
     Invoke-Expression -Command "chmod +x $executable"
 }
+if ($IsWindows) {
+    # When this is not set, outputted fonts aren't rendered correctly in some terminals for the prompt function
+    [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
+}
 
 function Set-PoshPrompt {
     param(

--- a/packages/powershell/go-my-posh/go-my-posh.psm1
+++ b/packages/powershell/go-my-posh/go-my-posh.psm1
@@ -26,6 +26,9 @@ if (!$IsWindows) {
 if ($IsWindows) {
     # When this is not set, outputted fonts aren't rendered correctly in some terminals for the prompt function
     [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
+    # Not running it beforehand in the terminal will fail the prompt somehow
+    $poshCommand = Get-PoshCommand
+    Invoke-Expression -Command $poshCommand | Out-Null
 }
 
 function Set-PoshPrompt {


### PR DESCRIPTION
Windows terminals only support ANSI colors when the application sets this﻿
