### PR TITLE
fix: set shell in Export-PoshImage

### DIFF
--- a/docs/docs/share-theme.mdx
+++ b/docs/docs/share-theme.mdx
@@ -42,7 +42,7 @@ There are a couple of parameters you can use to tweak the image rendering:
 The oh-my-posh executable has the `--export-png` switch to export your current theme configuration.
 
 ```powershell
-oh-my-posh --config ~/.mytheme.omp.json --export-png --cursor-padding 50
+oh-my-posh --shell shell --config ~/.mytheme.omp.json --export-png --cursor-padding 50
 ```
 
 There are a couple of additional switches you can use to tweak the image rendering:

--- a/src/init/omp.ps1
+++ b/src/init/omp.ps1
@@ -203,7 +203,7 @@ function global:Export-PoshImage {
 
     $omp = "::OMP::"
     $config, $cleanPWD, $cleanPSWD = Get-PoshContext
-    $standardOut = @(&$omp --config="$config" --pwd="$cleanPWD" --pswd="$cleanPSWD" --export-png --rprompt-offset="$RPromptOffset" --cursor-padding="$CursorPadding" $Author $BGColor 2>&1)
+    $standardOut = @(&$omp --shell=shell --config="$config" --pwd="$cleanPWD" --pswd="$cleanPSWD" --export-png --rprompt-offset="$RPromptOffset" --cursor-padding="$CursorPadding" $Author $BGColor 2>&1)
     $standardOut -join "`n"
 }
 


### PR DESCRIPTION
When the shell is not set, some ansi characters are added at the end of the prompt

fix #980

### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

fix Export-PoshImage issue (ansi characters at the end)

Tested on both pwsh on windows and linux(wsl)

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
