### PR TITLE
feat(git): display worktree count

### DIFF
--- a/docs/docs/segment-git.mdx
+++ b/docs/docs/segment-git.mdx
@@ -61,10 +61,12 @@ An alternative is to use the [Posh-Git segment][poshgit]
 - display_status: `boolean` - display the local changes or not - defaults to `false`
 - display_status_detail: `boolean` - display the local changes in detail or not - defaults to `true`
 - display_stash_count: `boolean` show stash count or not - defaults to `false`
+- display_worktree_count: `boolean` show worktree count or not - defaults to `false`
 - status_separator_icon: `string` icon/text to display between staging and working area changes - defaults to ` |`
 - local_working_icon: `string` - the icon to display in front of the working area changes - defaults to `\uF044`
 - local_staged_icon: `string` - the icon to display in front of the staged area changes - defaults to `\uF046`
 - stash_count_icon: `string` icon/text to display before the stash context - defaults to `\uF692`
+- worktree_count_icon: `string` icon/text to display before the worktree context - defaults to `\uF1BB`
 
 ### HEAD context
 

--- a/src/environment.go
+++ b/src/environment.go
@@ -57,6 +57,7 @@ type environmentInfo interface {
 	hasFilesInDir(dir, pattern string) bool
 	hasFolder(folder string) bool
 	getFileContent(file string) string
+	getFoldersList(path string) []string
 	getPathSeperator() string
 	getCurrentUser() string
 	isRunningAsRoot() bool
@@ -217,6 +218,21 @@ func (env *environment) getFileContent(file string) string {
 		return ""
 	}
 	return string(content)
+}
+
+func (env *environment) getFoldersList(path string) []string {
+	defer env.tracer.trace(time.Now(), "getFoldersList", path)
+	content, err := os.ReadDir(path)
+	if err != nil {
+		return nil
+	}
+	var folderNames []string
+	for _, s := range content {
+		if s.IsDir() {
+			folderNames = append(folderNames, s.Name())
+		}
+	}
+	return folderNames
 }
 
 func (env *environment) getPathSeperator() string {

--- a/src/segment_path.go
+++ b/src/segment_path.go
@@ -45,7 +45,7 @@ const (
 	MappedLocationsEnabled Property = "mapped_locations_enabled"
 	// StackCountEnabled enables the stack count display
 	StackCountEnabled Property = "stack_count_enabled"
-	// Maximum path depth to display whithout shortening
+	// MaxDepth Maximum path depth to display whithout shortening
 	MaxDepth Property = "max_depth"
 )
 

--- a/src/segment_path_test.go
+++ b/src/segment_path_test.go
@@ -49,6 +49,11 @@ func (env *MockedEnvironment) getFileContent(file string) string {
 	return args.String(0)
 }
 
+func (env *MockedEnvironment) getFoldersList(path string) []string {
+	args := env.Called(path)
+	return args.Get(0).([]string)
+}
+
 func (env *MockedEnvironment) getPathSeperator() string {
 	args := env.Called(nil)
 	return args.String(0)

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -569,6 +569,12 @@
                     "description": "Display the stash count or not",
                     "default": false
                   },
+                  "display_worktree_count": {
+                    "type": "boolean",
+                    "title": "Display Worktree Count",
+                    "description": "Display the worktree count or not",
+                    "default": false
+                  },
                   "status_separator_icon": {
                     "type": "string",
                     "title": "Status Separator Icon",
@@ -591,7 +597,13 @@
                     "type": "string",
                     "title": "Stash Count Icon",
                     "description": "The icon to display before the stash context",
-                    "default": "\uF692"
+                    "default": "\uF692 "
+                  },
+                  "worktree_count_icon": {
+                    "type": "string",
+                    "title": "Worktree Count Icon",
+                    "description": "The icon to display before the worktree context",
+                    "default": "\uF1bb "
                   },
                   "commit_icon": {
                     "type": "string",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

Display worktree count in git segment.  
There was also an issue with stash count not being displayed when using worktree.  
worktree and stash are global object and not stored in the worktree folder but in the root folder.

[Description of the change]

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
