### PR TITLE
fix: recognize tag and commit merges

### DIFF
--- a/src/segment_git.go
+++ b/src/segment_git.go
@@ -350,10 +350,20 @@ func (g *git) getGitHEADContext(ref string) string {
 	if g.hasGitFile("MERGE_MSG") && g.hasGitFile("MERGE_HEAD") {
 		icon := g.props.getString(MergeIcon, "\uE727 ")
 		mergeContext := g.getGitFileContents(g.repo.gitWorkingFolder, "MERGE_MSG")
-		matches := findNamedRegexMatch(`Merge (remote-tracking )?branch '(?P<head>.*)' into`, mergeContext)
+		matches := findNamedRegexMatch(`Merge (?P<type>(remote-tracking )?branch|commit|tag) '(?P<head>.*)' into`, mergeContext)
+
 		if matches != nil && matches["head"] != "" {
-			branch := g.truncateBranch(matches["head"])
-			return fmt.Sprintf("%s%s%s into %s", icon, branchIcon, branch, ref)
+			var headIcon string
+			switch matches["type"] {
+			case "tag":
+				headIcon = g.props.getString(TagIcon, "\uF412")
+			case "commit":
+				headIcon = g.props.getString(CommitIcon, "\uF417")
+			default:
+				headIcon = branchIcon
+			}
+			head := g.truncateBranch(matches["head"])
+			return fmt.Sprintf("%s%s%s into %s", icon, headIcon, head, ref)
 		}
 	}
 	// sequencer status

--- a/src/segment_git_test.go
+++ b/src/segment_git_test.go
@@ -325,6 +325,30 @@ func TestGetGitHEADContextMergeRemote(t *testing.T) {
 }
 
 func TestGetGitHEADContextMergeTag(t *testing.T) {
+	want := "\ue727 \uf412v7.8.9 into \ue0a0main"
+	context := &detachedContext{
+		merge:         true,
+		mergeHEAD:     "v7.8.9",
+		mergeMsgStart: "Merge tag",
+	}
+	g := setupHEADContextEnv(context)
+	got := g.getGitHEADContext("main")
+	assert.Equal(t, want, got)
+}
+
+func TestGetGitHEADContextMergeCommit(t *testing.T) {
+	want := "\ue727 \uf4178d7e869 into \ue0a0main"
+	context := &detachedContext{
+		merge:         true,
+		mergeHEAD:     "8d7e869",
+		mergeMsgStart: "Merge commit",
+	}
+	g := setupHEADContextEnv(context)
+	got := g.getGitHEADContext("main")
+	assert.Equal(t, want, got)
+}
+
+func TestGetGitHEADContextMergeIntoTag(t *testing.T) {
 	want := "\ue727 \ue0a0feat into \uf412v3.4.6"
 	context := &detachedContext{
 		tagName:       "v3.4.6",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)   **not needed**

### Description

In addition to merging branches, we can also merge commits and tags. omp should recognize these and display the correct head icon.

Sorry I didn't think of adding these in my previous PR!

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
