### PR TITLE
feat(theme): display git status for half-life theme

### DIFF
--- a/themes/half-life.omp.json
+++ b/themes/half-life.omp.json
@@ -43,13 +43,20 @@
             "branch_behind_icon": "",
             "branch_gone_icon": "",
             "branch_identical_icon": "",
+            "commit_icon": "",
+            "tag_icon": "",
+            "merge_icon": "",
+            "rebase_icon": "",
+            "cherry_pick_icon": "",
             "working_color": "#D75F00",
             "staging_color": "#87FF00",
             "local_working_icon": " ●",
             "local_staged_icon": " ●",
             "status_separator_icon": "",
+            "display_status": true,
             "display_status_detail": false,
-            "display_branch_status": false
+            "display_branch_status": false,
+            "display_stash_count": false
           }
         },
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Description

I noticed that the git status of my theme was missing when updating oh-my-posh. So I re-enabled it.

### Tips

If you're not comfortable working with git, we're working a [guide][docs] to help you out.
Oh my Posh advises [GitKraken][kraken] as your preferred cross platfrom git GUI powertool.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[docs]: https://ohmyposh.dev/docs/contributing_git
[kraken]: https://www.gitkraken.com/invite/nQmDPR9D
