### PR TITLE
feat: execution time for powershell 5

### DIFF
--- a/docs/docs/installation.mdx
+++ b/docs/docs/installation.mdx
@@ -234,8 +234,8 @@ Edit `$PROFILE` in your preferred PowerShell version and add the following lines
 
     $executionTime = -1
     $history = Get-History -ErrorAction Ignore -Count 1
-    if ($null -ne $history -and $null -ne $history.Duration) {
-        $executionTime = $history.Duration.TotalMilliseconds
+    if ($null -ne $history -and $null -ne $history.EndExecutionTime -and $null -ne $history.StartExecutionTime) {
+        $executionTime = ($history.EndExecutionTime - $history.StartExecutionTime).TotalMilliseconds
     }
 
     $startInfo = New-Object System.Diagnostics.ProcessStartInfo

--- a/packages/powershell/oh-my-posh/oh-my-posh.psm1
+++ b/packages/powershell/oh-my-posh/oh-my-posh.psm1
@@ -74,8 +74,8 @@ function Set-PoshPrompt {
 
         $executionTime = -1
         $history = Get-History -ErrorAction Ignore -Count 1
-        if ($null -ne $history -and $null -ne $history.Duration) {
-            $executionTime = $history.Duration.TotalMilliseconds
+        if ($null -ne $history -and $null -ne $history.EndExecutionTime -and $null -ne $history.StartExecutionTime) {
+            $executionTime = ($history.EndExecutionTime - $history.StartExecutionTime).TotalMilliseconds
         }
 
         $startInfo = New-Object System.Diagnostics.ProcessStartInfo


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

Powershell 5's history object does not contain the `Duration` property, but it does have `StartExecutionTime` and `EndExecutionTime` which can be used to calculate the duration.

The calculation didn't seem to impact performance, so I changed the code to only do the calculation (even for powershell 7). That decision was made in order to keep the powershell code as short as possible, since this is code we're asking people to paste into their profile. If you don't agree with this decision, let me know and we can check to see if `Duration` exists, and if not, fall back to doing the calculation.

BTW:  I believe this is what was happening in #236 

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
