### PR TITLE
chore: fix type in schema.json for enable_hyperlink

### DIFF
--- a/themes/schema.json
+++ b/themes/schema.json
@@ -946,7 +946,7 @@
                     "default": true
                   },
                   "enable_hyperlink": {
-                    "type": "string",
+                    "type": "boolean",
                     "title": "Enable hyperlink",
                     "description": "Displays an hyperlink for the current path",
                     "default": false


### PR DESCRIPTION
string was set instead of boolean

### Prerequisites

- [ ] I have read and understand the `CONTRIBUTING` guide
- [ ] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Description

[Description of the change]

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
