### PR TITLE
docs: fix "oh-my-posh" is not a valid cmdlet error

### DIFF
--- a/docs/docs/install-customize-cmd.mdx
+++ b/docs/docs/install-customize-cmd.mdx
@@ -20,7 +20,7 @@ Export-PoshTheme -FilePath ~/.mytheme.omp.json -Format json
 Once you're done editing, adjust your `$PROFILE` to use your newly created theme.
 
 ```powershell
-oh-my-posh --init --shell pwsh --config ~/.mytheme.omp.json | Invoke-Expression
+Set-PoshPrompt -Theme ~/.mytheme.omp.json
 ```
 
 </TabItem>


### PR DESCRIPTION
following the instructions in customization section, an error "oh-my-posh is not a valid cmdlet" will occur. It may be better to just use Set-Poshprompt in powershell

### Prerequisites

- [ x ] I have read and understood the `CONTRIBUTING` guide
- [ x ] The commit message follows the [conventional commits][cc] guidelines
- [ x ] Tests for the changes have been added (for bug fixes/features)
- [ x ] Docs have been added / updated (for bug fixes/features)

### Description

following the instructions in customization section [https://ohmyposh.dev/docs/windows#customize], an error "oh-my-posh is not a valid cmdlet" will occur. It may be better to just use Set-Poshprompt in powershell

### Tips

If you're not comfortable with working with Git, we're working a [guide][docs] to help you out.
Oh My Posh advises [GitKraken][kraken] as your preferred cross platform Git GUI power tool.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[docs]: https://ohmyposh.dev/docs/contributing_git
[kraken]: https://www.gitkraken.com/invite/nQmDPR9D
