### PR TITLE
docs(faq): how to stop conda from hijacking the prompt

### DIFF
--- a/docs/docs/faq.mdx
+++ b/docs/docs/faq.mdx
@@ -123,10 +123,19 @@ https://ohmyposh.dev/docs/faq#powershell-running-in-constrainedlanguage-mode
 When running PowerShell in ConstrainedLanguage mode, we can't set the console to UTF-8. This will cause the prompt to be rendered incorrectly.
 There's a few [options][utf-8] to set the console to UTF-8 from an OS perspective on Windows, other systems shouldn't be impacted.
 
-To remove the message after manual configuration, you can add the following to your `$PROFILE` before importing oh-my-posh:
+To remove the message after manual configuration, you can add the following to your `$PROFILE` before importing Oh My Posh:
 
 ```powershell
 $env:POSH_CONSTRAINED_LANGUAGE = 1
+```
+
+### Conda: environment name displayed in front of the prompt
+
+Conda will automatically prepend the prompt with the name of the environment you're in.
+To solely rely on Oh My Posh to set the prompt, you can configure the follwing setting to hide it:
+
+```bash
+conda config --set changeps1 False
 ```
 
 [new-issue]: https://github.com/JanDeDobbeleer/oh-my-posh/issues/new


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

relates to #1103

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
