### PR TITLE
Remove confusing quote

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -60,8 +60,6 @@ boxes with question marks, set up your terminal to use a supported font before c
 - terminal_background: `string` [color][colors] - terminal background color, set to your terminal's background color when
 you notice black elements in Windows Terminal or the Visual Studio Code integrated terminal
 
-> "I Like The Way You Speak Words" - Gary Goodspeed
-
 ### Console Title Style
 
 - `folder`: show the current folder name


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understand the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

### Description

The quote here has no context and makes zero sense. I suggest removing it.