### PR TITLE
fix: $global:LASTEXITCODE

### DIFF
--- a/packages/powershell/oh-my-posh/oh-my-posh.psm1
+++ b/packages/powershell/oh-my-posh/oh-my-posh.psm1
@@ -92,11 +92,11 @@ function Set-PoshPrompt {
         $standardOut = $process.StandardOutput.ReadToEnd()
         $process.WaitForExit()
         $standardOut
+        Set-GitStatus
         $global:LASTEXITCODE = $realLASTEXITCODE
         #remove temp variables
         Remove-Variable realLASTEXITCODE -Confirm:$false
         Remove-Variable lastCommandSuccess -Confirm:$false
-        Set-GitStatus
     }
     Set-Item -Path Function:prompt -Value $Prompt -Force
 }

--- a/src/init/omp.ps1
+++ b/src/init/omp.ps1
@@ -56,10 +56,10 @@ function Set-GitStatus {
     $standardOut = $process.StandardOutput.ReadToEnd()
     $process.WaitForExit()
     $standardOut
+    Set-GitStatus
     $global:LASTEXITCODE = $realLASTEXITCODE
     #remove temp variables
     Remove-Variable realLASTEXITCODE -Confirm:$false
     Remove-Variable lastCommandSuccess -Confirm:$false
-    Set-GitStatus
 }
 Set-Item -Path Function:prompt -Value $Prompt -Force


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] n/a Tests for the changes have been added (for bug fixes / features)
- [ ] n/a Docs have been added / updated (for bug fixes / features)

### Description

In the powershell prompt function, `Set-GitStatus` was clobbering the `$global:LASTEXITCODE`.  I moved `Set-GitStatus` and that seems to have resolved the issue.

closes #288 

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
