### PR TITLE
fix: remove vertical offset on first block

### DIFF
--- a/themes/bubbles.omp.json
+++ b/themes/bubbles.omp.json
@@ -4,7 +4,6 @@
     {
       "type": "prompt",
       "alignment": "right",
-      "vertical_offset": -1,
       "segments": [
         {
           "type": "session",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [ ] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Description

Remove vertical offset on first block to avoid truncating line above.