### PR TITLE
fix: escape backtick

### DIFF
--- a/src/ansi.go
+++ b/src/ansi.go
@@ -176,3 +176,21 @@ func (a *ansiUtils) consolePwd(pwd string) string {
 	}
 	return fmt.Sprintf(a.osc99, pwd)
 }
+
+func (a *ansiUtils) escapeText(text string) string {
+	// what to escape/replace is different per shell
+	// maybe we should refactor and maintain a list of characters to escap/replace
+	// like we do in ansi.go for ansi codes
+	switch a.shell {
+	case zsh:
+		// escape double quotes
+		text = strings.ReplaceAll(text, "\"", "\"\"")
+	case bash:
+		// escape backslashes to avoid replacements
+		// https://tldp.org/HOWTO/Bash-Prompt-HOWTO/bash-prompt-escape-sequences.html
+		text = strings.ReplaceAll(text, "\\", "\\\\")
+	}
+	// escape backtick
+	text = strings.ReplaceAll(text, "`", "'")
+	return text
+}

--- a/src/ansi_color.go
+++ b/src/ansi_color.go
@@ -108,7 +108,10 @@ func (a *AnsiColor) writeAndRemoveText(background, foreground, text, textToRemov
 }
 
 func (a *AnsiColor) write(background, foreground, text string) {
+	text = a.ansi.escapeText(text)
 	text = a.ansi.formatText(text)
+	text = a.ansi.generateHyperlink(text)
+
 	// first we match for any potentially valid colors enclosed in <>
 	match := findAllNamedRegexMatch(`<(?P<foreground>[^,>]+)?,?(?P<background>[^>]+)?>(?P<content>[^<]*)<\/>`, text)
 	for i := range match {

--- a/src/block.go
+++ b/src/block.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 )
@@ -91,13 +90,7 @@ func (b *Block) renderSegments() string {
 		}
 		b.activeSegment = segment
 		b.endPowerline()
-		segmentValue := segment.stringValue
-		// escape backslashes to avoid replacements
-		// https://tldp.org/HOWTO/Bash-Prompt-HOWTO/bash-prompt-escape-sequences.html
-		if b.env.getShellName() == bash {
-			segmentValue = strings.ReplaceAll(segment.stringValue, "\\", "\\\\")
-		}
-		b.renderSegmentText(segmentValue)
+		b.renderSegmentText(segment.stringValue)
 	}
 	if b.previousActiveSegment != nil && b.previousActiveSegment.Style == Powerline {
 		b.writePowerLineSeparator(Transparent, b.previousActiveSegment.background(), true)
@@ -174,7 +167,6 @@ func (b *Block) renderDiamondSegment(text string) {
 }
 
 func (b *Block) renderText(text string) {
-	text = b.ansi.generateHyperlink(text)
 	defaultValue := " "
 	prefix := b.activeSegment.getValue(Prefix, defaultValue)
 	postfix := b.activeSegment.getValue(Postfix, defaultValue)

--- a/src/console_title.go
+++ b/src/console_title.go
@@ -37,6 +37,7 @@ func (t *consoleTitle) getConsoleTitle() string {
 	default:
 		title = base(t.getPwd(), t.env)
 	}
+	title = t.ansi.escapeText(title)
 	return fmt.Sprintf(t.ansi.title, title)
 }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Description

Text inside backtick was interpreted by unix shells(bash, zsh)

![image](https://user-images.githubusercontent.com/1829553/119642035-97caa780-be1a-11eb-9cf5-8d922675f3c1.png)

First two lines: original situation
Last line: fix

### Tips

If you're not comfortable working with git, we're working a [guide][docs] to help you out.
Oh my Posh advises [GitKraken][kraken] as your preferred cross platfrom git GUI powertool.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[docs]: https://ohmyposh.dev/docs/contributing_git
[kraken]: https://www.gitkraken.com/invite/nQmDPR9D
