### PR TITLE
feat: add switch "-version" to output current version of ohmyposh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Build
       id: build
-      run: go build -o ${{ matrix.ARTIFACT }}
+      run: go build -o ${{ matrix.ARTIFACT }} -ldflags="-X 'main.version= ${{ needs.release.outputs.version }}'"
       env:
         GOARCH: "amd64"
     - name: Hash

--- a/main.go
+++ b/main.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 )
 
+var currentVersion = "development"
+
 type args struct {
 	ErrorCode   *int
 	PrintConfig *bool
@@ -14,6 +16,7 @@ type args struct {
 	Config      *string
 	Shell       *string
 	PWD         *string
+	Version     *bool
 	Debug       *bool
 }
 
@@ -43,6 +46,10 @@ func main() {
 			"pwd",
 			"",
 			"the path you are working in"),
+		Version: flag.Bool(
+			"version",
+			false,
+			"Print the current version of the binary"),
 		Debug: flag.Bool(
 			"debug",
 			false,
@@ -60,6 +67,10 @@ func main() {
 	}
 	if *args.PrintShell {
 		fmt.Println(env.getShellName())
+		return
+	}
+	if *args.Version {
+		fmt.Println(currentVersion)
 		return
 	}
 	colorWriter := &Renderer{


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Description

I've added a new switch to the binary to output the current verison.
The version will (hopefully) set automatically during the build

f.e.: 
![image](https://user-images.githubusercontent.com/22131101/99731629-78933c00-2abe-11eb-815e-4d8d6610ee87.png)
