### PR TITLE
fix: return the right error type from runCommand

### DIFF
--- a/src/environment.go
+++ b/src/environment.go
@@ -170,7 +170,12 @@ func (env *environment) runCommand(command string, args ...string) (string, erro
 	}
 	out, err := exec.Command(command, args...).Output()
 	if err != nil {
-		return "", err
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return "", &commandError{
+				err:      exitErr.Error(),
+				exitCode: exitErr.ExitCode(),
+			}
+		}
 	}
 	return strings.TrimSpace(string(out)), nil
 }

--- a/src/segment_language.go
+++ b/src/segment_language.go
@@ -77,9 +77,10 @@ func (l *language) getVersion() bool {
 		l.exitCode = 0
 		l.version = values["version"]
 	} else {
-		errors.As(err, &exerr)
-		l.exitCode = exerr.exitCode
 		l.version = ""
+		if errors.As(err, &exerr) {
+			l.exitCode = exerr.exitCode
+		}
 	}
 	return true
 }


### PR DESCRIPTION
The error returned by runCommand must be cast to exec.ExitError

### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Description

When calling runCommand, the error returned is of type exitError instead of commandError.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
