### PR TITLE
docs: adding encoding for Write-PoshTheme to upgrade guide

### DIFF
--- a/docs/docs/upgrading.md
+++ b/docs/docs/upgrading.md
@@ -57,11 +57,11 @@ If you don't remember which one, preview them all and take the one closest to yo
 Get-PoshThemes
 ```
 
-If you see one you like, set it, export its config so you can customize/extend the blocks ans segmnts.
+If you see one you like, set it, then export its config so you can customize/extend the blocks and segments.
 
 ```powershell
 Set-PoshPrompt -Theme jandedobbeleer
-Write-PoshTheme | Out-File -FilePath ~/.go-my-posh.json
+Write-PoshTheme | Out-File -FilePath ~/.go-my-posh.json -Encoding oem
 ```
 
 Adjust the config (`~/.go-my-posh.json`) to your liking by going through the [configuration][configuration] guide.


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines

### Description

Adding encoding to Write-PoshTheme in upgrade guide.
Correcting a couple typos.

https://github.com/JanDeDobbeleer/oh-my-posh3/issues/220#issuecomment-757354071

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
