### PR TITLE
fix: adoptopenjdk 16 version parsing

### DIFF
--- a/src/segment_java.go
+++ b/src/segment_java.go
@@ -11,7 +11,7 @@ func (j *java) string() string {
 }
 
 func (j *java) init(props *properties, env environmentInfo) {
-	javaRegex := `\((?P<version>(?P<major>[0-9]+)\.(?P<minor>[0-9]+)\.(?P<patch>[0-9]+)).*\).*(?:built|from)`
+	javaRegex := `(?: JRE) \((?P<version>(?P<major>[0-9]+)(?:\.(?P<minor>[0-9]+))?(?:\.(?P<patch>[0-9]+))?).*\),`
 	javaCmd := &cmd{
 		executable: "java",
 		args:       []string{"-Xinternalversion"},

--- a/src/segment_java_test.go
+++ b/src/segment_java_test.go
@@ -32,6 +32,20 @@ func TestJava(t *testing.T) {
 			JavaHomeVersion: "OpenJDK 64-Bit Server VM (25.275-b01) for bsd-amd64 JRE (1.7.0_275-b01), built on Nov  9 2020 12:07:35 by \"jenkins\" with gcc 4.2.1",
 			Version:         "OpenJDK 64-Bit Server VM (25.275-b01) for bsd-amd64 JRE (1.8.0_275-b01), built on Nov  9 2020 12:07:35 by \"jenkins\" with gcc 4.2.1",
 		},
+		{
+			Case:            "openjdk version \"15.0.2\" 2021-01-19",
+			ExpectedString:  "15.0.2",
+			JavaHomeEnabled: true,
+			JavaHomeVersion: "OpenJDK 64-Bit Server VM (15.0.2+7) for windows-amd64 JRE (15.0.2+7), built on Jan 21 2021 05:54:57 by \"\" with MS VC++ 15.9 (VS2017)",
+			Version:         "OpenJDK 64-Bit Server VM (15.0.2+7) for windows-amd64 JRE (15.0.2+7), built on Jan 21 2021 05:54:57 by \"\" with MS VC++ 15.9 (VS2017)",
+		},
+		{
+			Case:            "openjdk version \"16\" 2021-03-16",
+			ExpectedString:  "16",
+			JavaHomeEnabled: true,
+			JavaHomeVersion: "OpenJDK 64-Bit Server VM (16+36) for windows-amd64 JRE (16+36), built on Mar 11 2021 10:56:33 by \"\" with MS VC++ 16.7 (VS2019)",
+			Version:         "OpenJDK 64-Bit Server VM (16+36) for windows-amd64 JRE (16+36), built on Mar 11 2021 10:56:33 by \"\" with MS VC++ 16.7 (VS2019)",
+		},
 	}
 	for _, tc := range cases {
 		env := new(MockedEnvironment)


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Description

Fix the regex for java version parsing(added some tests for adoptopenjdk 15 and 16)

Fix #603 

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
