### PR TITLE
refactor: switch to original jsonc library

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -19,11 +19,9 @@ require (
 	golang.org/x/text v0.3.3
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 	howett.net/plist v0.0.0-20200419221736-3b63eb3a43b5 // indirect
-	muzzammil.xyz/jsonc v0.0.0
+	muzzammil.xyz/jsonc v0.0.0-20201229145248-615b0916ca38
 )
 
 replace github.com/distatus/battery v0.10.0 => github.com/JanDeDobbeleer/battery v0.10.0-1
 
 replace github.com/gookit/color v1.3.5 => github.com/JanDeDobbeleer/color v1.3.5-1
-
-replace muzzammil.xyz/jsonc v0.0.0 => github.com/JanDeDobbeleer/jsonc v0.0.0-1

--- a/src/go.sum
+++ b/src/go.sum
@@ -2,8 +2,6 @@ github.com/JanDeDobbeleer/battery v0.10.0-1 h1:3N3i3xgvrrb3eCuX4kJnmbKzOiqkH1Ly1
 github.com/JanDeDobbeleer/battery v0.10.0-1/go.mod h1:STnSvFLX//eEpkaN7qWRxCWxrWOcssTDgnG4yqq9BRE=
 github.com/JanDeDobbeleer/color v1.3.5-1 h1:joTGC9ShPgXUVWJW4sBv4q9M2rdpTopCysc8fRRAgkY=
 github.com/JanDeDobbeleer/color v1.3.5-1/go.mod h1:GqqLKF1le3EfrbHbYsYa5WdLqfc/PHMdMRbt6tMnqIc=
-github.com/JanDeDobbeleer/jsonc v0.0.0-1 h1:mNNA3kH8VcKdZY2JSjhTn23SEszXtA6tdeihf1EgFr8=
-github.com/JanDeDobbeleer/jsonc v0.0.0-1/go.mod h1:du99TTKDGgeJ8EWTOucG3G9Q8W8XRw0P5I7565cuZVc=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/alecthomas/assert v0.0.0-20170929043011-405dbfeb8e38 h1:smF2tmSOzy2Mm+0dGI2AIUHY+w0BUc+4tn40djz7+6U=
@@ -59,3 +57,5 @@ gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C
 howett.net/plist v0.0.0-20181124034731-591f970eefbb/go.mod h1:vMygbs4qMhSZSc4lCUl2OEE+rDiIIJAIdR4m7MiMcm0=
 howett.net/plist v0.0.0-20200419221736-3b63eb3a43b5 h1:AQkaJpH+/FmqRjmXZPELom5zIERYZfwTjnHpfoVMQEc=
 howett.net/plist v0.0.0-20200419221736-3b63eb3a43b5/go.mod h1:vMygbs4qMhSZSc4lCUl2OEE+rDiIIJAIdR4m7MiMcm0=
+muzzammil.xyz/jsonc v0.0.0-20201229145248-615b0916ca38 h1:RTgkUbDUEKgkFlwK9NsUAmI1t0zUo+kWKSm9bAbr0TQ=
+muzzammil.xyz/jsonc v0.0.0-20201229145248-615b0916ca38/go.mod h1:rFv8tUUKe+QLh7v02BhfxXEf4ZHhYD7unR93HL/1Uvo=


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [n/a] Tests for the changes have been added (for bug fixes / features)
- [n/a] Docs have been added / updated (for bug fixes / features)

### Description

[The PR we were waiting on](https://github.com/muhammadmuzzammil1998/jsonc/pull/11)  has been merged to muhammadmuzzammil1998/jsonc, so we can now revert back to that library instead of our own fork.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
