### PR TITLE
feat: inherit colors between segments

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -330,11 +330,12 @@ This means that for user Bill, who has a user account `Bill` on Windows and `bil
 
 #### Standard colors
 
-Oh My Posh mainly supports three different color types being
+Oh My Posh supports four different color types being:
 
 - Typical [hex colors][hexcolors] (for example `#CB4B16`).
 - The `transparent` keyword which can be used to create either a transparent foreground override
   or transparent background color using the segment's foreground property.
+- The `inherit` keyword which can be used to inherit the previous active segment's foreground and/or background color.
 - 16 [ANSI color names][ansicolors].
 
   These include 8 basic ANSI colors and `default`:

--- a/src/ansi_color.go
+++ b/src/ansi_color.go
@@ -59,6 +59,8 @@ type AnsiColor struct {
 const (
 	// Transparent implies a transparent color
 	Transparent = "transparent"
+	// Inherit take the previous segment's color
+	Inherit = "inherit"
 )
 
 // Gets the ANSI color code for a given color string.

--- a/src/block.go
+++ b/src/block.go
@@ -81,6 +81,20 @@ func (b *Block) setStringValues() {
 	}
 }
 
+func (b *Block) foreground() string {
+	if b.previousActiveSegment != nil && b.activeSegment.foreground() == Inherit {
+		return b.previousActiveSegment.foreground()
+	}
+	return b.activeSegment.foreground()
+}
+
+func (b *Block) background() string {
+	if b.previousActiveSegment != nil && b.activeSegment.background() == Inherit {
+		return b.previousActiveSegment.background()
+	}
+	return b.activeSegment.background()
+}
+
 func (b *Block) renderSegments() string {
 	defer b.writer.reset()
 	for _, segment := range b.Segments {
@@ -127,7 +141,7 @@ func (b *Block) getPowerlineColor(foreground bool) string {
 		return b.previousActiveSegment.background()
 	}
 	if b.activeSegment.Style == Diamond && len(b.activeSegment.LeadingDiamond) == 0 {
-		return b.activeSegment.background()
+		return b.background()
 	}
 	if !foreground && b.activeSegment.Style != Powerline {
 		return Transparent
@@ -151,7 +165,7 @@ func (b *Block) renderSegmentText(text string) {
 }
 
 func (b *Block) renderPowerLineSegment(text string) {
-	b.writePowerLineSeparator(b.activeSegment.background(), b.getPowerlineColor(true), false)
+	b.writePowerLineSeparator(b.background(), b.getPowerlineColor(true), false)
 	b.renderText(text)
 }
 
@@ -160,14 +174,14 @@ func (b *Block) renderPlainSegment(text string) {
 }
 
 func (b *Block) renderDiamondSegment(text string) {
-	b.writer.write(Transparent, b.activeSegment.background(), b.activeSegment.LeadingDiamond)
+	b.writer.write(Transparent, b.background(), b.activeSegment.LeadingDiamond)
 	b.renderText(text)
-	b.writer.write(Transparent, b.activeSegment.background(), b.activeSegment.TrailingDiamond)
+	b.writer.write(Transparent, b.background(), b.activeSegment.TrailingDiamond)
 }
 
 func (b *Block) renderText(text string) {
-	bg := b.activeSegment.background()
-	fg := b.activeSegment.foreground()
+	bg := b.background()
+	fg := b.foreground()
 	defaultValue := " "
 	b.writer.write(bg, fg, b.activeSegment.getValue(Prefix, defaultValue))
 	b.writer.write(bg, fg, text)

--- a/src/block_test.go
+++ b/src/block_test.go
@@ -27,3 +27,43 @@ func TestBlockEnabled(t *testing.T) {
 		assert.Equal(t, tc.Expected, block.enabled(), tc.Case)
 	}
 }
+
+func TestForegroundColor(t *testing.T) {
+	cases := []struct {
+		Case            string
+		Expected        string
+		PreviousSegment *Segment
+		Segment         *Segment
+	}{
+		{Case: "Standard", Expected: "black", Segment: &Segment{Foreground: "black"}},
+		{Case: "Segment color override", Expected: "red", Segment: &Segment{Foreground: "black", props: &properties{foreground: "red"}}},
+		{Case: "Inherit", Expected: "yellow", Segment: &Segment{Foreground: Inherit}, PreviousSegment: &Segment{Foreground: "yellow"}},
+	}
+
+	for _, tc := range cases {
+		block := &Block{}
+		block.previousActiveSegment = tc.PreviousSegment
+		block.activeSegment = tc.Segment
+		assert.Equal(t, tc.Expected, block.foreground(), tc.Case)
+	}
+}
+
+func TestBackgroundColor(t *testing.T) {
+	cases := []struct {
+		Case            string
+		Expected        string
+		PreviousSegment *Segment
+		Segment         *Segment
+	}{
+		{Case: "Standard", Expected: "black", Segment: &Segment{Background: "black"}},
+		{Case: "Segment color override", Expected: "red", Segment: &Segment{Background: "black", props: &properties{background: "red"}}},
+		{Case: "Inherit", Expected: "yellow", Segment: &Segment{Background: Inherit}, PreviousSegment: &Segment{Background: "yellow"}},
+	}
+
+	for _, tc := range cases {
+		block := &Block{}
+		block.previousActiveSegment = tc.PreviousSegment
+		block.activeSegment = tc.Segment
+		assert.Equal(t, tc.Expected, block.background(), tc.Case)
+	}
+}

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -7,7 +7,7 @@
   "definitions": {
     "color": {
       "type": "string",
-      "pattern": "^(#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})|black|red|green|yellow|blue|magenta|cyan|white|default|darkGray|lightRed|lightGreen|lightYellow|lightBlue|lightMagenta|lightCyan|lightWhite|transparent)$",
+      "pattern": "^(#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})|black|red|green|yellow|blue|magenta|cyan|white|default|darkGray|lightRed|lightGreen|lightYellow|lightBlue|lightMagenta|lightCyan|lightWhite|transparent|inherit)$",
       "title": "Color string",
       "description": "https://ohmyposh.dev/docs/configure#colors",
       "format": "color"


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

Inherit color from previous segment. Closes #994 

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
