### PR TITLE
docs: add info for the themes page

### DIFF
--- a/docs/docs/themes.md
+++ b/docs/docs/themes.md
@@ -4,6 +4,18 @@ title: Themes
 sidebar_label: 🎨 Themes
 ---
 
+Oh my Posh comes with many themes included out of the box. Below are some screenshots of the more common themes.
+For the full updated list of themes, [view the themes][themes] in Github.  If you are using PowerShell, you can
+display every available theme, use the following PowerShell cmdlet.
+
+```powershell
+Get-PoshThemes
+```
+
+Once you're ready to swap to a theme, follow the steps described in [🚀Installation/Replace your existing prompt][replace-you-existing-prompt].
+
+Themes with `minimal` in their names do not require a Nerd Font. Read about [🆎Fonts][fonts] for more information.
+
 ### [Agnoster]
 
 [![Agnoster](/img/themes/agnoster.png)][Agnoster]
@@ -79,6 +91,10 @@ sidebar_label: 🎨 Themes
 ### [Zash]
 
 [![Zash](/img/themes/zash.png)][Zash]
+
+[themes]: https://github.com/JanDeDobbeleer/oh-my-posh/tree/main/themes
+[fonts]: /docs/fonts
+[replace-you-existing-prompt]: /docs/installation#3-replace-your-existing-prompt
 
 [Agnoster]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/themes/agnoster.omp.json 'Agnoster'
 [AgnosterPlus]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/themes/agnosterplus.omp.json 'AgnosterPlus'

--- a/packages/powershell/oh-my-posh/oh-my-posh.psm1
+++ b/packages/powershell/oh-my-posh/oh-my-posh.psm1
@@ -76,13 +76,17 @@ function Get-PoshThemes {
     Write-Host $logo
     $poshCommand = Get-PoshCommand
     Get-ChildItem -Path "$PSScriptRoot\themes\*" -Include '*.omp.json' | Sort-Object Name | ForEach-Object -Process {
-        Write-Host ("=" * $consoleWidth)
-        Write-Host "$esc[1m$($_.BaseName)$esc[0m"
+        Write-Host ("─" * $consoleWidth)
+        Write-Host "Theme: $esc[1m$($_.BaseName.Replace('.omp', ''))$esc[0m"
         Write-Host ""
         & $poshCommand -config $($_.FullName) -pwd $PWD
         Write-Host ""
     }
-    Write-Host ("=" * $consoleWidth)
+    Write-Host ("─" * $consoleWidth)
+    Write-Host ""
+    Write-Host "To change your theme, use the Set-PoshPrompt command. Example:"
+    Write-Host "  Set-PoshPrompt -Theme jandedobbeleer"
+    Write-Host ""
 }
 
 function Export-PoshTheme {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] n/a Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

- Docs:
    - Add some information to the [Themes page](https://ohmyposh.dev/docs/themes)

- Get-PoshThemes powershell command:
    - Change the borders to an ascii box drawing character, for a cleaner look
    - Add "Theme: " label to the theme names to make the information easier to process
    - Remove `.omp` from the theme names because it's not needed for `Set-PoshPrompt`
    - Add some information about how to change your theme

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
