### PR TITLE
Forces the temporary file deletion when user uses a security rm alias

### DIFF
--- a/src/init/omp.bash
+++ b/src/init/omp.bash
@@ -12,7 +12,7 @@ function _omp_hook() {
         omp_now=$(::OMP:: --millis)
         omp_start_time=$(cat "$TIMER_START")
         omp_elapsed=$((omp_now-omp_start_time))
-        rm "$TIMER_START"
+        rm -f "$TIMER_START"
     fi
     PS1="$(::OMP:: --config $POSH_THEME --shell bash --error $ret --execution-time $omp_elapsed)"
 
@@ -24,7 +24,7 @@ if [ "$TERM" != "linux" ] && [ -x "$(command -v ::OMP::)" ] && ! [[ "$PROMPT_COM
 fi
 
 function _omp_runonexit() {
-  [[ -f $TIMER_START ]] && rm "$TIMER_START"
+  [[ -f $TIMER_START ]] && rm -f "$TIMER_START"
 }
 
 trap _omp_runonexit EXIT


### PR DESCRIPTION
Signed-off-by: ojullien <3778194+ojullien@users.noreply.github.com>

### Prerequisites

- [X] I have read and understand the `CONTRIBUTING` guide
- [X] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Description

Added the -f option to the rm command to override the security alias `alias rm="rm -i"`

Fix #623 
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
