### PR TITLE
Show python segment when Jupyter Notebook files are present

### DIFF
--- a/docs/docs/segment-python.md
+++ b/docs/docs/segment-python.md
@@ -6,7 +6,7 @@ sidebar_label: Python
 
 ## What
 
-Display the currently active python version and virtualenv when a folder contains `.py` files.
+Display the currently active python version and virtualenv when a folder contains `.py` files or `.ipynb` files.
 Supports conda, virtualenv and pyenv.
 
 ## Sample Configuration

--- a/segment_python.go
+++ b/segment_python.go
@@ -30,7 +30,7 @@ func (p *python) init(props *properties, env environmentInfo) {
 }
 
 func (p *python) enabled() bool {
-	if !p.env.hasFiles("*.py") {
+	if !p.env.hasFiles("*.py") && !p.env.hasFiles("*.ipynb") {
 		return false
 	}
 	pythonVersions := []string{


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

Adds a check for .ipynb files.
Jupyter Notebook is a popular tool that is often managed through anaconda.
Therefore it would be nice to show the python segment when a notebook file is present.
