### PR TITLE
feat: template for time segment

### DIFF
--- a/docs/docs/segment-time.md
+++ b/docs/docs/segment-time.md
@@ -26,3 +26,12 @@ Show the current timestamp.
 - time_format: `string` - format to use, follows the [golang standard][format] - defaults to `15:04:05`
 
 [format]: https://gobyexample.com/time-formatting-parsing
+
+- template: `string` - A go [text/template][go-text-template] template extended with [sprig][sprig] utilizing the
+properties below. Only used when a value is set, making the above properties obsolete.
+
+  example: `{{ now | date \"January 02, 2006 15:04:05 PM\" | lower }}`
+
+## Template Properties
+
+- `.CurrentDate`: `time` - The time to display(testing purpose)

--- a/src/segment_time_test.go
+++ b/src/segment_time_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimeSegmentTemplate(t *testing.T) {
+	// set date for unit test
+	currentDate := time.Now()
+	cases := []struct {
+		Case            string
+		ExpectedEnabled bool
+		ExpectedString  string
+		Template        string
+	}{
+		{
+			Case:            "no template",
+			Template:        "",
+			ExpectedString:  currentDate.Format("15:04:05"),
+			ExpectedEnabled: true,
+		},
+		{
+			Case:            "time only",
+			Template:        "{{.CurrentDate | date \"15:04:05\"}}",
+			ExpectedString:  currentDate.Format("15:04:05"),
+			ExpectedEnabled: true,
+		},
+		{
+			Case:            "lowercase",
+			Template:        "{{.CurrentDate | date \"January 02, 2006 15:04:05\" | lower }}",
+			ExpectedString:  strings.ToLower(currentDate.Format("January 02, 2006 15:04:05")),
+			ExpectedEnabled: true,
+		},
+	}
+
+	for _, tc := range cases {
+		env := new(MockedEnvironment)
+		props := &properties{
+			values: map[Property]interface{}{
+				SegmentTemplate: tc.Template,
+			},
+		}
+		tempus := &tempus{
+			env:         env,
+			props:       props,
+			CurrentDate: currentDate,
+		}
+		assert.Equal(t, tc.ExpectedEnabled, tempus.enabled())
+		if tc.ExpectedEnabled {
+			assert.Equal(t, tc.ExpectedString, tempus.string(), tc.Case)
+		}
+	}
+}

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -1282,6 +1282,9 @@
                     "title": "Time Format",
                     "description": "Format to use, follows the golang standard: https://gobyexample.com/time-formatting-parsing",
                     "default": "15:04:05"
+                  },
+                  "template": {
+                    "$ref": "#/definitions/template"
                   }
                 }
               }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

Template added for time segment

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
