### PR TITLE
feat: mapped_locations_enabled

### DIFF
--- a/docs/docs/segment-path.md
+++ b/docs/docs/segment-path.md
@@ -33,17 +33,18 @@ Display the current path.
 - folder_icon: `string` - the icon to use as a folder indication - defaults to `..`
 - windows_registry_icon: `string` - the icon to display when in the Windows registry - defaults to `\uE0B1`
 - style: `enum` - how to display the current path
-- mapped_locations: `map[string]string` - custom glyph/text for specific paths(only when `style` is set to `agnoster`,
-`agnoster_full`, `agnoster_short`, `short`, or `folder`)
+- mapped_locations: `map[string]string` - custom glyph/text for specific paths (only when `mapped_locations_enabled`
+is set to `true`)
+- mapped_locations_enabled: `boolean` - replace known locations in the path with the replacements before applying the
+style. defaults to `true`
 
 ## Style
 
-Style sets the way the path is displayed. Based on previous experience and popular themes, there are 4 flavors.
+Style sets the way the path is displayed. Based on previous experience and popular themes, there are 5 flavors.
 
 - agnoster
 - agnoster_full
 - agnoster_short
-- short
 - full
 - folder
 
@@ -61,15 +62,9 @@ Renders each folder name separated by the `folder_separator_icon`.
 
 When more than 1 level deep, it renders one `folder_icon` followed by the name of the current folder separated by the `folder_separator_icon`.
 
-### Short
-
-Display `$PWD` as a string, replace `$HOME` with the `home_icon` if you're inside the `$HOME` location or
-one of its children.
-Specific folders can be customized using the `mapped_locations` property.
-
 ### Full
 
-Display `$PWD` as a string
+Display `$PWD` as a string.
 
 ### Folder
 

--- a/themes/aliens.omp.json
+++ b/themes/aliens.omp.json
@@ -19,7 +19,7 @@
           "foreground": "#ffffff",
           "background": "#C678DD",
           "properties": {
-            "style": "short"
+            "style": "full"
           }
         },
         {

--- a/themes/avit.omp.json
+++ b/themes/avit.omp.json
@@ -10,7 +10,7 @@
           "foreground": "#ffffff",
           "properties": {
             "prefix": "",
-            "style": "short"
+            "style": "full"
           }
         },
         {

--- a/themes/darkblood.omp.json
+++ b/themes/darkblood.omp.json
@@ -56,7 +56,7 @@
           "style": "plain",
           "foreground": "#ffffff",
           "properties": {
-            "style": "short",
+            "style": "full",
             "prefix": "<#CB4B16>┖[</>",
             "postfix": "<#CB4B16>]></>"
           }

--- a/themes/fish.omp.json
+++ b/themes/fish.omp.json
@@ -27,12 +27,12 @@
           "style": "plain",
           "foreground": "#ffffff",
           "background": "#007ACC",
-          "properties" : {
-              "folder_icon": "\uF115",
-              "folder_separator_icon": "\uE0B1",
-              "style": "short",
-              "prefix": "<transparent>\uE0B0</> ",
-              "postfix": " "
+          "properties": {
+            "folder_icon": "\uF115",
+            "folder_separator_icon": "\uE0B1",
+            "style": "full",
+            "prefix": "<transparent>\uE0B0</> ",
+            "postfix": " "
           }
         },
         {

--- a/themes/honukai.omp.json
+++ b/themes/honukai.omp.json
@@ -22,7 +22,7 @@
           "properties": {
             "folder_icon": "\uF115",
             "folder_separator_icon": "\uE0B1",
-            "style": "short"
+            "style": "full"
           }
         },
         {

--- a/themes/paradox.omp.json
+++ b/themes/paradox.omp.json
@@ -27,7 +27,7 @@
           "properties": {
             "folder_icon": "\uF115",
             "folder_separator_icon": "\uE0B1",
-            "style": "short"
+            "style": "full"
           }
         },
         {

--- a/themes/powerlevel10k_classic.omp.json
+++ b/themes/powerlevel10k_classic.omp.json
@@ -25,7 +25,7 @@
           "foreground": "#26C6DA",
           "background": "#546E7A",
           "properties": {
-            "style": "short",
+            "style": "full",
             "postfix": " "
           }
         },

--- a/themes/powerlevel10k_lean.omp.json
+++ b/themes/powerlevel10k_lean.omp.json
@@ -28,7 +28,7 @@
           "foreground": "#77E4F7",
           "properties": {
             "prefix": "",
-            "style": "short"
+            "style": "full"
           }
         },
         {

--- a/themes/powerline.omp.json
+++ b/themes/powerline.omp.json
@@ -20,8 +20,8 @@
           "powerline_symbol": "\uE0B0",
           "foreground": "#100e23",
           "background": "#91ddff",
-          "properties" : {
-              "style": "short"
+          "properties": {
+            "style": "full"
           }
         },
         {

--- a/themes/sorin.omp.json
+++ b/themes/sorin.omp.json
@@ -24,7 +24,7 @@
           "style": "plain",
           "foreground": "#0973C0",
           "properties": {
-            "style": "short"
+            "style": "full"
           }
         },
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description
Discussed in #258 

This PR separates the concept of path `style` from whether the `mapped_locations` are enabled. This separation of concerns allows us to remove some of the permeations from `style`, and generally leads to a set of configuration options that are easier to reason about.

There is a new property called `mapped_locations_enabled` which defaults to true, and can be used with any style.

At this point, the styles `short` and `full` are duplicates of each other, because the only difference between the two was whether they support `mapped_locations`. I realize `short` was used in lots of default themes, however I chose to keep the name `full` and hide the name `short`. There is nothing particularly short about this style anymore. The only "shortness" was related to `mapped_locations`, which has been decoupled from style. Compared to the other styles, it's actually one of the longer options 😛 

Note: a future PR will take this concept a step further and make `folder_separator_icon` apply to all styles. At that point, I believe the style `agnoster_full` can be retired, as it will also be a duplicate of `full`.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary