### PR TITLE
fix: escape \ from segment value when in bash

### DIFF
--- a/src/block.go
+++ b/src/block.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 )
@@ -90,7 +91,13 @@ func (b *Block) renderSegments() string {
 		}
 		b.activeSegment = segment
 		b.endPowerline()
-		b.renderSegmentText(segment.stringValue)
+		segmentValue := segment.stringValue
+		// escape backslashes to avoid replacements
+		// https://tldp.org/HOWTO/Bash-Prompt-HOWTO/bash-prompt-escape-sequences.html
+		if b.env.getShellName() == bash {
+			segmentValue = strings.ReplaceAll(segment.stringValue, "\\", "\\\\")
+		}
+		b.renderSegmentText(segmentValue)
 	}
 	if b.previousActiveSegment != nil && b.previousActiveSegment.Style == Powerline {
 		b.writePowerLineSeparator(Transparent, b.previousActiveSegment.background(), true)


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Description

First draft of escaping \ for bash. I don't like it since the check is done inside block.go, which should be shell agnostic.
fix #738 

### Tips

If you're not comfortable working with git, we're working a [guide][docs] to help you out.
Oh my Posh advises [GitKraken][kraken] as your preferred cross platfrom git GUI powertool.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[docs]: https://ohmyposh.dev/docs/contributing_git
[kraken]: https://www.gitkraken.com/invite/nQmDPR9D
