### PR TITLE
refactor: allow color overrides in git status icons

### DIFF
--- a/src/segment_git.go
+++ b/src/segment_git.go
@@ -27,7 +27,7 @@ type gitStatus struct {
 	changed   bool
 }
 
-func (s *gitStatus) string(prefix, color string) string {
+func (s *gitStatus) string() string {
 	var status string
 	stringIfValue := func(value int, prefix string) string {
 		if value > 0 {
@@ -40,9 +40,6 @@ func (s *gitStatus) string(prefix, color string) string {
 	status += stringIfValue(s.deleted, "-")
 	status += stringIfValue(s.untracked, "?")
 	status += stringIfValue(s.unmerged, "x")
-	if status != "" {
-		return fmt.Sprintf("<%s>%s%s</>", color, prefix, status)
-	}
 	return status
 }
 
@@ -193,9 +190,19 @@ func (g *git) getStatusDetailString(status *gitStatus, color, icon Property, def
 	prefix := g.props.getString(icon, defaultIcon)
 	foregroundColor := g.props.getColor(color, g.props.foreground)
 	if !g.props.getBool(DisplayStatusDetail, true) {
-		return fmt.Sprintf("<%s>%s</>", foregroundColor, prefix)
+		return g.colorStatusString(prefix, "", foregroundColor)
 	}
-	return status.string(prefix, foregroundColor)
+	return g.colorStatusString(prefix, status.string(), foregroundColor)
+}
+
+func (g *git) colorStatusString(prefix, status, color string) string {
+	if color == g.props.foreground {
+		return fmt.Sprintf("%s%s", prefix, status)
+	}
+	if strings.Contains(prefix, "</>") {
+		return fmt.Sprintf("%s<%s>%s</>", prefix, color, status)
+	}
+	return fmt.Sprintf("<%s>%s%s</>", color, prefix, status)
 }
 
 func (g *git) getUpstreamSymbol() string {

--- a/src/segment_git_test.go
+++ b/src/segment_git_test.go
@@ -309,26 +309,26 @@ func TestParseGitBranchInfoRemoteGone(t *testing.T) {
 }
 
 func TestGitStatusUnmerged(t *testing.T) {
-	expected := "<#123456>working: x1</>"
+	expected := " x1"
 	status := &gitStatus{
 		unmerged: 1,
 	}
-	assert.Equal(t, expected, status.string("working:", "#123456"))
+	assert.Equal(t, expected, status.string())
 }
 
 func TestGitStatusUnmergedModified(t *testing.T) {
-	expected := "<#123456>working: ~3 x1</>"
+	expected := " ~3 x1"
 	status := &gitStatus{
 		unmerged: 1,
 		modified: 3,
 	}
-	assert.Equal(t, expected, status.string("working:", "#123456"))
+	assert.Equal(t, expected, status.string())
 }
 
 func TestGitStatusEmpty(t *testing.T) {
 	expected := ""
 	status := &gitStatus{}
-	assert.Equal(t, expected, status.string("working:", "#123456"))
+	assert.Equal(t, expected, status.string())
 }
 
 func TestParseGitStatsWorking(t *testing.T) {
@@ -601,7 +601,7 @@ func TestSetStatusColorForeground(t *testing.T) {
 }
 
 func TestGetStatusDetailStringDefault(t *testing.T) {
-	expected := "<#111111>icon +1</>"
+	expected := "icon +1"
 	status := &gitStatus{
 		changed: true,
 		added:   1,
@@ -614,8 +614,61 @@ func TestGetStatusDetailStringDefault(t *testing.T) {
 	assert.Equal(t, expected, g.getStatusDetailString(status, WorkingColor, LocalWorkingIcon, "icon"))
 }
 
+func TestGetStatusDetailStringDefaultColorOverride(t *testing.T) {
+	expected := "<#123456>icon +1</>"
+	status := &gitStatus{
+		changed: true,
+		added:   1,
+	}
+	g := &git{
+		props: &properties{
+			values: map[Property]interface{}{
+				WorkingColor: "#123456",
+			},
+			foreground: "#111111",
+		},
+	}
+	assert.Equal(t, expected, g.getStatusDetailString(status, WorkingColor, LocalWorkingIcon, "icon"))
+}
+
+func TestGetStatusDetailStringDefaultColorOverrideAndIconColorOverride(t *testing.T) {
+	expected := "<#789123>work</><#123456> +1</>"
+	status := &gitStatus{
+		changed: true,
+		added:   1,
+	}
+	g := &git{
+		props: &properties{
+			values: map[Property]interface{}{
+				WorkingColor:     "#123456",
+				LocalWorkingIcon: "<#789123>work</>",
+			},
+			foreground: "#111111",
+		},
+	}
+	assert.Equal(t, expected, g.getStatusDetailString(status, WorkingColor, LocalWorkingIcon, "icon"))
+}
+
+func TestGetStatusDetailStringDefaultColorOverrideNoIconColorOverride(t *testing.T) {
+	expected := "<#123456>work +1</>"
+	status := &gitStatus{
+		changed: true,
+		added:   1,
+	}
+	g := &git{
+		props: &properties{
+			values: map[Property]interface{}{
+				WorkingColor:     "#123456",
+				LocalWorkingIcon: "work",
+			},
+			foreground: "#111111",
+		},
+	}
+	assert.Equal(t, expected, g.getStatusDetailString(status, WorkingColor, LocalWorkingIcon, "icon"))
+}
+
 func TestGetStatusDetailStringNoStatus(t *testing.T) {
-	expected := "<#111111>icon</>"
+	expected := "icon"
 	status := &gitStatus{
 		changed: true,
 		added:   1,
@@ -647,4 +700,19 @@ func TestGetStatusDetailStringNoStatusColorOverride(t *testing.T) {
 		},
 	}
 	assert.Equal(t, expected, g.getStatusDetailString(status, WorkingColor, LocalWorkingIcon, "icon"))
+}
+
+func TestGitOutPut(t *testing.T) {
+	g := &git{
+		env: &environment{},
+		props: &properties{
+			values: map[Property]interface{}{
+				LocalWorkingIcon: "<#88C0D0>\u21e1 </>",
+			},
+			foreground: "#111111",
+		},
+	}
+	assert.True(t, g.enabled())
+	value := g.string()
+	assert.NotEmpty(t, value)
 }


### PR DESCRIPTION
### Prerequisites

- [ ] I have read and understand the `CONTRIBUTING` guide
- [ ] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Description

[Description of the change]

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
