### PR TITLE
feat: kubectl context display segment

### DIFF
--- a/docs/docs/segment-kubectl.md
+++ b/docs/docs/segment-kubectl.md
@@ -1,0 +1,24 @@
+---
+id: kubectl
+title: Kubectl Context
+sidebar_label: Kubectl
+---
+
+## What
+
+Display the currently active Kubernetes context name.
+
+## Sample Configuration
+
+```json
+{
+  "type": "kubectl",
+  "style": "powerline",
+  "powerline_symbol": "",
+  "foreground": "#000000",
+  "background": "#ebcc34",
+  "properties": {
+    "prefix": " ⎈ "
+  }
+}
+```

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -20,6 +20,7 @@ module.exports = {
         "environment",
         "exit",
         "git",
+        "kubectl",
         "node",
         "os",
         "path",

--- a/segment.go
+++ b/segment.go
@@ -65,6 +65,8 @@ const (
 	EnvVar SegmentType = "envvar"
 	//Az writes the Azure subscription info we're currently in
 	Az SegmentType = "az"
+	//Kubectl writes the Kubernetes context we're currently in
+	Kubectl SegmentType = "kubectl"
 	//Powerline writes it Powerline style
 	Powerline SegmentStyle = "powerline"
 	//Plain writes it without ornaments
@@ -120,6 +122,7 @@ func (segment *Segment) mapSegmentWithWriter(env environmentInfo) error {
 		Os:        &osInfo{},
 		EnvVar:    &envvar{},
 		Az:        &az{},
+		Kubectl:   &kubectl{},
 	}
 	if writer, ok := functions[segment.Type]; ok {
 		props := &properties{

--- a/segment_kubectl.go
+++ b/segment_kubectl.go
@@ -1,0 +1,24 @@
+package main
+
+type kubectl struct {
+	props       *properties
+	env         environmentInfo
+	contextName string
+}
+
+func (k *kubectl) string() string {
+	return k.contextName
+}
+
+func (k *kubectl) init(props *properties, env environmentInfo) {
+	k.props = props
+	k.env = env
+}
+
+func (k *kubectl) enabled() bool {
+	if !k.env.hasCommand("kubectl") {
+		return false
+	}
+	k.contextName = k.env.runCommand("kubectl", "config", "current-context")
+	return true
+}

--- a/segment_kubectl_test.go
+++ b/segment_kubectl_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type kubectlArgs struct {
+	enabled     bool
+	contextName string
+}
+
+func bootStrapKubectlTest(args *kubectlArgs) *kubectl {
+	env := new(MockedEnvironment)
+	env.On("hasCommand", "kubectl").Return(args.enabled)
+	env.On("runCommand", "kubectl", []string{"config", "current-context"}).Return(args.contextName)
+	k := &kubectl{
+		env:   env,
+		props: &properties{},
+	}
+	return k
+}
+
+func TestKubectlWriterDisabled(t *testing.T) {
+	args := &kubectlArgs{
+		enabled: false,
+	}
+	kubectl := bootStrapKubectlTest(args)
+	assert.False(t, kubectl.enabled())
+}
+
+func TestKubectlEnabled(t *testing.T) {
+	expected := "context-name"
+	args := &kubectlArgs{
+		enabled:     true,
+		contextName: expected,
+	}
+	kubectl := bootStrapKubectlTest(args)
+	assert.True(t, kubectl.enabled())
+	assert.Equal(t, expected, kubectl.string())
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

Segment displays the current Kubernetes context name when available.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
