### PR TITLE
feat: release notes hyperlink for all languages

### DIFF
--- a/src/segment_dotnet.go
+++ b/src/segment_dotnet.go
@@ -30,7 +30,10 @@ func (d *dotnet) init(props *properties, env environmentInfo) {
 		commands:     []string{"dotnet"},
 		versionParam: "--version",
 		extensions:   []string{"*.cs", "*.vb", "*.sln", "*.csproj", "*.vbproj"},
-		versionRegex: `(?P<version>[0-9]+.[0-9]+.[0-9]+)`,
+		version: &version{
+			regex:       `(?:(?P<version>((?P<major>[0-9]+).(?P<minor>[0-9]+).(?:\d{2})(?P<patch>[0-9]{1}))))`,
+			urlTemplate: "[%1s](https://github.com/dotnet/core/blob/master/release-notes/%[2]s.%[3]s/%[2]s.%[3]s.%[4]s/%[2]s.%[3]s.%[4]s.md)",
+		},
 	}
 }
 

--- a/src/segment_golang.go
+++ b/src/segment_golang.go
@@ -15,7 +15,10 @@ func (g *golang) init(props *properties, env environmentInfo) {
 		commands:     []string{"go"},
 		versionParam: "version",
 		extensions:   []string{"*.go", "go.mod"},
-		versionRegex: `go(?P<version>[0-9]+.[0-9]+.[0-9]+)`,
+		version: &version{
+			regex:       `(?:go(?P<version>((?P<major>[0-9]+).(?P<minor>[0-9]+).(?P<patch>[0-9]+))))`,
+			urlTemplate: "[%s](https://golang.org/doc/go%s.%s)",
+		},
 	}
 }
 

--- a/src/segment_julia.go
+++ b/src/segment_julia.go
@@ -15,7 +15,9 @@ func (j *julia) init(props *properties, env environmentInfo) {
 		commands:     []string{"julia"},
 		versionParam: "--version",
 		extensions:   []string{"*.jl"},
-		versionRegex: `julia version (?P<version>[0-9]+.[0-9]+.[0-9]+)`,
+		version: &version{
+			regex: `julia version (?P<version>[0-9]+.[0-9]+.[0-9]+)`,
+		},
 	}
 }
 

--- a/src/segment_node.go
+++ b/src/segment_node.go
@@ -15,7 +15,10 @@ func (n *node) init(props *properties, env environmentInfo) {
 		commands:     []string{"node"},
 		versionParam: "--version",
 		extensions:   []string{"*.js", "*.ts", "package.json"},
-		versionRegex: `(?P<version>[0-9]+.[0-9]+.[0-9]+)`,
+		version: &version{
+			regex:       `(?:v(?P<version>((?P<major>[0-9]+).(?P<minor>[0-9]+).(?P<patch>[0-9]+))))`,
+			urlTemplate: "[%[1]s](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V%[2]s.md#%[1]s)",
+		},
 	}
 }
 

--- a/src/segment_python.go
+++ b/src/segment_python.go
@@ -32,9 +32,12 @@ func (p *python) init(props *properties, env environmentInfo) {
 		commands:     []string{"python", "python3"},
 		versionParam: "--version",
 		extensions:   []string{"*.py", "*.ipynb", "pyproject.toml", "venv.bak", "venv", ".venv"},
-		versionRegex: `Python (?P<version>[0-9]+.[0-9]+.[0-9]+)`,
 		loadContext:  p.loadContext,
 		inContext:    p.inContext,
+		version: &version{
+			regex:       `(?:Python (?P<version>((?P<major>[0-9]+).(?P<minor>[0-9]+).(?P<patch>[0-9]+))))`,
+			urlTemplate: "[%s](https://www.python.org/downloads/release/python-%s%s%s/)",
+		},
 	}
 }
 


### PR DESCRIPTION
If version enabled and hyperlink enabled(global level), an hyperlink to the release notes of the current version is generated
The regex and the url template can be modified in the json template.

### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

All languages segment will generate an hyperlink pointing to the release notes the current version(if version and hyperlink enabled). 

![temp](https://user-images.githubusercontent.com/1829553/104814166-a4f0dd80-580d-11eb-9191-8746e9b0787a.gif)


[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
