### PR TITLE
fix(aws): Override default region if AWS_REGION is set

### DIFF
--- a/src/segment_aws.go
+++ b/src/segment_aws.go
@@ -36,7 +36,7 @@ func (a *aws) enabled() bool {
 	if !displayDefaultUser && a.Profile == defaultUser {
 		return false
 	}
-	a.Region = getEnvFirstMatch("AWS_DEFAULT_REGION", "AWS_REGION")
+	a.Region = getEnvFirstMatch("AWS_REGION", "AWS_DEFAULT_REGION")
 	if a.Profile != "" && a.Region != "" {
 		return true
 	}

--- a/src/segment_aws_test.go
+++ b/src/segment_aws_test.go
@@ -25,7 +25,8 @@ func TestAWSSegment(t *testing.T) {
 		{Case: "enabled with default user", ExpectedString: "default@eu-west", Profile: "default", Region: "eu-west", ExpectedEnabled: true, DisplayDefault: true},
 		{Case: "disabled with default user", ExpectedString: "default", Profile: "default", Region: "eu-west", ExpectedEnabled: false, DisplayDefault: false},
 		{Case: "enabled no region", ExpectedString: "company", ExpectedEnabled: true, Profile: "company"},
-		{Case: "enabled with region", ExpectedString: "company@eu-west", ExpectedEnabled: true, Profile: "company", Region: "eu-west"},
+		{Case: "enabled with region", ExpectedString: "company@eu-west", ExpectedEnabled: true, Profile: "company", Region: "eu-west", DefaultRegion: "us-west"},
+		{Case: "enabled with default region", ExpectedString: "company@us-west", ExpectedEnabled: true, Profile: "company", DefaultRegion: "us-west"},
 		{
 			Case:            "template: enabled no region",
 			ExpectedString:  "profile: company",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

I noticed that `AWS_REGION` is not overriding `AWS_DEFAULT_REGION`. This PR should fix that.
