### PR TITLE
WIP: fix(themes): powerlevel10k_classic renders without gaps on startup

### DIFF
--- a/themes/powerlevel10k_classic.omp.json
+++ b/themes/powerlevel10k_classic.omp.json
@@ -26,7 +26,7 @@
           "background": "#546E7A",
           "properties": {
             "style": "short",
-            "postfix": " "
+            "postfix": "<#546E7A>\u2588</>"
           }
         },
         {
@@ -62,7 +62,7 @@
           "background": "#546E7A",
           "leading_diamond": "\uE0B2",
           "properties": {
-            "postfix": " <#26C6DA>\uE0B3</> "
+            "postfix": " \uE0B3"
           }
         },
         {
@@ -72,7 +72,7 @@
           "background": "#546E7A",
           "properties": {
             "time_format": "15:04:05",
-            "postfix": " \uF017 "
+            "postfix": "<#546e7a>\u2588</>\uF017<#546E7A>\u2588</>"
           }
         }
       ]


### PR DESCRIPTION
fix: powerlevel10k_classic renders without gaps on startup 

Related to #201 

### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Description

My solution is pretty much replacing `postfix` spaces with \u2588 and the correct color.
The session segment could not be fixed that way here I had to remove the `postfix` color.
Reviewing my changes made me realize it could be related to inline coloring code for the prompt since the session segment added a gap every time I restored the original color on this segment. 

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary

_Off-Topic_: I see you require a test for the bug fix and documentation to be updated.

I would need guidance here though because I am not a Go programmer and I've never written an integration test in any language where PowerShell was a component. The documentation part is a bit unclear because it could mean that you require an entry in a CHANGELOG file which I understand or in the actual documentation which I wouldn't understand since the PR is fixing unexpected behavior.
