### PR TITLE
fix: foreground color admin icon

### DIFF
--- a/themes/jandedobbeleer.omp.json
+++ b/themes/jandedobbeleer.omp.json
@@ -83,7 +83,7 @@
           "type": "root",
           "style": "powerline",
           "powerline_symbol": "\uE0B0",
-          "foreground": "#ffffff",
+          "foreground": "#193549",
           "background": "#ffff66"
         },
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

fix: foreground color admin icon
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
