### PR TITLE
fix: wrong check when calling --debug with ignore_folders set

### DIFF
--- a/src/engine.go
+++ b/src/engine.go
@@ -175,7 +175,7 @@ func (e *engine) debug() {
 		for _, segment := range block.Segments {
 			err := segment.mapSegmentWithWriter(e.env)
 			if err != nil || segment.shouldIgnoreFolder(e.env.getcwd()) {
-				return
+				continue
 			}
 			var segmentTiming SegmentTiming
 			segmentTiming.name = string(segment.Type)


### PR DESCRIPTION
wrong check when calling --debug with ignore_folders set

### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

wrong check when calling --debug with ignore_folders set.
If a folder is ignored `--debug` prints nothing.
discovered here https://github.com/JanDeDobbeleer/oh-my-posh3/issues/311

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
