### PR TITLE
fix: Export-PoshTheme issue with relative path

### DIFF
--- a/src/init/omp.ps1
+++ b/src/init/omp.ps1
@@ -148,12 +148,9 @@ function global:Export-PoshTheme {
     $config = $global:PoshSettings.Theme
     $omp = "::OMP::"
     $configString = @(&$omp --config="$config" --config-format="$Format" --print-config 2>&1)
-
     # if no path, copy to clipboard by default
     if ($FilePath -ne "") {
-        if ($FilePath.StartsWith('~')) {
-            $FilePath = $FilePath.Replace('~', $HOME)
-        }
+        $FilePath = [IO.Path]::GetFullPath($FilePath)
         [IO.File]::WriteAllLines($FilePath, $configString)
     }
     else {


### PR DESCRIPTION
Path.GetFullPath used to resolve full or relative paths

### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Description

Path.GetFullPath can resolve all paths(relative, full, ~)

![image](https://user-images.githubusercontent.com/1829553/119929483-e5135a00-bf7d-11eb-8126-ee7b5b4927e3.png)



### Tips

If you're not comfortable working with git, we're working a [guide][docs] to help you out.
Oh my Posh advises [GitKraken][kraken] as your preferred cross platfrom git GUI powertool.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[docs]: https://ohmyposh.dev/docs/contributing_git
[kraken]: https://www.gitkraken.com/invite/nQmDPR9D
