### PR TITLE
docs: display_status warning in git segment doc + issue template updated

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -14,6 +14,11 @@
 - Operating System:
 - Shell:
 - Terminal:
+  
+#### Optional
+
+- posh-git version:
+- git version:
 
 ### Steps to Reproduce
 

--- a/docs/docs/segment-git.mdx
+++ b/docs/docs/segment-git.mdx
@@ -19,6 +19,12 @@ PowerShell offers support for the `posh-git` module for autocompletion, but it i
 To enable this, set `$env:POSH_GIT_ENABLED = $true` in your `$PROFILE`.
 :::
 
+:::warning
+Starting from version 3.152.0, `display_status` is disabled by default.  
+It improves performance but reduces the quantity of information. Don't forget to enable it in your theme if needed.  
+An alternative is to use the [Posh-Git segment][poshgit]
+:::
+
 ## Sample Configuration
 
 ```json
@@ -91,3 +97,4 @@ foreground/background (see `color_background`)
 foreground/background (see `color_background`)
 
 [colors]: /docs/configure#colors
+[poshgit]: /docs/poshgit


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Description

Doc updated for `display_status` change to false by default + issue template updated with optional git and posh-git version

### Tips

If you're not comfortable working with git, we're working a [guide][docs] to help you out.
Oh my Posh advises [GitKraken][kraken] as your preferred cross platfrom git GUI powertool.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[docs]: https://ohmyposh.dev/docs/contributing_git
[kraken]: https://www.gitkraken.com/invite/nQmDPR9D
