### PR TITLE
fix: avoid variable expansion when using postfix in zsh

### DIFF
--- a/src/ansi.go
+++ b/src/ansi.go
@@ -32,6 +32,12 @@ type ansiUtils struct {
 	underline             string
 	strikethrough         string
 	bashFormat            string
+	shellReservedKeywords []shellKeyWordReplacement
+}
+
+type shellKeyWordReplacement struct {
+	text        string
+	replacement string
 }
 
 func (a *ansiUtils) init(shell string) {
@@ -59,6 +65,8 @@ func (a *ansiUtils) init(shell string) {
 		a.italic = "%%{\x1b[3m%%}%s%%{\x1b[23m%%}"
 		a.underline = "%%{\x1b[4m%%}%s%%{\x1b[24m%%}"
 		a.strikethrough = "%%{\x1b[9m%%}%s%%{\x1b[29m%%}"
+		// escape double quotes and variable expansion
+		a.shellReservedKeywords = append(a.shellReservedKeywords, shellKeyWordReplacement{"\\", "\\\\"}, shellKeyWordReplacement{"%", "%%"})
 	case bash:
 		a.linechange = "\\[\x1b[%d%s\\]"
 		a.right = "\\[\x1b[%dC\\]"
@@ -80,6 +88,9 @@ func (a *ansiUtils) init(shell string) {
 		a.italic = "\\[\x1b[3m\\]%s\\[\x1b[23m\\]"
 		a.underline = "\\[\x1b[4m\\]%s\\[\x1b[24m\\]"
 		a.strikethrough = "\\[\x1b[9m\\]%s\\[\x1b[29m\\]"
+		// escape backslashes to avoid replacements
+		// https://tldp.org/HOWTO/Bash-Prompt-HOWTO/bash-prompt-escape-sequences.html
+		a.shellReservedKeywords = append(a.shellReservedKeywords, shellKeyWordReplacement{"\\", "\\\\"})
 	default:
 		a.linechange = "\x1b[%d%s"
 		a.right = "\x1b[%dC"
@@ -102,6 +113,8 @@ func (a *ansiUtils) init(shell string) {
 		a.underline = "\x1b[4m%s\x1b[24m"
 		a.strikethrough = "\x1b[9m%s\x1b[29m"
 	}
+	// common replacement for all shells
+	a.shellReservedKeywords = append(a.shellReservedKeywords, shellKeyWordReplacement{"`", "'"})
 }
 
 func (a *ansiUtils) lenWithoutANSI(text string) int {
@@ -187,18 +200,8 @@ func (a *ansiUtils) clearAfter() string {
 
 func (a *ansiUtils) escapeText(text string) string {
 	// what to escape/replace is different per shell
-	// maybe we should refactor and maintain a list of characters to escap/replace
-	// like we do in ansi.go for ansi codes
-	switch a.shell {
-	case zsh:
-		// escape double quotes
-		text = strings.ReplaceAll(text, "\"", "\"\"")
-	case bash:
-		// escape backslashes to avoid replacements
-		// https://tldp.org/HOWTO/Bash-Prompt-HOWTO/bash-prompt-escape-sequences.html
-		text = strings.ReplaceAll(text, "\\", "\\\\")
+	for _, s := range a.shellReservedKeywords {
+		text = strings.ReplaceAll(text, s.text, s.replacement)
 	}
-	// escape backtick
-	text = strings.ReplaceAll(text, "`", "'")
 	return text
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

If a `%` is used in `postfix` property, zsh try to expand the variable.  
like here(`%~` set in `postfix` property of battery segment):
![image](https://user-images.githubusercontent.com/1829553/129308878-12a018b4-4301-4a6a-914a-afea7b1b88c2.png)



<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
