### PR TITLE
feat: new ShowDebug parameter

### DIFF
--- a/docs/docs/segment-spotify.md
+++ b/docs/docs/segment-spotify.md
@@ -19,10 +19,10 @@ Be aware this can make the prompt a tad bit slower as it needs to get a response
   "foreground": "#ffffff",
   "background": "#1BD760",
   "properties": {
-    "prefix": "  ",
-    "playing_icon": " ",
-    "paused_icon": " ",
-    "stopped_icon": " ",
+    "prefix": "\uF9C6 ",
+    "playing_icon": "\uE602 ",
+    "paused_icon": "\uF8E3 ",
+    "stopped_icon": "\uF04D ",
     "track_separator" : " - "
   }
 }
@@ -32,5 +32,5 @@ Be aware this can make the prompt a tad bit slower as it needs to get a response
 
 - playing_icon: `string` - text/icon to show when playing - defaults to `\uE602 `
 - paused_icon: `string` - text/icon to show when paused - defaults to `\uF8E3 `
-- stopped_icon: `string` - text/icon to show when paused - defaults to `\uF04D  `
+- stopped_icon: `string` - text/icon to show when paused - defaults to `\uF04D `
 - track_separator: `string` - text/icon to put between the artist and song name - defaults to ` - `

--- a/engine.go
+++ b/engine.go
@@ -67,6 +67,9 @@ func (e *engine) renderText(text string) {
 	prefix := e.activeSegment.getValue(Prefix, " ")
 	postfix := e.activeSegment.getValue(Postfix, " ")
 	e.renderer.write(e.activeSegment.Background, e.activeSegment.Foreground, fmt.Sprintf("%s%s%s", prefix, text, postfix))
+	if *e.env.getArgs().Debug {
+		e.renderer.write(e.activeSegment.Background, e.activeSegment.Foreground, fmt.Sprintf("(%s:%s)", e.activeSegment.Type, e.activeSegment.timing))
+	}
 }
 
 func (e *engine) renderSegmentText(text string) {
@@ -107,13 +110,11 @@ func (e *engine) setStringValues(segments []*Segment) {
 	wg.Add(len(segments))
 	defer wg.Wait()
 	cwd := e.env.getcwd()
+	debug := *e.env.getArgs().Debug
 	for _, segment := range segments {
 		go func(s *Segment) {
 			defer wg.Done()
-			err := s.mapSegmentWithWriter(e.env)
-			if err == nil && !s.hasValue(IgnoreFolders, cwd) && s.enabled() {
-				s.stringValue = s.string()
-			}
+			s.setStringValue(e.env, cwd, debug)
 		}(segment)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ type args struct {
 	Config      *string
 	Shell       *string
 	PWD         *string
+	Debug       *bool
 }
 
 func main() {
@@ -42,6 +43,10 @@ func main() {
 			"pwd",
 			"",
 			"the path you are working in"),
+		Debug: flag.Bool(
+			"debug",
+			false,
+			"Print debug information"),
 	}
 	flag.Parse()
 	env := &environment{

--- a/packages/powershell/oh-my-posh/oh-my-posh.psm1
+++ b/packages/powershell/oh-my-posh/oh-my-posh.psm1
@@ -5,6 +5,7 @@
 
 $global:PoshSettings = New-Object -TypeName PSObject -Property @{
     Theme = "$PSScriptRoot\themes\jandedobbeleer.json";
+    ShowDebug = $false
 }
 
 function Get-PoshCommand {
@@ -36,8 +37,13 @@ function Set-PoshPrompt {
     param(
         [Parameter(Mandatory = $false)]
         [string]
-        $Theme
+        $Theme,
+        [Parameter(Mandatory = $false)]
+        [bool]
+        $ShowDebug = $false
     )
+
+    $global:PoshSettings.ShowDebug = $ShowDebug
 
     if (Test-Path "$PSScriptRoot/themes/$Theme.json") {
         $global:PoshSettings.Theme = "$PSScriptRoot/themes/$Theme.json"
@@ -68,8 +74,9 @@ function Set-PoshPrompt {
         $startInfo = New-Object System.Diagnostics.ProcessStartInfo
         $startInfo.FileName = Get-PoshCommand
         $config = $global:PoshSettings.Theme
+        $showDebug = $global:PoshSettings.ShowDebug
         $cleanPWD = $PWD.ProviderPath.TrimEnd("\")
-        $startInfo.Arguments = "-config=""$config"" -error=$errorCode -pwd=""$cleanPWD"""
+        $startInfo.Arguments = "-debug=""$showDebug"" -config=""$config"" -error=$errorCode -pwd=""$cleanPWD"""
         $startInfo.Environment["TERM"] = "xterm-256color"
         $startInfo.CreateNoWindow = $true
         $startInfo.StandardOutputEncoding = [System.Text.Encoding]::UTF8


### PR DESCRIPTION
display segments and total timing

### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

New `ShowDebug` parameter  used to add debug information on command line.  
Right now it displays only each segments execution time and the total execution time.  
![image](https://user-images.githubusercontent.com/1829553/99182229-f90b1300-2733-11eb-9365-9045b7b38c65.png)

![image](https://user-images.githubusercontent.com/1829553/99179614-a9bae780-271f-11eb-98f1-98e0288b4109.png)  


![timings](https://user-images.githubusercontent.com/1829553/99179730-a3793b00-2720-11eb-81cf-6cfb781a101a.gif)

rendering the same git folder:  
wsl2: 5ms
windows: 381ms

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
