### PR TITLE
docs: replace scoop with winget in theme location

### DIFF
--- a/docs/docs/install-windows.mdx
+++ b/docs/docs/install-windows.mdx
@@ -142,8 +142,8 @@ scoop update oh-my-posh
 }>
 <TabItem value="winget">
 
-You can find the themes scoop installs inside the `~\AppData\Local\Programs\oh-my-posh\themes\` folder.
-To use `jandedobbeleer.omp.json` for example, you can refer to it using `~\AppData\Local\Programs\oh-my-posh\themes\jandedobbeleer.omp.json"`
+You can find the themes winget installs inside the `~\AppData\Local\Programs\oh-my-posh\themes\` folder.
+To use `jandedobbeleer.omp.json` for example, you can refer to it using `~\AppData\Local\Programs\oh-my-posh\themes\jandedobbeleer.omp.json`
 when setting the prompt using the `--config` flag.
 
 </TabItem>


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines

### Description

Fixed a duplicate usage of scoop in "Replace your existing prompt" section.