### PR TITLE
fix: mapped_locations schema definition

### DIFF
--- a/themes/schema.json
+++ b/themes/schema.json
@@ -882,10 +882,31 @@
                     "default": "folder"
                   },
                   "mapped_locations": {
-                    "type": "object",
+                    "type": "array",
                     "title": "Mapped Locations",
                     "description": "Custom glyph/text for specific paths",
-                    "additionalProperties": { "type": "string" }
+                    "items": {
+                      "type": "array",
+                      "items": [
+                        {
+                          "type": "string",
+                          "title": "Filesystem path"
+                        },
+                        {
+                          "type": "string",
+                          "title": "Replacement text"
+                        }
+                      ],
+                      "minItems": 2,
+                      "maxItems": 2,
+                      "additionalItems": false
+                    }
+                  },
+                  "mapped_locations_enabled": {
+                    "type": "boolean",
+                    "title": "Enable the Mapped Locations feature",
+                    "description": "Replace known locations in the path with the replacements before applying the style.",
+                    "default": true
                   }
                 }
               }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] n/a Tests for the changes have been added (for bug fixes / features)
- [ ] n/a Docs have been added / updated (for bug fixes / features)

### Description

* The schema was wrong for the `mapped_locations` feature.
* The schema was missing for the `mapped_locations_enabled` feature.


Old:
![image](https://user-images.githubusercontent.com/934490/103409929-43025980-4b26-11eb-838a-70dab152125e.png)

New Happy Path:
![image](https://user-images.githubusercontent.com/934490/103410009-a12f3c80-4b26-11eb-84e8-c805eec09db7.png)

New if the user tries something invalid:
![image](https://user-images.githubusercontent.com/934490/103409985-7cd36000-4b26-11eb-851a-8c5630202f71.png)



[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
