### PR TITLE
feat: allow custom folder separator for all styles

### DIFF
--- a/src/segment_path.go
+++ b/src/segment_path.go
@@ -85,12 +85,10 @@ func (pt *path) getAgnosterPath() string {
 
 func (pt *path) getAgnosterFullPath() string {
 	pwd := pt.getPwd()
-	pathSeparator := pt.env.getPathSeperator()
-	folderSeparator := pt.props.getString(FolderSeparatorIcon, pathSeparator)
-	if string(pwd[0]) == pathSeparator {
+	if string(pwd[0]) == pt.env.getPathSeperator() {
 		pwd = pwd[1:]
 	}
-	return strings.ReplaceAll(pwd, pathSeparator, folderSeparator)
+	return pt.replaceFolderSeparators(pwd)
 }
 
 func (pt *path) getAgnosterShortPath() string {
@@ -111,7 +109,8 @@ func (pt *path) getAgnosterShortPath() string {
 }
 
 func (pt *path) getFullPath() string {
-	return pt.getPwd()
+	pwd := pt.getPwd()
+	return pt.replaceFolderSeparators(pwd)
 }
 
 func (pt *path) getFolderPath() string {
@@ -166,6 +165,17 @@ func (pt *path) replaceMappedLocations(pwd string) string {
 	return pwd
 }
 
+func (pt *path) replaceFolderSeparators(pwd string) string {
+	defaultSeparator := pt.env.getPathSeperator()
+	folderSeparator := pt.props.getString(FolderSeparatorIcon, defaultSeparator)
+	if folderSeparator == defaultSeparator {
+		return pwd
+	}
+
+	pwd = strings.ReplaceAll(pwd, defaultSeparator, folderSeparator)
+	return pwd
+}
+
 func (pt *path) inHomeDir(pwd string) bool {
 	return strings.HasPrefix(pwd, pt.env.homeDir())
 }
@@ -180,13 +190,12 @@ func (pt *path) rootLocation() string {
 
 func (pt *path) pathDepth(pwd string) int {
 	splitted := strings.Split(pwd, pt.env.getPathSeperator())
-	var validParts []string
+	depth := 0
 	for _, part := range splitted {
 		if part != "" {
-			validParts = append(validParts, part)
+			depth++
 		}
 	}
-	depth := len(validParts)
 	return depth - 1
 }
 

--- a/src/segment_path_test.go
+++ b/src/segment_path_test.go
@@ -449,6 +449,45 @@ func TestGetAgnosterShortPathOneLevel(t *testing.T) {
 	assert.Equal(t, "foo", got)
 }
 
+func TestGetFullPath(t *testing.T) {
+	cases := []struct {
+		UseFolderSeparatorIcon bool
+		Pwd                    string
+		Expected               string
+	}{
+		{UseFolderSeparatorIcon: false, Pwd: "", Expected: ""},
+		{UseFolderSeparatorIcon: false, Pwd: "/", Expected: "/"},
+		{UseFolderSeparatorIcon: false, Pwd: "/usr/home", Expected: "~"},
+		{UseFolderSeparatorIcon: false, Pwd: "/usr/home/abc", Expected: "~/abc"},
+		{UseFolderSeparatorIcon: false, Pwd: "/a/b/c/d", Expected: "/a/b/c/d"},
+
+		{UseFolderSeparatorIcon: true, Pwd: "", Expected: ""},
+		{UseFolderSeparatorIcon: true, Pwd: "/", Expected: "|"},
+		{UseFolderSeparatorIcon: true, Pwd: "/usr/home", Expected: "~"},
+		{UseFolderSeparatorIcon: true, Pwd: "/usr/home/abc", Expected: "~|abc"},
+		{UseFolderSeparatorIcon: true, Pwd: "/a/b/c/d", Expected: "|a|b|c|d"},
+	}
+
+	for _, tc := range cases {
+		env := new(MockedEnvironment)
+		env.On("getPathSeperator", nil).Return("/")
+		env.On("homeDir", nil).Return("/usr/home")
+		env.On("getcwd", nil).Return(tc.Pwd)
+		props := map[Property]interface{}{}
+		if tc.UseFolderSeparatorIcon {
+			props[FolderSeparatorIcon] = "|"
+		}
+		path := &path{
+			env: env,
+			props: &properties{
+				values: props,
+			},
+		}
+		got := path.getFullPath()
+		assert.Equal(t, tc.Expected, got)
+	}
+}
+
 func TestGetFolderPath(t *testing.T) {
 	pwd := "/usr/home/projects"
 	env := new(MockedEnvironment)


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [n/a] Docs have been added / updated (for bug fixes / features)

### Description
Discussed in #258 

Allow `folder_separator_icon` to be used in all themes, because why not?  If you want bicycle-delimited paths, you can now have them, even with the `full` style 🚴.

Originally I thought this was going to make `agnoster_full` and `full` be duplicates of each other, but that's not actually true, `agnoster_full` has a slight difference in that it removes the leading separator. Which makes a lot of sense on *nix file systems.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
