### PR TITLE
Bugfix/segment spotify windows

### DIFF
--- a/environment_windows_win32.go
+++ b/environment_windows_win32.go
@@ -40,6 +40,13 @@ func getWindowTitle(imageName, windowTitleRegex string) (string, error) {
 	if err != nil {
 		return "", nil
 	}
+
+	// is a spotify process running?
+	// no: returns an empty string
+	if len(processPid) == 0 {
+		return "", nil
+	}
+
 	// returns the first window of the first pid
 	_, windowTitle, err := GetWindowTitle(processPid[0], windowTitleRegex)
 	if err != nil {
@@ -168,9 +175,6 @@ func GetWindowTitle(pid int, windowTitleRegex string) (syscall.Handle, string, e
 		return 1 // continue enumeration
 	})
 	// Enumerates all top-level windows on the screen
-	err = EnumWindows(cb, 0)
-	if err != nil || hwnd == 0 {
-		return 0, "", fmt.Errorf("No window with title '%b' found", pid)
-	}
+	_ = EnumWindows(cb, 0)
 	return hwnd, title, nil
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

Fixes a bug when spotify is not running(lost during the squash I guess)
Fixes an issue with EnumWindows returning an error all the time

I've been using it for one week and this afternoon it stopped working. I had a windows update this morning and a golang update. No idea why it stopped working.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
