### PR TITLE
feat: add display_error to kubectl

### DIFF
--- a/docs/docs/segment-kubectl.md
+++ b/docs/docs/segment-kubectl.md
@@ -28,6 +28,7 @@ Display the currently active Kubernetes context name and namespace name.
 
 - template: `string` - A go [text/template][go-text-template] template extended with [sprig][sprig] utilizing the
 properties below. Defaults to `{{.Context}}{{if .Namespace}} :: {{.Namespace}}{{end}}`
+- display_error: `boolean` - show the error context when failing to retrieve the kubectl information - defaults to `false`
 
 ## Template Properties
 

--- a/src/properties.go
+++ b/src/properties.go
@@ -25,6 +25,8 @@ const (
 	AlwaysEnabled Property = "always_enabled"
 	// SegmentTemplate is the template to use to render the information
 	SegmentTemplate Property = "template"
+	// DisplayError to display when an error occurs or not
+	DisplayError Property = "display_error"
 )
 
 type properties struct {

--- a/src/segment_battery.go
+++ b/src/segment_battery.go
@@ -16,8 +16,6 @@ type batt struct {
 const (
 	// BatteryIcon to display in front of the battery
 	BatteryIcon Property = "battery_icon"
-	// DisplayError to display when an error occurs or not
-	DisplayError Property = "display_error"
 	// ChargingIcon to display when charging
 	ChargingIcon Property = "charging_icon"
 	// DischargingIcon o display when discharging

--- a/src/segment_kubectl.go
+++ b/src/segment_kubectl.go
@@ -31,10 +31,14 @@ func (k *kubectl) enabled() bool {
 		return false
 	}
 	result, err := k.env.runCommand(cmd, "config", "view", "--minify", "--output", "jsonpath={..current-context},{..namespace}")
-	if err != nil {
+	displayError := k.props.getBool(DisplayError, false)
+	if err != nil && displayError {
 		k.Context = "KUBECTL ERR"
 		k.Namespace = k.Context
 		return true
+	}
+	if err != nil {
+		return false
 	}
 
 	values := strings.Split(result, ",")

--- a/src/segment_kubectl_test.go
+++ b/src/segment_kubectl_test.go
@@ -10,6 +10,7 @@ type kubectlArgs struct {
 	kubectlExists bool
 	kubectlErr    bool
 	template      string
+	displayError  bool
 	context       string
 	namespace     string
 }
@@ -31,6 +32,7 @@ func bootStrapKubectlTest(args *kubectlArgs) *kubectl {
 		props: &properties{
 			values: map[Property]interface{}{
 				SegmentTemplate: args.template,
+				DisplayError:    args.displayError,
 			},
 		},
 	}
@@ -42,6 +44,7 @@ func TestKubectlSegment(t *testing.T) {
 	cases := []struct {
 		Case            string
 		Template        string
+		DisplayError    bool
 		KubectlExists   bool
 		Context         string
 		Namespace       string
@@ -52,14 +55,17 @@ func TestKubectlSegment(t *testing.T) {
 		{Case: "disabled", Template: standardTemplate, KubectlExists: false, Context: "aaa", Namespace: "bbb", ExpectedString: "", ExpectedEnabled: false},
 		{Case: "normal", Template: standardTemplate, KubectlExists: true, Context: "aaa", Namespace: "bbb", ExpectedString: "aaa :: bbb", ExpectedEnabled: true},
 		{Case: "no namespace", Template: standardTemplate, KubectlExists: true, Context: "aaa", Namespace: "", ExpectedString: "aaa", ExpectedEnabled: true},
-		{Case: "kubectl error", Template: standardTemplate, KubectlExists: true, Context: "aaa", Namespace: "bbb", KubectlErr: true,
+		{Case: "kubectl error", Template: standardTemplate, DisplayError: true, KubectlExists: true, Context: "aaa", Namespace: "bbb", KubectlErr: true,
 			ExpectedString: "KUBECTL ERR :: KUBECTL ERR", ExpectedEnabled: true},
+		{Case: "kubectl error hidden", Template: standardTemplate, DisplayError: false, KubectlExists: true, Context: "aaa", Namespace: "bbb", KubectlErr: true,
+			ExpectedString: "", ExpectedEnabled: false},
 	}
 
 	for _, tc := range cases {
 		args := &kubectlArgs{
 			kubectlExists: tc.KubectlExists,
 			template:      tc.Template,
+			displayError:  tc.DisplayError,
 			context:       tc.Context,
 			namespace:     tc.Namespace,
 			kubectlErr:    tc.KubectlErr,

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -718,6 +718,12 @@
                 "properties": {
                   "template": {
                     "$ref": "#/definitions/template"
+                  },
+                  "display_error": {
+                    "type": "boolean",
+                    "title": "Display Error",
+                    "description": "Show the error context when failing to retrieve the kubectl information",
+                    "default": false
                   }
                 }
               }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

Add `display_error` property to the kubectl segment.

Closes #400 

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
