### PR TITLE
docs: add git executable version info

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -39,7 +39,7 @@ escape characters to see the prompt as it would be shown inside a prompt functio
 
 :::info
 The command below will not persist the configuration for your shell but print the prompt in your terminal.
-If you want to use your own configuration permanently, adjust the [prompt configuration][promptconfig] to use your custom
+If you want to use your own configuration permanently, adjust the prompt configuration to use your custom
 theme.
 :::
 
@@ -48,7 +48,7 @@ oh-my-posh --config sample.json --shell universal
 ```
 
 If all goes according to plan, you should see the prompt being printed out on the line below. In case you see a lot of
-boxes with question marks, [set up your terminal][setupterm] to use a supported font before continuing.
+boxes with question marks, set up your terminal to use a supported font before continuing.
 
 ## General Settings
 
@@ -464,8 +464,6 @@ has to be enabled at the segment level. Hyperlink generation is disabled by defa
 }
 ```
 
-[promptconfig]: /docs/installation#4-replace-your-existing-prompt
-[setupterm]: /docs/installation#1-setup-your-terminal
 [releases]: https://github.com/JanDeDobbeleer/oh-my-posh/releases/latest
 [nf]: https://www.nerdfonts.com/
 [segments]: /docs/battery

--- a/docs/docs/install-linux.mdx
+++ b/docs/docs/install-linux.mdx
@@ -55,5 +55,4 @@ for file in ~/.poshthemes/*.omp.json; do echo "$file\n"; oh-my-posh --config $fi
 [iterm2]: https://www.iterm2.com/
 [powershell]: https://www.powershellgallery.com/packages/oh-my-posh
 [brew]: https://brew.sh
-[prompt]: /docs/installation#3-replace-your-existing-prompt
 [configuration]: /docs/configure

--- a/docs/docs/install-macos.mdx
+++ b/docs/docs/install-macos.mdx
@@ -61,5 +61,4 @@ brew upgrade oh-my-posh
 [iterm2]: https://www.iterm2.com/
 [powershell]: https://www.powershellgallery.com/packages/oh-my-posh
 [brew]: https://brew.sh
-[prompt]: /docs/installation#3-replace-your-existing-prompt
 [configuration]: /docs/configure

--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -55,13 +55,12 @@ when relevant. It can be styled any way you want, resulting in visualizing the p
 
 For your convenience, the existing [themes][themes] from [Oh my Posh][omp-themes] have been added to version 3, so you
 can get started even without having to understand the theming. So, let's no longer waste time on theory, have a look at the
-[installation guide][install] to get started right away!
+installation guide to get started right away!
 
 [omp]: https://github.com/JanDeDobbeleer/oh-my-posh2
 [omz]: https://github.com/ohmyzsh/ohmyzsh
 [omp3]: https://github.com/JanDeDobbeleer/oh-my-posh
 [wsl]: https://docs.microsoft.com/en-us/windows/wsl/install-win10
-[install]: /docs/installation
 [block]: /docs/configure#block
 [segment]: /docs/configure#segment
 [themes]: https://github.com/JanDeDobbeleer/oh-my-posh/tree/main/themes

--- a/docs/docs/segment-executiontime.md
+++ b/docs/docs/segment-executiontime.md
@@ -10,7 +10,7 @@ Displays the execution time of the previously executed command.
 
 To use this, use the PowerShell module, or confirm that you are passing an `execution-time` argument containing the
 elapsed milliseconds to the oh-my-posh executable.
-The [installation guide][install] shows how to include this argument for PowerShell and Zsh.
+The installation guide shows how to include this argument for PowerShell and Zsh.
 
 ## Sample Configuration
 
@@ -48,5 +48,3 @@ Style specifies the format in which the time will be displayed. The table below 
 | houston   | `00:00:00.001` | `00:00:02.1` | `00:03:02.1`  | `04:03:02.1`     |
 | amarillo  | `0.001s`       | `2.1s`       | `182.1s`      | `14,582.1s`      |
 | round     | `1ms`          | `2s`         | `3m 2s`       | `4h 3m`          |
-
-[install]: /docs/installation

--- a/docs/docs/segment-git.mdx
+++ b/docs/docs/segment-git.mdx
@@ -6,8 +6,10 @@ sidebar_label: Git
 
 ## What
 
-Display `git status` information when in a git repository. Also works for subfolders.
-Local changes can also shown by default using the following syntax for both the working and staging area:
+Display git information when in a git repository. Also works for subfolders. For maximum compatibility,
+make sure your `git` executable is up-to-date (when branch or status information is incorrect for example).
+
+Local changes can also be displayed which uses the following syntax for both the working and staging area:
 
 - `+` added
 - `~` modified

--- a/docs/docs/upgrading.md
+++ b/docs/docs/upgrading.md
@@ -90,7 +90,6 @@ Set-PoshPrompt -Theme jandedobbeleer
 You can either tweak the theme to your liking, add segments or [submit an issue][issues] for new functionality.
 Do not hesitate to [ask for assistance][issues] when you notice an issue or unexpected behavior.
 
-[manual]: /docs/installation
 [psgallery]: https://www.powershellgallery.com/packages/oh-my-posh
 [themesv2]: https://github.com/JanDeDobbeleer/oh-my-posh/tree/master/Themes
 [omz]: https://github.com/ohmyzsh/ohmyzsh


### PR DESCRIPTION
relates to #753

### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

[Description of the change]

### Tips

If you're not comfortable working with git, we're working a [guide][docs] to help you out.
Oh my Posh advises [GitKraken][kraken] as your preferred cross platfrom git GUI powertool.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[docs]: https://ohmyposh.dev/docs/contributing_git
[kraken]: https://www.gitkraken.com/invite/nQmDPR9D
