### PR TITLE
fix: only use ansi for newline on Powershell

### DIFF
--- a/docs/docs/contributing-segment.md
+++ b/docs/docs/contributing-segment.md
@@ -1,5 +1,5 @@
 ---
-id: contributing-segment
+id: contributing_segment
 title: Add Segment
 sidebar_label: Add Segment
 ---

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -38,7 +38,7 @@ module.exports = {
     {
       type: "category",
       label: "Contributing",
-      items: ["contributing-segment"],
+      items: ["contributing_segment"],
     },
   ],
 };

--- a/renderer.go
+++ b/renderer.go
@@ -131,11 +131,10 @@ func (r *Renderer) lenWithoutANSI(str string) int {
 }
 
 func (r *Renderer) lineBreak() string {
-	switch r.shell {
-	case "bash", "zsh", "nu":
-		return "\n"
+	if r.shell == "pwsh" {
+		return "\x1b[1000C "
 	}
-	return "\x1b[1000C "
+	return "\n"
 }
 
 func (r *Renderer) carriageForward() string {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

Newline has been way too challenging for PowerShell to work as it should.
Rather than impacting every other shell that works with `\n`, override
Powershell to use ANSI escape sequences.

This should finally resolve #83 

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
