### PR TITLE
feat: use mapped_locations in folder style

### DIFF
--- a/docs/docs/segment-path.md
+++ b/docs/docs/segment-path.md
@@ -34,7 +34,7 @@ Display the current path.
 - windows_registry_icon: `string` - the icon to display when in the Windows registry - defaults to `\uE0B1`
 - style: `enum` - how to display the current path
 - mapped_locations: `map[string]string` - custom glyph/text for specific paths(only when `style` is set to `agnoster`,
-`agnoster_full` or `short`)
+`agnoster_full`, `agnoster_short`, `short`, or `folder`)
 
 ## Style
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/distatus/battery v0.10.1-0.20200722221337-7e1bf2bbb15c
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/gookit/color v1.3.1
+	github.com/kevinburke/go-bindata v3.22.0+incompatible // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/shirou/gopsutil v2.20.9+incompatible

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=
 github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/kevinburke/go-bindata v3.22.0+incompatible h1:/JmqEhIWQ7GRScV0WjX/0tqBrC5D21ALg0H0U/KZ/ts=
+github.com/kevinburke/go-bindata v3.22.0+incompatible/go.mod h1:/pEEZ72flUW2p0yi30bslSp9YqD9pysLxunQDdb2CPM=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/segment_path.go
+++ b/segment_path.go
@@ -55,7 +55,7 @@ func (pt *path) string() string {
 	case Full:
 		return pt.env.getcwd()
 	case Folder:
-		return base(pt.env.getcwd(), pt.env)
+		return pt.getFolderPath()
 	default:
 		return fmt.Sprintf("Path style: %s is not available", style)
 	}
@@ -139,6 +139,11 @@ func (pt *path) getAgnosterShortPath() string {
 		return fmt.Sprintf("%s%s%s", root, folderSeparator, base)
 	}
 	return fmt.Sprintf("%s%s%s%s%s", root, folderSeparator, folderIcon, folderSeparator, base)
+}
+
+func (pt *path) getFolderPath() string {
+	pwd := pt.getShortPath()
+	return base(pwd, pt.env)
 }
 
 func (pt *path) inHomeDir(pwd string) bool {

--- a/segment_path_test.go
+++ b/segment_path_test.go
@@ -448,6 +448,52 @@ func TestGetAgnosterShortPathInsideHomeOneLevel(t *testing.T) {
 	assert.Equal(t, "~ > projects", got)
 }
 
+func TestGetFolderPath(t *testing.T) {
+	pwd := "/usr/home/projects"
+	env := new(MockedEnvironment)
+	env.On("getPathSeperator", nil).Return("/")
+	env.On("homeDir", nil).Return("/usr/home")
+	env.On("getcwd", nil).Return(pwd)
+	path := &path{
+		env: env,
+	}
+	got := path.getFolderPath()
+	assert.Equal(t, "projects", got)
+}
+
+func TestGetFolderPathInsideHome(t *testing.T) {
+	pwd := "/usr/home"
+	env := new(MockedEnvironment)
+	env.On("getPathSeperator", nil).Return("/")
+	env.On("homeDir", nil).Return("/usr/home")
+	env.On("getcwd", nil).Return(pwd)
+	path := &path{
+		env: env,
+	}
+	got := path.getFolderPath()
+	assert.Equal(t, "~", got)
+}
+
+func TestGetFolderPathCustomMappedLocations(t *testing.T) {
+	pwd := "/a/b/c/d"
+	env := new(MockedEnvironment)
+	env.On("getPathSeperator", nil).Return("/")
+	env.On("homeDir", nil).Return("/usr/home")
+	env.On("getcwd", nil).Return(pwd)
+	path := &path{
+		env: env,
+		props: &properties{
+			values: map[Property]interface{}{
+				MappedLocations: map[string]string{
+					"/a/b/c/d": "#",
+				},
+			},
+		},
+	}
+	got := path.getFolderPath()
+	assert.Equal(t, "#", got)
+}
+
 func testWritePathInfo(home, pwd, pathSeparator string) string {
 	props := &properties{
 		values: map[Property]interface{}{


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

Allow the `mapped_locations` property to work when using the `folder` style.

closes #261 

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
