### PR TITLE
feat: tooltip support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,6 +10,14 @@
       "args": ["--config=${workspaceRoot}/themes/jandedobbeleer.omp.json", "--shell=pwsh"]
     },
     {
+      "name": "Launch Tooltip",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceRoot}/src",
+      "args": ["--config=/Users/jan/.jandedobbeleer.omp.json", "--tooltip=git"]
+    },
+    {
       "name": "Launch tests",
       "type": "go",
       "request": "launch",

--- a/docs/docs/beta.mdx
+++ b/docs/docs/beta.mdx
@@ -1,0 +1,89 @@
+---
+id: beta
+title: Beta Features
+sidebar_label: 🍼 Beta Features
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+## Tooltips
+
+Tooltips are segments that are rendered as a right aligned prompt while you're typing certain keywords.
+They behave similar to the other segments when it comes to how and when they are shown so you can tweak
+them to act and look like you want. The key difference is that they can be invoked using `tips` which are the
+commands you are typing. Due to the possibility of the use of an alias, you can define for which keyword
+the segment should be rendered.
+
+Due to limitations (or not having found a way just yet) this feature only work for `zsh` and `powershell` at
+the time of writing.
+
+### Configuration
+
+You need to extend or create a custom theme with your tooltips. For example:
+
+```json
+{
+  "blocks": [
+      ...
+  ],
+  "tooltips": [
+    {
+      "type": "git",
+      "tips": ["git", "g"],
+      "style": "diamond",
+      "foreground": "#193549",
+      "background": "#fffb38",
+      "leading_diamond": "",
+      "trailing_diamond": "",
+      "properties": {
+        "display_status": true,
+        "display_upstream_icon": true,
+        "status_colors_enabled": true,
+        "local_changes_color": "#ff9248",
+        "ahead_and_behind_color": "#f26d50",
+        "behind_color": "#f17c37",
+        "ahead_color": "#89d1dc"
+      }
+    }
+  ]
+}
+```
+
+This configuration will render a right aligned git segment when you type `git` or `g` followed by a space. Keep in mind that
+this is a blocking call, meaning that if the segment renders slow, you can't type until it's visible. Optimizations in this space
+are being explored.
+
+### Enable the feature
+
+<Tabs
+  defaultValue="pwsh"
+  groupId="shell"
+  values={[
+    { label: 'powershell', value: 'pwsh', },
+    { label: 'zsh', value: 'zsh', },
+  ]
+}>
+<TabItem value="pwsh">
+
+Import/invoke Oh My Posh in your `$PROFILE` and add the following setting:
+
+```pwsh
+$Global:PoshSettings.EnableToolTips = $true
+```
+
+Restart your shell or reload your `$PROFILE` using `. $PROFILE` for the changes to take effect.
+
+</TabItem>
+<TabItem value="zsh">
+
+Invoke Oh My Posh in `.zshrc` and add the following setting:
+
+```bash
+enable_poshtooltips
+```
+
+Restart your shell or reload `.zshrc` using `source ~/.zshrc` for the changes to take effect.
+
+</TabItem>
+</Tabs>

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -17,6 +17,7 @@ module.exports = {
           ],
         },
         "configure",
+        "beta",
         "themes",
         "share",
         "fonts",

--- a/src/config.go
+++ b/src/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	ConsoleTitleTemplate string            `config:"console_title_template"`
 	TerminalBackground   string            `config:"terminal_background"`
 	Blocks               []*Block          `config:"blocks"`
+	Tooltips             []*Segment        `config:"tooltips"`
 }
 
 const (

--- a/src/init/omp.ps1
+++ b/src/init/omp.ps1
@@ -23,6 +23,7 @@ Set-DefaultEnvValue("POSH_GIT_ENABLED")
 
 $global:PoshSettings = New-Object -TypeName PSObject -Property @{
     Theme = "";
+    EnableToolTips = $false;
 }
 
 # used to detect empty hit
@@ -55,6 +56,24 @@ function global:Initialize-ModuleSupport {
             }
         }
         catch {}
+    }
+
+    # Set the keyhandler to enable tooltips
+    if ($global:PoshSettings.EnableToolTips -eq $true) {
+        Set-PSReadlineKeyHandler -Key SpaceBar -ScriptBlock {
+            [Microsoft.PowerShell.PSConsoleReadLine]::Insert(' ')
+            $position = $host.UI.RawUI.CursorPosition
+            $omp = "::OMP::"
+            $config = $global:PoshSettings.Theme
+            $cleanPWD = $PWD.ProviderPath.TrimEnd("\")
+            $cleanPSWD = $PWD.ToString().TrimEnd("\")
+            $tooltip = $null
+            $cursor = $null
+            [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$tooltip, [ref]$cursor)
+            $standardOut = @(&$omp --pwd="$cleanPWD" --pswd="$cleanPSWD" --config="$config" --tooltip="$tooltip" 2>&1)
+            Write-Host $standardOut -NoNewline
+            $host.UI.RawUI.CursorPosition = $position
+        }
     }
 }
 

--- a/src/init/omp.zsh
+++ b/src/init/omp.zsh
@@ -50,3 +50,22 @@ function export_poshconfig() {
     fi
     ::OMP:: --config $POSH_THEME --print-config --config-format $format > $1
 }
+
+function self-insert() {
+  # ignore an empty buffer
+  if [[ -z  "$BUFFER"  ]]; then
+    zle .self-insert
+    return
+  fi
+  tooltip=$(::OMP:: --config $POSH_THEME --shell zsh --tooltip $BUFFER)
+  # ignore an empty tooltip
+  if [[ ! -z "$tooltip" ]]; then
+    RPROMPT=$tooltip
+    zle reset-prompt
+  fi
+  zle .self-insert
+}
+
+function enable_poshtooltips() {
+  zle -N self-insert
+}

--- a/src/main.go
+++ b/src/main.go
@@ -57,6 +57,7 @@ type args struct {
 	CursorPadding *int
 	RPromptOffset *int
 	StackCount    *int
+	ToolTip       *string
 }
 
 func main() {
@@ -141,6 +142,10 @@ func main() {
 			"stack-count",
 			0,
 			"The current location stack count"),
+		ToolTip: flag.String(
+			"tooltip",
+			"",
+			"Render a tooltip based on the string value"),
 	}
 	flag.Parse()
 	env := &environment{}
@@ -191,9 +196,12 @@ func main() {
 		consoleTitle: title,
 		ansi:         ansi,
 	}
-
 	if *args.Debug {
 		fmt.Print(engine.debug())
+		return
+	}
+	if len(*args.ToolTip) != 0 {
+		fmt.Print(engine.renderTooltip(*args.ToolTip))
 		return
 	}
 	prompt := engine.render()

--- a/src/segment.go
+++ b/src/segment.go
@@ -9,6 +9,7 @@ import (
 // Segment represent a single segment and it's configuration
 type Segment struct {
 	Type                SegmentType              `config:"type"`
+	Tips                []string                 `config:"tips"`
 	Style               SegmentStyle             `config:"style"`
 	PowerlineSymbol     string                   `config:"powerline_symbol"`
 	InvertPowerline     bool                     `config:"invert_powerline"`
@@ -196,6 +197,15 @@ func (segment *Segment) getColor(templates []string, defaultColor string) string
 		return value
 	}
 	return defaultColor
+}
+
+func (segment *Segment) shouldInvokeWithTip(tip string) bool {
+	for _, t := range segment.Tips {
+		if t == tip {
+			return true
+		}
+	}
+	return false
 }
 
 func (segment *Segment) foreground() string {

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -1570,6 +1570,25 @@
       "default": [],
       "description": "https://ohmyposh.dev/docs/configure",
       "items": { "$ref": "#/definitions/block" }
+    },
+    "tooltips": {
+      "type": "array",
+      "title": "Tooltip list, prompt elements to display based on context",
+      "description": "https://ohmyposh.dev/docs/beta#tooltips",
+      "default": [],
+      "items": {
+        "allOf": [{ "$ref": "#/definitions/segment" }],
+        "properties": {
+          "tips": {
+            "type": "array",
+            "title": "The commands for which you want the segment to show",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["tips"]
+      }
     }
   }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

Show a single segment when typing a command to give that exact context.
This will be a beta feature as performance can be an issue.

![anim](https://user-images.githubusercontent.com/2492783/121637723-25003400-ca8a-11eb-8225-a56aad442b90.gif)

### To-Do

- [x] build the logic for the oh-my-posh CLI
- [x] support pwsh
- [x] support zsh
- [ ] write tests
- [x] write the docs

### Tips

If you're not comfortable working with git, we're working a [guide][docs] to help you out.
Oh My Posh advises [GitKraken][kraken] as your preferred cross platfrom git GUI powertool.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[docs]: https://ohmyposh.dev/docs/contributing_git
[kraken]: https://www.gitkraken.com/invite/nQmDPR9D
