### PR TITLE
fix: change robby russel exit code glyph to match ohmyzsh

### DIFF
--- a/themes/robbyrussel.omp.json
+++ b/themes/robbyrussel.omp.json
@@ -39,7 +39,7 @@
           "style": "plain",
           "foreground": "#DCB977",
           "properties": {
-            "prefix": "\uF119",
+            "prefix": "\u2717",
             "display_exit_code": false
           }
         }


### PR DESCRIPTION
### Prerequisites

- [y ] I have read and understand the `CONTRIBUTING` guide
- [y] The commit message follows the [conventional commits][cc] guidelines
- [y ] Tests for the changes have been added (for bug fixes / features)
- [y ] Docs have been added / updated (for bug fixes / features)

### Description

The exit code glyph prefix in the robby russel theme doesn't display correctly when using Cascadia Code PL. 
This fix changes the glyph to match ohmyzsh, which fixes this problem.

Let me know if you want me to change the other themes.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
