### PR TITLE
docs: unify language segment docs

### DIFF
--- a/docs/docs/segment-dotnet.md
+++ b/docs/docs/segment-dotnet.md
@@ -6,7 +6,7 @@ sidebar_label: Dotnet
 
 ## What
 
-Display the currently active .NET SDK version.
+Display the currently active .NET SDK version when a folder contains .NET files.
 
 ## Sample Configuration
 
@@ -28,5 +28,8 @@ Display the currently active .NET SDK version.
 - display_version: `boolean` - display the active version or not; useful if all you need is an icon indicating `dotnet`
   is present - defaults to `true`
 - missing_command_text: `string` - text to display when the command is missing - defaults to empty
+- display_mode: `string` - determines when the segment is displayed
+  - `always`: The segment is always displayed
+  - `files`: The segment is only displayed when `*.cs`, `*.vb`, `*.sln`, `*.csproj`, or `*.vbproj` files are present (default)
 - unsupported_version_icon: `string` - text/icon that is displayed when the active .NET SDK version (e.g., one specified
   by `global.json`) is not installed/supported - defaults to `\uf071` (X in a rectangle box)

--- a/docs/docs/segment-golang.md
+++ b/docs/docs/segment-golang.md
@@ -6,7 +6,7 @@ sidebar_label: Golang
 
 ## What
 
-Display the currently active golang version when a folder contains `.go` files.
+Display the currently active golang version when a folder contains golang files.
 
 ## Sample Configuration
 

--- a/docs/docs/segment-julia.md
+++ b/docs/docs/segment-julia.md
@@ -6,7 +6,7 @@ sidebar_label: Julia
 
 ## What
 
-Display the currently active julia version when a folder contains `.jl` files.
+Display the currently active julia version when a folder contains julia files.
 
 ## Sample Configuration
 

--- a/docs/docs/segment-node.md
+++ b/docs/docs/segment-node.md
@@ -6,7 +6,7 @@ sidebar_label: Node
 
 ## What
 
-Display the currently active node version when a folder contains `.js` or `.ts` files.
+Display the currently active node version when a folder contains node files.
 
 ## Sample Configuration
 
@@ -29,4 +29,4 @@ Display the currently active node version when a folder contains `.js` or `.ts` 
 - missing_command_text: `string` - text to display when the command is missing - defaults to empty
 - display_mode: `string` - determines when the segment is displayed
   - `always`: The segment is always displayed
-  - `files`: The segment is only displayed when `*.js`, `*.ts` or package.json files are present (default)
+  - `files`: The segment is only displayed when `*.js`, `*.ts`, or `package.json` files are present (default)

--- a/docs/docs/segment-python.md
+++ b/docs/docs/segment-python.md
@@ -33,6 +33,7 @@ or not - defaults to `true`
 - missing_command_text: `string` - text to display when the command is missing - defaults to empty
 - display_mode: `string` - determines when the segment is displayed
   - `always`: The segment is always displayed
-  - `files`: The segment is only displayed when `*.py` or `*.ipynb` files are present (default)
+  - `files`: The segment is only displayed when `*.py`, `*.ipynb`, `pyproject.toml`, `venv.bak`, `venv`, or `.venv`
+    files are present (default)
   - `environment`: The segment is only displayed when a virtual env is present
   - `context`: The segment is only displayed when either `environment` or `files` is active


### PR DESCRIPTION
### Prerequisites

- [X] I have read and understand the `CONTRIBUTING` guide
- [X] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

### Description

With the unification of how `language` segments are handled, the `dotnet` segment docs didn't get updated to include the `display_mode` property. While fixing that, I noticed some other minor inconsistencies in language segment docs that I fixed:

- Instead of duplicating the list of file extensions for which a segment will appear, standardized on a more general statement in the document "What" section and included the full list of file extensions/names for the segment in the "Properties" description.
- Updated the list of extensions for segments where that changed so the docs match what's happening in the code.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
