### PR TITLE
fix(dotnet): correct exit code on Windows

### DIFF
--- a/src/segment_dotnet.go
+++ b/src/segment_dotnet.go
@@ -13,10 +13,10 @@ const (
 func (d *dotnet) string() string {
 	version := d.language.string()
 
-	// Exit code 145 is a special indicator that dotnet
+	// Exit codes 145 and 0x80008091 are special indicators that dotnet
 	// ran, but the current project config settings specify
 	// use of an SDK that isn't installed.
-	if d.language.exitCode == 145 {
+	if d.language.exitCode == 145 || d.language.exitCode == 0x80008091 {
 		return d.language.props.getString(UnsupportedDotnetVersionIcon, "\uf071 ")
 	}
 

--- a/src/segment_dotnet_test.go
+++ b/src/segment_dotnet_test.go
@@ -9,7 +9,7 @@ import (
 type dotnetArgs struct {
 	enabled         bool
 	version         string
-	unsupported     bool
+	exitCode        int
 	unsupportedIcon string
 	displayVersion  bool
 }
@@ -17,8 +17,8 @@ type dotnetArgs struct {
 func bootStrapDotnetTest(args *dotnetArgs) *dotnet {
 	env := new(MockedEnvironment)
 	env.On("hasCommand", "dotnet").Return(args.enabled)
-	if args.unsupported {
-		err := &commandError{exitCode: 145}
+	if args.exitCode != 0 {
+		err := &commandError{exitCode: args.exitCode}
 		env.On("runCommand", "dotnet", []string{"--version"}).Return("", err)
 	} else {
 		env.On("runCommand", "dotnet", []string{"--version"}).Return(args.version, nil)
@@ -75,7 +75,20 @@ func TestDotnetVersionUnsupported(t *testing.T) {
 	args := &dotnetArgs{
 		enabled:         true,
 		displayVersion:  true,
-		unsupported:     true,
+		exitCode:        145,
+		unsupportedIcon: expected,
+	}
+	dotnet := bootStrapDotnetTest(args)
+	assert.True(t, dotnet.enabled())
+	assert.Equal(t, expected, dotnet.string())
+}
+
+func TestDotnetVersionUnsupportedWindows(t *testing.T) {
+	expected := "x"
+	args := &dotnetArgs{
+		enabled:         true,
+		displayVersion:  true,
+		exitCode:        0x80008091,
 		unsupportedIcon: expected,
 	}
 	dotnet := bootStrapDotnetTest(args)


### PR DESCRIPTION
### Prerequisites

- [X] I have read and understand the `CONTRIBUTING` guide
- [X] The commit message follows the [conventional commits][cc] guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

### Description

dotnet on windows returns a 32-bit exit code.

https://github.com/dotnet/runtime/blob/main/docs/design/features/host-error-codes.md

### Tips

If you're not comfortable working with git, we're working a [guide][docs] to help you out.
Oh My Posh advises [GitKraken][kraken] as your preferred cross platfrom git GUI powertool.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[docs]: https://ohmyposh.dev/docs/contributing_git
[kraken]: https://www.gitkraken.com/invite/nQmDPR9D
