### PR TITLE
feat: az segment for Azure subscription info

### DIFF
--- a/docs/docs/segment-az.md
+++ b/docs/docs/segment-az.md
@@ -1,0 +1,33 @@
+---
+id: az
+title: Azure Subscription
+sidebar_label: Azure
+---
+
+## What
+
+Display the currently active Azure subscription information.
+
+## Sample Configuration
+
+```json
+{
+  "type": "az",
+  "style": "powerline",
+  "powerline_symbol": "",
+  "foreground": "#000000",
+  "background": "#9ec3f0",
+  "properties": {
+    "display_id": true,
+    "display_name": true,
+    "info_separator": " @ ",
+    "prefix": " ﴃ "
+  }
+}
+```
+
+## Properties
+
+- info_separator: `string` - text/icon to put in between the subscription name and ID - defaults to ` | `
+- display_id: `boolean` - display the subscription ID or not - defaults to `false`
+- display_name: `boolean` - display the subscription name or not - defaults to `true`

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -14,6 +14,7 @@ module.exports = {
       type: "category",
       label: "Segments",
       items: [
+        "az",
         "battery",
         "command",
         "environment",

--- a/segment.go
+++ b/segment.go
@@ -63,6 +63,8 @@ const (
 	Os SegmentType = "os"
 	//EnvVar writes the content of an environment variable
 	EnvVar SegmentType = "envvar"
+	//Az writes the Azure subscription info we're currently in
+	Az SegmentType = "az"
 	//Powerline writes it Powerline style
 	Powerline SegmentStyle = "powerline"
 	//Plain writes it without ornaments
@@ -117,6 +119,7 @@ func (segment *Segment) mapSegmentWithWriter(env environmentInfo) error {
 		Node:      &node{},
 		Os:        &osInfo{},
 		EnvVar:    &envvar{},
+		Az:        &az{},
 	}
 	if writer, ok := functions[segment.Type]; ok {
 		props := &properties{

--- a/segment_az.go
+++ b/segment_az.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+type az struct {
+	props *properties
+	env   environmentInfo
+	name  string
+	id    string
+}
+
+const (
+	//SubscriptionInfoSeparator is put between the name and ID
+	SubscriptionInfoSeparator Property = "info_separator"
+	//DisplaySubscriptionID hides or show the subscription GUID
+	DisplaySubscriptionID Property = "display_id"
+	//DisplaySubscriptionName hides or shows the subscription display name
+	DisplaySubscriptionName Property = "display_name"
+)
+
+func (a *az) string() string {
+	separator := ""
+	if a.idEnabled() && a.nameEnabled() {
+		separator = a.props.getString(SubscriptionInfoSeparator, " | ")
+	}
+
+	return fmt.Sprintf("%s%s%s", a.getName(), separator, a.getID())
+}
+
+func (a *az) init(props *properties, env environmentInfo) {
+	a.props = props
+	a.env = env
+}
+
+func (a *az) enabled() bool {
+	if (!a.idEnabled() && !a.nameEnabled()) || !a.env.hasCommand("az") {
+		return false
+	}
+
+	output := a.env.runCommand("az", "account", "show", "--query=[name,id]", "-o=tsv")
+	if output == "" {
+		return false
+	}
+
+	splittedOutput := strings.Split(output, "\n")
+	if len(splittedOutput) < 2 {
+		return false
+	}
+
+	a.name = strings.TrimSpace(splittedOutput[0])
+	a.id = strings.TrimSpace(splittedOutput[1])
+	return true
+}
+
+func (a *az) getID() string {
+	if !a.idEnabled() {
+		return ""
+	}
+
+	return a.id
+}
+
+func (a *az) getName() string {
+	if !a.nameEnabled() {
+		return ""
+	}
+
+	return a.name
+}
+
+func (a *az) idEnabled() bool {
+	return a.props.getBool(DisplaySubscriptionID, false)
+}
+
+func (a *az) nameEnabled() bool {
+	return a.props.getBool(DisplaySubscriptionName, true)
+}

--- a/segment_az_test.go
+++ b/segment_az_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type azArgs struct {
+	enabled          bool
+	subscriptionName string
+	subscriptionID   string
+	infoSeparator    string
+	displayID        bool
+	displayName      bool
+}
+
+func bootStrapAzTest(args *azArgs) *az {
+	env := new(MockedEnvironment)
+	env.On("hasCommand", "az").Return(args.enabled)
+	env.On("runCommand", "az", []string{"account", "show", "--query=[name,id]", "-o=tsv"}).Return(fmt.Sprintf("%s\n%s\n", args.subscriptionName, args.subscriptionID), nil)
+	props := &properties{
+		values: map[Property]interface{}{
+			SubscriptionInfoSeparator: args.infoSeparator,
+			DisplaySubscriptionID:     args.displayID,
+			DisplaySubscriptionName:   args.displayName,
+		},
+	}
+
+	a := &az{
+		env:   env,
+		props: props,
+	}
+	return a
+}
+
+func TestEnabledAzNotFound(t *testing.T) {
+	args := &azArgs{
+		enabled: false,
+	}
+	az := bootStrapAzTest(args)
+	assert.False(t, az.enabled())
+}
+
+func TestEnabledNoAzDataToDisplay(t *testing.T) {
+	args := &azArgs{
+		enabled:     true,
+		displayID:   false,
+		displayName: false,
+	}
+	az := bootStrapAzTest(args)
+	assert.False(t, az.enabled())
+}
+
+func TestWriteAzSubscriptionId(t *testing.T) {
+	expected := "id"
+	args := &azArgs{
+		enabled:          true,
+		subscriptionID:   "id",
+		subscriptionName: "name",
+		displayID:        true,
+		displayName:      false,
+	}
+	az := bootStrapAzTest(args)
+	assert.True(t, az.enabled())
+	assert.Equal(t, expected, az.string())
+}
+
+func TestWriteAzSubscriptionName(t *testing.T) {
+	expected := "name"
+	args := &azArgs{
+		enabled:          true,
+		subscriptionID:   "id",
+		subscriptionName: "name",
+		displayID:        false,
+		displayName:      true,
+	}
+	az := bootStrapAzTest(args)
+	assert.True(t, az.enabled())
+	assert.Equal(t, expected, az.string())
+}
+
+func TestWriteAzNameAndID(t *testing.T) {
+	expected := "name@id"
+	args := &azArgs{
+		enabled:          true,
+		subscriptionID:   "id",
+		subscriptionName: "name",
+		infoSeparator:    "@",
+		displayID:        true,
+		displayName:      true,
+	}
+	az := bootStrapAzTest(args)
+	assert.True(t, az.enabled())
+	assert.Equal(t, expected, az.string())
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

New segment `az` allows display of current Azure subscription name and
ID with a configurable separator. Defaults to only display the name.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
