### PR TITLE
feat: include  schema declaration in themes

### DIFF
--- a/docs/docs/installation.mdx
+++ b/docs/docs/installation.mdx
@@ -329,21 +329,6 @@ and store it somehwere. Once adjusted to your liking, [change the prompt setting
 oh-my-posh --config ~/.mytheme.omp.json
 ```
 
-#### JSON Schema
-
-There's an easy to use [JSON schema][schema] available to validate your theme and have auto completion when editing.
-When using [Visual Studio Code][vscode], you can extend your settings file (F1 -> Preferences: Open Settings (JSON))
-by adding the following lines:
-
-```json
-"json.schemas": [
-  {
-    "fileMatch": ["*.omp.json"],
-    "url": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh3/main/themes/schema.json"
-  }
-]
-```
-
 🎉🎉🎉
 
 [wt]: https://github.com/microsoft/terminal
@@ -358,5 +343,3 @@ by adding the following lines:
 [brew]: /docs/homebrew
 [prompt]: /docs/installation#4-replace-your-existing-prompt
 [configuration]: /docs/configure
-[schema]: https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh3/main/themes/schema.json
-[vscode]: https://code.visualstudio.com/

--- a/themes/agnoster.omp.json
+++ b/themes/agnoster.omp.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh3/main/themes/schema.json",
   "blocks": [
     {
       "type": "prompt",

--- a/themes/agnosterplus.omp.json
+++ b/themes/agnosterplus.omp.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh3/main/themes/schema.json",
   "blocks": [
     {
       "type": "prompt",

--- a/themes/aliens.omp.json
+++ b/themes/aliens.omp.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh3/main/themes/schema.json",
   "blocks": [
     {
       "type": "prompt",

--- a/themes/avit.omp.json
+++ b/themes/avit.omp.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh3/main/themes/schema.json",
   "blocks": [
     {
       "type": "prompt",

--- a/themes/darkblood.omp.json
+++ b/themes/darkblood.omp.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh3/main/themes/schema.json",
   "blocks": [
     {
       "type": "prompt",

--- a/themes/emodipt.omp.json
+++ b/themes/emodipt.omp.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh3/main/themes/schema.json",
   "blocks": [
     {
       "type": "prompt",

--- a/themes/fish.omp.json
+++ b/themes/fish.omp.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh3/main/themes/schema.json",
   "blocks": [
     {
       "type": "prompt",

--- a/themes/honukai.omp.json
+++ b/themes/honukai.omp.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh3/main/themes/schema.json",
   "blocks": [
     {
       "type": "prompt",

--- a/themes/jandedobbeleer.omp.json
+++ b/themes/jandedobbeleer.omp.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh3/main/themes/schema.json",
   "blocks": [
     {
       "type": "prompt",

--- a/themes/lambda.omp.json
+++ b/themes/lambda.omp.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh3/main/themes/schema.json",
   "blocks": [
     {
       "type": "prompt",

--- a/themes/material.omp.json
+++ b/themes/material.omp.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh3/main/themes/schema.json",
   "blocks": [
     {
       "type": "prompt",

--- a/themes/paradox.omp.json
+++ b/themes/paradox.omp.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh3/main/themes/schema.json",
   "blocks": [
     {
       "type": "prompt",

--- a/themes/pararussel.omp.json
+++ b/themes/pararussel.omp.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh3/main/themes/schema.json",
   "blocks": [
     {
       "type": "prompt",

--- a/themes/powerlevel10k_classic.omp.json
+++ b/themes/powerlevel10k_classic.omp.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh3/main/themes/schema.json",
   "blocks": [
     {
       "type": "prompt",

--- a/themes/powerlevel10k_lean.omp.json
+++ b/themes/powerlevel10k_lean.omp.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh3/main/themes/schema.json",
   "blocks": [
     {
       "type": "prompt",

--- a/themes/powerline.omp.json
+++ b/themes/powerline.omp.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh3/main/themes/schema.json",
   "blocks": [
     {
       "type": "prompt",

--- a/themes/robbyrussel.omp.json
+++ b/themes/robbyrussel.omp.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh3/main/themes/schema.json",
   "blocks": [
     {
       "type": "prompt",

--- a/themes/sorin.omp.json
+++ b/themes/sorin.omp.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh3/main/themes/schema.json",
   "blocks": [
     {
       "type": "prompt",

--- a/themes/star.omp.json
+++ b/themes/star.omp.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh3/main/themes/schema.json",
   "blocks": [
     {
       "type": "prompt",

--- a/themes/zash.omp.json
+++ b/themes/zash.omp.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh3/main/themes/schema.json",
   "blocks": [
     {
       "type": "prompt",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] n/a Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

[The docs](https://ohmyposh.dev/docs/installation/#json-schema)  instruct the user how to add the schema to VS Code for `*.omp.json` files, however I feel that's not very discoverable and we can take this a step further. By including the `$schema` key in the default theme files, it improves the out of the box experience, so that users don't need to mess with their IDE settings.  I assume most users who are creating their own theme are probably starting with one of the default themes, so they will likely end up with this key in their custom theme if it's present in all default themes.

BTW there is another option, which is to submit our schema to [SchemaStore](https://github.com/SchemaStore/schemastore), which I believe VS Code and other IDEs periodically pull from. However, this carries additional responsibilities of maintaining the schema in that project, and I'm not sure how often the IDEs will refresh from this source.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
