### PR TITLE
perf(az): improve performance for az powershell

### DIFF
--- a/src/init/omp.ps1
+++ b/src/init/omp.ps1
@@ -23,10 +23,20 @@ function global:Initialize-ModuleSupport {
         $env:POSH_GIT_STATUS = Write-GitStatus -Status $global:GitStatus
     }
 
+
+    if ($null -eq $env:AZ_ENABLED) {
+        if (Get-Module -ListAvailable -Name "Az.Accounts") {
+            $env:AZ_ENABLED = $true
+        }
+        else {
+            $env:AZ_ENABLED = $false
+        }
+    }
+
     $env:AZ_SUBSCRIPTION_NAME = $null
     $env:AZ_SUBSCRIPTION_ID = $null
 
-    if (Get-Module -ListAvailable -Name "Az.Accounts") {
+    if ($env:AZ_ENABLED -eq $true) {
         try {
             $subscription = Get-AzContext | Select-Object -ExpandProperty "Subscription" | Select-Object "Name", "Id"
             if ($null -ne $subscription) {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] n/a Tests for the changes have been added (for bug fixes / features)
- [ ] n/a Docs have been added / updated (for bug fixes / features)

### Description

The first time the prompt runs, it will check for the existence of the "Az.Accounts" module, and never check again.  This makes the init fast, at the expensive of knowing whether the existence of this module changes (gets installed or uninstalled).  If the user installs or uninstalls this module, OMP won't notice until the next time the terminal is loaded.

This has a secondary benefit, if this code is causing a problem for a user, they could add `$env:AZ_ENABLED = $false` to $profile which will force this code to never execute.

Closes #612

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
