### PR TITLE
fix: export-poshtheme ~ issue

### DIFF
--- a/src/init/omp.ps1
+++ b/src/init/omp.ps1
@@ -150,6 +150,9 @@ function global:Export-PoshTheme {
     $configString = @(&$omp --config="$config" --config-format="$Format" --print-config 2>&1)
     # if no path, copy to clipboard by default
     if ($FilePath -ne "") {
+        if ($FilePath.StartsWith('~')) {
+            $FilePath = $FilePath.Replace('~', $HOME)
+        }
         $FilePath = [IO.Path]::GetFullPath($FilePath)
         [IO.File]::WriteAllLines($FilePath, $configString)
     }


### PR DESCRIPTION
Fix regression introduced by previous commit(~)

### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Description

Sorry but the ~ part of the code has to be kept. Terminal refresh issue on my side...

### Tips

If you're not comfortable working with git, we're working a [guide][docs] to help you out.
Oh my Posh advises [GitKraken][kraken] as your preferred cross platfrom git GUI powertool.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[docs]: https://ohmyposh.dev/docs/contributing_git
[kraken]: https://www.gitkraken.com/invite/nQmDPR9D
