### PR TITLE
feat(battery): display_charged parameter added

### DIFF
--- a/docs/docs/segment-battery.md
+++ b/docs/docs/segment-battery.md
@@ -27,7 +27,8 @@ Battery displays the remaining power percentage for your battery.
     "charging_color": "#40c4ff",
     "discharging_color": "#ff5722",
     "postfix": "\uF295 ",
-    "display_charging": true
+    "display_charging": true,
+    "display_charged": true
   }
 }
 ```
@@ -44,7 +45,8 @@ properties below. Defaults to `{{.Icon}}{{ if not .Error }}{{.Percentage}}{{ end
 - charged_color: `string` [color][colors] - color to use when fully charged - defaults to segment color
 - charging_color: `string` [color][colors] - color to use when charging - defaults to segment color
 - discharging_color: `string` [color][colors] - color to use when discharging - defaults to segment color
-- display_charging: `bool` - displays the battery status while charging (Charging or Full)
+- display_charging: `bool` - displays the battery status while charging (Charging)
+- display_charged: `bool` - displays the battery status when charged (Full)
 
 ## Template Properties
 

--- a/src/segment_battery.go
+++ b/src/segment_battery.go
@@ -30,6 +30,8 @@ const (
 	DischargingColor Property = "discharging_color"
 	// DisplayCharging Hide the battery icon while it's charging
 	DisplayCharging Property = "display_charging"
+	// DisplayCharged Hide the battery icon when it's charged
+	DisplayCharged Property = "display_charged"
 )
 
 func (b *batt) enabled() bool {
@@ -51,8 +53,12 @@ func (b *batt) enabled() bool {
 		b.Battery.State = b.mapMostLogicalState(b.Battery.State, bt.State)
 	}
 
-	display := b.props.getBool(DisplayCharging, true)
-	if !display && (b.Battery.State == battery.Charging || b.Battery.State == battery.Full) {
+	displayCharged := b.props.getBool(DisplayCharged, true)
+	if !displayCharged && (b.Battery.State == battery.Full) {
+		return false
+	}
+	displayCharging := b.props.getBool(DisplayCharging, true)
+	if !displayCharging && (b.Battery.State == battery.Charging) {
 		return false
 	}
 

--- a/src/segment_battery_test.go
+++ b/src/segment_battery_test.go
@@ -25,6 +25,7 @@ func TestBatterySegmentSingle(t *testing.T) {
 		DisplayError    bool
 		Error           error
 		DisableCharging bool
+		DisableCharged  bool
 	}{
 		{Case: "80% charging", Batteries: []*battery.Battery{{Full: 100, State: battery.Charging, Current: 80}}, ExpectedString: "charging 80", ExpectedEnabled: true},
 		{Case: "battery full", Batteries: []*battery.Battery{{Full: 100, State: battery.Full, Current: 100}}, ExpectedString: "charged 100", ExpectedEnabled: true},
@@ -79,7 +80,17 @@ func TestBatterySegmentSingle(t *testing.T) {
 		{Case: "no batteries", DisplayError: true, Error: &noBatteryError{}},
 		{Case: "no batteries without error"},
 		{Case: "display charging disabled: charging", Batteries: []*battery.Battery{{Full: 100, State: battery.Charging}}, DisableCharging: true},
-		{Case: "display charging disabled: charged", Batteries: []*battery.Battery{{Full: 100, State: battery.Full}}, DisableCharging: true},
+		{Case: "display charged disabled: charged", Batteries: []*battery.Battery{{Full: 100, State: battery.Full}}, DisableCharged: true},
+		{
+			Case:            "display charging disabled/display charged enabled: charging",
+			Batteries:       []*battery.Battery{{Full: 100, State: battery.Charging}},
+			DisableCharging: true,
+			DisableCharged:  false},
+		{
+			Case:            "display charged disabled/display charging enabled: charged",
+			Batteries:       []*battery.Battery{{Full: 100, State: battery.Full}},
+			DisableCharged:  true,
+			DisableCharging: false},
 		{
 			Case:            "display charging disabled: discharging",
 			Batteries:       []*battery.Battery{{Full: 100, State: battery.Discharging, Current: 70}},
@@ -105,8 +116,12 @@ func TestBatterySegmentSingle(t *testing.T) {
 				DisplayError:     tc.DisplayError,
 			},
 		}
+		// default values
 		if tc.DisableCharging {
 			props.values[DisplayCharging] = false
+		}
+		if tc.DisableCharged {
+			props.values[DisplayCharged] = false
 		}
 		env.On("getBatteryInfo", nil).Return(tc.Batteries, tc.Error)
 		b := &batt{

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -367,7 +367,13 @@
                   "display_charging": {
                     "type": "boolean",
                     "title": "Display while charging",
-                    "description": "displays the battery status while charging (Charging or Full)",
+                    "description": "displays the battery status while charging (Charging)",
+                    "default": true
+                  },
+                  "display_charged": {
+                    "type": "boolean",
+                    "title": "Display when full",
+                    "description": "displays the battery status when charged (Full)",
                     "default": true
                   },
                   "template": {


### PR DESCRIPTION
display_charging splitted to two parameters instead of a single one

### Prerequisites

- [X] I have read and understood the `CONTRIBUTING` guide
- [X] The commit message follows the [conventional commits][cc] guidelines
- [X] Tests for the changes have been added (for bug fixes/features)
- [X] Docs have been added / updated (for bug fixes/features)

### Description

display_charging splitted in two parameters instead of one
By default, display_charged and display_charging are true.
#958 

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
