### PR TITLE
fix:  folder style not using folder_separator_icon

### DIFF
--- a/src/segment_path.go
+++ b/src/segment_path.go
@@ -115,7 +115,8 @@ func (pt *path) getFullPath() string {
 
 func (pt *path) getFolderPath() string {
 	pwd := pt.getPwd()
-	return base(pwd, pt.env)
+	pwd = base(pwd, pt.env)
+	return pt.replaceFolderSeparators(pwd)
 }
 
 func (pt *path) getPwd() string {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] n/a Docs have been added / updated (for bug fixes / features)

### Description

In the path segment, the 'folder' style was not respecting the user's `folder_separator_icon`. This is really only relevant when pwd is root.

Closes #306 

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
