### PR TITLE
fix: powershell exports config files as utf8 without BOM

### DIFF
--- a/packages/powershell/oh-my-posh/oh-my-posh.psm1
+++ b/packages/powershell/oh-my-posh/oh-my-posh.psm1
@@ -89,10 +89,15 @@ function Export-PoshTheme {
 
     $config = $global:PoshSettings.Theme
     $poshCommand = Get-PoshCommand
-    # Save current encoding and swap for UTF8
+
+    # Save current encoding and swap for UTF8 without BOM
     $originalOutputEncoding = [Console]::OutputEncoding
-    [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
-    & $poshCommand -config $config -print-config | Out-File -FilePath $FilePath
+    [Console]::OutputEncoding = [Text.UTF8Encoding]::new($false)
+
+    # Create Config File
+    $configString = & $poshCommand -config $config -print-config
+    [IO.File]::WriteAllLines($FilePath, $configString)
+
     # Restore initial encoding
     [Console]::OutputEncoding = $originalOutputEncoding
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Description

Corrected how Export-PoshTheme outputs files, corrects #452 

Tested and worked on;
PowerShell 5.1 on Windows 10
PowerShell 7.0 on Debian 10

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
