### PR TITLE
docs: fix bashrc not recognizing oh-my-posh is installed

### DIFF
--- a/docs/docs/installation.mdx
+++ b/docs/docs/installation.mdx
@@ -124,7 +124,7 @@ function _update_ps1() {
     PS1="$(oh-my-posh -config ~/downloadedtheme.json -error $?)"
 }
 
-if [ "$TERM" != "linux" ] && [ -f oh-my-posh ]; then
+if [ "$TERM" != "linux" ] && [ -x "$(command -v oh-my-posh)" ]; then
     PROMPT_COMMAND="_update_ps1; $PROMPT_COMMAND"
 fi
 ```


### PR DESCRIPTION
### Prerequisites

- [X] I have read and understand the `CONTRIBUTING` guide
- [X] The commit message follows the [conventional commits][cc] guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

### Description

Bash doesn't seem to recognize oh-my-posh is installed with `-f oh-my-posh`
using `-x "$(command -v oh-my-posh)"` instead fixes this

