### PR TITLE
fix: os fonts in theme renders

### DIFF
--- a/src/image.go
+++ b/src/image.go
@@ -223,7 +223,7 @@ var doubleWidthRunes = []RuneRange{
 	{Start: '\u23fb', End: '\u23fe'},
 	{Start: '\u2b58', End: '\u2b58'},
 	// Font Logos
-	{Start: '\uf300', End: '\uf313'},
+	{Start: '\uf300', End: '\uf31c'},
 	// Pomicons
 	{Start: '\ue000', End: '\ue00d'},
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

There's a bug in the wiki ranges that I noticed in the final Ubuntu renders cutting off the Ubuntu logo,
this should resolve it. I didn't see this on Windows renders because _part_ of the OS range is covered.
Ubuntu however fell in the gap, so that's what we're seeing on the live site:
https://ohmyposh.dev/docs/themes

Issue filed on nerd fonts to fix their wiki here: https://github.com/ryanoasis/nerd-fonts/issues/667

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
