### PR TITLE
fix: sort mapped locations to solve the folder/subfolder issue

### DIFF
--- a/segment_path.go
+++ b/segment_path.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -78,9 +79,20 @@ func (pt *path) getShortPath() string {
 		mappedLocations[key] = val
 	}
 
-	for location, value := range mappedLocations {
-		if strings.HasPrefix(pwd, location) {
-			return strings.Replace(pwd, location, value, 1)
+	// sort map keys in reverse order
+	// fixes case when a subfoder and its parent are mapped
+	// ex /users/test and /users/test/dev
+	keys := make([]string, len(mappedLocations))
+	i := 0
+	for k := range mappedLocations {
+		keys[i] = k
+		i++
+	}
+	sort.Sort(sort.Reverse(sort.StringSlice(keys)))
+
+	for _, value := range keys {
+		if strings.HasPrefix(pwd, value) {
+			return strings.Replace(pwd, value, mappedLocations[value], 1)
 		}
 	}
 	return pwd


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

I found an issue in this scenario:
```
"mappedlocations": [
["/home/XXX/dev", "\ue799"]
]
```

By default the home folder is mapped with `~`. As the map is unsorted, sometimes the prompt will display the text from the subfolder config and sometimes from the parent.  
It's not perfect but now the map keys are sorted in reverse order to avoid such collisions.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
