### PR TITLE
fix: stack count variable names + compability with all init modes

### DIFF
--- a/src/init/omp.bash
+++ b/src/init/omp.bash
@@ -7,7 +7,7 @@ PS0='$(::OMP:: --millis > $TIMER_START)'
 function _omp_hook() {
     local ret=$?
 
-    stack_count=$((${#DIRSTACK[@]} - 1))
+    omp_stack_count=$((${#DIRSTACK[@]} - 1))
     omp_elapsed=-1
     if [[ -f $TIMER_START ]]; then
         omp_now=$(::OMP:: --millis)
@@ -15,7 +15,7 @@ function _omp_hook() {
         omp_elapsed=$((omp_now-omp_start_time))
         rm -f "$TIMER_START"
     fi
-    PS1="$(::OMP:: --config $POSH_THEME --shell bash --error $ret --execution-time $omp_elapsed --stack-count $stack_count)"
+    PS1="$(::OMP:: --config $POSH_THEME --shell bash --error $ret --execution-time $omp_elapsed --stack-count $omp_stack_count)"
 
     return $ret
 }

--- a/src/init/omp.fish
+++ b/src/init/omp.fish
@@ -1,7 +1,7 @@
 set -g posh_theme ::CONFIG::
 
 function fish_prompt
-    set -l stack_count (count $dirstack)
+    set -l omp_stack_count (count $dirstack)
     set -l omp_duration "$CMD_DURATION$cmd_duration"
     # check if variable set, < 3.2 case
     if set -q omp_lastcommand; and test "$omp_lastcommand" = ""
@@ -15,7 +15,7 @@ function fish_prompt
       set -gx omp_last_status_generation $status_generation
     end
 
-    ::OMP:: --config $posh_theme --error $status --execution-time $omp_duration --stack-count $stack_count
+    ::OMP:: --config $posh_theme --error $status --execution-time $omp_duration --stack-count $omp_stack_count
 end
 
 function postexec_omp --on-event fish_postexec

--- a/src/init/omp.ps1
+++ b/src/init/omp.ps1
@@ -65,9 +65,12 @@ function global:Initialize-ModuleSupport {
         }
     }
 
-    $stackCount = 0
+    # read stack count from current stack(if invoked from profile=right value,otherwise use the global variable set in Set-PoshPrompt(stack scoped to module))
+    $stackCount = (Get-Location -stack).Count
     try {
-        $stackCount = ($global:omp_global_sessionstate).path.locationstack('').count
+        if($global:omp_global_sessionstate -ne $null){
+            $stackCount = ($global:omp_global_sessionstate).path.locationstack('').count
+        }
     }
     catch {}
 

--- a/src/init/omp.zsh
+++ b/src/init/omp.zsh
@@ -5,18 +5,19 @@ function omp_preexec() {
 }
 
 function omp_precmd() {
-  stack_count=${#dirstack[@]}
+  omp_stack_count=${#dirstack[@]}
   omp_last_error=$?
   omp_elapsed=-1
   if [ $omp_start_time ]; then
     omp_now=$(::OMP:: --millis)
     omp_elapsed=$(($omp_now-$omp_start_time))
   fi
-  eval "$(::OMP:: --config $POSH_THEME --error $omp_last_error --execution-time $omp_elapsed --stack-count $stack_count --eval --shell zsh)"
+  eval "$(::OMP:: --config $POSH_THEME --error $omp_last_error --execution-time $omp_elapsed --stack-count $omp_stack_count --eval --shell zsh)"
   unset omp_start_time
   unset omp_now
   unset omp_elapsed
   unset omp_last_error
+  unset omp_stack_count
 }
 
 function install_omp_hooks() {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Description

Variable name alignment + compability with both Invoke-Expression or Set-PoshPrompt

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
