### PR TITLE
feat: use os segment in powerlevel10k_classic theme

### DIFF
--- a/themes/powerlevel10k_classic.json
+++ b/themes/powerlevel10k_classic.json
@@ -5,12 +5,11 @@
       "alignment": "left",
       "segments": [
         {
-          "type": "text",
+          "type": "os",
           "style": "plain",
           "foreground": "#26C6DA",
           "background": "#546E7A",
           "properties": {
-            "text": "",
             "postfix": " "
           }
         },


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

modify powerlevel10k_classic them to use new os segment instead of hardcoded windows icon.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
