### PR TITLE
feat: session segment updates

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -138,9 +138,12 @@ func cleanHostName(hostName string) string {
 	garbage := []string{
 		".lan",
 		".local",
+		".localdomain",
 	}
 	for _, g := range garbage {
-		hostName = strings.Replace(hostName, g, "", 1)
+		if strings.HasSuffix(hostName, g) {
+			hostName = strings.Replace(hostName, g, "", 1)
+		}
 	}
 	return hostName
 }

--- a/segment_session.go
+++ b/segment_session.go
@@ -39,7 +39,11 @@ func (s *session) init(props *properties, env environmentInfo) {
 func (s *session) getFormattedText() string {
 	username := s.getUserName()
 	computername := s.getComputerName()
-	return fmt.Sprintf("<%s>%s</>%s<%s>%s</>", s.props.getColor(UserColor, s.props.foreground), username, s.props.getString(UserInfoSeparator, "@"), s.props.getColor(HostColor, s.props.foreground), computername)
+	separator := ""
+	if s.props.getBool(DisplayHost, true) && s.props.getBool(DisplayUser, true) {
+		separator = s.props.getString(UserInfoSeparator, "@")
+	}
+	return fmt.Sprintf("<%s>%s</>%s<%s>%s</>", s.props.getColor(UserColor, s.props.foreground), username, separator, s.props.getColor(HostColor, s.props.foreground), computername)
 }
 
 func (s *session) getComputerName() string {

--- a/segment_session_test.go
+++ b/segment_session_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func testUserInfoWriter(userInfoSeparator string, username string, hostname string, goos string) string {
+func setupSession(userInfoSeparator string, username string, hostname string, goos string) session {
 	env := new(MockedEnvironment)
 	user := user.User{
 		Username: username,
@@ -24,6 +24,11 @@ func testUserInfoWriter(userInfoSeparator string, username string, hostname stri
 		env:   env,
 		props: props,
 	}
+	return s
+}
+
+func testUserInfoWriter(userInfoSeparator string, username string, hostname string, goos string) string {
+	s := setupSession(userInfoSeparator, username, hostname, goos)
 	return s.getFormattedText()
 }
 
@@ -36,5 +41,23 @@ func TestWriteUserInfo(t *testing.T) {
 func TestWriteUserInfoWindowsIncludingHostname(t *testing.T) {
 	want := "<#fff>bill</>@<#fff>surface</>"
 	got := testUserInfoWriter("@", "surface\\bill", "surface", "windows")
+	assert.EqualValues(t, want, got)
+}
+
+func TestWriteOnlyUsername(t *testing.T) {
+	s := setupSession("@", "surface\\bill", "surface", "windows")
+	s.props.values[DisplayHost] = false
+
+	want := "<#fff>bill</><#fff></>"
+	got := s.getFormattedText()
+	assert.EqualValues(t, want, got)
+}
+
+func TestWriteOnlyHostname(t *testing.T) {
+	s := setupSession("@", "surface\\bill", "surface", "windows")
+	s.props.values[DisplayUser] = false
+
+	want := "<#fff></><#fff>surface</>"
+	got := s.getFormattedText()
 	assert.EqualValues(t, want, got)
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

only display UserInfoSeparator if both username and hostname are dislayed
cleanHostName only if it ends with garbage instead of contains.  fixes .localdomain having just .local stripped
add .localdomain to garbage

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
