### PR TITLE
chore: fix typos in segment-path.md

### DIFF
--- a/docs/docs/segment-path.md
+++ b/docs/docs/segment-path.md
@@ -33,7 +33,7 @@ Display the current path.
 - folder_icon: `string` - the icon to use as a folder indication - defaults to `..`
 - windows_registry_icon: `string` - the icon to display when in the Windows registry - defaults to `\uE0B1`
 - style: `enum` - how to display the current path
-- mapped_locations: `map[string]string` - custom glyph/text for specific paths(only when `style` is set to `agnoster`, `agnosterfull` or `short`)
+- mapped_locations: `map[string]string` - custom glyph/text for specific paths(only when `style` is set to `agnoster`, `agnoster_full` or `short`)
 
 ## Style
 
@@ -59,7 +59,7 @@ Renders each folder name separated by the `folder_separator_icon`.
 
 Display `$PWD` as a string, replace `$HOME` with the `home_icon` if you're inside the `$HOME` location or
 one of its children.
-Specific folders can be customized using the `mappedlocations` property.
+Specific folders can be customized using the `mapped_locations` property.
 
 ### Full
 


### PR DESCRIPTION
fixed a few typos for property names

### Prerequisites

- [✔] I have read and understand the `CONTRIBUTING` guide
- [✔] The commit message follows the [conventional commits][cc] guidelines
- [✔] Tests for the changes have been added (for bug fixes / features)
- [✔] Docs have been added / updated (for bug fixes / features)

### Description

some property names had missing underscores for some reason. 

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
