### PR TITLE
<fix> windows arm PowerShell select to x86_64 exe binary

### DIFF
--- a/packages/powershell/oh-my-posh/oh-my-posh.psm1
+++ b/packages/powershell/oh-my-posh/oh-my-posh.psm1
@@ -15,7 +15,10 @@ function Get-PoshCommand {
         }
         return "$PSScriptRoot/bin/posh-linux-amd64"
     }
-    if ([Environment]::Is64BitOperatingSystem) {
+    if ((Get-CimInstance Win32_OperatingSystem).OSArchitecture -icontains "arm") {
+        return "$PSScriptRoot/bin/posh-windows-arm.exe"
+    }
+    elseif ([Environment]::Is64BitOperatingSystem) {
         return "$PSScriptRoot/bin/posh-windows-amd64.exe"
     }
     return "$PSScriptRoot/bin/posh-windows-386.exe"


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Description

fix:
just compile arm build and repair if statement.
tested in win10 arm 19042.868 PowerShell arm 7.0.3
binary build go 1.16.2 windows/arm

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
