### PR TITLE
fix: theme paths with spaces

### DIFF
--- a/docs/docs/installation.mdx
+++ b/docs/docs/installation.mdx
@@ -93,14 +93,14 @@ Edit `$PROFILE` in your preferred PowerShell version and add the following lines
     $startInfo = New-Object System.Diagnostics.ProcessStartInfo
     $startInfo.FileName = "C:\tools\oh-my-posh.exe"
     $config = $global:PoshSettings.Theme
-    $startInfo.Arguments = "-config C:\Users\User\Downloads\downloadedtheme.json -pwd $PWD -error $realLASTEXITCODE"
+    $startInfo.Arguments = "-config ""C:\Users\User\Downloads\downloadedtheme.json"" -pwd ""$PWD"" -error $realLASTEXITCODE"
     $startInfo.Environment["TERM"] = "xterm-256color"
     $startInfo.CreateNoWindow = $true
     $startInfo.StandardOutputEncoding = [System.Text.Encoding]::UTF8
     $startInfo.RedirectStandardOutput = $true
     $startInfo.UseShellExecute = $false
     if ($PWD.Provider.Name -eq "FileSystem") {
-      $startInfo.WorkingDirectory = $PWD
+      $startInfo.WorkingDirectory = "$PWD"
     }
     $process = New-Object System.Diagnostics.Process
     $process.StartInfo = $startInfo

--- a/packages/powershell/oh-my-posh/oh-my-posh.psm1
+++ b/packages/powershell/oh-my-posh/oh-my-posh.psm1
@@ -51,7 +51,7 @@ function Set-PoshPrompt {
         $startInfo = New-Object System.Diagnostics.ProcessStartInfo
         $startInfo.FileName = Get-PoshCommand
         $config = $global:PoshSettings.Theme
-        $startInfo.Arguments = "-config $config -pwd ""$PWD"" -error $realLASTEXITCODE"
+        $startInfo.Arguments = "-config ""$config"" -pwd ""$PWD"" -error $realLASTEXITCODE"
         $startInfo.Environment["TERM"] = "xterm-256color"
         $startInfo.CreateNoWindow = $true
         $startInfo.StandardOutputEncoding = [System.Text.Encoding]::UTF8


### PR DESCRIPTION
resolves #100

### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

Due to the invocation of the binary, all paths need to be wrapped in quotes.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
