### PR TITLE
fix: right prompt in zsh

### DIFF
--- a/renderer.go
+++ b/renderer.go
@@ -49,7 +49,7 @@ func (r *Renderer) init(shell string) {
 		r.formats.transparent = "%%{\x1b[%s;49m\x1b[7m%%}%s%%{\x1b[m\x1b[0m%%}"
 		r.formats.linebreak = "\n"
 		r.formats.linechange = "%%{\x1b[%d%s%%}"
-		r.formats.left = "%%{\x1b[%d%%}"
+		r.formats.left = "%%{\x1b[%dC%%}"
 		r.formats.right = "%%{\x1b[%dD%%}"
 		r.shell = zsh
 	default:


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

Right prompts in zsh tested on Mac were failing due to bad formats.left escape code.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
