### PR TITLE
feat: kubectl namespace

### DIFF
--- a/docs/docs/segment-kubectl.md
+++ b/docs/docs/segment-kubectl.md
@@ -6,7 +6,7 @@ sidebar_label: Kubectl
 
 ## What
 
-Display the currently active Kubernetes context name.
+Display the currently active Kubernetes context name and namespace name.
 
 ## Sample Configuration
 
@@ -18,7 +18,27 @@ Display the currently active Kubernetes context name.
   "foreground": "#000000",
   "background": "#ebcc34",
   "properties": {
-    "prefix": " \uFD31 "
+    "prefix": " \uFD31 ",
+    "template": "{{.Context}}{{if .Namespace}} :: {{.Namespace}}{{end}}"
   }
 }
 ```
+
+## Properties
+
+- template: `string` - A go [text/template][go-text-template] template utilizing the properties below.
+Defaults to `{{.Context}}{{if .Namespace}} :: {{.Namespace}}{{end}}`
+
+## Template Properties
+
+- `.Context`: `string` - the current kubectl context
+- `.Namespace`: `string` - the current kubectl namespace
+
+## Tips
+
+It is common for the Kubernetes "default" namespace to be used when no namespace is provided. If you want your prompt to
+ render an empty current namespace using the word "default", you can use something like this for the template:
+
+`{{.Context}} :: {{if .Namespace}}{{.Namespace}}{{else}}default{{end}}`
+
+[go-text-template]: https://golang.org/pkg/text/template/

--- a/src/segment_kubectl.go
+++ b/src/segment_kubectl.go
@@ -1,13 +1,23 @@
 package main
 
+import (
+	"strings"
+)
+
 type kubectl struct {
-	props       *properties
-	env         environmentInfo
-	contextName string
+	props     *properties
+	env       environmentInfo
+	Context   string
+	Namespace string
 }
 
 func (k *kubectl) string() string {
-	return k.contextName
+	segmentTemplate := k.props.getString(SegmentTemplate, "{{.Context}}{{if .Namespace}} :: {{.Namespace}}{{end}}")
+	template := &textTemplate{
+		Template: segmentTemplate,
+		Context:  k,
+	}
+	return template.render()
 }
 
 func (k *kubectl) init(props *properties, env environmentInfo) {
@@ -20,6 +30,15 @@ func (k *kubectl) enabled() bool {
 	if !k.env.hasCommand(cmd) {
 		return false
 	}
-	k.contextName, _ = k.env.runCommand(cmd, "config", "current-context")
-	return k.contextName != ""
+	result, err := k.env.runCommand(cmd, "config", "view", "--minify", "--output", "jsonpath={..current-context},{..namespace}")
+	if err != nil {
+		k.Context = "KUBECTL ERR"
+		k.Namespace = k.Context
+		return true
+	}
+
+	values := strings.Split(result, ",")
+	k.Context = values[0]
+	k.Namespace = values[1]
+	return k.Context != ""
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

Add support for displaying the current namespace in the Kubectl segment.

Closes #392 

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
