### PR TITLE
feat: execution time formats

### DIFF
--- a/docs/docs/segment-executiontime.md
+++ b/docs/docs/segment-executiontime.md
@@ -21,6 +21,7 @@ To use this, use the PowerShell module, or confirm that you are passing an `exec
   "background": "#8800dd",
   "properties": {
     "threshold": 500,
+    "style": "austin",
     "prefix": " <#fefefe>\ufbab</> "
   }
 }
@@ -29,5 +30,21 @@ To use this, use the PowerShell module, or confirm that you are passing an `exec
 ## Properties
 
 - threshold: `number` - minimum duration (milliseconds) required to enable this segment - defaults to `500`
+- style: `enum` - one of the available format options - defaults to `austin`
+
+
+## Style
+
+Style specifies the format in which the time will be displayed. The table below shows some example times in each option.
+
+| format    | 0.001s         | 2.1s         | 3m2.1s        | 4h3m2.1s         |
+|-----------|----------------|--------------|---------------|------------------|
+| austin    | `1ms`          | `2.1s`       | `3m 2.1s`     | `4h 3m 2.1s`     |
+| roundrock | `1ms`          | `2s 100ms`   | `3m 2s 100ms` | `4h 3m 2s 100ms` |
+| dallas    | `0.001`        | `2.1`        | `3:2.1`       | `4:3:2.1`        |
+| galveston | `00:00:00`     | `00:00:02`   | `00:03:02`    | `04:03:02`       |
+| houston   | `00:00:00.001` | `00:00:02.1` | `00:03:02.1`  | `04:03:02.1`     |
+| amarillo  | `0.001s`       | `2.1s`       | `182.1s`      | `14,582.1s`      |
+
 
 [install]: /docs/installation

--- a/segment_executiontime.go
+++ b/segment_executiontime.go
@@ -1,7 +1,11 @@
 package main
 
 import (
-	"time"
+	"fmt"
+	"strconv"
+
+	lang "golang.org/x/text/language"
+	"golang.org/x/text/message"
 )
 
 type executiontime struct {
@@ -10,9 +14,26 @@ type executiontime struct {
 	output string
 }
 
+type DurationStyle string
+
 const (
 	// ThresholdProperty represents minimum duration (milliseconds) required to enable this segment
 	ThresholdProperty Property = "threshold"
+
+	Austin    DurationStyle = "austin"
+	Roundrock DurationStyle = "roundrock"
+	Dallas    DurationStyle = "dallas"
+	Galveston DurationStyle = "galveston"
+	Houston   DurationStyle = "houston"
+	Amarillo  DurationStyle = "amarillo"
+
+	second           = 1000
+	minute           = 60000
+	hour             = 3600000
+	day              = 86400000
+	secondsPerMinute = 60
+	minutesPerHour   = 60
+	hoursPerDay      = 24
 )
 
 func (t *executiontime) enabled() bool {
@@ -21,9 +42,9 @@ func (t *executiontime) enabled() bool {
 	if executionTimeMs < thresholdMs {
 		return false
 	}
+	style := DurationStyle(t.props.getString(Style, string(Austin)))
+	t.output = t.formatDuration(int64(executionTimeMs), style)
 
-	duration := time.Duration(executionTimeMs) * time.Millisecond
-	t.output = duration.String()
 	return t.output != ""
 }
 
@@ -34,4 +55,116 @@ func (t *executiontime) string() string {
 func (t *executiontime) init(props *properties, env environmentInfo) {
 	t.props = props
 	t.env = env
+}
+
+func (t *executiontime) formatDuration(ms int64, style DurationStyle) string {
+	switch style {
+	case Austin:
+		return t.formatDurationAustin(ms)
+	case Roundrock:
+		return t.formatDurationRoundrock(ms)
+	case Dallas:
+		return t.formatDurationDallas(ms)
+	case Galveston:
+		return t.formatDurationGalveston(ms)
+	case Houston:
+		return t.formatDurationHouston(ms)
+	case Amarillo:
+		return t.formatDurationAmarillo(ms)
+	default:
+		return fmt.Sprintf("Style: %s is not available", style)
+	}
+}
+
+func (t *executiontime) formatDurationAustin(ms int64) string {
+	if ms < second {
+		return fmt.Sprintf("%dms", ms%second)
+	}
+
+	seconds := float64(ms%minute) / second
+	result := strconv.FormatFloat(seconds, 'f', -1, 64) + "s"
+
+	if ms >= minute {
+		result = fmt.Sprintf("%dm %s", ms/minute%secondsPerMinute, result)
+	}
+	if ms >= hour {
+		result = fmt.Sprintf("%dh %s", ms/hour%hoursPerDay, result)
+	}
+	if ms >= day {
+		result = fmt.Sprintf("%dd %s", ms/day, result)
+	}
+	return result
+}
+
+func (t *executiontime) formatDurationRoundrock(ms int64) string {
+	result := fmt.Sprintf("%dms", ms%second)
+	if ms >= second {
+		result = fmt.Sprintf("%ds %s", ms/second%secondsPerMinute, result)
+	}
+	if ms >= minute {
+		result = fmt.Sprintf("%dm %s", ms/minute%minutesPerHour, result)
+	}
+	if ms >= hour {
+		result = fmt.Sprintf("%dh %s", ms/hour%hoursPerDay, result)
+	}
+	if ms >= day {
+		result = fmt.Sprintf("%dd %s", ms/day, result)
+	}
+	return result
+}
+
+func (t *executiontime) formatDurationDallas(ms int64) string {
+	seconds := float64(ms%minute) / second
+	result := strconv.FormatFloat(seconds, 'f', -1, 64)
+
+	if ms >= minute {
+		result = fmt.Sprintf("%d:%s", ms/minute%minutesPerHour, result)
+	}
+	if ms >= hour {
+		result = fmt.Sprintf("%d:%s", ms/hour%hoursPerDay, result)
+	}
+	if ms >= day {
+		result = fmt.Sprintf("%d:%s", ms/day, result)
+	}
+	return result
+}
+
+func (t *executiontime) formatDurationGalveston(ms int64) string {
+	result := fmt.Sprintf("%02d:%02d:%02d", ms/hour, ms/minute%minutesPerHour, ms%minute/second)
+	return result
+}
+
+func (t *executiontime) formatDurationHouston(ms int64) string {
+	milliseconds := ".0"
+	if ms%second > 0 {
+		// format milliseconds as a string with truncated trailing zeros
+		milliseconds = strconv.FormatFloat(float64(ms%second)/second, 'f', -1, 64)
+		// at this point milliseconds looks like "0.5". remove the leading "0"
+		milliseconds = milliseconds[1:]
+	}
+
+	result := fmt.Sprintf("%02d:%02d:%02d%s", ms/hour, ms/minute%minutesPerHour, ms%minute/second, milliseconds)
+	return result
+}
+
+func (t *executiontime) formatDurationAmarillo(ms int64) string {
+	// wholeNumber represents the value to the left of the decimal point (seconds)
+	wholeNumber := ms / second
+	// decimalNumber represents the value to the right of the decimal point (milliseconds)
+	decimalNumber := float64(ms%second) / second
+
+	// format wholeNumber as a string with thousands separators
+	printer := message.NewPrinter(lang.English)
+	result := printer.Sprintf("%d", wholeNumber)
+
+	if decimalNumber > 0 {
+		// format decimalNumber as a string with truncated trailing zeros
+		decimalResult := strconv.FormatFloat(decimalNumber, 'f', -1, 64)
+		// at this point decimalResult looks like "0.5"
+		// remove the leading "0" and append
+		result += decimalResult[1:]
+	}
+	result += "s"
+
+	return result
 }

--- a/segment_executiontime_test.go
+++ b/segment_executiontime_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -68,7 +69,7 @@ func TestExecutionTimeWriterDuration(t *testing.T) {
 
 func TestExecutionTimeWriterDuration2(t *testing.T) {
 	input := 13371337
-	expected := "3h42m51.337s"
+	expected := "3h 42m 51.337s"
 	env := new(MockedEnvironment)
 	env.On("executionTime", nil).Return(input)
 	executionTime := &executiontime{
@@ -76,4 +77,154 @@ func TestExecutionTimeWriterDuration2(t *testing.T) {
 	}
 	executionTime.enabled()
 	assert.Equal(t, expected, executionTime.output)
+}
+
+func TestExecutionTimeFormatDurationAustin(t *testing.T) {
+	cases := []struct {
+		Input    string
+		Expected string
+	}{
+		{Input: "0.001s", Expected: "1ms"},
+		{Input: "0.1s", Expected: "100ms"},
+		{Input: "1s", Expected: "1s"},
+		{Input: "2.1s", Expected: "2.1s"},
+		{Input: "1m", Expected: "1m 0s"},
+		{Input: "3m2.1s", Expected: "3m 2.1s"},
+		{Input: "1h", Expected: "1h 0m 0s"},
+		{Input: "4h3m2.1s", Expected: "4h 3m 2.1s"},
+		{Input: "124h3m2.1s", Expected: "5d 4h 3m 2.1s"},
+		{Input: "124h3m2.0s", Expected: "5d 4h 3m 2s"},
+	}
+
+	for _, tc := range cases {
+		duration, _ := time.ParseDuration(tc.Input)
+		executionTime := &executiontime{}
+		output := executionTime.formatDurationAustin(duration.Milliseconds())
+		assert.Equal(t, tc.Expected, output)
+	}
+}
+
+func TestExecutionTimeFormatDurationRoundrock(t *testing.T) {
+	cases := []struct {
+		Input    string
+		Expected string
+	}{
+		{Input: "0.001s", Expected: "1ms"},
+		{Input: "0.1s", Expected: "100ms"},
+		{Input: "1s", Expected: "1s 0ms"},
+		{Input: "2.1s", Expected: "2s 100ms"},
+		{Input: "1m", Expected: "1m 0s 0ms"},
+		{Input: "3m2.1s", Expected: "3m 2s 100ms"},
+		{Input: "1h", Expected: "1h 0m 0s 0ms"},
+		{Input: "4h3m2.1s", Expected: "4h 3m 2s 100ms"},
+		{Input: "124h3m2.1s", Expected: "5d 4h 3m 2s 100ms"},
+		{Input: "124h3m2.0s", Expected: "5d 4h 3m 2s 0ms"},
+	}
+
+	for _, tc := range cases {
+		duration, _ := time.ParseDuration(tc.Input)
+		executionTime := &executiontime{}
+		output := executionTime.formatDurationRoundrock(duration.Milliseconds())
+		assert.Equal(t, tc.Expected, output)
+	}
+}
+
+func TestExecutionTimeFormatDallas(t *testing.T) {
+	cases := []struct {
+		Input    string
+		Expected string
+	}{
+		{Input: "0.001s", Expected: "0.001"},
+		{Input: "0.1s", Expected: "0.1"},
+		{Input: "1s", Expected: "1"},
+		{Input: "2.1s", Expected: "2.1"},
+		{Input: "1m", Expected: "1:0"},
+		{Input: "3m2.1s", Expected: "3:2.1"},
+		{Input: "1h", Expected: "1:0:0"},
+		{Input: "4h3m2.1s", Expected: "4:3:2.1"},
+		{Input: "124h3m2.1s", Expected: "5:4:3:2.1"},
+		{Input: "124h3m2.0s", Expected: "5:4:3:2"},
+	}
+
+	for _, tc := range cases {
+		duration, _ := time.ParseDuration(tc.Input)
+		executionTime := &executiontime{}
+		output := executionTime.formatDurationDallas(duration.Milliseconds())
+		assert.Equal(t, tc.Expected, output)
+	}
+}
+
+func TestExecutionTimeFormatGalveston(t *testing.T) {
+	cases := []struct {
+		Input    string
+		Expected string
+	}{
+		{Input: "0.001s", Expected: "00:00:00"},
+		{Input: "0.1s", Expected: "00:00:00"},
+		{Input: "1s", Expected: "00:00:01"},
+		{Input: "2.1s", Expected: "00:00:02"},
+		{Input: "1m", Expected: "00:01:00"},
+		{Input: "3m2.1s", Expected: "00:03:02"},
+		{Input: "1h", Expected: "01:00:00"},
+		{Input: "4h3m2.1s", Expected: "04:03:02"},
+		{Input: "124h3m2.1s", Expected: "124:03:02"},
+		{Input: "124h3m2.0s", Expected: "124:03:02"},
+	}
+
+	for _, tc := range cases {
+		duration, _ := time.ParseDuration(tc.Input)
+		executionTime := &executiontime{}
+		output := executionTime.formatDurationGalveston(duration.Milliseconds())
+		assert.Equal(t, tc.Expected, output)
+	}
+}
+
+func TestExecutionTimeFormatHouston(t *testing.T) {
+	cases := []struct {
+		Input    string
+		Expected string
+	}{
+		{Input: "0.001s", Expected: "00:00:00.001"},
+		{Input: "0.1s", Expected: "00:00:00.1"},
+		{Input: "1s", Expected: "00:00:01.0"},
+		{Input: "2.1s", Expected: "00:00:02.1"},
+		{Input: "1m", Expected: "00:01:00.0"},
+		{Input: "3m2.1s", Expected: "00:03:02.1"},
+		{Input: "1h", Expected: "01:00:00.0"},
+		{Input: "4h3m2.1s", Expected: "04:03:02.1"},
+		{Input: "124h3m2.1s", Expected: "124:03:02.1"},
+		{Input: "124h3m2.0s", Expected: "124:03:02.0"},
+	}
+
+	for _, tc := range cases {
+		duration, _ := time.ParseDuration(tc.Input)
+		executionTime := &executiontime{}
+		output := executionTime.formatDurationHouston(duration.Milliseconds())
+		assert.Equal(t, tc.Expected, output)
+	}
+}
+
+func TestExecutionTimeFormatAmarillo(t *testing.T) {
+	cases := []struct {
+		Input    string
+		Expected string
+	}{
+		{Input: "0.001s", Expected: "0.001s"},
+		{Input: "0.1s", Expected: "0.1s"},
+		{Input: "1s", Expected: "1s"},
+		{Input: "2.1s", Expected: "2.1s"},
+		{Input: "1m", Expected: "60s"},
+		{Input: "3m2.1s", Expected: "182.1s"},
+		{Input: "1h", Expected: "3,600s"},
+		{Input: "4h3m2.1s", Expected: "14,582.1s"},
+		{Input: "124h3m2.1s", Expected: "446,582.1s"},
+		{Input: "124h3m2.0s", Expected: "446,582s"},
+	}
+
+	for _, tc := range cases {
+		duration, _ := time.ParseDuration(tc.Input)
+		executionTime := &executiontime{}
+		output := executionTime.formatDurationAmarillo(duration.Milliseconds())
+		assert.Equal(t, tc.Expected, output)
+	}
 }

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -1150,6 +1150,20 @@
                     "title": "Threshold",
                     "description": "minimum duration (milliseconds) required to enable this segment",
                     "default": 500
+                  },
+                  "style": {
+                    "type": "string",
+                    "title": "Style",
+                    "description": "The style in which the time will be displayed",
+                    "enum": [
+                      "austin",
+                      "roundrock",
+                      "dallas",
+                      "galveston",
+                      "houston",
+                      "amarillo"
+                    ],
+                    "default": "austin"
                   }
                 }
               }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

Allow the user to select a display format for the execution time.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
