### PR TITLE
fix: correct ANSI sequence for line break

### DIFF
--- a/renderer.go
+++ b/renderer.go
@@ -72,7 +72,7 @@ func (r *Renderer) init(shell string) {
 		r.formats.single = "\x1b[%sm%s\x1b[0m"
 		r.formats.full = "\x1b[%sm\x1b[%sm%s\x1b[0m"
 		r.formats.transparent = "\x1b[%s;49m\x1b[7m%s\x1b[m\x1b[0m"
-		r.formats.linebreak = "\x1b[1000C "
+		r.formats.linebreak = "\x1b[E"
 		r.formats.linechange = "\x1b[%d%s"
 		r.formats.left = "\x1b[%dC"
 		r.formats.right = "\x1b[%dD"


### PR DESCRIPTION
relates to #83

### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

Use the correct ANSI escape sequence for the default shell configuration.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
