### PR TITLE
🗒️have linux install to `~/.poshthemes/` not `~/`

### DIFF
--- a/docs/docs/install-shells.mdx
+++ b/docs/docs/install-shells.mdx
@@ -41,7 +41,7 @@ Once added, reload your profile for the changes to take effect.
 Add the following to `~/.zshrc`:
 
 ```bash
-eval "$(oh-my-posh --init --shell zsh --config ~/jandedobbeleer.omp.json)"
+eval "$(oh-my-posh --init --shell zsh --config ~/.poshthemes/jandedobbeleer.omp.json)"
 ```
 
 Once added, reload your profile for the changes to take effect.
@@ -56,7 +56,7 @@ source ~/.zshrc
 Add the following to `~/.bashrc` (could be `~/.profile` or `~/.bash_profile` depending on your environment):
 
 ```bash
-eval "$(oh-my-posh --init --shell bash --config ~/jandedobbeleer.omp.json)"
+eval "$(oh-my-posh --init --shell bash --config ~/.poshthemes/jandedobbeleer.omp.json)"
 ```
 
 Once added, reload your profile for the changes to take effect.
@@ -81,7 +81,7 @@ It's advised to be on the latest version of fish. Versions below 3.1.2 have issu
 Initialize Oh My Posh in `~/.config/fish/config.fish`:
 
 ```bash
-oh-my-posh --init --shell fish --config ~/jandedobbeleer.omp.json | source
+oh-my-posh --init --shell fish --config ~/.poshthemes/jandedobbeleer.omp.json | source
 ```
 
 Once added, reload your config for the changes to take effect.
@@ -98,13 +98,13 @@ Set the prompt and restart nu shell:
 ### Nu < 0.32.0
 
 ```bash
-config set prompt  "= `{{$(oh-my-posh --config ~/jandedobbeleer.omp.json | str collect)}}`"
+config set prompt  "= `{{$(oh-my-posh --config ~/.poshthemes/jandedobbeleer.omp.json | str collect)}}`"
 ```
 
 ### Nu >= 0.32.0
 
 ```bash
-config set prompt  "(oh-my-posh --config ~/jandedobbeleer.omp.json | str collect)"
+config set prompt  "(oh-my-posh --config ~/.poshthemes/jandedobbeleer.omp.json | str collect)"
 ```
 
 Restart nu shell for the changes to take effect.


### PR DESCRIPTION
Bash install snippet installs to `~/.poshthemes/` not `~/`. Cf., https://github.com/JanDeDobbeleer/oh-my-posh/blob/d84b92ef139f05fa4903ff5d1c885be2c90d482f/docs/docs/install-linux.mdx

![Screenshot of `install-linux` portion](https://user-images.githubusercontent.com/5055400/138857413-ea5890b5-4d0f-46dd-95e6-03d65c0f9f14.png)

### Prerequisites

- [X] I have read and understood the `CONTRIBUTING` guide
- [X] The commit message follows the [conventional commits][cc] guidelines
- [X] Tests for the changes have been added (for bug fixes/features)
- [X] Docs have been added / updated (for bug fixes/features)

### Description

[Description of the change]

Replace `~/jandedobbeleer.omp.json` with `~/.poshthemes/jandedobbeleer.omp.json` in the linux install snippets to accord with the install instructions.


[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
