### PR TITLE
feat(pwsh): force session to UTF8

### DIFF
--- a/packages/powershell/oh-my-posh/oh-my-posh.psm1
+++ b/packages/powershell/oh-my-posh/oh-my-posh.psm1
@@ -3,6 +3,10 @@
         Generates the prompt before each line in the console
 #>
 
+# Powershell doesn't default to UTF8 just yet, so we're forcing it as there are too many problems
+# that pop up when we don't
+[console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
+
 function Get-PoshCommand {
     if ($IsMacOS) {
         return "$PSScriptRoot/bin/posh-darwin-amd64"

--- a/src/init/omp.ps1
+++ b/src/init/omp.ps1
@@ -1,3 +1,7 @@
+# Powershell doesn't default to UTF8 just yet, so we're forcing it as there are too many problems
+# that pop up when we don't
+[console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding
+
 $global:PoshSettings = New-Object -TypeName PSObject -Property @{
     Theme = "";
 }
@@ -38,16 +42,11 @@ function global:Set-PoshGitStatus {
     if ($null -ne $history -and $null -ne $history.EndExecutionTime -and $null -ne $history.StartExecutionTime) {
         $executionTime = ($history.EndExecutionTime - $history.StartExecutionTime).TotalMilliseconds
     }
-    # Save current encoding and swap for UTF8
-    $originalOutputEncoding = [Console]::OutputEncoding
-    [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
     $omp = "::OMP::"
     $config = $global:PoshSettings.Theme
     $cleanPWD = $PWD.ProviderPath.TrimEnd("\")
     $cleanPSWD = $PWD.ToString().TrimEnd("\")
     $standardOut = @(&$omp --error="$errorCode" --pwd="$cleanPWD" --pswd="$cleanPSWD" --execution-time="$executionTime" --config="$config" 2>&1)
-    # Restore initial encoding
-    [Console]::OutputEncoding = $originalOutputEncoding
     # the ouput can be multiline, joining these ensures proper rendering by adding line breaks with `n
     $standardOut -join "`n"
     Set-PoshGitStatus
@@ -59,14 +58,10 @@ function global:Set-PoshGitStatus {
 Set-Item -Path Function:prompt -Value $Prompt -Force
 
 function global:Write-PoshDebug {
-    $originalOutputEncoding = [Console]::OutputEncoding
-    [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
     $omp = "::OMP::"
     $config = $global:PoshSettings.Theme
     $cleanPWD = $PWD.ProviderPath.TrimEnd("\")
     $cleanPSWD = $PWD.ToString().TrimEnd("\")
     $standardOut = @(&$omp --error=1337 --pwd="$cleanPWD" --pswd="$cleanPSWD" --execution-time=9001 --config="$config" --debug 2>&1)
-    $standardOut
-    # Restore initial encoding
-    [Console]::OutputEncoding = $originalOutputEncoding
+    $standardOut -join "`n"
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

Force the current Powershell session to use UTF8. As we see A LOT of issues with encoding and Powershell will [move towards UTF8](https://github.com/PowerShell/PowerShell/issues/7233) in the near™️ future, it might be a good idea to already do so here.

@TravisTX @lnu thoughts?

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
