### PR TITLE
feat: flexible matching for include/exclude folders

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -293,8 +293,9 @@ will not be rendered when in one of the excluded locations.
 ]
 ```
 
-You can also specify a [regular expression][regex] to create folder wildcards.
-In the sample below, any folders inside the `/Users/posh/Projects` path will be matched.
+The strings specified in these properties are evaluated as [regular expressions][regex]. You
+can use any valid regular expression construct, but the regular expression must match the entire directory
+name. The following will match `/Users/posh/Projects/Foo` but not `/home/Users/posh/Projects/Foo`.
 
 ```json
 "include_folders": [
@@ -313,16 +314,17 @@ You can also combine these properties:
 ]
 ```
 
-Note for Windows users: Windows directory separators should be specified as 4 backslashes.
+##### Notes
 
-```json
-"include_folders": [
-  "C:\\\\Projects.*"
-],
-"exclude_folders": [
-  "C:\\\\Projects\\\\secret-project.*"
-]
-```
+- Oh My Posh will accept both `/` and `\` as path separators for a folder and will match regardless of which
+is used by the current operating system.
+- Because the strings are evaluated as regular expressions, if you want to use a `\` in a Windows
+directory name, you need to specify it as `\\\\`.
+- The character `~` at the start of a specified folder will match the user's home directory.
+- The comparison is case-insensitive on Windows and macOS, but case-sensitive on other operating systems.
+
+This means that for user Bill, who has a user account `Bill` on Windows and `bill` on Linux,  `~/Foo` might match
+`C:\Users\Bill\Foo` or `C:\Users\Bill\foo` on Windows but only `/home/bill/Foo` on Linux.
 
 ### Colors
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

Give include/exclude folders the same powers as mapped_locations (#976) -- can use slash instead of backslash and ~ instead of home dir, and case-insensitive on Windows and macOS.

I know in the previous PR we talked about centralizing and refactoring the "normalize" functionality. I found this tricky -- and possibly not desirable -- for a couple of reasons. First, the needs of normalizing are somewhat different in `Segment` and `path`, making it a little tricky to formulate a graceful function that they can share. And second, moving normalization into `environment`, which seemed like the most appropriate place, means that any tests that use `MockedEnvironment` and do something with the path now need to mock all the possible calls to `normalizePath()` by replicating most of its logic.

I've been working on that, and can continue down that path if you like, but in the meantime I thought I'd show you what this looks like without refactoring, with similar code in `Segment` and `path`, to see how much it bothers you. 

I also noticed that `path.replaceMappedLocations()` gets rid of `Microsoft.PowerShell.Core\FileSystem::` before doing any matching, but `Segment.cwdMatchesOneOf()` does not. I wasn't sure if this was intentional; I can add this to `cwdMatchesOneOf()` if you want.

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
