### PR TITLE
feat: -list parameter added to Get-PoshThemes

### DIFF
--- a/docs/docs/install-pwsh.mdx
+++ b/docs/docs/install-pwsh.mdx
@@ -42,7 +42,7 @@ Get-PoshThemes
 The module installs all themes in the module folder. To find the actual files, you can use the following command:
 
 ```powershell
-Get-ChildItem "$((Get-Module oh-my-posh).ModuleBase)/themes"
+Get-PoshThemes -list
 ```
 
 ## Replace your existing prompt


### PR DESCRIPTION
-list display the theme full path instead of the preview
Themes location added at the end

### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

-list switch added to Get-PoshThemes. It display only the theme full path instead of the preview  
Themes location added at the end:
![image](https://user-images.githubusercontent.com/1829553/120891229-bf362700-c607-11eb-99fa-9ec94a41d206.png)


### Tips

If you're not comfortable working with git, we're working a [guide][docs] to help you out.
Oh my Posh advises [GitKraken][kraken] as your preferred cross platfrom git GUI powertool.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[docs]: https://ohmyposh.dev/docs/contributing_git
[kraken]: https://www.gitkraken.com/invite/nQmDPR9D
