### PR TITLE
fix: wrong stack count when init from Set-PoshPrompt

### DIFF
--- a/packages/powershell/oh-my-posh/oh-my-posh.psm1
+++ b/packages/powershell/oh-my-posh/oh-my-posh.psm1
@@ -56,6 +56,11 @@ function Set-PoshPrompt {
         $config = "$PSScriptRoot/themes/jandedobbeleer.omp.json"
     }
 
+    # Workaround for get-location/push-location/pop-location from within a module
+    # https://github.com/PowerShell/PowerShell/issues/12868
+    # https://github.com/JanDeDobbeleer/oh-my-posh2/issues/113
+    $global:omp_global_sessionstate = $PSCmdlet.SessionState
+
     $poshCommand = Get-PoshCommand
     Invoke-Expression (& $poshCommand --init --shell=pwsh --config="$config")
 }

--- a/src/init/omp.ps1
+++ b/src/init/omp.ps1
@@ -65,7 +65,12 @@ function global:Initialize-ModuleSupport {
         }
     }
 
-    $stackCount = (Get-Location -Stack).Count
+    $stackCount = 0
+    try {
+        $stackCount = ($global:omp_global_sessionstate).path.locationstack('').count
+    }
+    catch {}
+
     $executionTime = -1
     $history = Get-History -ErrorAction Ignore -Count 1
     if ($null -ne $history -and $null -ne $history.EndExecutionTime -and $null -ne $history.StartExecutionTime -and $global:omp_lastHistoryId -ne $history.Id) {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Description

Fix an issue with get-location when omp is initialised with Set-PoshPrompt.
Set-PoshPrompt being defined in a module, a new scope is created and get-location does not return the unnamed stack from the current session. Initializing omp with invoke-expression was already working.
fixes #634 
JanDeDobbeleer/oh-my-posh2#113
PowerShell/PowerShell#12868


[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
