### PR TITLE
fix: java docs added pom.xml

### DIFF
--- a/docs/docs/segment-java.md
+++ b/docs/docs/segment-java.md
@@ -31,6 +31,7 @@ Display the currently active java version.
 - display_mode: `string` - determines when the segment is displayed
   - `always`: the segment is always displayed
   - `files`: the segment is only displayed when one of the following files is present:
+    - `pom.xml`
     - `build.gradle.kts`
     - `build.sbt`
     - `.java-version`


### PR DESCRIPTION
Added pom.xml to the display_mode files to check as it is in the code.

### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

Added po.xml to the docs as it is checking for the file in the code.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
