### PR TITLE
fix: incorrect args in theme exports from #964

### DIFF
--- a/docs/export_themes.js
+++ b/docs/export_themes.js
@@ -71,9 +71,9 @@ themeConfigOverrrides.set('zash.omp.json', newThemeConfig(40, 40));
     let poshCommand = `oh-my-posh --config=${configPath} --shell shell --export-png`;
     poshCommand += ` --rprompt-offset=${config.rpromptOffset}`;
     poshCommand += ` --cursor-padding=${config.cursorPadding}`;
-    poshCommand += ` --bg-color=${config.cursorPadding}`;
+    poshCommand += ` --bg-color=${config.bgColor}`;
     if (config.author !== '') {
-      poshCommand += ` --author=${config.author}`;
+      poshCommand += ` --author="${config.author}"`;
     }
 
     const { _, stderr } = await exec(poshCommand);


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

This fixes the background color to actually work, and quotes author as well (first usage of the field introduced in #964). I don't know of existing tests for this (unfamiliar with the build pipe), but happy to add if there's a path there.


[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
