### PR TITLE
docs: Added docs for installing on Windows/WSL specifically

### DIFF
--- a/docs/docs/install-customize-wsl.mdx
+++ b/docs/docs/install-customize-wsl.mdx
@@ -1,0 +1,84 @@
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+<Tabs
+  defaultValue="powershell"
+  groupId="shell"
+  values={[
+    { label: 'powershell', value: 'powershell', },
+    { label: 'zsh', value: 'zsh', },
+    { label: 'bash', value: 'bash', },
+    { label: 'fish', value: 'fish', },
+  ]
+}>
+<TabItem value="powershell">
+
+```powershell
+Export-PoshTheme -FilePath ~/.mytheme.omp.json -Format json
+```
+
+Once you're done editing, adjust your `$PROFILE` to use your newly created theme.
+
+```powershell
+oh-my-posh --init --shell pwsh --config ~/.mytheme.omp.json | Invoke-Expression
+```
+
+</TabItem>
+<TabItem value="zsh">
+
+```bash
+export_poshconfig "~/.mytheme.omp.json" json
+```
+
+Once you're done editing, adjust `~/.zshrc` to use your newly created theme.
+
+```bash
+eval "$(oh-my-posh --init --shell zsh --config ~/.mytheme.omp.json)"
+```
+
+When adjusted, reload your profile for the changes to take effect.
+
+```bash
+. ~/.zshrc
+```
+
+</TabItem>
+<TabItem value="bash">
+
+```bash
+export_poshconfig "~/.mytheme.omp.json" json
+```
+
+Once you're done editing, adjust `~/.bashrc` to use your newly created theme.
+
+```bash
+eval "$(oh-my-posh --init --shell bash --config ~/.mytheme.omp.json)"
+```
+
+When adjusted, reload your profile for the changes to take effect.
+
+```bash
+. ~/.bashrc
+```
+
+</TabItem>
+<TabItem value="fish">
+
+```bash
+export_poshconfig "~/.mytheme.omp.json" json
+```
+
+Once you're done editing, adjust `config.fish` to use your newly created theme.
+
+```bash
+oh-my-posh --init --shell fish --config ~/.mytheme.omp.json | source
+```
+
+Once adjusted, reload your config for the changes to take effect.
+
+```bash
+. ~/.config/fish/config.fish
+```
+
+</TabItem>
+</Tabs>

--- a/docs/docs/install-shells-wsl.mdx
+++ b/docs/docs/install-shells-wsl.mdx
@@ -1,0 +1,113 @@
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+:::info
+If you have no idea which shell you're currently using, Oh My Posh has a utility switch that can tell that to you (not relevant
+for the Powershell module).
+:::
+
+```bash
+oh-my-posh --print-shell
+```
+
+<Tabs
+  defaultValue="powershell"
+  groupId="shell"
+  values={[
+    { label: 'powershell', value: 'powershell', },
+    { label: 'zsh', value: 'zsh', },
+    { label: 'bash', value: 'bash', },
+    { label: 'fish', value: 'fish', },
+    { label: 'nu', value: 'nu', },
+  ]
+}>
+<TabItem value="powershell">
+
+Edit `$PROFILE` in your preferred PowerShell version and add the following line.
+
+```powershell
+oh-my-posh --init --shell pwsh --config ~/jandedobbeleer.omp.json | Invoke-Expression
+```
+
+Once added, reload your profile for the changes to take effect.
+
+```powershell
+. $PROFILE
+```
+
+</TabItem>
+<TabItem value="zsh">
+
+Add the following to `~/.zshrc`:
+
+```bash
+eval "$(oh-my-posh-wsl --init --shell zsh --config /mnt/c/Users/<WINDOWSUSERNAME>/AppData/Local/Programs/oh-my-posh/themes/ys.omp.json)"
+```
+
+Once added, reload your profile for the changes to take effect.
+
+```bash
+source ~/.zshrc
+```
+
+</TabItem>
+<TabItem value="bash">
+
+Add the following to `~/.bashrc` (or `~/.profile` on MacOS):
+
+```bash
+eval "$(oh-my-posh-wsl --init --shell bash --config /mnt/c/Users/<WINDOWSUSERNAME>/AppData/Local/Programs/oh-my-posh/themes/ys.omp.json)"
+```
+
+Once added, reload your profile for the changes to take effect.
+
+```bash
+. ~/.bashrc
+```
+
+Or, when using `~/.profile`.
+
+```bash
+. ~/.profile
+```
+
+</TabItem>
+<TabItem value="fish">
+
+:::caution
+It's advised to be on the latest version of fish. Versions below 3.1.2 have issues displaying the prompt.
+:::
+
+Initialize Oh My Posh in `~/.config/fish/config.fish`:
+
+```bash
+oh-my-posh-wsl --init --shell fish --config /mnt/c/Users/<WINDOWSUSERNAME>/AppData/Local/Programs/oh-my-posh/themes/ys.omp.json | source
+```
+
+Once added, reload your config for the changes to take effect.
+
+```bash
+. ~/.config/fish/config.fish
+```
+
+</TabItem>
+<TabItem value="nu">
+
+Set the prompt and restart nu shell:
+
+### Nu < 0.32.0
+
+```bash
+config set prompt  "= `{{$(oh-my-posh-wsl --config /mnt/c/Users/<WINDOWSUSERNAME>/AppData/Local/Programs/oh-my-posh/themes/ys.omp.json | str collect)}}`"
+```
+
+### Nu >= 0.32.0
+
+```bash
+config set prompt  "(oh-my-posh-wsl --config /mnt/c/Users/<WINDOWSUSERNAME>/AppData/Local/Programs/oh-my-posh/themes/ys.omp.json | str collect)"
+```
+
+Restart nu shell for the changes to take effect.
+
+</TabItem>
+</Tabs>

--- a/docs/docs/install-windows.mdx
+++ b/docs/docs/install-windows.mdx
@@ -6,9 +6,9 @@ sidebar_label: ⊞ Windows
 
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
-import Shells from "./install-shells.mdx";
+import Shells from "./install-shells-wsl.mdx";
 import Customize from "./install-customize.md";
-import CustomizeCmd from "./install-customize-cmd.mdx";
+import CustomizeWsl from "./install-customize-wsl.mdx";
 
 ### Setup your terminal
 
@@ -185,7 +185,7 @@ Based on the installation method used, you can find this theme at the following 
 
 <Customize />
 
-<CustomizeCmd />
+<CustomizeWsl />
 
 🎉🎉🎉
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

Current documentation does not correctly inform users how to configure on WSL. Copied the relevant .mdx files and added  WSL specific instructions.

I edited the "Override the theme settings" section but those instructions won't work on PowerShell if the user installed via winget or scoop
