### PR TITLE
Changing the $profile reference to uppercase

### DIFF
--- a/docs/docs/install-pwsh.mdx
+++ b/docs/docs/install-pwsh.mdx
@@ -51,7 +51,7 @@ Set-PoshPrompt -Theme jandedobbeleer
 Once added, reload your profile for the changes to take effect.
 
 ```powershell
-. $profile
+. $PROFILE
 ```
 
 <Customize />


### PR DESCRIPTION
Although PowerShell variables aren't case sensitive, should the variable be labelled consistently with the rest of the docs?

### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

I have changed the lowercase reference to $profile, to uppercase so it is consistent with the rest of the documentation. PowerShell isn't case sensitive with variables, but it threw me off when using them.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
