### PR TITLE
Theme: add craver theme

### DIFF
--- a/docs/export_themes.js
+++ b/docs/export_themes.js
@@ -25,6 +25,7 @@ themeConfigOverrrides.set('avit.omp.json', newThemeConfig(40, 80));
 themeConfigOverrrides.set('blueish.omp.json', newThemeConfig(40, 100));
 themeConfigOverrrides.set('cert.omp.json', newThemeConfig(40, 50));
 themeConfigOverrrides.set('cinnamon.omp.json', newThemeConfig(40, 80));
+themeConfigOverrrides.set('craver.omp.json', newThemeConfig(40, 80, 'Nick Craver', '#282c34'));
 themeConfigOverrrides.set('darkblood.omp.json', newThemeConfig(40, 40));
 themeConfigOverrrides.set('honukai.omp.json', newThemeConfig(20));
 themeConfigOverrrides.set('hotstick.minimal.omp.json', newThemeConfig(40, 10));

--- a/themes/craver.omp.json
+++ b/themes/craver.omp.json
@@ -1,0 +1,123 @@
+{
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
+  "console_title": true,
+  "console_title_style": "template",
+  "console_title_template": "{{if .Root}}(Admin) {{end}}{{.Folder}}",
+  "blocks": [
+    {
+      "type": "prompt",
+      "alignment": "left",
+      "segments": [
+        {
+          "type": "root",
+          "style": "powerline",
+          "powerline_symbol": "\uE0C4",
+          "foreground": "#242424",
+          "background": "#f1184c",
+          "properties": {
+            "prefix": "",
+            "postfix": ""
+          }
+        },
+        {
+          "type": "os",
+          "style": "diamond",
+          "leading_diamond": " ",
+          "powerline_symbol": "",
+          "foreground": "#3A86FF",
+          "background": "#282c34",
+          "properties": {
+            "prefix": ""
+          }
+        },
+        {
+          "type": "time",
+          "style": "powerline",
+          "powerline_symbol": "\uE0C4",
+          "foreground": "#FFBB00",
+          "background": "#242424",
+          "properties": {
+            "time_format": "15:04:05",
+            "prefix": ""
+          }
+        },
+        {
+          "type": "path",
+          "style": "powerline",
+          "powerline_symbol": "\uE0B0",
+          "foreground": "#33DD2D",
+          "background": "#242424",
+          "properties": {
+            "prefix": "\uE5FF ",
+            "style": "folder",
+            "folder_separator_icon": "/"
+          }
+        },
+        {
+          "type": "git",
+          "style": "powerline",
+          "powerline_symbol": "\uE0B0",
+          "foreground": "#3A86FF",
+          "background": "#242424",
+          "properties": {
+            "display_status": true,
+            "display_stash_count": true,
+            "display_upstream_icon": true,
+            "prefix": ""
+          }
+        },
+        {
+          "type": "dotnet",
+          "style": "powerline",
+          "powerline_symbol": "\uE0C4",
+          "foreground": "#ffffff",
+          "background": "#0184bc",
+          "properties": {
+            "prefix": "  "
+          }
+        },
+        {
+          "type": "executiontime",
+          "style": "powerline",
+          "powerline_symbol": "\uE0C4",
+          "foreground": "#ffffff",
+          "background": "#8800dd",
+          "properties": {
+            "threshold": 1,
+            "style": "austin",
+            "prefix": " <#fefefe>\ufbab</> "
+          }
+        },
+        {
+          "type": "exit",
+          "style": "powerline",
+          "powerline_symbol": "\uE0B4",
+          "foreground": "#242424",
+          "background": "#33DD2D",
+          "properties": {
+            "display_exit_code": false,
+            "color_background": true,
+            "error_color": "#f1184c",
+            "prefix": " \ufc8d"
+          }
+        }
+      ]
+    },
+    {
+      "type": "prompt",
+      "alignment": "left",
+      "newline": true,
+      "segments": [
+        {
+          "type": "text",
+          "style": "plain",
+          "foreground": "#f1184c",
+          "properties": {
+            "prefix": "",
+            "text": "\u279C"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

This adds a new theme to the gallery, taking advantage of the new background color option in the renderer. Screenshot of theme:

![craver](https://user-images.githubusercontent.com/454813/133846927-45cbc3da-30c4-4f4c-b56e-9adc232749be.png)

The trailing ASCII must be a difference on my Windows system (it's the `clearBelow` text) and what's used in the gallery...not an issue for this PR but is locally for some reason.

I'll open another PR for some tweaks here if wanted: I've been playing with that has tweaks to the renderer and experimented with using the latest Hack nerd font and tweaking spacing based on things outside the ASCII range. I think it's a pretty good win, here's the comparison with that code:

![craver-new](https://user-images.githubusercontent.com/454813/133847083-8d70cf25-8abe-43f4-bed6-9152c4e3d12f.png)

@JanDeDobbeleer I don't want to hop in and change fonts and everything, was just curious and trying to make this work - would the above rendering tweak be a change that's wanted?

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
