### PR TITLE
docs: fix various spelling errors

### DIFF
--- a/docs/docs/installation.mdx
+++ b/docs/docs/installation.mdx
@@ -406,7 +406,7 @@ oh-my-posh --print-config
 ```
 
 This will write the current configuration in your shell, allowing you to copy paste it in a new file
-and store it somehwere. Once adjusted to your liking, [change the prompt setting][prompt] to use the newly created file.
+and store it somewhere. Once adjusted to your liking, [change the prompt setting][prompt] to use the newly created file.
 
 ```powershell
 oh-my-posh --config ~/.mytheme.omp.json
@@ -422,7 +422,7 @@ oh-my-posh --print-config
 ```
 
 This will write the current configuration in your shell, allowing you to copy paste it in a new file
-and store it somehwere. Once adjusted to your liking, [change the prompt setting][prompt] to use the newly created file.
+and store it somewhere. Once adjusted to your liking, [change the prompt setting][prompt] to use the newly created file.
 
 ```bash
 oh-my-posh --config ~/.mytheme.omp.json
@@ -438,7 +438,7 @@ oh-my-posh --print-config
 ```
 
 This will write the current configuration in your shell, allowing you to copy paste it in a new file
-and store it somehwere. Once adjusted to your liking, [change the prompt setting][prompt] to use the newly created file.
+and store it somewhere. Once adjusted to your liking, [change the prompt setting][prompt] to use the newly created file.
 
 ```bash
 oh-my-posh --config ~/.mytheme.omp.json

--- a/docs/docs/segment-exit.md
+++ b/docs/docs/segment-exit.md
@@ -33,7 +33,7 @@ Displays the last exit code or that the last command failed based on the configu
 - display_exit_code: `boolean` - show or hide the exit code - defaults to `true`
 - always_enabled: `boolean` - always show the status - defaults to `false`
 - color_background: `boolean` - color the background or foreground when an error occurs - defaults to `false`
-- error_color: `string` [color][colors] - color to use when an error occured
+- error_color: `string` [color][colors] - color to use when an error occurred
 - always_numeric: `boolean` - always display exit code as a number - defaults to `false`
 - success_icon: `string` - displays when there's no error and `"always_enabled": true` - defaults to `""`
 - error_icon: `string` - displays when there's an error - defaults to `""`

--- a/docs/docs/segment-path.md
+++ b/docs/docs/segment-path.md
@@ -28,7 +28,7 @@ Display the current path.
 
 ## Properties
 
-- folder_separator_icon: `string` - the symbol to use as a separator between folders - defaults to platfrom path separator
+- folder_separator_icon: `string` - the symbol to use as a separator between folders - defaults to platform path separator
 - home_icon: `string` - the icon to display when at `$HOME` - defaults to `~`
 - folder_icon: `string` - the icon to use as a folder indication - defaults to `..`
 - windows_registry_icon: `string` - the icon to display when in the Windows registry - defaults to `\uE0B1`

--- a/packages/inno/build.ps1
+++ b/packages/inno/build.ps1
@@ -13,7 +13,7 @@ Copy-Item -Path "../../themes" -Destination "./bin" -Recurse
     $download = "https://github.com/jandedobbeleer/oh-my-posh/releases/download/v$Version/$($_.name)"
     Invoke-WebRequest $download -Out "./bin/$($_.name)"
 }
-# lisence
+# license
 Invoke-WebRequest "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/v$Version/COPYING" -Out "./bin/COPYING.txt"
 $content = Get-Content '.\oh-my-posh.iss' -Raw
 $content = $content.Replace('<VERSION>', $Version)

--- a/packages/powershell/oh-my-posh/oh-my-posh.psm1
+++ b/packages/powershell/oh-my-posh/oh-my-posh.psm1
@@ -34,7 +34,7 @@ function Set-ExecutablePermissions {
 
     $executable = Get-PoshCommand
     if (-Not (Test-Path $executable)) {
-        # This should only happend with a corrupt installation
+        # This should only happen with a corrupt installation
         Write-Warning "Executable at $executable was not found"
         return
     }

--- a/src/init/omp.ps1
+++ b/src/init/omp.ps1
@@ -21,7 +21,7 @@ function global:Set-PoshGitStatus {
 }
 
 [ScriptBlock]$Prompt = {
-    #store if the last command was successfull
+    #store if the last command was successful
     $lastCommandSuccess = $?
     #store the last exit code for restore
     $realLASTEXITCODE = $global:LASTEXITCODE
@@ -47,7 +47,7 @@ function global:Set-PoshGitStatus {
     $cleanPWD = $PWD.ProviderPath.TrimEnd("\")
     $cleanPSWD = $PWD.ToString().TrimEnd("\")
     $standardOut = @(&$omp --error="$errorCode" --pwd="$cleanPWD" --pswd="$cleanPSWD" --execution-time="$executionTime" --config="$config" 2>&1)
-    # the ouput can be multiline, joining these ensures proper rendering by adding line breaks with `n
+    # the output can be multiline, joining these ensures proper rendering by adding line breaks with `n
     $standardOut -join "`n"
     Set-PoshGitStatus
     $global:LASTEXITCODE = $realLASTEXITCODE


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

I noticed a few typos and another tool found a few more small typos, so this fixes those.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
