### PR TITLE
Fixes an issue with Exit Code segments in ZSH

### DIFF
--- a/src/init/omp.zsh
+++ b/src/init/omp.zsh
@@ -5,8 +5,8 @@ function omp_preexec() {
 }
 
 function omp_precmd() {
-  omp_stack_count=${#dirstack[@]}
   omp_last_error=$?
+  omp_stack_count=${#dirstack[@]}
   omp_elapsed=-1
   if [ $omp_start_time ]; then
     omp_now=$(::OMP:: --millis)


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Description

Fixes #659

Addresses an issue causing exit code segments to incorrectly report an exit code of `0`

**Note**: No tests were added for this fix as I don't see any existing tests in place for shell-level code. If I'm mistaken, let me know.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
