### PR TITLE
feat: add format option to owm segment

### DIFF
--- a/docs/docs/segment-owm.md
+++ b/docs/docs/segment-owm.md
@@ -29,6 +29,7 @@ The free tier for *Current weather and forecasts collection* is sufficient.
     "location": "AMSTERDAM,NL",
     "units": "metric",
     "enable_hyperlink" : false,
+    "format": "%s (%g%s)",
     "http_timeout": 20
   }
 }
@@ -43,4 +44,6 @@ The free tier for *Current weather and forecasts collection* is sufficient.
 - units: `string` - Units of measurement.
                     Available values are standard (kelvin), metric (celsius), and imperial (fahrenheit) - defaults to `standard`
 - enable_hyperlink: `bool` - Displays an hyperlink to get openweathermap data
+- format: `string` - The format string used to generate text. Defaults to `%s (%g%s)`, receiving the current weather icon,
+temperature, and temperature unit as arguments. See [the Go `fmt` docs](https://pkg.go.dev/fmt) for details.
 - http_timeout: `int` - The default timeout for http request is 20ms.

--- a/src/segment_owm.go
+++ b/src/segment_owm.go
@@ -21,6 +21,8 @@ const (
 	LOCATION Property = "location"
 	// UNITS openweathermap units
 	UNITS Property = "units"
+	// FORMAT display format
+	FORMAT Property = "format"
 )
 
 type weather struct {
@@ -54,7 +56,9 @@ func (d *owm) string() string {
 	case "standard":
 		unitIcon = "°K" // \ufa05"
 	}
-	text := fmt.Sprintf("%s (%g%s)", d.weather, d.temperature, unitIcon)
+
+	format := d.props.getString(FORMAT, "%s (%g%s)")
+	text := fmt.Sprintf(format, d.weather, d.temperature, unitIcon)
 	if d.props.getBool(EnableHyperlink, false) {
 		text = fmt.Sprintf("[%s](%s)", text, d.url)
 	}

--- a/src/segment_owm_test.go
+++ b/src/segment_owm_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const URL = "http://api.openweathermap.org/data/2.5/weather?q=AMSTERDAM,NL&units=metric&appid=key"
+
 func TestOWMSegmentSingle(t *testing.T) {
 	cases := []struct {
 		Case            string
@@ -40,9 +42,7 @@ func TestOWMSegmentSingle(t *testing.T) {
 			},
 		}
 
-		url := "http://api.openweathermap.org/data/2.5/weather?q=AMSTERDAM,NL&units=metric&appid=key"
-
-		env.On("doGet", url).Return([]byte(tc.JSONResponse), tc.Error)
+		env.On("doGet", URL).Return([]byte(tc.JSONResponse), tc.Error)
 
 		o := &owm{
 			props: props,
@@ -168,11 +168,10 @@ func TestOWMSegmentIcons(t *testing.T) {
 			},
 		}
 
-		url := "http://api.openweathermap.org/data/2.5/weather?q=AMSTERDAM,NL&units=metric&appid=key"
 		response := fmt.Sprintf(`{"weather":[{"icon":"%s"}],"main":{"temp":20}}`, tc.IconID)
 		expectedString := fmt.Sprintf("%s (20°C)", tc.ExpectedIconString)
 
-		env.On("doGet", url).Return([]byte(response), nil)
+		env.On("doGet", URL).Return([]byte(response), nil)
 
 		o := &owm{
 			props: props,
@@ -186,24 +185,24 @@ func TestOWMSegmentIcons(t *testing.T) {
 
 func TestOWMSegmentFormat(t *testing.T) {
 	cases := []struct {
-		Case               string
-		Format             string
-		ExpectedString 	   string
+		Case           string
+		Format         string
+		ExpectedString string
 	}{
 		{
-			Case:               "Default format",
-			Format:             "%s (%g%s)",
-			ExpectedString:     "\ufa98 (20.02°C)",
+			Case:           "Default format",
+			Format:         "%s (%g%s)",
+			ExpectedString: "\ufa98 (20.02°C)",
 		},
 		{
-			Case:               "Custom format",
-			Format:             "%s - %g%s",
-			ExpectedString:     "\ufa98 - 20.02°C",
+			Case:           "Custom format",
+			Format:         "%s - %g%s",
+			ExpectedString: "\ufa98 - 20.02°C",
 		},
 		{
-			Case:               "Change number of digits",
-			Format:             "%s - %.0f%s",
-			ExpectedString:     "\ufa98 - 20°C",
+			Case:           "Change number of digits",
+			Format:         "%s - %.0f%s",
+			ExpectedString: "\ufa98 - 20°C",
 		},
 	}
 
@@ -218,10 +217,9 @@ func TestOWMSegmentFormat(t *testing.T) {
 			},
 		}
 
-		url := "http://api.openweathermap.org/data/2.5/weather?q=AMSTERDAM,NL&units=metric&appid=key"
-		response := fmt.Sprintf(`{"weather":[{"icon":"%s"}],"main":{"temp":20.02}}`, "01d" )
+		response := fmt.Sprintf(`{"weather":[{"icon":"%s"}],"main":{"temp":20.02}}`, "01d")
 
-		env.On("doGet", url).Return([]byte(response), nil)
+		env.On("doGet", URL).Return([]byte(response), nil)
 
 		o := &owm{
 			props: props,

--- a/src/segment_owm_test.go
+++ b/src/segment_owm_test.go
@@ -183,3 +183,52 @@ func TestOWMSegmentIcons(t *testing.T) {
 		assert.Equal(t, expectedString, o.string(), tc.Case)
 	}
 }
+
+func TestOWMSegmentFormat(t *testing.T) {
+	cases := []struct {
+		Case               string
+		Format             string
+		ExpectedString 	   string
+	}{
+		{
+			Case:               "Default format",
+			Format:             "%s (%g%s)",
+			ExpectedString:     "\ufa98 (20.02°C)",
+		},
+		{
+			Case:               "Custom format",
+			Format:             "%s - %g%s",
+			ExpectedString:     "\ufa98 - 20.02°C",
+		},
+		{
+			Case:               "Change number of digits",
+			Format:             "%s - %.0f%s",
+			ExpectedString:     "\ufa98 - 20°C",
+		},
+	}
+
+	for _, tc := range cases {
+		env := &MockedEnvironment{}
+		props := &properties{
+			values: map[Property]interface{}{
+				APIKEY:   "key",
+				LOCATION: "AMSTERDAM,NL",
+				UNITS:    "metric",
+				FORMAT:   tc.Format,
+			},
+		}
+
+		url := "http://api.openweathermap.org/data/2.5/weather?q=AMSTERDAM,NL&units=metric&appid=key"
+		response := fmt.Sprintf(`{"weather":[{"icon":"%s"}],"main":{"temp":20.02}}`, "01d" )
+
+		env.On("doGet", url).Return([]byte(response), nil)
+
+		o := &owm{
+			props: props,
+			env:   env,
+		}
+
+		assert.Nil(t, o.setStatus())
+		assert.Equal(t, tc.ExpectedString, o.string(), tc.Case)
+	}
+}

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -1579,11 +1579,13 @@
                     "title": "units",
                     "description": "Units of measurement. Available values are standard (kelvin), metric (celsius), and imperial (fahrenheit). Default is standard",
                     "default": "standard",
-                    "enum": [
-                      "standard",
-                      "metric",
-                      "imperial"
-                    ]
+                    "enum": ["standard", "metric", "imperial"]
+                  },
+                  "format": {
+                    "type": "string",
+                    "title": "format",
+                    "description": "The format string used to generate the text",
+                    "default": "%s (%g%s)"
                   },
                   "enable_hyperlink": {
                     "$ref": "#/definitions/enable_hyperlink"


### PR DESCRIPTION
adds a format property to the owm segment, allowing users to change the
format used to generate the weather label (e.g. remove the parentheses,
display weather with less than absolute accuracy).
