### PR TITLE
fix: agnoster_short with <1 depth

### DIFF
--- a/segment_path.go
+++ b/segment_path.go
@@ -135,6 +135,9 @@ func (pt *path) getAgnosterShortPath() string {
 	root := pt.rootLocation()
 	base := base(pt.env.getcwd(), pt.env)
 	pathDepth := pt.pathDepth(pt.getShortPath())
+	if pathDepth <= 0 {
+		return root
+	}
 	if pathDepth == 1 {
 		return fmt.Sprintf("%s%s%s", root, folderSeparator, base)
 	}

--- a/segment_path_test.go
+++ b/segment_path_test.go
@@ -448,6 +448,60 @@ func TestGetAgnosterShortPathInsideHomeOneLevel(t *testing.T) {
 	assert.Equal(t, "~ > projects", got)
 }
 
+func TestGetAgnosterShortPathZeroLevelsWindows(t *testing.T) {
+	pwd := "C:"
+	env := new(MockedEnvironment)
+	env.On("getPathSeperator", nil).Return("\\")
+	env.On("homeDir", nil).Return(homeBillWindows)
+	env.On("getcwd", nil).Return(pwd)
+	path := &path{
+		env: env,
+		props: &properties{
+			values: map[Property]interface{}{
+				FolderSeparatorIcon: " > ",
+			},
+		},
+	}
+	got := path.getAgnosterShortPath()
+	assert.Equal(t, "C:", got)
+}
+
+func TestGetAgnosterShortPathZeroLevelsLinux(t *testing.T) {
+	pwd := "/"
+	env := new(MockedEnvironment)
+	env.On("getPathSeperator", nil).Return("/")
+	env.On("homeDir", nil).Return(homeBillWindows)
+	env.On("getcwd", nil).Return(pwd)
+	path := &path{
+		env: env,
+		props: &properties{
+			values: map[Property]interface{}{
+				FolderSeparatorIcon: " > ",
+			},
+		},
+	}
+	got := path.getAgnosterShortPath()
+	assert.Equal(t, "", got)
+}
+
+func TestGetAgnosterShortPathOneLevel(t *testing.T) {
+	pwd := "/foo"
+	env := new(MockedEnvironment)
+	env.On("getPathSeperator", nil).Return("/")
+	env.On("homeDir", nil).Return(homeBillWindows)
+	env.On("getcwd", nil).Return(pwd)
+	path := &path{
+		env: env,
+		props: &properties{
+			values: map[Property]interface{}{
+				FolderSeparatorIcon: " > ",
+			},
+		},
+	}
+	got := path.getAgnosterShortPath()
+	assert.Equal(t, "foo", got)
+}
+
 func TestGetFolderPath(t *testing.T) {
 	pwd := "/usr/home/projects"
 	env := new(MockedEnvironment)


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Description

the `agnoster_short` style was behaving strangely on both Windows and Linux.

Windows:
| cwd | expected output | actual output |
|-|-|-|
|C:\ | `C:` | ` C: > .. > \`|

Linux:
| cwd | expected output | actual output |
|-|-|-|
| / | (empty string) | `/..//`|
| /var | `var` | `var/../var`|

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
