### PR TITLE
fix(session): use DefaultUserName

### DIFF
--- a/src/segment_session.go
+++ b/src/segment_session.go
@@ -51,7 +51,7 @@ func (s *session) enabled() bool {
 		return len(s.templateText) > 0
 	}
 	showDefaultUser := s.props.getBool(DisplayDefault, true)
-	if !showDefaultUser && defaultUser == s.UserName {
+	if !showDefaultUser && s.DefaultUserName == s.UserName {
 		return false
 	}
 	return true


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

since all segments are in the same folder, the constant `defaultUser=default` from AWS segment had leaked into session segment.
https://github.com/JanDeDobbeleer/oh-my-posh/blob/7377f31d70bf42c4e738e229e0f39b036c9f57c6/src/segment_aws.go#L15-L17

Perhaps the segments could benefit from being isolated into folders to avoid sharing each others code.

fixes #453 

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
