### PR TITLE
fix: disable battery segment when no batteries

### DIFF
--- a/src/segment_battery.go
+++ b/src/segment_battery.go
@@ -34,7 +34,13 @@ const (
 
 func (b *batt) enabled() bool {
 	batteries, err := b.env.getBatteryInfo()
+
 	if !b.enabledWhileError(err) {
+		return false
+	}
+
+	// case on computer without batteries(no error, empty array)
+	if err == nil && len(batteries) == 0 {
 		return false
 	}
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

I tested the latest version on a desktop without batteries(opensuse tumbleweed, zsh latest, omp latest) and it doesn't return any error but an empty batteries list. I did a quick fix for it but I'm not sure it covers all scenarios.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
