### PR TITLE
feat: hyperlink support in engine + hyperlink for path segment

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -291,6 +291,19 @@ Oh my Posh mainly supports three different color types being
 
   `darkGray` `lightRed` `lightGreen` `lightYellow` `lightBlue` `lightMagenta` `lightCyan` `lightWhite`
 
+### Hyperlinks
+
+The engine has the ability to render hyperlinks. Your terminal has to support it and the option
+has to be enabled at the segment level. Hyperlink generation is disabled by default.
+
+#### Supported segments
+
+- [Path](segment-path.md)
+
+#### Supported terminals
+
+- [Terminal list](thttps://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda)
+
 ## Full Sample
 
 ```json
@@ -341,7 +354,8 @@ Oh my Posh mainly supports three different color types being
             "style": "folder",
             "ignore_folders": [
               "/super/secret/project"
-            ]
+            ],
+            "enable_hyperlink": false
           }
         },
         {

--- a/docs/docs/segment-path.md
+++ b/docs/docs/segment-path.md
@@ -37,6 +37,7 @@ Display the current path.
 is set to `true`)
 - mapped_locations_enabled: `boolean` - replace known locations in the path with the replacements before applying the
 style. defaults to `true`
+- enable_hyperlink: `boolean` - displays an hyperlink for the path - defaults to `false`
 
 ## Style
 

--- a/src/ansi_formats_test.go
+++ b/src/ansi_formats_test.go
@@ -23,3 +23,57 @@ func TestLenWithoutAnsi(t *testing.T) {
 		assert.Equal(t, 5, strippedLength)
 	}
 }
+
+func TestGenerateHyperlinkNoUrl(t *testing.T) {
+	cases := []struct {
+		Text      string
+		ShellName string
+		Expected  string
+	}{
+		{Text: "sample text with no url", ShellName: zsh, Expected: "sample text with no url"},
+		{Text: "sample text with no url", ShellName: pwsh, Expected: "sample text with no url"},
+		{Text: "sample text with no url", ShellName: bash, Expected: "sample text with no url"},
+	}
+	for _, tc := range cases {
+		a := ansiFormats{}
+		a.init(tc.ShellName)
+		hyperlinkText := a.generateHyperlink(tc.Text)
+		assert.Equal(t, tc.Expected, hyperlinkText)
+	}
+}
+
+func TestGenerateHyperlinkWithUrl(t *testing.T) {
+	cases := []struct {
+		Text      string
+		ShellName string
+		Expected  string
+	}{
+		{Text: "[google](http://www.google.be)", ShellName: zsh, Expected: "%{\x1b]8;;http://www.google.be\x1b\\%}google%{\x1b]8;;\x1b\\%}"},
+		{Text: "[google](http://www.google.be)", ShellName: pwsh, Expected: "\x1b]8;;http://www.google.be\x1b\\google\x1b]8;;\x1b\\"},
+		{Text: "[google](http://www.google.be)", ShellName: bash, Expected: "\\[\x1b]8;;http://www.google.be\x1b\\\\\\]google\\[\x1b]8;;\x1b\\\\\\]"},
+	}
+	for _, tc := range cases {
+		a := ansiFormats{}
+		a.init(tc.ShellName)
+		hyperlinkText := a.generateHyperlink(tc.Text)
+		assert.Equal(t, tc.Expected, hyperlinkText)
+	}
+}
+
+func TestGenerateHyperlinkWithUrlNoName(t *testing.T) {
+	cases := []struct {
+		Text      string
+		ShellName string
+		Expected  string
+	}{
+		{Text: "[](http://www.google.be)", ShellName: zsh, Expected: "[](http://www.google.be)"},
+		{Text: "[](http://www.google.be)", ShellName: pwsh, Expected: "[](http://www.google.be)"},
+		{Text: "[](http://www.google.be)", ShellName: bash, Expected: "[](http://www.google.be)"},
+	}
+	for _, tc := range cases {
+		a := ansiFormats{}
+		a.init(tc.ShellName)
+		hyperlinkText := a.generateHyperlink(tc.Text)
+		assert.Equal(t, tc.Expected, hyperlinkText)
+	}
+}

--- a/src/engine.go
+++ b/src/engine.go
@@ -82,6 +82,9 @@ func (e *engine) renderText(text string) {
 	if e.activeSegment.Background != "" {
 		defaultValue = fmt.Sprintf("<%s>\u2588</>", e.activeSegment.Background)
 	}
+
+	text = e.color.formats.generateHyperlink(text)
+
 	prefix := e.activeSegment.getValue(Prefix, defaultValue)
 	postfix := e.activeSegment.getValue(Postfix, defaultValue)
 	e.color.write(e.activeSegment.Background, e.activeSegment.Foreground, fmt.Sprintf("%s%s%s", prefix, text, postfix))
@@ -109,10 +112,9 @@ func (e *engine) renderBlockSegments(block *Block) string {
 		}
 		e.activeSegment = segment
 		e.endPowerline()
-		text := segment.stringValue
 		e.activeSegment.Background = segment.props.background
 		e.activeSegment.Foreground = segment.props.foreground
-		e.renderSegmentText(text)
+		e.renderSegmentText(segment.stringValue)
 	}
 	if e.previousActiveSegment != nil && e.previousActiveSegment.Style == Powerline {
 		e.writePowerLineSeparator(Transparent, e.previousActiveSegment.Background, true)
@@ -166,7 +168,7 @@ func (e *engine) render() {
 	e.write()
 }
 
-// debug will lool through your config file and output the timings for each segments
+// debug will loop through your config file and output the timings for each segments
 func (e *engine) debug() {
 	var segmentTimings []SegmentTiming
 	largestSegmentNameLength := 0

--- a/src/segment_path.go
+++ b/src/segment_path.go
@@ -44,23 +44,31 @@ func (pt *path) enabled() bool {
 }
 
 func (pt *path) string() string {
+	cwd := pt.env.getcwd()
+	var formattedPath string
 	switch style := pt.props.getString(Style, Agnoster); style {
 	case Agnoster:
-		return pt.getAgnosterPath()
+		formattedPath = pt.getAgnosterPath()
 	case AgnosterFull:
-		return pt.getAgnosterFullPath()
+		formattedPath = pt.getAgnosterFullPath()
 	case AgnosterShort:
-		return pt.getAgnosterShortPath()
+		formattedPath = pt.getAgnosterShortPath()
 	case Short:
 		// "short" is a duplicate of "full", just here for backwards compatibility
 		fallthrough
 	case Full:
-		return pt.getFullPath()
+		formattedPath = pt.getFullPath()
 	case Folder:
-		return pt.getFolderPath()
+		formattedPath = pt.getFolderPath()
 	default:
 		return fmt.Sprintf("Path style: %s is not available", style)
 	}
+
+	if pt.props.getBool(EnableHyperlink, false) {
+		return fmt.Sprintf("[%s](file://%s)", formattedPath, cwd)
+	}
+
+	return formattedPath
 }
 
 func (pt *path) init(props *properties, env environmentInfo) {

--- a/src/settings.go
+++ b/src/settings.go
@@ -34,6 +34,8 @@ const (
 	Left BlockAlignment = "left"
 	// Right aligns right
 	Right BlockAlignment = "right"
+	// EnableHyperlink enable hyperlink
+	EnableHyperlink Property = "enable_hyperlink"
 )
 
 // Block defines a part of the prompt with optional segments

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -944,6 +944,12 @@
                     "title": "Enable the Mapped Locations feature",
                     "description": "Replace known locations in the path with the replacements before applying the style.",
                     "default": true
+                  },
+                  "enable_hyperlink": {
+                    "type": "string",
+                    "title": "Enable hyperlink",
+                    "description": "Displays an hyperlink for the current path",
+                    "default": false
                   }
                 }
               }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

Hyperlink in git and path segment. Supported in windows terminal 1.5(in preview now and available this month for the stable one)

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
