### PR TITLE
feat: git area colors

### DIFF
--- a/docs/docs/segment-git.md
+++ b/docs/docs/segment-git.md
@@ -63,3 +63,10 @@ Local changes can also shown by default using the following syntax for both the 
 - gitlab_icon: `string` - icon/text to display when the upstream is Gitlab - defaults to `\uF296 `
 - bitbucket_icon: `string` - icon/text to display when the upstream is Bitbucket - defaults to `\uF171 `
 - git_icon: `string` - icon/text to display when the upstream is not known/mapped - defaults to `\uE5FB `
+
+### Colors
+
+- working_color: `string` [hex color code][colors] - foreground color for the working area status - defaults to segment foreground
+- staging_color: `string` [hex color code][colors] - foreground color for the staging area status - defaults to segment foreground
+
+[colors]: https://htmlcolorcodes.com/color-chart/material-design-color-chart/

--- a/segment_git.go
+++ b/segment_git.go
@@ -27,7 +27,7 @@ type gitStatus struct {
 	untracked int
 }
 
-func (s *gitStatus) string(prefix string) string {
+func (s *gitStatus) string(prefix string, color string) string {
 	var status string
 	stringIfValue := func(value int, prefix string) string {
 		if value > 0 {
@@ -41,7 +41,7 @@ func (s *gitStatus) string(prefix string) string {
 	status += stringIfValue(s.untracked, "?")
 	status += stringIfValue(s.unmerged, "x")
 	if status != "" {
-		return fmt.Sprintf(" %s%s", prefix, status)
+		return fmt.Sprintf(" <%s>%s%s</>", color, prefix, status)
 	}
 	return status
 }
@@ -95,6 +95,10 @@ const (
 	GitlabIcon Property = "gitlab_icon"
 	//GitIcon shows when the upstream can't be identified
 	GitIcon Property = "git_icon"
+	//WorkingColor if set, the color to use on the working area
+	WorkingColor Property = "working_color"
+	//StagingColor if set, the color to use on the staging area
+	StagingColor Property = "staging_color"
 )
 
 func (g *git) enabled() bool {
@@ -130,8 +134,8 @@ func (g *git) string() string {
 	} else if g.repo.upstream == "" {
 		fmt.Fprintf(buffer, " %s", g.props.getString(BranchGoneIcon, "\u2262"))
 	}
-	staging := g.repo.staging.string(g.props.getString(LocalStagingIcon, "\uF046"))
-	working := g.repo.working.string(g.props.getString(LocalWorkingIcon, "\uF044"))
+	staging := g.repo.staging.string(g.props.getString(LocalStagingIcon, "\uF046"), g.props.getColor(StagingColor, g.props.foreground))
+	working := g.repo.working.string(g.props.getString(LocalWorkingIcon, "\uF044"), g.props.getColor(WorkingColor, g.props.foreground))
 	fmt.Fprint(buffer, staging)
 	if staging != "" && working != "" {
 		fmt.Fprint(buffer, g.props.getString(StatusSeparatorIcon, " |"))

--- a/segment_git_test.go
+++ b/segment_git_test.go
@@ -268,26 +268,26 @@ func TestParseGitBranchInfoNoRemote(t *testing.T) {
 }
 
 func TestGitStatusUnmerged(t *testing.T) {
-	expected := " working: x1"
+	expected := " <#123456>working: x1</>"
 	status := &gitStatus{
 		unmerged: 1,
 	}
-	assert.Equal(t, expected, status.string("working:"))
+	assert.Equal(t, expected, status.string("working:", "#123456"))
 }
 
 func TestGitStatusUnmergedModified(t *testing.T) {
-	expected := " working: ~3 x1"
+	expected := " <#123456>working: ~3 x1</>"
 	status := &gitStatus{
 		unmerged: 1,
 		modified: 3,
 	}
-	assert.Equal(t, expected, status.string("working:"))
+	assert.Equal(t, expected, status.string("working:", "#123456"))
 }
 
 func TestGitStatusEmpty(t *testing.T) {
 	expected := ""
 	status := &gitStatus{}
-	assert.Equal(t, expected, status.string("working:"))
+	assert.Equal(t, expected, status.string("working:", "#123456"))
 }
 
 func TestParseGitStatsWorking(t *testing.T) {


### PR DESCRIPTION
resolves #4

### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

Add Git area colors for easy distinction

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
