### PR TITLE
feat: added Mixed path option - displays the path if it's short enough.

### DIFF
--- a/docs/docs/segment-path.md
+++ b/docs/docs/segment-path.md
@@ -38,6 +38,8 @@ is set to `true`)
 - mapped_locations_enabled: `boolean` - replace known locations in the path with the replacements before applying the
 style. defaults to `true`
 - enable_hyperlink: `boolean` - displays an hyperlink for the path - defaults to `false`
+- mixed_threshold: `number` - the maximum length of a path segment that will be displayed when using `Mixed` -
+  defaults to `4`
 
 ## Style
 
@@ -48,6 +50,7 @@ Style sets the way the path is displayed. Based on previous experience and popul
 - agnoster_short
 - full
 - folder
+- mixed
 
 ### Agnoster
 
@@ -70,3 +73,8 @@ Display `$PWD` as a string.
 ### Folder
 
 Display the name of the current folder.
+
+### Mixed
+
+Works like `Agnoster Full`, but for any middle folder short enough it will display its name instead. The maximum length
+for the folders to display is governed by the `mixed_threshold` property.

--- a/src/segment_path.go
+++ b/src/segment_path.go
@@ -33,6 +33,10 @@ const (
 	Full string = "full"
 	// Folder displays the current folder
 	Folder string = "folder"
+	// Mixed like agnoster, but if the path is short it displays it
+	Mixed string = "mixed"
+	// MixedThreshold the threshold of the length of the path Mixed will display
+	MixedThreshold Property = "mixed_threshold"
 	// MappedLocations allows overriding certain location with an icon
 	MappedLocations Property = "mapped_locations"
 	// MappedLocationsEnabled enables overriding certain locations with an icon
@@ -53,6 +57,8 @@ func (pt *path) string() string {
 		formattedPath = pt.getAgnosterFullPath()
 	case AgnosterShort:
 		formattedPath = pt.getAgnosterShortPath()
+	case Mixed:
+		formattedPath = pt.getMixedPath()
 	case Short:
 		// "short" is a duplicate of "full", just here for backwards compatibility
 		fallthrough
@@ -78,6 +84,30 @@ func (pt *path) string() string {
 func (pt *path) init(props *properties, env environmentInfo) {
 	pt.props = props
 	pt.env = env
+}
+
+func (pt *path) getMixedPath() string {
+	var buffer strings.Builder
+	pwd := pt.getPwd()
+	splitted := strings.Split(pwd, pt.env.getPathSeperator())
+	threshold := int(pt.props.getFloat64(MixedThreshold, 4))
+	for i, part := range splitted {
+		if part == "" {
+			continue
+		}
+
+		folder := part
+		if len(part) > threshold && i != 0 && i != len(splitted)-1 {
+			folder = pt.props.getString(FolderIcon, "..")
+		}
+		separator := pt.props.getString(FolderSeparatorIcon, pt.env.getPathSeperator())
+		if i == 0 {
+			separator = ""
+		}
+		buffer.WriteString(fmt.Sprintf("%s%s", separator, folder))
+	}
+
+	return buffer.String()
 }
 
 func (pt *path) getAgnosterPath() string {

--- a/src/segment_path_test.go
+++ b/src/segment_path_test.go
@@ -280,6 +280,9 @@ func TestAgnosterPathStyles(t *testing.T) {
 
 		{Style: AgnosterFull, Expected: "PSDRIVE: | src", HomePath: homeBillWindows, Pwd: "/foo", Pswd: "PSDRIVE:/src", PathSeperator: "/", FolderSeparatorIcon: " | "},
 		{Style: AgnosterShort, Expected: "PSDRIVE: | .. | init", HomePath: homeBillWindows, Pwd: "/foo", Pswd: "PSDRIVE:/src/init", PathSeperator: "/", FolderSeparatorIcon: " | "},
+
+		{Style: Mixed, Expected: "~ > .. > man", HomePath: "/usr/home", Pwd: "/usr/home/whatever/man", PathSeperator: "/", FolderSeparatorIcon: " > "},
+		{Style: Mixed, Expected: "~ > ab > .. > man", HomePath: "/usr/home", Pwd: "/usr/home/ab/whatever/man", PathSeperator: "/", FolderSeparatorIcon: " > "},
 	}
 	for _, tc := range cases {
 		env := new(MockedEnvironment)


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

I was tired of having short folders being abbreviated.
If the name of the folder is "src" for example, that would take the same amount of space as the seperator, so it might as well display it.

So I made this for myself, but I might as well contribute if you think it's a worthwhile feature.
