### PR TITLE
feat: allow comments in json

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	golang.org/x/text v0.3.3
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 	howett.net/plist v0.0.0-20200419221736-3b63eb3a43b5 // indirect
+	muzzammil.xyz/jsonc v0.0.0-20200627155943-e1c384b63054
 )
 
 replace github.com/distatus/battery v0.10.1-0.20200722221337-7e1bf2bbb15c => github.com/JanDeDobbeleer/battery v0.10.1-0.20200909080331-bb0a7566dbb8

--- a/go.sum
+++ b/go.sum
@@ -57,3 +57,5 @@ gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C
 howett.net/plist v0.0.0-20181124034731-591f970eefbb/go.mod h1:vMygbs4qMhSZSc4lCUl2OEE+rDiIIJAIdR4m7MiMcm0=
 howett.net/plist v0.0.0-20200419221736-3b63eb3a43b5 h1:AQkaJpH+/FmqRjmXZPELom5zIERYZfwTjnHpfoVMQEc=
 howett.net/plist v0.0.0-20200419221736-3b63eb3a43b5/go.mod h1:vMygbs4qMhSZSc4lCUl2OEE+rDiIIJAIdR4m7MiMcm0=
+muzzammil.xyz/jsonc v0.0.0-20200627155943-e1c384b63054 h1:HhSLntk5Waqyx19MS886eRyllKmLtxBt6Lr0Z5Bk2bM=
+muzzammil.xyz/jsonc v0.0.0-20200627155943-e1c384b63054/go.mod h1:rFv8tUUKe+QLh7v02BhfxXEf4ZHhYD7unR93HL/1Uvo=

--- a/settings.go
+++ b/settings.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+
+	"muzzammil.xyz/jsonc"
 )
 
 // Settings holds all the theme for rendering the prompt
@@ -67,15 +69,13 @@ func loadUserConfiguration(env environmentInfo) (*Settings, error) {
 	if _, err := os.Stat(settingsFile); os.IsNotExist(err) {
 		return nil, errors.New("INVALID CONFIG PATH")
 	}
-	defaultSettings, err := os.Open(settingsFile)
-	defer func() {
-		_ = defaultSettings.Close()
-	}()
+
+	_, j, err := jsonc.ReadFromFile(settingsFile)
 	if err != nil {
 		return nil, errors.New("UNABLE TO OPEN CONFIG")
 	}
-	jsonParser := json.NewDecoder(defaultSettings)
-	err = jsonParser.Decode(&settings)
+
+	err = json.Unmarshal(j, &settings)
 	if err != nil {
 		return nil, errors.New("INVALID CONFIG")
 	}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Description

As a user who is playing with my theme files quite a bit, I would like the ability to use comments in the json configuration. This would be useful for explanations of configuration as well as for temporarily commenting out configuration.  

Comments aren't permitted in JSON, but other products have adopted JSONC, a superset of JSON which does allow comments. Products like VS Code and Windows Terminal for example.  JSONC is a superset of JSON, so existing JSON configurations are still perfectly valid.

This PR uses [muhammadmuzzammil1998/jsonc](https://github.com/muhammadmuzzammil1998/jsonc) to convert the JSONC to JSON.  Go's standard `encoding/json` is used after that, just like before.

The `--print-config` option still returns regular JSON.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
