### PR TITLE
feat: use tilde in console title

### DIFF
--- a/src/console_title.go
+++ b/src/console_title.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"text/template"
 )
 
@@ -39,13 +40,13 @@ func (t *consoleTitle) getConsoleTitle() string {
 	var title string
 	switch t.settings.ConsoleTitleStyle {
 	case FullPath:
-		title = t.env.getcwd()
+		title = t.getPwd()
 	case Template:
 		title = t.getTemplateText()
 	case FolderName:
 		fallthrough
 	default:
-		title = base(t.env.getcwd(), t.env)
+		title = base(t.getPwd(), t.env)
 	}
 	return fmt.Sprintf(t.formats.title, title)
 }
@@ -53,8 +54,8 @@ func (t *consoleTitle) getConsoleTitle() string {
 func (t *consoleTitle) getTemplateText() string {
 	context := &TitleTemplateContext{
 		Root:   t.env.isRunningAsRoot(),
-		Path:   t.env.getcwd(),
-		Folder: base(t.env.getcwd(), t.env),
+		Path:   t.getPwd(),
+		Folder: base(t.getPwd(), t.env),
 		Shell:  t.env.getShellName(),
 	}
 	tmpl, err := template.New("title").Parse(t.settings.ConsoleTitleTemplate)
@@ -68,4 +69,10 @@ func (t *consoleTitle) getTemplateText() string {
 		return incorrectTitleTemplate
 	}
 	return buffer.String()
+}
+
+func (t *consoleTitle) getPwd() string {
+	pwd := t.env.getcwd()
+	pwd = strings.Replace(pwd, t.env.homeDir(), "~", 1)
+	return pwd
 }

--- a/src/console_title_test.go
+++ b/src/console_title_test.go
@@ -16,8 +16,8 @@ func TestGetConsoleTitle(t *testing.T) {
 		ShellName     string
 		Expected      string
 	}{
-		{Style: FolderName, Cwd: "/usr/home", PathSeperator: "/", ShellName: "default", Expected: "\x1b]0;home\a"},
-		{Style: FullPath, Cwd: "/usr/home/jan", PathSeperator: "/", ShellName: "default", Expected: "\x1b]0;/usr/home/jan\a"},
+		{Style: FolderName, Cwd: "/usr/home", PathSeperator: "/", ShellName: "default", Expected: "\x1b]0;~\a"},
+		{Style: FullPath, Cwd: "/usr/home/jan", PathSeperator: "/", ShellName: "default", Expected: "\x1b]0;~/jan\a"},
 		{
 			Style:         Template,
 			Template:      "{{.Path}}{{if .Root}} :: Admin{{end}} :: {{.Shell}}",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] n/a Docs have been added / updated (for bug fixes / features)

### Description

Use tilde for the home directory in console title.

Closes #340 

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
