### PR TITLE
feat: success/error icon for exit segment

### DIFF
--- a/src/properties.go
+++ b/src/properties.go
@@ -21,6 +21,8 @@ const (
 	IgnoreFolders Property = "ignore_folders"
 	// DisplayVersion show the version number or not
 	DisplayVersion Property = "display_version"
+	// AlwaysEnabled decides whether or not to always display the info
+	AlwaysEnabled Property = "always_enabled"
 )
 
 type properties struct {

--- a/src/segment_exit.go
+++ b/src/segment_exit.go
@@ -10,12 +10,14 @@ type exit struct {
 const (
 	// DisplayExitCode shows or hides the error code
 	DisplayExitCode Property = "display_exit_code"
-	// AlwaysEnabled decides whether or not to always display the exitcode info
-	AlwaysEnabled Property = "always_enabled"
 	// ErrorColor specify a different foreground color for the error text when using always_show = true
 	ErrorColor Property = "error_color"
 	// AlwaysNumeric shows error codes as numbers
 	AlwaysNumeric Property = "always_numeric"
+	// SuccessIcon displays when there's no error and AlwaysEnabled = true
+	SuccessIcon Property = "success_icon"
+	// ErrorIcon displays when there's an error
+	ErrorIcon Property = "error_icon"
 )
 
 func (e *exit) enabled() bool {
@@ -43,7 +45,10 @@ func (e *exit) getFormattedText() string {
 	if e.env.lastErrorCode() != 0 && colorBackground {
 		e.props.background = e.props.getColor(ErrorColor, e.props.background)
 	}
-	return exitCode
+	if e.env.lastErrorCode() == 0 {
+		return e.props.getString(SuccessIcon, "")
+	}
+	return fmt.Sprintf("%s%s", e.props.getString(ErrorIcon, ""), exitCode)
 }
 
 func (e *exit) getMeaningFromExitCode() string {


### PR DESCRIPTION
### Prerequisites

- [ ] I have read and understand the `CONTRIBUTING` guide
- [ ] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Description

[Description of the change]

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
