### PR TITLE
feat: 'exit' segment: option to always use numeric codes

### DIFF
--- a/docs/docs/segment-exit.md
+++ b/docs/docs/segment-exit.md
@@ -34,5 +34,6 @@ Displays the last exit code or that the last command failed based on the configu
 - always_enabled: `boolean` - always show the status - defaults to `false`
 - color_background: `boolean` - color the background or foreground when an error occurs - defaults to `false`
 - error_color: `string` [color][colors] - color to use when an error occured
+- always_numeric: `boolean` - always display exit code as a number - defaults to `false`
 
 [colors]: /docs/configure#colors

--- a/segment_exit.go
+++ b/segment_exit.go
@@ -14,6 +14,8 @@ const (
 	AlwaysEnabled Property = "always_enabled"
 	// ErrorColor specify a different foreground color for the error text when using always_show = true
 	ErrorColor Property = "error_color"
+	// AlwaysNumeric shows error codes as numbers
+	AlwaysNumeric Property = "always_numeric"
 )
 
 func (e *exit) enabled() bool {
@@ -47,6 +49,9 @@ func (e *exit) getFormattedText() string {
 func (e *exit) getMeaningFromExitCode() string {
 	if !e.props.getBool(DisplayExitCode, true) {
 		return ""
+	}
+	if e.props.getBool(AlwaysNumeric, false) {
+		return fmt.Sprintf("%d", e.env.lastErrorCode())
 	}
 	switch e.env.lastErrorCode() {
 	case 1:

--- a/segment_exit_test.go
+++ b/segment_exit_test.go
@@ -91,3 +91,18 @@ func TestGetMeaningFromExitCode(t *testing.T) {
 		assert.Equal(t, want, e.getMeaningFromExitCode())
 	}
 }
+
+func TestAlwaysNumericExitCode(t *testing.T) {
+	env := new(MockedEnvironment)
+	env.On("lastErrorCode", nil).Return(1)
+	props := &properties{
+		values: map[Property]interface{}{
+			AlwaysNumeric: true,
+		},
+	}
+	e := &exit{
+		env:   env,
+		props: props,
+	}
+	assert.Equal(t, "1", e.getMeaningFromExitCode())
+}


### PR DESCRIPTION
### Prerequisites

- [X] I have read and understand the `CONTRIBUTING` guide
- [X] The commit message follows the [conventional commits][cc] guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

### Description

Adds a new option `always_numeric` for the `exit` segment to always output exit codes as numbers (rather than substituting labels for known values).  Defaults to `false` to maintain existing behavior.

Example config:

```
{
  "type": "exit",
  "style": "plain",
  "properties": {
    "display_exit_code": true,
    "always_enabled": false,
    "always_numeric": true,
    "color_background": true
  }
}
```

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
