### PR TITLE
feat: support color names for basic 16 ANSI colors

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -103,8 +103,8 @@ understand how to configure a segment.
 - invert_powerline: `boolean`
 - leading_diamond: `string`
 - trailing_diamond: `string`
-- foreground: `string` [hex color code][colors]
-- background: `string` [hex color code][colors]
+- foreground: `string` [color][colors]
+- background: `string` [color][colors]
 - properties: `array` of `Property`: `string`
 
 ### Type
@@ -205,8 +205,21 @@ do so like this:
 "prefix": "<#CB4B16>┏[</>",
 ```
 
-Oh my Posh offers support for hex [colors][colors] as well as the `transparent` keyword to create either a transparent foreground
-override or transparent background color using the segement's [foreground][fg] property.
+Oh my Posh mainly supports three different color types being
+* Typical [hex colors][hexcolors] (for example `#CB4B16`).
+
+* The `transparent` keyword which can be used to create either a transparent foreground override
+  or transparent background color using the segement's foreground property.
+
+* 16 [ANSI color names][ansicolors].
+
+  These include 8 basic ANSI colors and `default`:
+
+  `black` `red` `green` `yellow` `blue` `magenta` `cyan` `white` `default`
+
+  as well as 8 extended ANSI colors:
+
+  `darkGray` `lightRed` `lightGreen` `lightYellow` `lightBlue` `lightMagenta` `lightCyan` `lightWhite`
 
 ## Full Sample
 
@@ -294,5 +307,7 @@ override or transparent background color using the segement's [foreground][fg] p
 [releases]: https://github.com/JanDeDobbeleer/oh-my-posh3/releases/latest
 [nf]: https://www.nerdfonts.com/
 [segments]: /docs/battery
-[colors]: https://htmlcolorcodes.com/color-chart/material-design-color-chart/
+[colors]: #colors
+[hexcolors]: https://htmlcolorcodes.com/color-chart/material-design-color-chart/
+[ansicolors]: https://htmlcolorcodes.com/color-chart/material-design-color-chart/
 [fg]: /docs/configure#foreground

--- a/docs/docs/segment-battery.md
+++ b/docs/docs/segment-battery.md
@@ -39,8 +39,8 @@ Battery displays the remaining power percentage for your battery.
 - discharging_icon: `string` - icon to display on the left when discharging - defaults to empty
 - charged_icon: `string` - icon to display on the left when fully charged - defaults to empty
 - color_background: `boolean` - color the background or foreground for properties below - defaults to `false`
-- charged_color: `string` [hex color code][colors] - color to use when fully charged - defaults to segment color
-- charging_color: `string` [hex color code][colors] - color to use when charging - defaults to segment color
-- discharging_color: `string` [hex color code][colors] - color to use when discharging - defaults to segment color
+- charged_color: `string` [color][colors] - color to use when fully charged - defaults to segment color
+- charging_color: `string` [color][colors] - color to use when charging - defaults to segment color
+- discharging_color: `string` [color][colors] - color to use when discharging - defaults to segment color
 
-[colors]: https://htmlcolorcodes.com/color-chart/material-design-color-chart/
+[colors]: /docs/configure#colors

--- a/docs/docs/segment-exit.md
+++ b/docs/docs/segment-exit.md
@@ -33,6 +33,6 @@ Displays the last exit code or that the last command failed based on the configu
 - display_exit_code: `boolean` - show or hide the exit code - defaults to `true`
 - always_enabled: `boolean` - always show the status - defaults to `false`
 - color_background: `boolean` - color the background or foreground when an error occurs - defaults to `false`
-- error_color: `string` [hex color code][colors] - color to use when an error occured
+- error_color: `string` [color][colors] - color to use when an error occured
 
-[colors]: https://htmlcolorcodes.com/color-chart/material-design-color-chart/
+[colors]: /docs/configure#colors

--- a/docs/docs/segment-git.md
+++ b/docs/docs/segment-git.md
@@ -67,17 +67,17 @@ Local changes can also shown by default using the following syntax for both the 
 
 ### Colors
 
-- working_color: `string` [hex color code][colors] - foreground color for the working area status - defaults to segment foreground
-- staging_color: `string` [hex color code][colors] - foreground color for the staging area status - defaults to segment foreground
+- working_color: `string` [color][colors] - foreground color for the working area status - defaults to segment foreground
+- staging_color: `string` [color][colors] - foreground color for the staging area status - defaults to segment foreground
 - status_colors_enabled: `boolean` - color the segment based on the repository status - defaults to `false`
 - color_background: `boolean` - color background or foreground - defaults to `true`
-- local_changes_color: `string` [hex color code][colors] - segment color when there are local changes - defaults to segment
+- local_changes_color: `string` [color][colors] - segment color when there are local changes - defaults to segment
 foreground/background (see `color_background`)
-- ahead_and_behind_color: `string` [hex color code][colors] - segment color when the branch is ahead and behind -
+- ahead_and_behind_color: `string` [color][colors] - segment color when the branch is ahead and behind -
 defaults to segment foreground/background (see `color_background`)
-- behind_color: `string` [hex color code][colors] - segment color when the branch is behind - defaults to segment
+- behind_color: `string` [color][colors] - segment color when the branch is behind - defaults to segment
 foreground/background (see `color_background`)
-- ahead_color: `string` [hex color code][colors] - segment color when the branch is ahead - defaults to segment
+- ahead_color: `string` [color][colors] - segment color when the branch is ahead - defaults to segment
 foreground/background (see `color_background`)
 
-[colors]: https://htmlcolorcodes.com/color-chart/material-design-color-chart/
+[colors]: /docs/configure#colors

--- a/docs/docs/segment-session.md
+++ b/docs/docs/segment-session.md
@@ -26,9 +26,9 @@ Show the current user and host name.
 - user_info_separator: `string` - text/icon to put in between the user and host name - defaults to `@`
 - ssh_icon: `string` - text/icon to display first when in an active SSH session - defaults
 to `\uF817 `
-- user_color: `string` [hex color code][colors] - override the foreground color of the user name
-- host_color: `string` [hex color code][colors] - override the foreground color of the host name
+- user_color: `string` [color][colors] - override the foreground color of the user name
+- host_color: `string` [color][colors] - override the foreground color of the host name
 - display_user: `boolean` - display the user name or not - defaults to `true`
 - display_host: `boolean` - display the host name or not - defaults to `true`
 
-[colors]: https://htmlcolorcodes.com/color-chart/material-design-color-chart/
+[colors]: /docs/configure#colors

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -12,7 +12,7 @@ const features = [
     description: (
       <>
         Oh my Posh enables you to use the full color set of your terminal
-        by using hex colors to define and render the prompt.
+        by using colors to define and render the prompt.
       </>
     ),
   },

--- a/renderer_test.go
+++ b/renderer_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/gookit/color"
 )
 
 func TestWriteAndRemoveText(t *testing.T) {
@@ -49,6 +50,36 @@ func TestWriteColorTransparent(t *testing.T) {
 	t.Log(renderer.string())
 }
 
+func TestWriteColorName(t *testing.T) {
+	// given
+	renderer := &Renderer{
+		Buffer: new(bytes.Buffer),
+	}
+	renderer.init("pwsh")
+	text := "This is white, <red>this is red</>, white again"
+
+	// when
+	renderer.write("#193549", "red", text)
+
+	// then
+	assert.NotContains(t, renderer.string(), "<red>")
+}
+
+func TestWriteColorInvalid(t *testing.T) {
+	// given
+	renderer := &Renderer{
+		Buffer: new(bytes.Buffer),
+	}
+	renderer.init("pwsh")
+	text := "This is white, <invalid>this is orange</>, white again"
+
+	// when
+	renderer.write("#193549", "invalid", text)
+
+	// then
+	assert.Contains(t, renderer.string(), "<invalid>")
+}
+
 func TestLenWithoutANSI(t *testing.T) {
 	text := "\x1b[44mhello\x1b[0m"
 	renderer := &Renderer{
@@ -67,4 +98,69 @@ func TestLenWithoutANSIZsh(t *testing.T) {
 	renderer.init("zsh")
 	strippedLength := renderer.lenWithoutANSI(text)
 	assert.Equal(t, 5, strippedLength)
+}
+
+func TestGetAnsiFromColorStringBg(t *testing.T) {
+	// given
+	renderer := &Renderer{
+		Buffer: new(bytes.Buffer),
+	}
+
+	// when
+	colorCode := renderer.getAnsiFromColorString("blue", true)
+
+	// then
+	assert.Equal(t, color.BgBlue.Code(), colorCode)
+}
+
+func TestGetAnsiFromColorStringFg(t *testing.T) {
+	// given
+	renderer := &Renderer{
+		Buffer: new(bytes.Buffer),
+	}
+
+	// when
+	colorCode := renderer.getAnsiFromColorString("red", false)
+
+	// then
+	assert.Equal(t, color.FgRed.Code(), colorCode)
+}
+
+func TestGetAnsiFromColorStringHex(t *testing.T) {
+	// given
+	renderer := &Renderer{
+		Buffer: new(bytes.Buffer),
+	}
+
+	// when
+	colorCode := renderer.getAnsiFromColorString("#AABBCC", false)
+
+	// then
+	assert.Equal(t, color.HEX("#AABBCC").Code(), colorCode)
+}
+
+func TestGetAnsiFromColorStringInvalidFg(t *testing.T) {
+	// given
+	renderer := &Renderer{
+		Buffer: new(bytes.Buffer),
+	}
+
+	// when
+	colorCode := renderer.getAnsiFromColorString("invalid", false)
+
+	// then
+	assert.Equal(t, "", colorCode)
+}
+
+func TestGetAnsiFromColorStringInvalidBg(t *testing.T) {
+	// given
+	renderer := &Renderer{
+		Buffer: new(bytes.Buffer),
+	}
+
+	// when
+	colorCode := renderer.getAnsiFromColorString("invalid", true)
+
+	// then
+	assert.Equal(t, "", colorCode)
 }


### PR DESCRIPTION
Closes #127

### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

Adds support to also use basic color names such as `green` or `lightBlue` for the basic 16 ANSI color escape codes. From now on such names can be specified in addition to hex color codes. I added some more details to the issue #127.

I am not very familiar with go (tbh, not at all, I got to know it a bit on the fly), so I'd love to get some feedback on improving the code. In general I'd appreaciate any kind of feedback and suggestions here 😄 

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
