### PR TITLE
fix: correct parameter in instructions

### DIFF
--- a/docs/docs/installation.mdx
+++ b/docs/docs/installation.mdx
@@ -43,7 +43,7 @@ Invoke-Webrequest https://github.com/JanDeDobbeleer/oh-my-posh3/releases/latest/
 
 
 ```bash
-wget https://github.com/JanDeDobbeleer/oh-my-posh3/releases/latest/download/posh-darwin-amd64 -o /usr/local/bin/oh-my-posh
+wget https://github.com/JanDeDobbeleer/oh-my-posh3/releases/latest/download/posh-darwin-amd64 -O /usr/local/bin/oh-my-posh
 chmod +x /usr/local/bin/oh-my-posh
 ```
 
@@ -52,7 +52,7 @@ chmod +x /usr/local/bin/oh-my-posh
 
 
 ```bash
-wget https://github.com/JanDeDobbeleer/oh-my-posh3/releases/latest/download/posh-linux-amd64 -o /usr/local/bin/oh-my-posh
+wget https://github.com/JanDeDobbeleer/oh-my-posh3/releases/latest/download/posh-linux-amd64 -O /usr/local/bin/oh-my-posh
 chmod +x /usr/local/bin/oh-my-posh
 ```
 


### PR DESCRIPTION
fix: correct parameter in instructions

### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

Installation instructions mention -o, however -o writes the log file:
       -o logfile
       --output-file=logfile
           Log all messages to logfile.  The messages are normally reported to standard error.
To write the document to an output file, in this case, you could use -O:
       -O file
       --output-document=file

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
