### PR TITLE
feat: owd custom timeout + all units support + hyperlink

### DIFF
--- a/docs/docs/segment-owm.md
+++ b/docs/docs/segment-owm.md
@@ -27,7 +27,9 @@ The free tier for *Current weather and forecasts collection* is sufficient.
   "properties": {
     "apikey": "<YOUR_API_KEY>",
     "location": "AMSTERDAM,NL",
-    "units": "metric"
+    "units": "metric",
+    "enable_hyperlink" : false,
+    "http_timeout": 20
   }
 }
 ```
@@ -39,4 +41,6 @@ The free tier for *Current weather and forecasts collection* is sufficient.
                         Formatted as <City,STATE,COUNTRY_CODE>. City name, state code and country code divided by comma.
                         Please, refer to ISO 3166 for the state codes or country codes - defaults to `DE BILT,NL`
 - units: `string` - Units of measurement.
+- enable_hyperlink: `bool` - Displays an hyperlink to get openweathermap data
+- http_timeout: `int` - The default timeout for http request is 20ms.
 Available values are standard (kelvin), metric (celsius), and imperial (fahrenheit) - defaults to `standard`

--- a/src/ansi.go
+++ b/src/ansi.go
@@ -121,8 +121,8 @@ func (a *ansiUtils) lenWithoutANSI(text string) int {
 	if len(text) == 0 {
 		return 0
 	}
-	// replace hyperlinks
-	matches := findAllNamedRegexMatch(`(?P<STR>\x1b]8;;file:\/\/(.+)\x1b\\(?P<URL>.+)\x1b]8;;\x1b\\)`, text)
+	// replace hyperlinks(file/http/https)
+	matches := findAllNamedRegexMatch(`(?P<STR>\x1b]8;;(file|http|https):\/\/(.+?)\x1b\\(?P<URL>.+?)\x1b]8;;\x1b\\)`, text)
 	for _, match := range matches {
 		text = strings.ReplaceAll(text, match[str], match[url])
 	}

--- a/src/config.go
+++ b/src/config.go
@@ -40,6 +40,10 @@ type TransientPrompt struct {
 const (
 	// EnableHyperlink enable hyperlink
 	EnableHyperlink Property = "enable_hyperlink"
+	// HTTPTimeout timeout used when executing http request
+	HTTPTimeout Property = "http_timeout"
+	// DefaultHTTPTimeout default timeout used when executing http request
+	DefaultHTTPTimeout = 20
 )
 
 func printConfigError(err error) {

--- a/src/environment.go
+++ b/src/environment.go
@@ -72,7 +72,7 @@ type environmentInfo interface {
 	getBatteryInfo() ([]*battery.Battery, error)
 	getShellName() string
 	getWindowTitle(imageName, windowTitleRegex string) (string, error)
-	doGet(url string) ([]byte, error)
+	doGet(url string, timeout int) ([]byte, error)
 	hasParentFilePath(path string) (fileInfo *fileInfo, err error)
 	isWsl() bool
 	stackCount() int
@@ -389,9 +389,9 @@ func (env *environment) getShellName() string {
 	return *env.args.Shell
 }
 
-func (env *environment) doGet(url string) ([]byte, error) {
+func (env *environment) doGet(url string, timeout int) ([]byte, error) {
 	defer env.tracer.trace(time.Now(), "doGet", url)
-	ctx, cncl := context.WithTimeout(context.Background(), time.Millisecond*20)
+	ctx, cncl := context.WithTimeout(context.Background(), time.Millisecond*time.Duration(timeout))
 	defer cncl()
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {

--- a/src/segment.go
+++ b/src/segment.go
@@ -121,7 +121,8 @@ const (
 	Nbgv SegmentType = "nbgv"
 	// Rust writes the cargo version information if cargo.toml is present
 	Rust SegmentType = "rust"
-	OWM  SegmentType = "owm"
+	// OWM writes the weather coming from openweatherdata
+	OWM SegmentType = "owm"
 )
 
 func (segment *Segment) string() string {

--- a/src/segment_owm_test.go
+++ b/src/segment_owm_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestOWDSegmentSingle(t *testing.T) {
+func TestOWMSegmentSingle(t *testing.T) {
 	cases := []struct {
 		Case            string
 		JSONResponse    string
@@ -19,7 +19,7 @@ func TestOWDSegmentSingle(t *testing.T) {
 		{
 			Case:            "Sunny Display",
 			JSONResponse:    `{"weather":[{"icon":"01d"}],"main":{"temp":20}}`,
-			ExpectedString:  "\ufa98 (20\ue33e)",
+			ExpectedString:  "\ufa98 (20°C)",
 			ExpectedEnabled: true,
 		},
 		{
@@ -59,7 +59,7 @@ func TestOWDSegmentSingle(t *testing.T) {
 	}
 }
 
-func TestOWDSegmentIcons(t *testing.T) {
+func TestOWMSegmentIcons(t *testing.T) {
 	cases := []struct {
 		Case               string
 		IconID             string
@@ -124,7 +124,7 @@ func TestOWDSegmentIcons(t *testing.T) {
 
 		url := "http://api.openweathermap.org/data/2.5/weather?q=AMSTERDAM,NL&units=metric&appid=key"
 		response := fmt.Sprintf(`{"weather":[{"icon":"%s"}],"main":{"temp":20}}`, tc.IconID)
-		expectedString := fmt.Sprintf("%s (20\ue33e)", tc.ExpectedIconString)
+		expectedString := fmt.Sprintf("%s (20°C)", tc.ExpectedIconString)
 
 		env.On("doGet", url).Return([]byte(response), nil)
 

--- a/src/segment_path_test.go
+++ b/src/segment_path_test.go
@@ -124,7 +124,7 @@ func (env *MockedEnvironment) getWindowTitle(imageName, windowTitleRegex string)
 	return args.String(0), args.Error(1)
 }
 
-func (env *MockedEnvironment) doGet(url string) ([]byte, error) {
+func (env *MockedEnvironment) doGet(url string, timeout int) ([]byte, error) {
 	args := env.Called(url)
 	return args.Get(0).([]byte), args.Error(1)
 }

--- a/src/segment_ytm.go
+++ b/src/segment_ytm.go
@@ -85,7 +85,8 @@ type track struct {
 func (y *ytm) setStatus() error {
 	// https://github.com/ytmdesktop/ytmdesktop/wiki/Remote-Control-API
 	url := y.props.getString(APIURL, "http://127.0.0.1:9863")
-	body, err := y.env.doGet(url + "/query")
+	httpTimeout := y.props.getInt(APIURL, DefaultHTTPTimeout)
+	body, err := y.env.doGet(url+"/query", httpTimeout)
 	if err != nil {
 		return err
 	}

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -27,6 +27,18 @@
       "description": "Show or hide the version number",
       "default": true
     },
+    "enable_hyperlink": {
+      "type": "boolean",
+      "title": "Enable hyperlink",
+      "description": "Displays an hyperlink for the current segment",
+      "default": false
+    },
+    "http_timeout": {
+      "type": "integer",
+      "title": "Http requst timeout",
+      "description": "Timeout value to use for http request",
+      "default": 20
+    },
     "display_mode": {
       "type": "string",
       "title": "Display Mode",
@@ -155,7 +167,8 @@
             "azfunc",
             "crystal",
             "dart",
-            "rust"
+            "rust",
+            "owm"
           ]
         },
         "style": {
@@ -681,10 +694,10 @@
                   "behind_color": { "$ref": "#/definitions/color" },
                   "ahead_color": { "$ref": "#/definitions/color" },
                   "branch_max_length": {
-                      "type": "integer",
-                      "title": "Branch max length",
-                      "description": "the max length for the displayed branch name where 0 implies full length",
-                      "default": 0
+                    "type": "integer",
+                    "title": "Branch max length",
+                    "description": "the max length for the displayed branch name where 0 implies full length",
+                    "default": 0
                   }
                 }
               }
@@ -1227,17 +1240,14 @@
                   "description": "Replace known locations in the path with the replacements before applying the style.",
                   "default": true
                 },
-                "enable_hyperlink": {
-                  "type": "boolean",
-                  "title": "Enable hyperlink",
-                  "description": "Displays an hyperlink for the current path",
-                  "default": false
-                },
                 "stack_count_enabled": {
                   "type": "boolean",
                   "title": "Show/hide stack count",
                   "description": "Displays the stack count when using pushd/popd",
                   "default": false
+                },
+                "enable_hyperlink": {
+                  "$ref": "#/definitions/enable_hyperlink"
                 }
               }
             }
@@ -1512,6 +1522,9 @@
                     "title": "API URL",
                     "description": "The YTMDA Remote Control API URL",
                     "default": "http://127.0.0.1:9863"
+                  },
+                  "http_timeout": {
+                    "$ref": "#/definitions/http_timeout"
                   }
                 }
               }
@@ -1547,6 +1560,12 @@
                     "title": "units",
                     "description": "Units of measurement. Available values are standard (kelvin), metric (celsius), and imperial (fahrenheit). Default is standard",
                     "default": "standard"
+                  },
+                  "enable_hyperlink": {
+                    "$ref": "#/definitions/enable_hyperlink"
+                  },
+                  "http_timeout": {
+                    "$ref": "#/definitions/http_timeout"
                   }
                 }
               }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

there is an issue with right prompt and hyperlink(nothing to do with the segment, ansi len calculation) to fix. 
![image](https://user-images.githubusercontent.com/1829553/129849442-6cb69e91-8840-49f9-9101-3ce56812512e.png)

all units support for openweathermap 
json schema updated(missing entries for owm)
owd files renamed to owm(mixed before)
hyperlink support for owm + fix when hyperlink used in the right prompt(pwsh only)
custom http timeout added



<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
