### PR TITLE
docs: instructions to set font in Windows Terminal

### DIFF
--- a/docs/docs/installation.mdx
+++ b/docs/docs/installation.mdx
@@ -54,6 +54,22 @@ Oh my Posh was designed using [Meslo LGM NF][meslo], but any Nerd Font should be
 Make sure to install fonts system wide to avoid seeing rectangles in your terminal. See this [thread][font-thread] for more context.
 :::
 
+:::caution Setting the default font in the Windows Terminal
+Once you have installed a powerline enabled font, don't forget to tell the Windows Terminal to use it. This can be easily done by modifying the Windows Terminal settings (default shortcut: `CTRL + ,`). In your `settings.json` file, add the `fontFace` attribute under the `defaults` attribute in `profiles`:
+
+```json
+{
+    "profiles":
+    {
+        "defaults":
+        {
+            "fontFace": "MesloLGL Nerd Font"
+        }
+    }
+}            
+```
+:::
+
 ### 2. Install Oh my Posh
 
 <Tabs


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

Hope these instructions will save some time for people (like me) who installed the font, but still had weird rectangles instead of fancy icons, because Windows Terminal was not yet using the font ...

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
