### PR TITLE
fix: exit code always equal 0(zsh)

### DIFF
--- a/src/init/omp.zsh
+++ b/src/init/omp.zsh
@@ -5,15 +5,17 @@ function omp_preexec() {
 }
 
 function omp_precmd() {
+  omp_last_error=$?
   omp_elapsed=-1
   if [ $omp_start_time ]; then
     omp_now=$(::OMP:: --millis)
     omp_elapsed=$(($omp_now-$omp_start_time))
   fi
-  eval "$(::OMP:: --config $POSH_THEME --error $? --execution-time $omp_elapsed --eval)"
+  eval "$(::OMP:: --config $POSH_THEME --error $omp_last_error --execution-time $omp_elapsed --eval)"
   unset omp_start_time
   unset omp_now
   unset omp_elapsed
+  unset omp_last_error
 }
 
 function install_omp_hooks() {


### PR DESCRIPTION
The exit code was not captured correctly since the move to the new bootstrap system.  
It never displays the actual exit code.

### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

The exit code was not correctly captured and was always returning 0(zsh).
Maybe the doc should also be updated to reflect the fact that execution time is currently only available with pwsh and zsh.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
