### PR TITLE
feat(git): only show HEAD context on display_status=false

### DIFF
--- a/src/segment_git_test.go
+++ b/src/segment_git_test.go
@@ -104,6 +104,7 @@ func setupHEADContextEnv(context *detachedContext) *git {
 	env.mockGitCommand(context.tagName, "describe", "--tags", "--exact-match")
 	env.mockGitCommand(context.origin, "name-rev", "--name-only", "--exclude=tags/*", context.origin)
 	env.mockGitCommand(context.onto, "name-rev", "--name-only", "--exclude=tags/*", context.onto)
+	env.mockGitCommand(context.branchName, "branch", "--show-current")
 	env.On("getRuntimeGOOS", nil).Return("unix")
 	g := &git{
 		env: env,


### PR DESCRIPTION
### Prerequisites

- [ ] I have read and understand the `CONTRIBUTING` guide
- [ ] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Description

[Description of the change]

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
