### PR TITLE
docs: remove incorrect information

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -55,8 +55,7 @@ boxes with question marks, [set up your terminal][setupterm] to use a supported 
 - final_space: `boolean` - when true adds a space at the end of the prompt
 - console_title: `boolean` - when true sets the current location as the console title
 - console_title_style: `string` - the title to set in the console - defaults to `folder`
-- console_title_template: `string` - the template to use when `"console_title_style" = "template"` - defaults
-to `{{ .Shell }} in {{ .Folder }}`
+- console_title_template: `string` - the template to use when `"console_title_style" = "template"`
 
 > "I Like The Way You Speak Words" - Gary Goodspeed
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] n/a Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

There is no default for this setting. I thought maybe I broke something, but looking through history, I don't see that there was ever a default here. Removing the incorrect information.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
