### PR TITLE
fix(owm): icon display at night

### DIFF
--- a/src/segment_owm.go
+++ b/src/segment_owm.go
@@ -80,22 +80,40 @@ func (d *owm) setStatus() error {
 	d.temperature = q.temperature.Value
 	icon := ""
 	switch q.Data[0].TypeID {
+	case "01n":
+		fallthrough
 	case "01d":
 		icon = "\ufa98"
+	case "02n":
+		fallthrough
 	case "02d":
 		icon = "\ufa94"
+	case "03n":
+		fallthrough
 	case "03d":
 		icon = "\ue33d"
+	case "04n":
+		fallthrough
 	case "04d":
 		icon = "\ue312"
+	case "09n":
+		fallthrough
 	case "09d":
 		icon = "\ufa95"
+	case "10n":
+		fallthrough
 	case "10d":
 		icon = "\ue308"
+	case "11n":
+		fallthrough
 	case "11d":
 		icon = "\ue31d"
+	case "13n":
+		fallthrough
 	case "13d":
 		icon = "\ue31a"
+	case "50n":
+		fallthrough
 	case "50d":
 		icon = "\ue313"
 	}

--- a/src/segment_owm_test.go
+++ b/src/segment_owm_test.go
@@ -66,48 +66,94 @@ func TestOWMSegmentIcons(t *testing.T) {
 		ExpectedIconString string
 	}{
 		{
-			Case:               "Sunny Display",
+			Case:               "Sunny Display day",
 			IconID:             "01d",
 			ExpectedIconString: "\ufa98",
 		},
 		{
-			Case:               "Light clouds Display",
+			Case:               "Light clouds Display day",
 			IconID:             "02d",
 			ExpectedIconString: "\ufa94",
 		},
 		{
-			Case:               "Cloudy Display",
+			Case:               "Cloudy Display day",
 			IconID:             "03d",
 			ExpectedIconString: "\ue33d",
 		},
 		{
-			Case:               "Broken Clouds Display",
+			Case:               "Broken Clouds Display day",
 			IconID:             "04d",
 			ExpectedIconString: "\ue312",
 		},
 		{
-			Case:               "Shower Rain Display",
+			Case:               "Shower Rain Display day",
 			IconID:             "09d",
 			ExpectedIconString: "\ufa95",
 		},
 		{
-			Case:               "Rain Display",
+			Case:               "Rain Display day",
 			IconID:             "10d",
 			ExpectedIconString: "\ue308",
 		},
 		{
-			Case:               "Thunderstorm Display",
+			Case:               "Thunderstorm Display day",
 			IconID:             "11d",
 			ExpectedIconString: "\ue31d",
 		},
 		{
-			Case:               "Snow Display",
+			Case:               "Snow Display day",
 			IconID:             "13d",
 			ExpectedIconString: "\ue31a",
 		},
 		{
-			Case:               "Fog Display",
+			Case:               "Fog Display day",
 			IconID:             "50d",
+			ExpectedIconString: "\ue313",
+		},
+
+		{
+			Case:               "Sunny Display night",
+			IconID:             "01n",
+			ExpectedIconString: "\ufa98",
+		},
+		{
+			Case:               "Light clouds Display night",
+			IconID:             "02n",
+			ExpectedIconString: "\ufa94",
+		},
+		{
+			Case:               "Cloudy Display night",
+			IconID:             "03n",
+			ExpectedIconString: "\ue33d",
+		},
+		{
+			Case:               "Broken Clouds Display night",
+			IconID:             "04n",
+			ExpectedIconString: "\ue312",
+		},
+		{
+			Case:               "Shower Rain Display night",
+			IconID:             "09n",
+			ExpectedIconString: "\ufa95",
+		},
+		{
+			Case:               "Rain Display night",
+			IconID:             "10n",
+			ExpectedIconString: "\ue308",
+		},
+		{
+			Case:               "Thunderstorm Display night",
+			IconID:             "11n",
+			ExpectedIconString: "\ue31d",
+		},
+		{
+			Case:               "Snow Display night",
+			IconID:             "13n",
+			ExpectedIconString: "\ue31a",
+		},
+		{
+			Case:               "Fog Display night",
+			IconID:             "50n",
 			ExpectedIconString: "\ue313",
 		},
 	}


### PR DESCRIPTION
Icon id is different for day/night

### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

The icon returned by the api is different for night and day. Set the same icon for now to avoid empty display.

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
