### PR TITLE
fix: wrong background for powerline in some cases

### DIFF
--- a/src/block.go
+++ b/src/block.go
@@ -89,6 +89,9 @@ func (b *Block) renderSegments() string {
 			continue
 		}
 		b.activeSegment = segment
+		b.activeBackground = b.activeSegment.background()
+		b.activeForeground = b.activeSegment.foreground()
+		b.writer.setColors(b.activeBackground, b.activeForeground)
 		b.endPowerline()
 		b.renderSegmentText(segment.stringValue)
 	}
@@ -140,9 +143,6 @@ func (b *Block) getPowerlineColor(foreground bool) string {
 }
 
 func (b *Block) renderSegmentText(text string) {
-	b.activeBackground = b.activeSegment.background()
-	b.activeForeground = b.activeSegment.foreground()
-	b.writer.setColors(b.activeBackground, b.activeForeground)
 	switch b.activeSegment.Style {
 	case Plain:
 		b.renderPlainSegment(text)


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

Fix an issue with powerline having the wrong background color(powerline->diamond).  
Examples:

![image](https://user-images.githubusercontent.com/1829553/139457866-8fa7abc2-be61-4c30-ba57-f1dc1d2638f4.png)

![image](https://user-images.githubusercontent.com/1829553/139457708-0f077368-ea67-4756-8f07-2cc5ba0ded46.png)

![image](https://user-images.githubusercontent.com/1829553/139457898-6a634d35-359e-42b9-824c-73a46cfaf39e.png)

![image](https://user-images.githubusercontent.com/1829553/139457728-f6ce5ea2-3d09-4c18-bc36-d6991b264fe7.png)

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
