### PR TITLE
docs: update the theme storage path on windows

### DIFF
--- a/docs/docs/installation.mdx
+++ b/docs/docs/installation.mdx
@@ -126,10 +126,10 @@ When using [Scoop][scoop], all themes are downloaded as well.
 #### Manual
 
 ```powershell
-mkdir C:\tools\poshthemes
-Invoke-Webrequest https://github.com/JanDeDobbeleer/oh-my-posh3/releases/latest/download/themes.zip -OutFile C:\tools\poshthemes\themes.zip
-Expand-Archive C:\tools\poshthemes\themes.zip -DestinationPath C:\tools\poshthemes -Force
-Remove-Item C:\tools\poshthemes\themes.zip
+mkdir ~\.poshthemes
+Invoke-Webrequest https://github.com/JanDeDobbeleer/oh-my-posh3/releases/latest/download/themes.zip -OutFile ~\.poshthemes\themes.zip
+Expand-Archive ~\.poshthemes\themes.zip -DestinationPath ~\.poshthemes -Force
+Remove-Item ~\.poshthemes\themes.zip
 ```
 
 </TabItem>
@@ -205,7 +205,7 @@ Edit `$PROFILE` in your preferred PowerShell version and add the following lines
     $startInfo = New-Object System.Diagnostics.ProcessStartInfo
     $startInfo.FileName = "C:\tools\oh-my-posh.exe"
     $cleanPWD = $PWD.ProviderPath.TrimEnd("\")
-    $startInfo.Arguments = "-config=""C:\Users\User\.poshthemes\jandedobbeleer.json"" -error=$errorCode -pwd=""$cleanPWD"""
+    $startInfo.Arguments = "-config=""$env:USERPROFILE\.poshthemes\jandedobbeleer.json"" -error=$errorCode -pwd=""$cleanPWD"""
     $startInfo.Environment["TERM"] = "xterm-256color"
     $startInfo.CreateNoWindow = $true
     $startInfo.StandardOutputEncoding = [System.Text.Encoding]::UTF8


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

Update the theme storage path to match subsequent documentation.
> Adjust your configuration to use any other theme from the folder we created (`~/.poshthemes`).

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
