### PR TITLE
[WIP] feat: Added display_mode Property to Language Segment

### DIFF
--- a/docs/docs/segment-golang.md
+++ b/docs/docs/segment-golang.md
@@ -26,3 +26,7 @@ Display the currently active golang version when a folder contains `.go` files.
 ## Properties
 
 - display_version: `boolean` - display the golang version - defaults to `true`
+- display_mode: `string` - determines when the segment is displayed
+  - `always`: The segment is always displayed
+  - `context`: The segment is only displayed when *.go or go.mod files are present (default)
+  - `never`: The segement is hidden

--- a/docs/docs/segment-julia.md
+++ b/docs/docs/segment-julia.md
@@ -26,3 +26,7 @@ Display the currently active julia version when a folder contains `.jl` files.
 ## Properties
 
 - display_version: `boolean` - display the julia version - defaults to `true`
+- display_mode: `string` - determines when the segment is displayed
+  - `always`: The segment is always displayed
+  - `context`: The segment is only displayed when *.jl files are present (default)
+  - `never`: The segement is hidden

--- a/docs/docs/segment-node.md
+++ b/docs/docs/segment-node.md
@@ -26,3 +26,7 @@ Display the currently active node version when a folder contains `.js` or `.ts` 
 ## Properties
 
 - display_version: `boolean` - display the node version - defaults to `true`
+- display_mode: `string` - determines when the segment is displayed
+  - `always`: The segment is always displayed
+  - `context`: The segment is only displayed when *.js, *.ts or package.json files are present (default)
+  - `never`: The segement is hidden

--- a/docs/docs/segment-python.md
+++ b/docs/docs/segment-python.md
@@ -6,7 +6,7 @@ sidebar_label: Python
 
 ## What
 
-Display the currently active python version and virtualenv when a folder contains `.py` files or `.ipynb` files.
+Display the currently active python version and virtualenv.
 Supports conda, virtualenv and pyenv.
 
 ## Sample Configuration
@@ -27,3 +27,7 @@ Supports conda, virtualenv and pyenv.
 ## Properties
 
 - display_virtual_env: `boolean` - show the name of the virtualenv or not - defaults to `true`
+- display_mode: `string` - determines when the segment is displayed
+  - `always`: The segment is always displayed
+  - `context`: The segment is only displayed when *.py or *.ipynb files are present (default)
+  - `never`: The segement is hidden

--- a/segment_language_test.go
+++ b/segment_language_test.go
@@ -15,6 +15,7 @@ const (
 type languageArgs struct {
 	version           string
 	displayVersion    bool
+	displayMode       string
 	extensions        []string
 	enabledExtensions []string
 	commands          []string
@@ -43,7 +44,8 @@ func bootStrapLanguageTest(args *languageArgs) *language {
 	}
 	props := &properties{
 		values: map[Property]interface{}{
-			DisplayVersion: args.displayVersion,
+			DisplayVersion:      args.displayVersion,
+			DisplayModeProperty: args.displayMode,
 		},
 	}
 	l := &language{
@@ -57,7 +59,19 @@ func bootStrapLanguageTest(args *languageArgs) *language {
 	return l
 }
 
-func TestLanguageFilesFoundButNoCommand(t *testing.T) {
+func TestLanguageFilesFoundButNoCommandAndVersion(t *testing.T) {
+	args := &languageArgs{
+		commands:          []string{"unicorn"},
+		versionParam:      "--version",
+		extensions:        []string{uni},
+		enabledExtensions: []string{uni},
+		displayVersion:    true,
+	}
+	lang := bootStrapLanguageTest(args)
+	assert.False(t, lang.enabled(), "unicorn is not available")
+}
+
+func TestLanguageFilesFoundButNoCommandAndNoVersion(t *testing.T) {
 	args := &languageArgs{
 		commands:          []string{"unicorn"},
 		versionParam:      "--version",
@@ -65,7 +79,7 @@ func TestLanguageFilesFoundButNoCommand(t *testing.T) {
 		enabledExtensions: []string{uni},
 	}
 	lang := bootStrapLanguageTest(args)
-	assert.False(t, lang.enabled(), "unicorn is not available")
+	assert.True(t, lang.enabled(), "unicorn is not available")
 }
 
 func TestLanguageDisabledNoFiles(t *testing.T) {

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -912,6 +912,13 @@
                     "title": "Display Virtual Env",
                     "description": "Show the name of the virtualenv or not",
                     "default": true
+                  },
+                  "display_mode": {
+                    "type": "string",
+                    "title": "Display Mode",
+                    "description": "Determines whether the segment is displayed always or only if *.py or *.ipynb file are present in the current folder",
+                    "enum": ["always", "context", "never"],
+                    "default": "context"
                   }
                 }
               }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description
It would be nice if language segments (for example python) could always be displayed
This PR adds an 'display_mode' property to the language segment which determines when the segment is displayed.

Following values are allowed for the `display_mode` property:
* `always`: The segment is always displayed
* `when_in_context`: The segment is only displayed if the current folder contains files with certain extensions
* `never`: The segment is never displayed

Default value is: `when_in_context`

Example:
```json
{
    "type": "python",
    "style": "plain",
    "foreground": "magenta",
    "properties": {
        "display_mode": "when_in_context",
	"display_version": true
    }
},
```

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
