### PR TITLE
feat(dotnet): display segment extensions updated

### DIFF
--- a/src/segment_dotnet.go
+++ b/src/segment_dotnet.go
@@ -25,7 +25,7 @@ func (d *dotnet) init(props *properties, env environmentInfo) {
 	d.language = &language{
 		env:        env,
 		props:      props,
-		extensions: []string{"*.cs", "*.csx", "*.vb", "*.sln", "*.csproj", "*.vbproj", "*.fs", "*.fsx", "*.fsproj"},
+		extensions: []string{"*.cs", "*.csx", "*.vb", "*.sln", "*.csproj", "*.vbproj", "*.fs", "*.fsx", "*.fsproj", "global.json"},
 		commands: []*cmd{
 			{
 				executable: "dotnet",


### PR DESCRIPTION
display segment when global.json exists

### Prerequisites

- [X] I have read and understood the `CONTRIBUTING` guide
- [X] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

Display the dotnet segment when global.json exists in the folder.

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
