### PR TITLE
fix: avoid emitting empty ansi color codes

### DIFF
--- a/src/ansi_color.go
+++ b/src/ansi_color.go
@@ -92,6 +92,10 @@ func (a *AnsiColor) getAnsiFromColorString(colorString string, isBackground bool
 }
 
 func (a *AnsiColor) writeColoredText(background, foreground, text string) {
+	// Avoid emitting empty strings with color codes
+	if text == "" {
+		return
+	}
 	var coloredText string
 	if foreground == Transparent && background != "" {
 		ansiColor := a.getAnsiFromColorString(background, false)


### PR DESCRIPTION
When there's no color override an empty string is emitted.  
The fix reduces the emitted output by 40% approximatively with the default theme(1604 -> 1138).

### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

When there's no color override an empty string is emitted.  
The fix reduces the emitted output by 40% approximatively with the default theme(1604 -> 1138).

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
