### PR TITLE
refactor: swap go-ps for gopsutil

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 
 	"github.com/distatus/battery"
-	ps "github.com/mitchellh/go-ps"
 	"github.com/shirou/gopsutil/host"
+	"github.com/shirou/gopsutil/process"
 )
 
 type environmentInfo interface {
@@ -173,12 +173,12 @@ func (env *environment) getBatteryInfo() (*battery.Battery, error) {
 
 func (env *environment) getShellName() string {
 	pid := os.Getppid()
-	p, err := ps.FindProcess(pid)
-
+	p, _ := process.NewProcess(int32(pid))
+	name, err := p.Name()
 	if err != nil {
 		return "unknown"
 	}
-	shell := strings.Replace(p.Executable(), ".exe", "", 1)
+	shell := strings.Replace(name, ".exe", "", 1)
 	return strings.Trim(shell, " ")
 }
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/distatus/battery v0.10.1-0.20200722221337-7e1bf2bbb15c
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/gookit/color v1.3.1
-	github.com/mitchellh/go-ps v1.0.0
 	github.com/shirou/gopsutil v2.20.9+incompatible
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/JanDeDobbeleer/battery v0.10.1-0.20200909080331-bb0a7566dbb8 h1:+SZ7q
 github.com/JanDeDobbeleer/battery v0.10.1-0.20200909080331-bb0a7566dbb8/go.mod h1:STnSvFLX//eEpkaN7qWRxCWxrWOcssTDgnG4yqq9BRE=
 github.com/JanDeDobbeleer/color v1.3.1-0.20201014085303-5ffcdf66388a h1:0gU8YI1Z9jXOeMbUxRQR6/XznZTKXSQcVuoFZtbrkN8=
 github.com/JanDeDobbeleer/color v1.3.1-0.20201014085303-5ffcdf66388a/go.mod h1:R3ogXq2B9rTbXoSHJ1HyUVAZ3poOJHpd9nQmyGZsfvQ=
-github.com/JanDeDobbeleer/go-ps v1.0.0 h1:3nqwUNAIzjrjQoEdZDVcS5OCm+KIoShKnANJ5xfkgBY=
-github.com/JanDeDobbeleer/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

since gopsutil is being used other places for the os info, use it for proc/shell info as well, no longer requires go-ps.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
