### PR TITLE
Updated documentation of Path segment to reflect JSON schema

### DIFF
--- a/docs/docs/segment-path.md
+++ b/docs/docs/segment-path.md
@@ -47,15 +47,15 @@ locations before doing a replacement.
 
 - mapped_locations_enabled: `boolean` - replace known locations in the path with the replacements before applying the
 style. defaults to `true`
-- mapped_locations: `map[string]string` - custom glyph/text for specific paths (only when `mapped_locations_enabled`
+- mapped_locations: `[][]string, string` - custom glyph/text for specific paths (only when `mapped_locations_enabled`
 is set to `true`)
 
 For example, to swap out `C:\Users\Leet\GitHub` with a GitHub icon, you can do the following:
 
 ```json
-"mapped_locations": {
-  "C:\\Users\\Leet\\GitHub": "\uF09B"
-}
+"mapped_locations": [
+  ["C:\\Users\\Leet\\GitHub", "\uF09B"]
+]
 ```
 
 ## Style


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

Updated the documentation for Path Segments as it was still reporting that it accepted a map while the connected schema requires a list of 2-elements lists.

I tried to infer how to represent that as a type in documentation from other places in the documentation but I couldn't find a relevant example.

### Tips

If you're not comfortable working with git, we're working a [guide][docs] to help you out.
Oh my Posh advises [GitKraken][kraken] as your preferred cross platfrom git GUI powertool.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[docs]: https://ohmyposh.dev/docs/contributing_git
[kraken]: https://www.gitkraken.com/invite/nQmDPR9D
