### PR TITLE
fix: .gitignore updated with the new /src structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,4 +149,4 @@ dist
 # End of https://www.toptal.com/developers/gitignore/api/node,go,visualstudiocode
 
 # linux binary
-/oh-my-posh3
+/src/oh-my-posh3


### PR DESCRIPTION
/oh-my-posh3 set to /src/oh-my-posh3

### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

.gitignore forgotten when the new src folder has been created(ed2eac8e12f369eff35a40c440c4f33795792ed0).
It seems also the history has been lost after the move?


[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
