### PR TITLE
fix: *env.args.Shell not set in getShellName(cache never used)

### DIFF
--- a/src/environment.go
+++ b/src/environment.go
@@ -233,8 +233,9 @@ func (env *environment) getShellName() string {
 	if err != nil {
 		return unknown
 	}
-	shell := strings.Replace(name, ".exe", "", 1)
-	return strings.Trim(shell, " ")
+	// Cache the shell value to speed things up.
+	*env.args.Shell = strings.Trim(strings.Replace(name, ".exe", "", 1), " ")
+	return *env.args.Shell
 }
 
 func (env *environment) doGet(url string) ([]byte, error) {


### PR DESCRIPTION
*env.args.Shell was never set in getShellName.

### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

*env.args.Shell not set in getShellName(cache never used)

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
