### PR TITLE
chore: add color format to schema

### DIFF
--- a/themes/schema.json
+++ b/themes/schema.json
@@ -9,7 +9,8 @@
       "type": "string",
       "pattern": "^(#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})|black|red|green|yellow|blue|magenta|cyan|white|default|darkGray|lightRed|lightGreen|lightYellow|lightBlue|lightMagenta|lightCyan|lightWhite|transparent)$",
       "title": "Color string",
-      "description": "https://ohmyposh.dev/docs/configure#colors"
+      "description": "https://ohmyposh.dev/docs/configure#colors",
+      "format": "color"
     },
     "color_templates": {
       "type": "array",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Description

This sets the format to color which allows vscode to show previews and the color picker. This doesn't effect the values you can use, it just tells vscode to show previews if you're using a hex value.

ref: https://github.com/microsoft/vscode/issues/34663#issuecomment-331126791 and https://github.com/microsoft/vscode/issues/34663#issuecomment-331818604

![image](https://user-images.githubusercontent.com/831974/108674912-06166b80-74b4-11eb-93e4-7082bc4312b4.png)

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
