### PR TITLE
fix: handle YAML/TOML key value entries

### DIFF
--- a/src/properties.go
+++ b/src/properties.go
@@ -167,6 +167,14 @@ func parseKeyValueArray(param interface{}) map[string]string {
 	switch v := param.(type) {
 	default:
 		return map[string]string{}
+	case map[interface{}]interface{}:
+		keyValueArray := make(map[string]string)
+		for key, value := range v {
+			val := value.(string)
+			keyString := fmt.Sprintf("%v", key)
+			keyValueArray[keyString] = val
+		}
+		return keyValueArray
 	case map[string]interface{}:
 		keyValueArray := make(map[string]string)
 		for key, value := range v {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description
Key-Value pair settings from YAML/TOML come in as map[interface{}]interface{} instead of map[string]interface{} so this handles that use case.

Note: This probably should be resolved closer to the config itself to avoid a garbage in/garbage out problem

Fixes #860

### Tips

If you're not comfortable with working with Git, we're working a [guide][docs] to help you out.
Oh My Posh advises [GitKraken][kraken] as your preferred cross platform Git GUI power tool.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[docs]: https://ohmyposh.dev/docs/contributing_git
[kraken]: https://www.gitkraken.com/invite/nQmDPR9D
