### PR TITLE
docs: fix invalid json in docs

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -83,12 +83,12 @@ the current working directory is `/usr/home/omp` and the shell is `zsh`.
 
 ```json
 {
-    "console_title_template" = "{{.Folder}}{{if .Root}} :: root{{end}} :: {{.Shell}}",
+    "console_title_template": "{{.Folder}}{{if .Root}} :: root{{end}} :: {{.Shell}}",
     // outputs:
     // when root == false: omp :: zsh
     // when root == true: omp :: root :: zsh
-    "console_title_template" = "{{.Folder}}", // outputs: omp
-    "console_title_template" = "{{.Shell}} in {{.Path}}", // outputs: zsh in /usr/home/omp
+    "console_title_template": "{{.Folder}}", // outputs: omp
+    "console_title_template": "{{.Shell}} in {{.Path}}", // outputs: zsh in /usr/home/omp
 }
 ```
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [n/a] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

example was invalid json (equal signs instead of colons)

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
