### PR TITLE
feat: add terraform workspace segment

### DIFF
--- a/docs/docs/segment-terraform.md
+++ b/docs/docs/segment-terraform.md
@@ -1,0 +1,25 @@
+---
+id: terraform
+title: Terraform Context
+sidebar_label: Terraform
+---
+
+## What
+
+Display the currently active Terraform Workspace name.
+
+Note:
+- Will need a terraform binary in your PATH
+- Will only be displayed in directories that contain a `.terraform` subdirectory
+
+## Sample Configuration
+
+```json
+{
+  "type": "terraform",
+  "style": "powerline",
+  "powerline_symbol": "\uE0B0",
+  "foreground": "#000000",
+  "background": "#ebcc34"
+}
+```

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -30,6 +30,7 @@ module.exports = {
         "session",
         "shell",
         "spotify",
+        "terraform",
         "text",
         "time",
       ]

--- a/segment.go
+++ b/segment.go
@@ -69,6 +69,8 @@ const (
 	Kubectl SegmentType = "kubectl"
 	//Dotnet writes which dotnet version is currently active
 	Dotnet SegmentType = "dotnet"
+	//Terraform writes the terraform workspace we're currently in
+	Terraform SegmentType = "terraform"
 	//Powerline writes it Powerline style
 	Powerline SegmentStyle = "powerline"
 	//Plain writes it without ornaments
@@ -126,6 +128,7 @@ func (segment *Segment) mapSegmentWithWriter(env environmentInfo) error {
 		Az:        &az{},
 		Kubectl:   &kubectl{},
 		Dotnet:    &dotnet{},
+		Terraform: &terraform{},
 	}
 	if writer, ok := functions[segment.Type]; ok {
 		props := &properties{

--- a/segment_terraform.go
+++ b/segment_terraform.go
@@ -1,0 +1,24 @@
+package main
+
+type terraform struct {
+	props         *properties
+	env           environmentInfo
+	workspaceName string
+}
+
+func (tf *terraform) string() string {
+	return tf.workspaceName
+}
+
+func (tf *terraform) init(props *properties, env environmentInfo) {
+	tf.props = props
+	tf.env = env
+}
+
+func (tf *terraform) enabled() bool {
+	if !tf.env.hasCommand("terraform") || !tf.env.hasFolder(".terraform") {
+		return false
+	}
+	tf.workspaceName, _ = tf.env.runCommand("terraform", "workspace", "show")
+	return true
+}

--- a/segment_terraform_test.go
+++ b/segment_terraform_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type terraformArgs struct {
+	hasTfCommand  bool
+	hasTfFolder   bool
+	workspaceName string
+}
+
+func bootStrapTerraformTest(args *terraformArgs) *terraform {
+	env := new(MockedEnvironment)
+	env.On("hasCommand", "terraform").Return(args.hasTfCommand)
+	env.On("hasFolder", ".terraform").Return(args.hasTfFolder)
+	env.On("runCommand", "terraform", []string{"workspace", "show"}).Return(args.workspaceName, nil)
+	k := &terraform{
+		env:   env,
+		props: &properties{},
+	}
+	return k
+}
+
+func TestTerraformWriterDisabled(t *testing.T) {
+	args := &terraformArgs{
+		hasTfCommand: false,
+		hasTfFolder:  false,
+	}
+	terraform := bootStrapTerraformTest(args)
+	assert.False(t, terraform.enabled())
+}
+
+func TestTerraformMissingDir(t *testing.T) {
+	args := &terraformArgs{
+		hasTfCommand: true,
+		hasTfFolder:  false,
+	}
+	terraform := bootStrapTerraformTest(args)
+	assert.False(t, terraform.enabled())
+}
+
+func TestTerraformMissingBinary(t *testing.T) {
+	args := &terraformArgs{
+		hasTfCommand: false,
+		hasTfFolder:  true,
+	}
+	terraform := bootStrapTerraformTest(args)
+	assert.False(t, terraform.enabled())
+}
+
+func TestTerraformEnabled(t *testing.T) {
+	expected := "default"
+	args := &terraformArgs{
+		hasTfCommand:  true,
+		hasTfFolder:   true,
+		workspaceName: expected,
+	}
+	terraform := bootStrapTerraformTest(args)
+	assert.True(t, terraform.enabled())
+	assert.Equal(t, expected, terraform.string())
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

This adds support for showing the [current terraform workspace name](https://www.terraform.io/docs/commands/workspace/show.html).

Inspired by a bash prompt I've used to show the current workspace:

```
function terraform_prompt()
  {
     if [ -d .terraform ]; then
       workspace="$(command terraform workspace show 2>/dev/null)"
       echo " (${workspace})"
     fi
  }
```

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
