### PR TITLE
fix: recognize remote branch merge

### DIFF
--- a/src/segment_git.go
+++ b/src/segment_git.go
@@ -350,7 +350,7 @@ func (g *git) getGitHEADContext(ref string) string {
 	if g.hasGitFile("MERGE_MSG") && g.hasGitFile("MERGE_HEAD") {
 		icon := g.props.getString(MergeIcon, "\uE727 ")
 		mergeContext := g.getGitFileContents(g.repo.gitWorkingFolder, "MERGE_MSG")
-		matches := findNamedRegexMatch(`Merge branch '(?P<head>.*)' into`, mergeContext)
+		matches := findNamedRegexMatch(`Merge (remote-tracking )?branch '(?P<head>.*)' into`, mergeContext)
 		if matches != nil && matches["head"] != "" {
 			branch := g.truncateBranch(matches["head"])
 			return fmt.Sprintf("%s%s%s into %s", icon, branchIcon, branch, ref)


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)  **not needed**

### Description

segment_git.go looks specifically for a string in MERGE_MSG starting with "Merge branch" in order to format the prompt line. This works fine for `git merge main`. However, if I do `git merge origin/main`, then MERGE_MSG has "Merge remote-tracking branch", causing omp not to return a "merging" message. This commit adds `(remote-tracking)?` to the search regex.

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
