### PR TITLE
docs: correct 'dart version' (was 'julia version')

### DIFF
--- a/docs/docs/segment-dart.md
+++ b/docs/docs/segment-dart.md
@@ -25,7 +25,7 @@ Display the currently active dart version.
 
 ## Properties
 
-- display_version: `boolean` - display the julia version - defaults to `true`
+- display_version: `boolean` - display the dart version - defaults to `true`
 - display_error: `boolean` - show the error context when failing to retrieve the version information - defaults to `true`
 - missing_command_text: `string` - text to display when the command is missing - defaults to empty
 - display_mode: `string` - determines when the segment is displayed


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

In the docs for Dart, it says that it shows the julia version. This corrects it.
