### PR TITLE
fix(pwsh): use correct directory when exporting theme

### DIFF
--- a/src/init/omp.ps1
+++ b/src/init/omp.ps1
@@ -150,10 +150,8 @@ function global:Export-PoshTheme {
     $configString = @(&$omp --config="$config" --config-format="$Format" --print-config 2>&1)
     # if no path, copy to clipboard by default
     if ($FilePath -ne "") {
-        if ($FilePath.StartsWith('~')) {
-            $FilePath = $FilePath.Replace('~', $HOME)
-        }
-        $FilePath = [IO.Path]::GetFullPath($FilePath, (Get-Location -PSProvider FileSystem).ProviderPath)
+        #https://stackoverflow.com/questions/3038337/powershell-resolve-path-that-might-not-exist
+        $FilePath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($FilePath)
         [IO.File]::WriteAllLines($FilePath, $configString)
     }
     else {


### PR DESCRIPTION
resolves #768

### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### Description

Fixes all issues with relative path conversion. Tested on powershell core and powershell 5.1. The advantage is that the command can be tested manually:
```
 $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("d:\dev\mytheme.omp.json")
 $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("d:\dev\..\mytheme.omp.json")
 $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath(".mytheme.omp.json")
 $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("..\mytheme.omp.json")
 $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("~\mytheme.omp.json")
```
![image](https://user-images.githubusercontent.com/1829553/120264726-aabbfc80-c29e-11eb-8d0f-26196c754a34.png)
![image](https://user-images.githubusercontent.com/1829553/120264737-b1e30a80-c29e-11eb-8d00-3f91d0db55dc.png)


### Tips

If you're not comfortable working with git, we're working a [guide][docs] to help you out.
Oh my Posh advises [GitKraken][kraken] as your preferred cross platfrom git GUI powertool.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[docs]: https://ohmyposh.dev/docs/contributing_git
[kraken]: https://www.gitkraken.com/invite/nQmDPR9D
