### PR TITLE
fix: missing mixed in path style enum

### DIFF
--- a/themes/schema.json
+++ b/themes/schema.json
@@ -1007,7 +1007,8 @@
                       "agnoster_short",
                       "short",
                       "full",
-                      "folder"
+                      "folder",
+                      "mixed"
                     ],
                     "default": "folder"
                   },


### PR DESCRIPTION
missing mixed in path style enum.

### Prerequisites

- [ ] I have read and understand the `CONTRIBUTING` guide
- [ ] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Description

[Description of the change]

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
