### PR TITLE
feat: add os segment

### DIFF
--- a/docs/docs/segment-os.md
+++ b/docs/docs/segment-os.md
@@ -1,0 +1,31 @@
+---
+id: os
+title: os
+sidebar_label: OS
+---
+
+## What
+
+Display OS specific info. Defaults to Icon.
+
+## Sample Configuration
+
+```json
+{
+  "type": "os",
+  "style": "plain",
+  "foreground": "#26C6DA",
+  "background": "#546E7A",
+  "properties": {
+    "postfix": " ",
+    "macos": "mac"
+  }
+}
+```
+
+## Properties
+
+- macos: `string` - the string to use for macOS - defaults to macOS icon 
+- linux: `string` - the icon to use for Linux - defaults to Linux icon
+- windows: `string` - the icon to use for Windows - defaults to Windows icon
+

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -19,6 +19,7 @@ module.exports = {
         "exit",
         "git",
         "node",
+        "os",
         "path",
         "python",
         "root",

--- a/segment.go
+++ b/segment.go
@@ -56,6 +56,8 @@ const (
 	ShellInfo SegmentType = "shell"
 	//Node writes which node version is currently active
 	Node SegmentType = "node"
+	//OS write os specific icon
+	Os SegmentType = "os"
 	//Powerline writes it Powerline style
 	Powerline SegmentStyle = "powerline"
 	//Plain writes it without ornaments
@@ -107,6 +109,7 @@ func (segment *Segment) mapSegmentWithWriter(env environmentInfo) (*properties, 
 		Spotify:   &spotify{},
 		ShellInfo: &shell{},
 		Node:      &node{},
+		Os:        &osInfo{},
 	}
 	if writer, ok := functions[segment.Type]; ok {
 		props := &properties{

--- a/segment_os.go
+++ b/segment_os.go
@@ -1,0 +1,38 @@
+package main
+
+type osInfo struct {
+	props          *properties
+	env            environmentInfo
+}
+
+const (
+	//Macos the string to use for macOS
+	macOS Property = "macos"
+	//LinuxIcon the string to use for linux
+	Linux Property = "linux"
+	//WindowsIcon the icon to use for windows
+	Windows Property = "windows"
+)
+
+func (n *osInfo) enabled() bool {
+	return true
+}
+
+func (n *osInfo) string() string {
+	goos := n.env.getRuntimeGOOS()
+	switch goos {
+	case "windows":
+		return n.props.getString(Windows, "\uE62A")
+	case "darwin":
+		return n.props.getString(macOS, "\uF179")
+	case "linux":
+		return n.props.getString(Linux, "\uF17C")
+	default:
+		return ""
+	}
+}
+
+func (n *osInfo) init(props *properties, env environmentInfo) {
+	n.props = props
+	n.env = env
+}

--- a/segment_os_test.go
+++ b/segment_os_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOsInfo(t *testing.T) {
+	env := new(MockedEnvironment)
+	env.On("getRuntimeGOOS", nil).Return("windows")
+	props := &properties{
+		values:     map[Property]interface{}{Windows: "win"},
+		foreground: "#fff",
+		background: "#000",
+	}
+	osInfo := &osInfo{
+		env: env,
+		props: props,
+	}
+	want := "win"
+	got := osInfo.string()
+	assert.Equal(t, want, got)
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

Add new os segment that display an OS specific string which defaults to an icon.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
