### PR TITLE
feat(language): enable in home dir when always_enabled

### DIFF
--- a/docs/docs/installation.mdx
+++ b/docs/docs/installation.mdx
@@ -164,8 +164,8 @@ brew upgrade oh-my-posh
 #### Installation
 
 ```bash
-wget https://github.com/JanDeDobbeleer/oh-my-posh/releases/latest/download/posh-linux-amd64 -O /usr/local/bin/oh-my-posh
-chmod +x /usr/local/bin/oh-my-posh
+sudo wget https://github.com/JanDeDobbeleer/oh-my-posh/releases/latest/download/posh-linux-amd64 -O /usr/local/bin/oh-my-posh
+sudo chmod +x /usr/local/bin/oh-my-posh
 ```
 
 #### Download the themes

--- a/src/segment_language.go
+++ b/src/segment_language.go
@@ -116,11 +116,14 @@ func (l *language) string() string {
 }
 
 func (l *language) enabled() bool {
-	if l.env.getcwd() == l.env.homeDir() {
+	inHomeDir := func() bool {
+		return l.env.getcwd() == l.env.homeDir()
+	}
+	displayMode := l.props.getString(DisplayMode, DisplayModeFiles)
+	if inHomeDir() && displayMode != DisplayModeAlways {
 		return false
 	}
 	l.loadLanguageContext()
-	displayMode := l.props.getString(DisplayMode, DisplayModeFiles)
 	switch displayMode {
 	case DisplayModeAlways:
 		return true

--- a/src/segment_language_test.go
+++ b/src/segment_language_test.go
@@ -438,6 +438,39 @@ func TestLanguageHyperlinkEnabledLessParamInTemplate(t *testing.T) {
 	assert.Equal(t, "[1.3.307](https://unicor.org/doc/1)", lang.string())
 }
 
+func TestLanguageEnabledInHome(t *testing.T) {
+	cases := []struct {
+		Case            string
+		DisplayMode     string
+		ExpectedEnabled bool
+	}{
+		{Case: "Always enabled", DisplayMode: DisplayModeAlways, ExpectedEnabled: true},
+		{Case: "Context disabled", DisplayMode: DisplayModeContext, ExpectedEnabled: false},
+	}
+	for _, tc := range cases {
+		props := map[Property]interface{}{
+			DisplayMode: tc.DisplayMode,
+		}
+		args := &languageArgs{
+			commands: []*cmd{
+				{
+					executable: "uni",
+					args:       []string{"--version"},
+					regex:      `(?P<version>((?P<major>[0-9]+).(?P<minor>[0-9]+).(?P<patch>[0-9]+)))`,
+				},
+			},
+			extensions:        []string{uni, corn},
+			enabledExtensions: []string{corn},
+			enabledCommands:   []string{"corn"},
+			version:           universion,
+			properties:        props,
+			inHome:            true,
+		}
+		lang := bootStrapLanguageTest(args)
+		assert.Equal(t, tc.ExpectedEnabled, lang.enabled(), tc.Case)
+	}
+}
+
 func TestLanguageHyperlinkEnabledMoreParamInTemplate(t *testing.T) {
 	props := map[Property]interface{}{
 		EnableHyperlink: true,


### PR DESCRIPTION
### Prerequisites

- [ ] I have read and understand the `CONTRIBUTING` guide
- [ ] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Description

[Description of the change]

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
