### PR TITLE
fix: set $Global:GitStatus when Get-GitStatus exists

### DIFF
--- a/packages/powershell/oh-my-posh/oh-my-posh.psm1
+++ b/packages/powershell/oh-my-posh/oh-my-posh.psm1
@@ -26,6 +26,12 @@ if (!$IsWindows) {
 
 function Set-PoshContext {}
 
+function Set-GitStatus {
+    if (Get-Command -Name "Get-GitStatus" -ErrorAction SilentlyContinue) {
+        $Global:GitStatus = Get-GitStatus
+    }
+}
+
 function Set-PoshPrompt {
     param(
         [Parameter(Mandatory = $false)]
@@ -70,6 +76,7 @@ function Set-PoshPrompt {
         $standardOut
         $global:LASTEXITCODE = $realLASTEXITCODE
         Remove-Variable realLASTEXITCODE -Confirm:$false
+        Set-GitStatus
     }
     Set-Item -Path Function:prompt -Value $Prompt -Force
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

[Description of the change]

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
