### PR TITLE
fix: show branch name when upstream gone

### DIFF
--- a/segment_git.go
+++ b/segment_git.go
@@ -206,7 +206,9 @@ func (g *git) setGitStatus() {
 	if status["local"] != "" {
 		g.repo.ahead, _ = strconv.Atoi(status["ahead"])
 		g.repo.behind, _ = strconv.Atoi(status["behind"])
-		g.repo.upstream = status["upstream"]
+		if status["upstream_status"] != "gone" {
+			g.repo.upstream = status["upstream"]
+		}
 	}
 	g.repo.HEAD = g.getGitHEADContext(status["local"])
 	g.repo.stashCount = g.getStashContext()
@@ -346,7 +348,7 @@ func (g *git) getStashContext() string {
 }
 
 func (g *git) parseGitStatusInfo(branchInfo string) map[string]string {
-	var branchRegex = regexp.MustCompile(`^## (?P<local>\S+?)(\.{3}(?P<upstream>\S+?)( \[(ahead (?P<ahead>\d+)(, )?)?(behind (?P<behind>\d+))?])?)?$`)
+	var branchRegex = regexp.MustCompile(`^## (?P<local>\S+?)(\.{3}(?P<upstream>\S+?)( \[(?P<upstream_status>(ahead (?P<ahead>\d+)(, )?)?(behind (?P<behind>\d+))?(gone)?)])?)?$`)
 	return groupDict(branchRegex, branchInfo)
 }
 

--- a/segment_git_test.go
+++ b/segment_git_test.go
@@ -267,6 +267,14 @@ func TestParseGitBranchInfoNoRemote(t *testing.T) {
 	assert.Empty(t, got["upstream"])
 }
 
+func TestParseGitBranchInfoRemoteGone(t *testing.T) {
+	g := git{}
+	branchInfo := "## test-branch...origin/test-branch [gone]"
+	got := g.parseGitStatusInfo(branchInfo)
+	assert.Equal(t, "test-branch", got["local"])
+	assert.Equal(t, "gone", got["upstream_status"])
+}
+
 func TestGitStatusUnmerged(t *testing.T) {
 	expected := "<#123456>working: x1</>"
 	status := &gitStatus{


### PR DESCRIPTION
### Prerequisites

- [ ] I have read and understand the `CONTRIBUTING` guide
- [ ] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Description

[Description of the change]

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
