### PR TITLE
feat: option to hide the battery status when it's charging

### DIFF
--- a/docs/docs/segment-battery.md
+++ b/docs/docs/segment-battery.md
@@ -26,7 +26,8 @@ Battery displays the remaining power percentage for your battery.
     "charged_color": "#4caf50",
     "charging_color": "#40c4ff",
     "discharging_color": "#ff5722",
-    "postfix": "\uF295 "
+    "postfix": "\uF295 ",
+    "display_charging": true
   }
 }
 ```
@@ -42,5 +43,6 @@ Battery displays the remaining power percentage for your battery.
 - charged_color: `string` [color][colors] - color to use when fully charged - defaults to segment color
 - charging_color: `string` [color][colors] - color to use when charging - defaults to segment color
 - discharging_color: `string` [color][colors] - color to use when discharging - defaults to segment color
+- display_charging: `bool` - displays the battery status while charging (Charging or Full)
 
 [colors]: /docs/configure#colors

--- a/segment_battery.go
+++ b/segment_battery.go
@@ -30,10 +30,18 @@ const (
 	ChargingColor Property = "charging_color"
 	// DischargingColor to display when discharging
 	DischargingColor Property = "discharging_color"
+	// DisplayCharging Hide the battery icon while it's charging
+	DisplayCharging Property = "display_charging"
 )
 
 func (b *batt) enabled() bool {
 	bt, err := b.env.getBatteryInfo()
+
+	display := b.props.getBool(DisplayCharging, true)
+	if !display && (bt.State == battery.Charging || bt.State == battery.Full) {
+		return false
+	}
+
 	displayError := b.props.getBool(DisplayError, false)
 	if err != nil && !displayError {
 		b.percentageText = "100%"

--- a/segment_battery_test.go
+++ b/segment_battery_test.go
@@ -149,3 +149,37 @@ func TestBatteryErrorHidden(t *testing.T) {
 	assert.True(t, b.enabled())
 	assert.Equal(t, "100%", b.string())
 }
+
+func TestBatteryDischargingAndDisplayChargingDisabled(t *testing.T) {
+	props := &properties{
+		values: map[Property]interface{}{
+			DischargingIcon: "going down ",
+			DisplayCharging: false,
+		},
+	}
+	b := setupBatteryTests(battery.Discharging, 70, props)
+	assert.Equal(t, true, b.enabled())
+	assert.Equal(t, "going down 70", b.string())
+}
+
+func TestBatteryChargingAndDisplayChargingDisabled(t *testing.T) {
+	props := &properties{
+		values: map[Property]interface{}{
+			ChargingIcon:    "charging ",
+			DisplayCharging: false,
+		},
+	}
+	b := setupBatteryTests(battery.Charging, 80, props)
+	assert.Equal(t, false, b.enabled())
+}
+
+func TestBatteryChargedAndDisplayChargingDisabled(t *testing.T) {
+	props := &properties{
+		values: map[Property]interface{}{
+			ChargedIcon:     "charged ",
+			DisplayCharging: false,
+		},
+	}
+	b := setupBatteryTests(battery.Full, 100, props)
+	assert.Equal(t, false, b.enabled())
+}

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -277,7 +277,13 @@
                   },
                   "charged_color": { "$ref": "#/definitions/color" },
                   "charging_color": { "$ref": "#/definitions/color" },
-                  "discharging_color": { "$ref": "#/definitions/color" }
+                  "discharging_color": { "$ref": "#/definitions/color" },
+                  "display_charging": {
+                    "type": "boolean",
+                    "title": "Display while charging",
+                    "description": "displays the battery status while charging (Charging or Full)",
+                    "default": true
+                  }
                 }
               }
             }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

New option to show the battery status only when it's charging. I'm not quite sure about the name of the property, if you have a better idea.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
