### PR TITLE
fix(path): display root path icon when using agnoster

### DIFF
--- a/src/segment_path.go
+++ b/src/segment_path.go
@@ -169,7 +169,7 @@ func (pt *path) getLetterPath() string {
 
 func (pt *path) getAgnosterFullPath() string {
 	pwd := pt.getPwd()
-	if string(pwd[0]) == pt.env.getPathSeperator() {
+	if len(pwd) > 1 && string(pwd[0]) == pt.env.getPathSeperator() {
 		pwd = pwd[1:]
 	}
 	return pt.replaceFolderSeparators(pwd)

--- a/src/segment_path_test.go
+++ b/src/segment_path_test.go
@@ -305,7 +305,7 @@ func TestAgnosterPathStyles(t *testing.T) {
 		{Style: AgnosterShort, Expected: "~ > .. > man", HomePath: "/usr/home", Pwd: "/usr/home/whatever/man", PathSeperator: "/", FolderSeparatorIcon: " > "},
 		{Style: AgnosterShort, Expected: "~ > projects", HomePath: "/usr/home", Pwd: "/usr/home/projects", PathSeperator: "/", FolderSeparatorIcon: " > "},
 		{Style: AgnosterShort, Expected: "C:", HomePath: homeBillWindows, Pwd: "C:", PathSeperator: "\\", FolderSeparatorIcon: " > "},
-		{Style: AgnosterShort, Expected: "", HomePath: homeBillWindows, Pwd: "/", PathSeperator: "/", FolderSeparatorIcon: " > "},
+		{Style: AgnosterShort, Expected: "/", HomePath: homeBillWindows, Pwd: "/", PathSeperator: "/", FolderSeparatorIcon: " > "},
 		{Style: AgnosterShort, Expected: "foo", HomePath: homeBillWindows, Pwd: "/foo", PathSeperator: "/", FolderSeparatorIcon: " > "},
 
 		{Style: AgnosterShort, Expected: "usr > .. > bar > man", HomePath: "/usr/home", Pwd: "/usr/foo/bar/man", PathSeperator: "/", FolderSeparatorIcon: " > ", MaxDepth: 2},


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

When using agnoster and path is the root drive:
![image](https://user-images.githubusercontent.com/1829553/135417605-902f083f-f513-481b-8311-cac74ca6e51d.png)

The pull will change the layout to:
![image](https://user-images.githubusercontent.com/1829553/135418166-38306f13-5d7d-4df6-8f55-4172d7fe6409.png)

It impacts only the root drive case.

Don't know if it's the best solution, @JanDeDobbeleer ?

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
