### PR TITLE
feat: allow for custom text in place of shell names

### DIFF
--- a/docs/docs/segment-shell.md
+++ b/docs/docs/segment-shell.md
@@ -18,7 +18,7 @@ Show the current shell name (ZSH, powershell, bash, ...).
   "foreground": "#ffffff",
   "background": "#0077c2",
   "properties": {
-    "custom_text": {
+    "mapped_shell_names": {
       "pwsh": "PS"
     }
   }
@@ -27,4 +27,4 @@ Show the current shell name (ZSH, powershell, bash, ...).
 
 ## Properties
 
-- custom_text: `object` - custom glyph/text to use in place of specified shell names (case-insensitive)
+- mapped_shell_names: `object` - custom glyph/text to use in place of specified shell names (case-insensitive)

--- a/docs/docs/segment-shell.md
+++ b/docs/docs/segment-shell.md
@@ -18,7 +18,13 @@ Show the current shell name (ZSH, powershell, bash, ...).
   "foreground": "#ffffff",
   "background": "#0077c2",
   "properties": {
-    "prefix": " \uFCB5 "
+    "custom_text": {
+      "pwsh": "PS"
+    }
   }
 }
 ```
+
+## Properties
+
+- custom_text: `object` - custom glyph/text to use in place of specified shell names (case-insensitive)

--- a/src/segment_shell.go
+++ b/src/segment_shell.go
@@ -1,16 +1,31 @@
 package main
 
+import "strings"
+
 type shell struct {
 	props *properties
 	env   environmentInfo
 }
+
+const (
+	// CustomText allows for custom text in place of shell names
+	CustomText Property = "custom_text"
+)
 
 func (s *shell) enabled() bool {
 	return true
 }
 
 func (s *shell) string() string {
-	return s.env.getShellName()
+	customText := s.props.getKeyValueMap(CustomText, make(map[string]string))
+	shellName := s.env.getShellName()
+	for key, val := range customText {
+		if strings.EqualFold(shellName, key) {
+			shellName = val
+			break
+		}
+	}
+	return shellName
 }
 
 func (s *shell) init(props *properties, env environmentInfo) {

--- a/src/segment_shell.go
+++ b/src/segment_shell.go
@@ -8,8 +8,8 @@ type shell struct {
 }
 
 const (
-	// CustomText allows for custom text in place of shell names
-	CustomText Property = "custom_text"
+	// MappedShellNames allows for custom text in place of shell names
+	MappedShellNames Property = "mapped_shell_names"
 )
 
 func (s *shell) enabled() bool {
@@ -17,9 +17,9 @@ func (s *shell) enabled() bool {
 }
 
 func (s *shell) string() string {
-	customText := s.props.getKeyValueMap(CustomText, make(map[string]string))
+	mappedNames := s.props.getKeyValueMap(MappedShellNames, make(map[string]string))
 	shellName := s.env.getShellName()
-	for key, val := range customText {
+	for key, val := range mappedNames {
 		if strings.EqualFold(shellName, key) {
 			shellName = val
 			break

--- a/src/segment_shell_test.go
+++ b/src/segment_shell_test.go
@@ -17,3 +17,28 @@ func TestWriteCurrentShell(t *testing.T) {
 	}
 	assert.Equal(t, expected, s.string())
 }
+
+func TestUseCustomStrings(t *testing.T) {
+	cases := []struct {
+		Shell    string
+		Expected string
+	}{
+		{Shell: "zsh", Expected: "zsh"},
+		{Shell: "pwsh", Expected: "PS"},
+		{Shell: "PWSH", Expected: "PS"},
+	}
+	for _, tc := range cases {
+		env := new(MockedEnvironment)
+		env.On("getShellName", nil).Return(tc.Expected, nil)
+		s := &shell{
+			env: env,
+			props: &properties{
+				values: map[Property]interface{}{
+					CustomText: map[string]string{"pwsh": "PS"},
+				},
+			},
+		}
+		got := s.string()
+		assert.Equal(t, tc.Expected, got)
+	}
+}

--- a/src/segment_shell_test.go
+++ b/src/segment_shell_test.go
@@ -18,7 +18,7 @@ func TestWriteCurrentShell(t *testing.T) {
 	assert.Equal(t, expected, s.string())
 }
 
-func TestUseCustomStrings(t *testing.T) {
+func TestUseMappedShellNames(t *testing.T) {
 	cases := []struct {
 		Shell    string
 		Expected string
@@ -34,7 +34,7 @@ func TestUseCustomStrings(t *testing.T) {
 			env: env,
 			props: &properties{
 				values: map[Property]interface{}{
-					CustomText: map[string]string{"pwsh": "PS"},
+					MappedShellNames: map[string]string{"pwsh": "PS"},
 				},
 			},
 		}

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -1402,7 +1402,19 @@
           },
           "then": {
             "title": "Shell Segment",
-            "description": "https://ohmyposh.dev/docs/shell"
+            "description": "https://ohmyposh.dev/docs/shell",
+            "properties": {
+              "properties": {
+                "properties": {
+                  "custom_text": {
+                    "type": "object",
+                    "title": "Custom Text",
+                    "description": "Custom glyph/text for specific shells",
+                    "default": {}
+                  }
+                }
+              }
+            }
           }
         },
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

Give the `shell` segment the ability to use custom text in place of the shell name -- e.g., display `PS` instead of `pwsh`.

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
