### PR TITLE
feat: get native and powershell error code

### DIFF
--- a/docs/docs/installation.mdx
+++ b/docs/docs/installation.mdx
@@ -186,14 +186,22 @@ Edit `$PROFILE` in your preferred PowerShell version and add the following lines
 
 ```powershell
 [ScriptBlock]$Prompt = {
+    $lastCommandSuccess = $?
     $realLASTEXITCODE = $global:LASTEXITCODE
-    if ($realLASTEXITCODE -isnot [int]) {
-      $realLASTEXITCODE = 0
+    $errorCode = 0
+    if ($lastCommandSuccess -eq $false) {
+        #native app exit code
+        if ($realLASTEXITCODE -ne 0) {
+            $errorCode = $realLASTEXITCODE
+        }
+        else {
+            $errorCode = 1
+        }
     }
     $startInfo = New-Object System.Diagnostics.ProcessStartInfo
     $startInfo.FileName = "C:\tools\oh-my-posh.exe"
     $cleanPWD = $PWD.ProviderPath.TrimEnd("\")
-    $startInfo.Arguments = "-config=""C:\Users\User\.poshthemes\jandedobbeleer.json"" -error=$realLASTEXITCODE -pwd=""$cleanPWD"""
+    $startInfo.Arguments = "-config=""C:\Users\User\.poshthemes\jandedobbeleer.json"" -error=$errorCode -pwd=""$cleanPWD"""
     $startInfo.Environment["TERM"] = "xterm-256color"
     $startInfo.CreateNoWindow = $true
     $startInfo.StandardOutputEncoding = [System.Text.Encoding]::UTF8
@@ -209,7 +217,9 @@ Edit `$PROFILE` in your preferred PowerShell version and add the following lines
     $process.WaitForExit()
     $standardOut
     $global:LASTEXITCODE = $realLASTEXITCODE
+    #remove temp variables
     Remove-Variable realLASTEXITCODE -Confirm:$false
+    Remove-Variable lastCommandSuccess -Confirm:$false
 }
 Set-Item -Path Function:prompt -Value $Prompt -Force
 ```


### PR DESCRIPTION
Check native and powershell errors before sending it to oh-my-posh

### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

The exit segment displays the last command status. Before, it was only in error when a native process failed.  
With this change, the `$?` variable is checked for error (both native and powershell error).

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
