### PR TITLE
fix: escape double quotes for zsh prompt

### DIFF
--- a/src/engine.go
+++ b/src/engine.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 )
@@ -247,7 +248,8 @@ func (e *engine) print() {
 	switch e.env.getShellName() {
 	case zsh:
 		if *e.env.getArgs().Eval {
-			fmt.Printf("PS1=\"%s\"", e.renderer.string())
+			// escape double quotes contained in the prompt
+			fmt.Printf("PS1=\"%s\"", strings.ReplaceAll(e.renderer.string(), "\"", "\"\""))
 			fmt.Printf("\nRPROMPT=\"%s\"", e.rprompt)
 			return
 		}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [ ] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Description

Only with zsh. Add the following block to your config(left prompt only, rprompt is ok):
```
{
          "type": "text",
          "style": "powerline",
          "powerline_symbol": "\uE0B0",
          "foreground": "#ffffff",
          "background": "#0077C2",
          "properties": {
            "text": " \"Hello world\" "
          }
}
```
it will break zsh with the following message:
<img width="1677" alt="image" src="https://user-images.githubusercontent.com/1829553/111863086-9c299e80-8959-11eb-8589-7637b4d05e30.png">

It seems all double quotes must be escaped. BUT even when escaped, they are not rendered in the prompt:
<img width="1675" alt="image" src="https://user-images.githubusercontent.com/1829553/111863118-c67b5c00-8959-11eb-9a22-f58f1c0e0228.png">

But at least, it's rendered without any error.

I checked and the text is rendered with double quotes in all shell except zsh.... 

Any suggestions are welcome :).

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
