### PR TITLE
fix(owm): cache also the url used to get the data

### DIFF
--- a/src/segment_owm.go
+++ b/src/segment_owm.go
@@ -23,8 +23,10 @@ const (
 	Units Property = "units"
 	// CacheTimeout cache timeout
 	CacheTimeout Property = "cache_timeout"
-	// CacheKey key used when caching the response
-	CacheKey string = "owm_response"
+	// CacheKeyResponse key used when caching the response
+	CacheKeyResponse string = "owm_response"
+	// CacheKeyUrl key used when caching the url responsible for the response
+	CacheKeyURL string = "owm_url"
 )
 
 type weather struct {
@@ -70,13 +72,14 @@ func (d *owm) getResult() (*OWMDataResponse, error) {
 	response := new(OWMDataResponse)
 	if cacheTimeout > 0 {
 		// check if data stored in cache
-		val, found := d.env.cache().get(CacheKey)
+		val, found := d.env.cache().get(CacheKeyResponse)
 		// we got something from te cache
 		if found {
 			err := json.Unmarshal([]byte(val), response)
 			if err != nil {
 				return nil, err
 			}
+			d.url, _ = d.env.cache().get(CacheKeyURL)
 			return response, nil
 		}
 	}
@@ -98,7 +101,8 @@ func (d *owm) getResult() (*OWMDataResponse, error) {
 
 	if cacheTimeout > 0 {
 		// persist new forecasts in cache
-		d.env.cache().set(CacheKey, string(body), cacheTimeout)
+		d.env.cache().set(CacheKeyResponse, string(body), cacheTimeout)
+		d.env.cache().set(CacheKeyURL, d.url, cacheTimeout)
 	}
 	return response, nil
 }


### PR DESCRIPTION
The url is used after do generate the hyperlink

### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

The url was blank when the response was cached. There were two solutions:

1. Moving back the getprops at the top
2. Caching also the url used to call the service

I did the second one. Don't know which one is better, but caching the url seemed logic.

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
