### PR TITLE
feat: use RWMutex for map access

### DIFF
--- a/src/environment.go
+++ b/src/environment.go
@@ -68,7 +68,7 @@ type environmentInfo interface {
 
 type commandCache struct {
 	commands map[string]string
-	lock     sync.Mutex
+	lock     sync.RWMutex
 }
 
 func (c *commandCache) set(command, path string) {
@@ -78,8 +78,8 @@ func (c *commandCache) set(command, path string) {
 }
 
 func (c *commandCache) get(command string) (string, bool) {
-	c.lock.Lock()
-	defer c.lock.Unlock()
+	c.lock.RLock()
+	defer c.lock.RUnlock()
 	if cmd, ok := c.commands[command]; ok {
 		command = cmd
 		return command, true
@@ -97,7 +97,7 @@ func (env *environment) init(args *args) {
 	env.args = args
 	cmdCache := &commandCache{
 		commands: make(map[string]string),
-		lock:     sync.Mutex{},
+		lock:     sync.RWMutex{},
 	}
 	env.cmdCache = cmdCache
 }

--- a/src/regex.go
+++ b/src/regex.go
@@ -7,12 +7,14 @@ import (
 
 var (
 	regexCache     map[string]*regexp.Regexp = make(map[string]*regexp.Regexp)
-	regexCacheLock                           = sync.Mutex{}
+	regexCacheLock                           = sync.RWMutex{}
 )
 
 func getCompiledRegex(pattern string) *regexp.Regexp {
 	// try in cache first
+	regexCacheLock.RLock()
 	re := regexCache[pattern]
+	regexCacheLock.RUnlock()
 	if re != nil {
 		return re
 	}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [ ] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Description

Small improvement on concurrent map access: since a map supports multiple readers and one write, we can use a RWMutex instead of a plain Mutex.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
