### PR TITLE
fix: theme completion

### DIFF
--- a/packages/powershell/oh-my-posh/oh-my-posh.psm1
+++ b/packages/powershell/oh-my-posh/oh-my-posh.psm1
@@ -123,7 +123,7 @@ function ThemeCompletion {
     )
     $themes = Get-ChildItem -Path "$PSScriptRoot\themes\*" -Include '*.omp.json' | Sort-Object Name | Select-Object -Property @{
         label='BaseName'
-        expression={$_.BaseName.TrimEnd(".omp")}
+        expression={$_.BaseName.Replace('.omp', '')}
     }
     $themes |
     Where-Object { $_.BaseName.ToLower().StartsWith($wordToComplete.ToLower()); } |


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] n/a Tests for the changes have been added (for bug fixes / features)
- [ ] n/a Docs have been added / updated (for bug fixes / features)

### Description
Fix autocomplete for the powershell command `Set-PoshPrompt -Theme `

Closes #381

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
