### PR TITLE
fix(git): StatusColors without DisplayStatus

### DIFF
--- a/src/segment_git.go
+++ b/src/segment_git.go
@@ -139,11 +139,18 @@ func (g *git) enabled() bool {
 }
 
 func (g *git) string() string {
+	statusColorsEnabled := g.props.getBool(StatusColorsEnabled, false)
 	displayStatus := g.props.getBool(DisplayStatus, true)
+
+	if displayStatus || statusColorsEnabled {
+		g.setGitStatus()
+	}
+	if statusColorsEnabled {
+		g.SetStatusColor()
+	}
 	if !displayStatus {
 		return g.getPrettyHEADName()
 	}
-	g.setGitStatus()
 	buffer := new(bytes.Buffer)
 	// remote (if available)
 	if g.repo.upstream != "" && g.props.getBool(DisplayUpstreamIcon, false) {
@@ -165,9 +172,6 @@ func (g *git) string() string {
 	}
 	if g.repo.stashCount != 0 {
 		fmt.Fprintf(buffer, " %s%d", g.props.getString(StashCountIcon, "\uF692 "), g.repo.stashCount)
-	}
-	if g.props.getBool(StatusColorsEnabled, false) {
-		g.SetStatusColor()
 	}
 	return buffer.String()
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] n/a Docs have been added / updated (for bug fixes / features)

### Description

Fixes a use-case that was broken in #502 .

Prior to #502, when using the combination of `"display_status": false` and `"status_colors_enabled": true`, 
the branch name would display in the configured color for the  current git status. This PR restores that functionality, and adds a test-case to cover it.

Example segment:

```json
{
  "type": "git",
  "style": "plain",
  "foreground": "#13A10E",
  "properties": {
    "display_status": false,
    "display_stash_count": false,
    "display_upstream_icon": false,
    "status_colors_enabled": true,
    "color_background": false,
    "local_changes_color": "#C19C00",
    "ahead_and_behind_color": "#C50F1F",
    "behind_color": "#C50F1F",
    "ahead_color": "#881798"
  }
},
```


[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
