### PR TITLE
feat: add the User and Host properties to the console title template.

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -76,6 +76,8 @@ properties to work with.
 - `.Path`: `string` - the current working directory
 - `.Folder`: `string` - the current working folder
 - `.Shell`: `string` - the current shell name
+- `.User`: `string` - the current user name
+- `.Host`: `string` - the host name
 - `.Env.VarName`: `string` - Any environment variable where `VarName` is the environment variable name
 
 A `boolean` can be used for conditional display purposes, a `string` can be displayed.
@@ -91,6 +93,7 @@ the current working directory is `/usr/home/omp` and the shell is `zsh`.
     // when root == true: omp :: root :: zsh
     "console_title_template": "{{.Folder}}", // outputs: omp
     "console_title_template": "{{.Shell}} in {{.Path}}", // outputs: zsh in /usr/home/omp
+    "console_title_template": "{{.User}}@{{.Host}} {{.Shell}} in {{.Path}}", // outputs: MyUser@MyMachine zsh in /usr/home/omp
     "console_title_template": "{{.Env.USERDOMAIN}} {{.Shell}} in {{.Path}}", // outputs: MyCompany zsh in /usr/home/omp
 }
 ```

--- a/src/console_title.go
+++ b/src/console_title.go
@@ -50,6 +50,11 @@ func (t *consoleTitle) getTemplateText() string {
 	context["Path"] = t.getPwd()
 	context["Folder"] = base(t.getPwd(), t.env)
 	context["Shell"] = t.env.getShellName()
+	context["User"] = t.env.getCurrentUser()
+	context["Host"] = ""
+	if host, err := t.env.getHostName(); err == nil {
+		context["Host"] = host
+	}
 
 	// load environment variables into the map
 	envVars := map[string]string{}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

This pull request adds the User and Host to the console title template so we can make a cross-platform configuration.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
