### PR TITLE
fix: handle kubectl context unset

### DIFF
--- a/segment_kubectl.go
+++ b/segment_kubectl.go
@@ -20,5 +20,5 @@ func (k *kubectl) enabled() bool {
 		return false
 	}
 	k.contextName, _ = k.env.runCommand("kubectl", "config", "current-context")
-	return true
+	return k.contextName != ""
 }

--- a/segment_kubectl_test.go
+++ b/segment_kubectl_test.go
@@ -40,3 +40,12 @@ func TestKubectlEnabled(t *testing.T) {
 	assert.True(t, kubectl.enabled())
 	assert.Equal(t, expected, kubectl.string())
 }
+
+func TestKubectlNoContext(t *testing.T) {
+	args := &kubectlArgs{
+		enabled:     true,
+		contextName: "",
+	}
+	kubectl := bootStrapKubectlTest(args)
+	assert.False(t, kubectl.enabled())
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

No doc changes required.

### Description

In a situation where `kubectl` is available but no `~/.kube/config` has been established, you can get a situation where `kubectl` runs but doesn't return a context. In this edge case, the `kubectl` segment will be disabled.

Without this, you get weird issues like the trailing Powerline arrow not showing up.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
