### PR TITLE
feat: Azure DevOps support for git upstream icons

### DIFF
--- a/docs/docs/segment-git.md
+++ b/docs/docs/segment-git.md
@@ -66,6 +66,7 @@ Local changes can also shown by default using the following syntax for both the 
 - github_icon: `string` - icon/text to display when the upstream is Github - defaults to `\uF408 `
 - gitlab_icon: `string` - icon/text to display when the upstream is Gitlab - defaults to `\uF296 `
 - bitbucket_icon: `string` - icon/text to display when the upstream is Bitbucket - defaults to `\uF171 `
+- azure_devops_icon: `string` - icon/text to display when the upstream is Azure DevOps - defaults to `\uFD03 `
 - git_icon: `string` - icon/text to display when the upstream is not known/mapped - defaults to `\uE5FB `
 
 ### Colors

--- a/src/segment_git.go
+++ b/src/segment_git.go
@@ -92,6 +92,8 @@ const (
 	GithubIcon Property = "github_icon"
 	// BitbucketIcon shows  when upstream is bitbucket
 	BitbucketIcon Property = "bitbucket_icon"
+	// AzureDevOpsIcon shows  when upstream is azure devops
+	AzureDevOpsIcon Property = "azure_devops_icon"
 	// GitlabIcon shows when upstream is gitlab
 	GitlabIcon Property = "gitlab_icon"
 	// GitIcon shows when the upstream can't be identified
@@ -228,6 +230,9 @@ func (g *git) getUpstreamSymbol() string {
 	}
 	if strings.Contains(url, "bitbucket") {
 		return g.props.getString(BitbucketIcon, "\uF171 ")
+	}
+	if strings.Contains(url, "dev.azure.com") || strings.Contains(url, "visualstudio.com") {
+		return g.props.getString(AzureDevOpsIcon, "\uFD03 ")
 	}
 	return g.props.getString(GitIcon, "\uE5FB ")
 }

--- a/src/segment_git_test.go
+++ b/src/segment_git_test.go
@@ -407,10 +407,11 @@ func bootstrapUpstreamTest(upstream string) *git {
 	env.On("getRuntimeGOOS", nil).Return("unix")
 	props := &properties{
 		values: map[Property]interface{}{
-			GithubIcon:    "GH",
-			GitlabIcon:    "GL",
-			BitbucketIcon: "BB",
-			GitIcon:       "G",
+			GithubIcon:      "GH",
+			GitlabIcon:      "GL",
+			BitbucketIcon:   "BB",
+			AzureDevOpsIcon: "AD",
+			GitIcon:         "G",
 		},
 	}
 	g := &git{
@@ -439,6 +440,16 @@ func TestGetUpstreamSymbolBitBucket(t *testing.T) {
 	g := bootstrapUpstreamTest("bitbucket.org/test")
 	upstreamIcon := g.getUpstreamSymbol()
 	assert.Equal(t, "BB", upstreamIcon)
+}
+
+func TestGetUpstreamSymbolAzureDevOps(t *testing.T) {
+	g := bootstrapUpstreamTest("dev.azure.com/test")
+	upstreamIcon := g.getUpstreamSymbol()
+	assert.Equal(t, "AD", upstreamIcon)
+
+	g = bootstrapUpstreamTest("test.visualstudio.com")
+	upstreamIcon = g.getUpstreamSymbol()
+	assert.Equal(t, "AD", upstreamIcon)
 }
 
 func TestGetUpstreamSymbolGit(t *testing.T) {

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -633,6 +633,12 @@
                     "description": "Icon/text to display when the upstream is Bitbucket",
                     "default": "\uF171"
                   },
+                  "azure_devops_icon": {
+                    "type": "string",
+                    "title": "Azure DevOps Icon",
+                    "description": "Icon/text to display when the upstream is Azure DevOps",
+                    "default": "\uFD03"
+                  },
                   "git_icon": {
                     "type": "string",
                     "title": "Git Icon",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

Adds Azure DevOps support to the upstream icons

![image](https://user-images.githubusercontent.com/6989492/118364738-b3ef5e80-b567-11eb-86b5-b8d260422503.png)
