### PR TITLE
docs: move fonts to its own page

### DIFF
--- a/docs/docs/fonts.md
+++ b/docs/docs/fonts.md
@@ -1,0 +1,47 @@
+---
+id: fonts
+title: Fonts
+sidebar_label: 🆎 Fonts
+---
+
+### Nerd Fonts
+
+Oh my Posh was designed to use [Nerd Fonts][nerdfonts]. Nerd Fonts are popular fonts that are patched to include icons.
+We recommend [Meslo LGM NF][meslo], but any Nerd Font should be compatible with the standard [themes][themes].
+
+To see the icons displayed in Oh my Posh, **install** a [Nerd Font][nerdfonts], and **configure** your terminal to use it.
+
+#### Windows
+
+Download your chosen Nerd Font, and install the font system-wide. See this [thread][font-thread] for more context.
+
+#### Windows Terminal
+
+Once you have installed a Nerd Font, you will need to configure the Windows Terminal to use it. This can be easily done
+by modifying the Windows Terminal settings (default shortcut: `CTRL + ,`). In your `settings.json` file, add the
+`fontFace` attribute under the `defaults` attribute in `profiles`:
+
+```json
+{
+    "profiles":
+    {
+        "defaults":
+        {
+            "fontFace": "MesloLGM NF"
+        }
+    }
+}
+```
+
+### Other Fonts
+
+If you are not interested in using a Nerd Font, you will want to use a theme which doesn't include any Nerd Font icons.
+The `minimal` themes do not make use of Nerd Font icons.
+
+[Creating your own theme][configuration] is always an option too 😊
+
+[nerdfonts]: https://www.nerdfonts.com/
+[meslo]: https://github.com/ryanoasis/nerd-fonts/releases/download/v2.1.0/Meslo.zip
+[themes]: https://github.com/JanDeDobbeleer/oh-my-posh/tree/main/themes
+[font-thread]: https://github.com/JanDeDobbeleer/oh-my-posh/issues/145#issuecomment-730162622
+[configuration]: /docs/configure

--- a/docs/docs/installation.mdx
+++ b/docs/docs/installation.mdx
@@ -43,33 +43,6 @@ but you may have to set the environment variable `$TERM` to `xterm-256color` for
 </TabItem>
 </Tabs>
 
-#### Font
-
-To see the icons displayed in Oh my Posh, **install** and **configure** your terminal to use a powerline enabled font.
-The fonts we use are patched by [Nerd Fonts][nerdfonts], which offer a maximum of icons you can use.
-
-Oh my Posh was designed using [Meslo LGM NF][meslo], but any Nerd Font should be compatible with the standard [themes][themes].
-
-:::caution Windows fonts
-Make sure to install fonts system wide to avoid seeing rectangles in your terminal. See this [thread][font-thread] for more context.
-:::
-
-:::caution Setting the default font in the Windows Terminal
-Once you have installed a powerline enabled font, don't forget to tell the Windows Terminal to use it. This can be easily done by modifying the Windows Terminal settings (default shortcut: `CTRL + ,`). In your `settings.json` file, add the `fontFace` attribute under the `defaults` attribute in `profiles`:
-
-```json
-{
-    "profiles":
-    {
-        "defaults":
-        {
-            "fontFace": "MesloLGL Nerd Font"
-        }
-    }
-}            
-```
-:::
-
 ### 2. Install Oh my Posh
 
 <Tabs
@@ -475,13 +448,7 @@ oh-my-posh --config ~/.mytheme.omp.json
 [scoop]: https://scoop.sh/
 [wt]: https://github.com/microsoft/terminal
 [iterm2]: https://www.iterm2.com/
-[nerdfonts]: https://www.nerdfonts.com/
-[nf-cheat]: https://www.nerdfonts.com/cheat-sheet
-[meslo]: https://github.com/ryanoasis/nerd-fonts/releases/download/v2.1.0/Meslo.zip
-[font-thread]: https://github.com/JanDeDobbeleer/oh-my-posh/issues/145#issuecomment-730162622
 [powershell]: https://www.powershellgallery.com/packages/oh-my-posh
-[themes]: https://github.com/JanDeDobbeleer/oh-my-posh/tree/main/themes
-[scoop]: https://scoop.sh
 [brew]: https://brew.sh
 [prompt]: /docs/installation#3-replace-your-existing-prompt
 [configuration]: /docs/configure

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -3,7 +3,7 @@ module.exports = {
     {
       type: "category",
       label: "Getting Started",
-      items: ["introduction", "upgrading", "installation", "configure", "themes"],
+      items: ["introduction", "upgrading", "installation", "configure", "themes", "fonts"],
     },
     {
       type: "category",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] n/a Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

Font-related issues are some of the most common issues that get posted. By bringing Fonts to it's own page in the docs, I'm hoping to improve the discoverability of this information so that users are able to have a smoother setup process.

Being on it's own page also affords us a bit more space to explain things like the "minimal" convention if users really don't want to use a Nerd Font.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
