### PR TITLE
feat(theme): adding 'mojada' theme

### DIFF
--- a/themes/mojada.omp.json
+++ b/themes/mojada.omp.json
@@ -6,7 +6,7 @@
             "segments": [{
                     "type": "os",
                     "style": "diamond",
-                    "leading_diamond": "",
+                    "leading_diamond": "\uE0B6",
                     "trailing_diamond": "",
                     "foreground": "#0077c2",
                     "background": "#fbfbfb",
@@ -28,8 +28,7 @@
                     "style": "powerline",
                     "foreground": "#0077c2",
                     "background": "#fbfbfb",
-                    "powerline_symbol": "",
-                    "trailing_diamond": "",
+                    "powerline_symbol": "\uE0B0",
                     "properties": {
                         "prefix": "",
                         "display_host": true,
@@ -40,7 +39,7 @@
                 {
                     "type": "root",
                     "style": "powerline",
-                    "powerline_symbol": "",
+                    "powerline_symbol": "\uE0B0",
                     "foreground": "#ffffff",
                     "background": "#e06c75",
                     "properties": {
@@ -51,7 +50,7 @@
                 {
                     "type": "path",
                     "style": "powerline",
-                    "powerline_symbol": "",
+                    "powerline_symbol": "\uE0B0",
                     "foreground": "#ffffff",
                     "background": "#0077c2",
                     "properties": {
@@ -66,7 +65,7 @@
                 {
                     "type": "git",
                     "style": "powerline",
-                    "powerline_symbol": "",
+                    "powerline_symbol": "\uE0B0",
                     "foreground": "#193549",
                     "background": "#fffb38",
                     "properties": {

--- a/themes/mojada.omp.json
+++ b/themes/mojada.omp.json
@@ -1,0 +1,152 @@
+{
+    "blocks": [{
+            "type": "prompt",
+            "alignment": "left",
+            "newline": true,
+            "segments": [{
+                    "type": "os",
+                    "style": "diamond",
+                    "leading_diamond": "",
+                    "trailing_diamond": "",
+                    "foreground": "#0077c2",
+                    "background": "#fbfbfb",
+                    "properties": {
+                        "prefix": "",
+                        "postfix": " ",
+                        "macos": "mac",
+                        "windows": ""
+                    }
+                },
+                {
+                    "type": "session",
+                    "style": "powerline",
+                    "foreground": "#0077c2",
+                    "background": "#fbfbfb",
+                    "powerline_symbol": "",
+                    "trailing_diamond": "",
+                    "properties": {
+                        "prefix": "",
+                        "postfix": " ",
+                        "display_host": true,
+                        "host_color": "#e06c75",
+                        "user_info_separator": "<#000000>@</>"
+
+                    }
+                },
+                {
+                    "type": "root",
+                    "style": "powerline",
+                    "powerline_symbol": "",
+                    "foreground": "#ffffff",
+                    "background": "#e06c75",
+                    "properties": {
+                        "root_icon": " ",
+                        "postfix": "\u2800"
+                    }
+                },
+                {
+                    "type": "path",
+                    "style": "powerline",
+                    "powerline_symbol": "",
+                    "foreground": "#ffffff",
+                    "background": "#0077c2",
+                    "properties": {
+                        "style": "letter",
+                        "folder_separator_icon": "/",
+                        "prefix": "  ",
+                        "home_icon": "~",
+                        "enable_hyperlink": true,
+                        "max_depth": 2
+                    }
+                },
+                {
+                    "type": "git",
+                    "style": "powerline",
+                    "powerline_symbol": "",
+                    "foreground": "#193549",
+                    "background": "#fffb38",
+                    "properties": {
+                        "display_stash_count": true,
+                        "display_upstream_icon": true,
+                        "status_colors_enabled": true,
+                        "local_changes_color": "#ff9248",
+                        "ahead_and_behind_color": "#f26d50",
+                        "behind_color": "#f17c37",
+                        "ahead_color": "#89d1dc",
+                        "stash_count_icon": "\uF692 "
+                    }
+                },
+                {
+                    "type": "text",
+                    "style": "plain",
+                    "foreground": "#FFD54F",
+                    "properties": {
+                        "prefix": " ",
+                        "text": "{{if .Root}}#{{else}}${{end}}"
+                    }
+                }
+            ]
+        },
+        {
+            "type": "rprompt",
+            "segments": [{
+                    "type": "exit",
+                    "style": "plain",
+                    "foreground": "#ffffff",
+                    "properties": {
+                        "display_exit_code": false,
+                        "always_enabled": true,
+                        "error_icon": "<#ff0000></>",
+                        "success_icon": "<#00ff00></>",
+                        "prefix": ""
+                    }
+                },
+                {
+                    "type": "executiontime",
+                    "style": "plain",
+                    "foreground": "#ffffff",
+                    "properties": {
+                        "always_enabled": true,
+                        "prefix": "",
+                        "postfix": " "
+                    }
+                },
+                {
+                    "type": "battery",
+                    "style": "powerline",
+                    "invert_powerline": true,
+                    "powerline_symbol": "\uE0B2",
+                    "foreground": "#ffffff",
+                    "background": "#f36943",
+                    "properties": {
+                        "battery_icon": "",
+                        "discharging_icon": " ",
+                        "charging_icon": " ",
+                        "charged_icon": " ",
+                        "color_background": true,
+                        "charged_color": "#4caf50",
+                        "charging_color": "#40c4ff",
+                        "discharging_color": "#ff5722",
+                        "postfix": "% "
+                    }
+                },
+                {
+                    "type": "time",
+                    "style": "diamond",
+                    "invert_powerline": true,
+                    "leading_diamond": "",
+                    "trailing_diamond": "\uE0B4",
+                    "background": "#61afef",
+                    "foreground": "#ffffff",
+                    "properties": {
+                        "time_format": "15:04 (Mon)"
+                    }
+                }
+            ]
+        }
+    ],
+    "final_space": true,
+    "console_title": true,
+    "console_title_style": "template",
+    "console_title_template": "{{.User}}@{{.Host}} : {{.Folder}}"
+}

--- a/themes/mojada.omp.json
+++ b/themes/mojada.omp.json
@@ -11,10 +11,16 @@
                     "foreground": "#0077c2",
                     "background": "#fbfbfb",
                     "properties": {
-                        "prefix": "",
                         "postfix": " ",
-                        "macos": "mac",
-                        "windows": ""
+                        "macos": "\uEF179",
+                        "windows": "\uF17A",
+                        "linux": "\uF17C",
+                        "debian": "\uF306",
+                        "ubuntu": "\uF31B",
+                        "arch": "\uF303",
+                        "fedora": "\uF30A",
+                        "manjaro": "\uF312",
+                        "opensuse": "\uF314"
                     }
                 },
                 {
@@ -26,11 +32,9 @@
                     "trailing_diamond": "",
                     "properties": {
                         "prefix": "",
-                        "postfix": " ",
                         "display_host": true,
                         "host_color": "#e06c75",
                         "user_info_separator": "<#000000>@</>"
-
                     }
                 },
                 {
@@ -40,7 +44,7 @@
                     "foreground": "#ffffff",
                     "background": "#e06c75",
                     "properties": {
-                        "root_icon": " ",
+                        "root_icon": "\uE799 ",
                         "postfix": "\u2800"
                     }
                 },
@@ -53,7 +57,7 @@
                     "properties": {
                         "style": "letter",
                         "folder_separator_icon": "/",
-                        "prefix": "  ",
+                        "prefix": " \uE5FE ",
                         "home_icon": "~",
                         "enable_hyperlink": true,
                         "max_depth": 2
@@ -82,7 +86,8 @@
                     "foreground": "#FFD54F",
                     "properties": {
                         "prefix": " ",
-                        "text": "{{if .Root}}#{{else}}${{end}}"
+                        "text": "{{if .Root}}#{{else}}${{end}}",
+                        "postfix": ""
                     }
                 }
             ]
@@ -96,9 +101,8 @@
                     "properties": {
                         "display_exit_code": false,
                         "always_enabled": true,
-                        "error_icon": "<#ff0000></>",
-                        "success_icon": "<#00ff00></>",
-                        "prefix": ""
+                        "success_icon": "<#00ff00>\uF633</>",
+                        "error_icon": "<#ff0000>\uF659</>"
                     }
                 },
                 {
@@ -107,8 +111,7 @@
                     "foreground": "#ffffff",
                     "properties": {
                         "always_enabled": true,
-                        "prefix": "",
-                        "postfix": " "
+                        "prefix": ""
                     }
                 },
                 {
@@ -120,9 +123,9 @@
                     "background": "#f36943",
                     "properties": {
                         "battery_icon": "",
-                        "discharging_icon": " ",
-                        "charging_icon": " ",
-                        "charged_icon": " ",
+                        "discharging_icon": "\uF57D ",
+                        "charging_icon": "\uF588 ",
+                        "charged_icon": "\uF583 ",
                         "color_background": true,
                         "charged_color": "#4caf50",
                         "charging_color": "#40c4ff",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

Another theme that is created based on the default theme of "oh-my-posh" is <code>jandedobbeleer.omp.json</code>. Customized with mostly Atom One Dark color scheme for aesthetic appearance.

![image](https://user-images.githubusercontent.com/17336102/139652165-186d1d69-359f-46a7-a4d8-3e287efd9759.png)

