### PR TITLE
fix(path): correctly handle replaced paths for letter style

### DIFF
--- a/docs/docs/segment-path.md
+++ b/docs/docs/segment-path.md
@@ -111,4 +111,10 @@ for the folders to display is governed by the `mixed_threshold` property.
 
 ### Letter
 
-Works like `Full`, but will write every subfolder name using the first letter only.
+Works like `Full`, but will write every subfolder name using the first letter only, except when the folder name
+starts with a symbol or icon.
+
+- `folder` will be shortened to `f`
+- `.config` will be shortened to `.c`
+- `__pycache__` will be shortened to `__p`
+- `➼ folder` will be shortened to `➼ f`

--- a/src/segment_path.go
+++ b/src/segment_path.go
@@ -155,12 +155,20 @@ func (pt *path) getLetterPath() string {
 		if len(folder) == 0 {
 			continue
 		}
-		var letter string
-		if strings.HasPrefix(folder, ".") && len(folder) > 1 {
-			letter = folder[0:2]
-		} else {
-			letter = folder[0:1]
+
+		// check if there is at least a letter we can use
+		matches := findNamedRegexMatch(`(?P<letter>[\p{L}0-9]).*`, folder)
+
+		if matches == nil || matches["letter"] == "" {
+			// no letter found, keep the folder unchanged
+			buffer.WriteString(fmt.Sprintf("%s%s", folder, separator))
+			continue
 		}
+
+		letter := matches["letter"]
+		// handle non-letter characters before the first found letter
+		letter = folder[0:strings.Index(folder, letter)] + letter
+
 		buffer.WriteString(fmt.Sprintf("%s%s", letter, separator))
 	}
 	buffer.WriteString(splitted[len(splitted)-1])

--- a/src/segment_path_test.go
+++ b/src/segment_path_test.go
@@ -366,6 +366,13 @@ func TestAgnosterPathStyles(t *testing.T) {
 		{Style: Letter, Expected: "u > b > a > w > man", HomePath: "/usr/home", Pwd: "/usr/burp/ab/whatever/man", PathSeperator: "/", FolderSeparatorIcon: " > "},
 		{Style: Letter, Expected: "u > .b > a > w > man", HomePath: "/usr/home", Pwd: "/usr/.burp/ab/whatever/man", PathSeperator: "/", FolderSeparatorIcon: " > "},
 		{Style: Letter, Expected: "u > .b > a > .w > man", HomePath: "/usr/home", Pwd: "/usr/.burp/ab/.whatever/man", PathSeperator: "/", FolderSeparatorIcon: " > "},
+		{Style: Letter, Expected: "u > .b > a > ._w > man", HomePath: "/usr/home", Pwd: "/usr/.burp/ab/._whatever/man", PathSeperator: "/", FolderSeparatorIcon: " > "},
+		{Style: Letter, Expected: "u > .ä > ū > .w > man", HomePath: "/usr/home", Pwd: "/usr/.äufbau/ūmgebung/.whatever/man", PathSeperator: "/", FolderSeparatorIcon: " > "},
+		{Style: Letter, Expected: "u > .b > 1 > .w > man", HomePath: "/usr/home", Pwd: "/usr/.burp/12345/.whatever/man", PathSeperator: "/", FolderSeparatorIcon: " > "},
+		{Style: Letter, Expected: "u > .b > 1 > .w > man", HomePath: "/usr/home", Pwd: "/usr/.burp/12345abc/.whatever/man", PathSeperator: "/", FolderSeparatorIcon: " > "},
+		{Style: Letter, Expected: "u > .b > __p > .w > man", HomePath: "/usr/home", Pwd: "/usr/.burp/__pycache__/.whatever/man", PathSeperator: "/", FolderSeparatorIcon: " > "},
+		{Style: Letter, Expected: "➼ > .w > man", HomePath: "/usr/home", Pwd: "➼/.whatever/man", PathSeperator: "/", FolderSeparatorIcon: " > "},
+		{Style: Letter, Expected: "➼ s > .w > man", HomePath: "/usr/home", Pwd: "➼ something/.whatever/man", PathSeperator: "/", FolderSeparatorIcon: " > "},
 	}
 	for _, tc := range cases {
 		env := new(MockedEnvironment)


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

Currently, when using the `letter` style on the `path` segment, together with `mapped_locations` that replace directories with icons, the icon gets malformed as the mapped locations are applied before the segment style is applied, and the segment code naively gets the first character of the folder for every level.

This also affects directories that have characters on the extended unicode range, like `äcker`, as getting the first character from that string doesn't pick up the whole letter `ä`.

example:
<img width="760" alt="Screenshot 2021-10-16 at 08 32 35" src="https://user-images.githubusercontent.com/8055505/137576603-a3fc9880-c1e2-4f6d-ac5f-3d25ddbab413.png">

This merge request addresses this problem by extracting from the folder name the first letter, taking in account the unicode extended range, and not doing any replacement in case there is no letter on the folder at all, which would happen when the icon gets replaced by the mapped locations processor, or if the folder name would be exclusively formed by non-letters nor numbers, which I think it's unlikely to happen

so now it looks like:
<img width="760" alt="Screenshot 2021-10-16 at 08 46 57" src="https://user-images.githubusercontent.com/8055505/137576964-68e59c60-66cf-4c32-a6de-613ee7c061f1.png">

---

note:
currently, directories like python's `__pycache__` are get shortened to just `_`; as I wanted to handle the case where the replacement would include an icon and some text, e.g. `➼ something`, I've changed this logic, and shorten to until the first letter that was found instead
* for `__pycache__` it would get shortened to `__p`
* for `➼ something` it would get shortened to `➼ s`