### PR TITLE
fix(git): support in-progress cherry-pick/revert

### DIFF
--- a/docs/docs/segment-git.mdx
+++ b/docs/docs/segment-git.mdx
@@ -72,6 +72,7 @@ An alternative is to use the [Posh-Git segment][poshgit]
 - tag_icon: `string` - icon/text to display before the tag context - defaults to `\uF412`
 - rebase_icon: `string` - icon/text to display before the context when in a rebase - defaults to `\uE728 `
 - cherry_pick_icon: `string` - icon/text to display before the context when doing a cherry-pick - defaults to `\uE29B `
+- revert_icon: `string` - icon/text to display before the context when doing a revert - defaults to `\uF0E2 `
 - merge_icon: `string` icon/text to display before the merge context - defaults to `\uE727 `
 - no_commits_icon: `string` icon/text to display when there are no commits in the repo - defaults to `\uF594 `
 

--- a/src/segment_git_test.go
+++ b/src/segment_git_test.go
@@ -93,6 +93,7 @@ func setupHEADContextEnv(context *detachedContext) *git {
 	env := new(MockedEnvironment)
 	env.On("hasFolder", "/rebase-merge").Return(context.rebaseMerge)
 	env.On("hasFolder", "/rebase-apply").Return(context.rebaseApply)
+	env.On("hasFolder", "/sequencer").Return(context.sequencer)
 	env.On("getFileContent", "/rebase-merge/head-name").Return(context.origin)
 	env.On("getFileContent", "/rebase-merge/onto").Return(context.onto)
 	env.On("getFileContent", "/rebase-merge/msgnum").Return(context.step)
@@ -103,12 +104,12 @@ func setupHEADContextEnv(context *detachedContext) *git {
 	env.On("getFileContent", "/CHERRY_PICK_HEAD").Return(context.cherryPickSHA)
 	env.On("getFileContent", "/REVERT_HEAD").Return(context.revertSHA)
 	env.On("getFileContent", "/MERGE_MSG").Return(fmt.Sprintf("Merge branch '%s' into %s", context.mergeHEAD, context.onto))
+	env.On("getFileContent", "/sequencer/todo").Return(context.sequencerTodo)
 	env.On("hasFilesInDir", "", "CHERRY_PICK_HEAD").Return(context.cherryPick)
 	env.On("hasFilesInDir", "", "REVERT_HEAD").Return(context.revert)
-	env.On("hasFolder", "sequencer").Return(context.sequencer)
-	env.On("getFileContent", "/sequencer/todo").Return(context.sequencerTodo)
 	env.On("hasFilesInDir", "", "MERGE_MSG").Return(context.merge)
 	env.On("hasFilesInDir", "", "MERGE_HEAD").Return(context.merge)
+	env.On("hasFilesInDir", "", "sequencer/todo").Return(context.sequencer)
 	env.mockGitCommand(context.currentCommit, "rev-parse", "--short", "HEAD")
 	env.mockGitCommand(context.tagName, "describe", "--tags", "--exact-match")
 	env.mockGitCommand(context.origin, "name-rev", "--name-only", "--exclude=tags/*", context.origin)
@@ -251,7 +252,7 @@ func TestGetGitHEADContextSequencerCherryPickOnBranch(t *testing.T) {
 		currentCommit: "whatever",
 		branchName:    "main",
 		sequencer:     true,
-		sequencerTodo: "pick pickme",
+		sequencerTodo: "pick pickme message\npick notme message",
 	}
 	g := setupHEADContextEnv(context)
 	got := g.getGitHEADContext("main")

--- a/src/segment_git_test.go
+++ b/src/segment_git_test.go
@@ -221,12 +221,12 @@ func TestGetGitHEADContextCherryPickOnTag(t *testing.T) {
 }
 
 func TestGetGitHEADContextRevertOnBranch(t *testing.T) {
-	want := "\uf0e2 pickme onto \ue0a0main"
+	want := "\uf0e2 012345 onto \ue0a0main"
 	context := &detachedContext{
 		currentCommit: "whatever",
 		branchName:    "main",
 		revert:        true,
-		revertSHA:     "pickme",
+		revertSHA:     "01234567",
 	}
 	g := setupHEADContextEnv(context)
 	got := g.getGitHEADContext("main")
@@ -234,12 +234,12 @@ func TestGetGitHEADContextRevertOnBranch(t *testing.T) {
 }
 
 func TestGetGitHEADContextRevertOnTag(t *testing.T) {
-	want := "\uf0e2 pickme onto \uf412v3.4.6"
+	want := "\uf0e2 012345 onto \uf412v3.4.6"
 	context := &detachedContext{
 		currentCommit: "whatever",
 		tagName:       "v3.4.6",
 		revert:        true,
-		revertSHA:     "pickme",
+		revertSHA:     "01234567",
 	}
 	g := setupHEADContextEnv(context)
 	got := g.getGitHEADContext("")
@@ -265,7 +265,7 @@ func TestGetGitHEADContextSequencerCherryPickOnTag(t *testing.T) {
 		currentCommit: "whatever",
 		tagName:       "v3.4.6",
 		sequencer:     true,
-		sequencerTodo: "pick pickme",
+		sequencerTodo: "pick pickme message\npick notme message",
 	}
 	g := setupHEADContextEnv(context)
 	got := g.getGitHEADContext("")
@@ -273,12 +273,12 @@ func TestGetGitHEADContextSequencerCherryPickOnTag(t *testing.T) {
 }
 
 func TestGetGitHEADContextSequencerRevertOnBranch(t *testing.T) {
-	want := "\ue29b pickme onto \ue0a0main"
+	want := "\uf0e2 012345 onto \ue0a0main"
 	context := &detachedContext{
 		currentCommit: "whatever",
 		branchName:    "main",
 		sequencer:     true,
-		sequencerTodo: "revert pickme",
+		sequencerTodo: "revert 01234567 message\nrevert notme message",
 	}
 	g := setupHEADContextEnv(context)
 	got := g.getGitHEADContext("main")
@@ -286,12 +286,12 @@ func TestGetGitHEADContextSequencerRevertOnBranch(t *testing.T) {
 }
 
 func TestGetGitHEADContextSequencerRevertOnTag(t *testing.T) {
-	want := "\ue29b pickme onto \uf412v3.4.6"
+	want := "\uf0e2 012345 onto \uf412v3.4.6"
 	context := &detachedContext{
 		currentCommit: "whatever",
 		tagName:       "v3.4.6",
 		sequencer:     true,
-		sequencerTodo: "revert pickme",
+		sequencerTodo: "revert 01234567 message\nrevert notme message",
 	}
 	g := setupHEADContextEnv(context)
 	got := g.getGitHEADContext("")

--- a/themes/half-life.omp.json
+++ b/themes/half-life.omp.json
@@ -48,6 +48,7 @@
             "merge_icon": "",
             "rebase_icon": "",
             "cherry_pick_icon": "",
+            "revert_icon": "",
             "working_color": "#D75F00",
             "staging_color": "#87FF00",
             "local_working_icon": " ●",

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -604,6 +604,12 @@
                     "description": "Icon/text to display before the context when doing a cherry-pick",
                     "default": "\uE29B"
                   },
+                  "revert_icon": {
+                    "type": "string",
+                    "title": "Revert Icon",
+                    "description": "Icon/text to display before the context when doing a revert",
+                    "default": "\uF0E2"
+                  },
                   "merge_icon": {
                     "type": "string",
                     "title": "Merge Icon",


### PR DESCRIPTION
### Prerequisites

- [X] I have read and understood the `CONTRIBUTING` guide
- [X] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [X] Docs have been added / updated (for bug fixes/features)

### Description

When a cherry-pick is in progress, .git/CHERRY_PICK_HEAD doesn't exist, so read .git/sequencer/todo instead.

The canonical git prompt in [git/contrib]https://github.com/git/git/blob/master/contrib/completion/git-prompt.sh) has this in its cherry-pick section, which it refers to as the "sequencer" status.

The sequencer also includes support for "git revert", so I am also adding that.

**Icon:** I chose the `fa-undo` icon for "revert" (`\uF0E2`; &#xF0E2;).  Please let me know if another icon is appropriate.

### Tips

If you're not comfortable with working with Git, we're working a [guide][docs] to help you out.
Oh My Posh advises [GitKraken][kraken] as your preferred cross platform Git GUI power tool.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[docs]: https://ohmyposh.dev/docs/contributing_git
[kraken]: https://www.gitkraken.com/invite/nQmDPR9D
