### PR TITLE
feat(pwsh): render hyperlink for theme name

### DIFF
--- a/packages/powershell/oh-my-posh/oh-my-posh.psm1
+++ b/packages/powershell/oh-my-posh/oh-my-posh.psm1
@@ -79,6 +79,30 @@ function Set-PoshPrompt {
 
 <#
 .SYNOPSIS
+    Returns an ansi formatted hyperlink
+    if name not set, uri is used as the name of the hyperlink
+.EXAMPLE
+    Get-Hyperlink
+#>
+function Get-Hyperlink {
+    param(
+        [Parameter(Mandatory)]
+        [string]$uri,
+        [string]$name
+    )
+    $esc = [char]27
+    if ("" -eq $name) {
+        $name = $uri
+    }
+    if ($env:WSL_DISTRO_NAME -ne $null){
+        # wsl conversion if needed
+        $uri= &wslpath -m $uri
+    }
+    return "$esc]8;;file://$uri$esc\$name$esc]8;;$esc\"
+}
+
+<#
+.SYNOPSIS
     Display a preview or a list of installed themes.
 .EXAMPLE
     Get-PoshThemes
@@ -91,7 +115,6 @@ function Get-PoshThemes() {
         [Parameter(Mandatory = $false, HelpMessage = "List themes path")]
         $list
     )
-    $esc = [char]27
     $consoleWidth = $Host.UI.RawUI.WindowSize.Width
     $logo = @'
    __  _____ _      ___  ___       ______         _      __
@@ -112,7 +135,7 @@ function Get-PoshThemes() {
     else {
         $poshCommand = Get-PoshCommand
         $themes | ForEach-Object -Process {
-            Write-Host "Theme: $esc[1m$($_.BaseName.Replace('.omp', ''))$esc[0m"
+            Write-Host "Theme: $(Get-Hyperlink -uri $_.fullname -name $_.BaseName.Replace('.omp', ''))"
             Write-Host ""
             & $poshCommand -config $($_.FullName) -pwd $PWD
             Write-Host ""
@@ -120,7 +143,7 @@ function Get-PoshThemes() {
     }
     Write-Host ("-" * $consoleWidth)
     Write-Host ""
-    Write-Host "Themes location: $PSScriptRoot\themes"
+    Write-Host "Themes location: $(Get-Hyperlink -uri "$PSScriptRoot/themes")"
     Write-Host ""
     Write-Host "To change your theme, use the Set-PoshPrompt command. Example:"
     Write-Host "  Set-PoshPrompt -Theme jandedobbeleer"


### PR DESCRIPTION
render hyperlink for theme name and themes location in Get-PoshThemes
bold attribute removed since it's not really working in windows terminal(https://github.com/microsoft/terminal/issues/109)

### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

hyperlink for theme path and theme loction in Get-PoshThemes.
works with wsl but windows terminal does not allow to open network uri(wip on their side). The link can be copied and opened as is with explorer.

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
