### PR TITLE
fix: empty error code handling in docs and module

### DIFF
--- a/docs/docs/installation.mdx
+++ b/docs/docs/installation.mdx
@@ -195,7 +195,7 @@ Edit `$PROFILE` in your preferred PowerShell version and add the following lines
     $errorCode = 0
     if ($lastCommandSuccess -eq $false) {
         #native app exit code
-        if ($realLASTEXITCODE -ne 0) {
+        if ($realLASTEXITCODE -is [int]) {
             $errorCode = $realLASTEXITCODE
         }
         else {

--- a/packages/powershell/oh-my-posh/oh-my-posh.psm1
+++ b/packages/powershell/oh-my-posh/oh-my-posh.psm1
@@ -64,7 +64,7 @@ function Set-PoshPrompt {
         Set-PoshContext
         if ($lastCommandSuccess -eq $false) {
             #native app exit code
-            if ($realLASTEXITCODE -ne 0) {
+            if ($realLASTEXITCODE -is [int]) {
                 $errorCode = $realLASTEXITCODE
             }
             else {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description
This change fixes the behaviour if errorcode is empty.
Without this fix oh-my-posh is started with an empty error argument preventing it to work.
Fixes: https://github.com/JanDeDobbeleer/oh-my-posh3/issues/193


[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
