### PR TITLE
git template

### DIFF
--- a/docs/docs/beta.mdx
+++ b/docs/docs/beta.mdx
@@ -41,13 +41,9 @@ You need to extend or create a custom theme with your tooltips. For example:
       "leading_diamond": "",
       "trailing_diamond": "",
       "properties": {
-        "display_status": true,
+        "fetch_status": true,
         "display_upstream_icon": true,
-        "status_colors_enabled": true,
-        "local_changes_color": "#ff9248",
-        "ahead_and_behind_color": "#f26d50",
-        "behind_color": "#f17c37",
-        "ahead_color": "#89d1dc"
+        "template": "{{ .Repo.HEAD }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}"
       }
     }
   ]

--- a/docs/docs/beta.mdx
+++ b/docs/docs/beta.mdx
@@ -42,7 +42,7 @@ You need to extend or create a custom theme with your tooltips. For example:
       "trailing_diamond": "",
       "properties": {
         "fetch_status": true,
-        "display_upstream_icon": true,
+        "fetch_upstream_icon": true,
         "template": "{{ .Repo.HEAD }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}"
       }
     }

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -222,7 +222,7 @@ The following sample is based on the [AWS Segment][aws].
 {
   "type": "aws",
   "style": "powerline",
-  "powerline_symbol": "",
+  "powerline_symbol": "\uE0B0",
   "foreground": "#ffffff",
   "background": "#111111",
   "foreground_templates": [

--- a/docs/docs/segment-angular.md
+++ b/docs/docs/segment-angular.md
@@ -14,7 +14,7 @@ Display the currently active Angular CLI version.
 {
   "type": "angular",
   "style": "powerline",
-  "powerline_symbol": "",
+  "powerline_symbol": "\uE0B0",
   "foreground": "#000000",
   "background": "#1976d2",
   "properties": {

--- a/docs/docs/segment-azfunc.md
+++ b/docs/docs/segment-azfunc.md
@@ -14,7 +14,7 @@ Display the currently active Azure functions CLI version.
 {
     "type": "azfunc",
     "style": "powerline",
-    "powerline_symbol": "",
+    "powerline_symbol": "\uE0B0",
     "foreground": "#ffffff",
     "background": "#FEAC19",
     "properties": {

--- a/docs/docs/segment-dotnet.md
+++ b/docs/docs/segment-dotnet.md
@@ -14,7 +14,7 @@ Display the currently active .NET SDK version.
 {
   "type": "dotnet",
   "style": "powerline",
-  "powerline_symbol": "",
+  "powerline_symbol": "\uE0B0",
   "foreground": "#000000",
   "background": "#00ffff",
   "properties": {

--- a/docs/docs/segment-git.mdx
+++ b/docs/docs/segment-git.mdx
@@ -38,9 +38,9 @@ An alternative is to use the [Posh-Git segment][poshgit]
   "background": "#ffeb3b",
   "background_templates": [
     "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#FFEB3B{{ end }}",
-    "{{ if and (.Repo.Ahead gt 0) (.Repo.Behind gt 0) }}#FFCC80{{ end }}",
-    "{{ if .Repo.Ahead gt 0 }}#B388FF{{ end }}",
-    "{{ if .Repo.Behind gt 0 }}#B388FB{{ end }}"
+    "{{ if and (gt .Repo.Ahead 0) (gt .Repo.Behind 0) }}#FFCC80{{ end }}",
+    "{{ if gt .Repo.Ahead 0 }}#B388FF{{ end }}",
+    "{{ if gt .Repo.Behind 0 }}#B388FB{{ end }}"
   ],
   "properties": {
     "fetch_status": true,

--- a/docs/docs/segment-git.mdx
+++ b/docs/docs/segment-git.mdx
@@ -45,7 +45,8 @@ An alternative is to use the [Posh-Git segment][poshgit]
   "properties": {
     "fetch_status": true,
     "fetch_stash_count": true,
-    "display_upstream_icon": true
+    "fetch_upstream_icon": true,
+    "template": "{{ .Repo.UpstreamIcon }}{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
   }
 }
 ```
@@ -63,6 +64,7 @@ You can set the following properties to `true` to enable fetching additional inf
 - fetch_status: `boolean` - fetch the local changes - defaults to `false`
 - fetch_stash_count: `boolean` fetch stash count - defaults to `false`
 - fetch_worktree_count: `boolean` fetch worktree count - defaults to `false`
+- fetch_upstream_icon: `boolean` - fetch upstream icon - defaults to `false`
 
 ### Icons
 
@@ -87,7 +89,6 @@ You can set the following properties to `true` to enable fetching additional inf
 
 #### Upstream
 
-- display_upstream_icon: `boolean` - fetch upstream icon - defaults to `false`
 - github_icon: `string` - icon/text to display when the upstream is Github - defaults to `\uF408 `
 - gitlab_icon: `string` - icon/text to display when the upstream is Gitlab - defaults to `\uF296 `
 - bitbucket_icon: `string` - icon/text to display when the upstream is Bitbucket - defaults to `\uF171 `

--- a/docs/docs/segment-git.mdx
+++ b/docs/docs/segment-git.mdx
@@ -36,9 +36,15 @@ An alternative is to use the [Posh-Git segment][poshgit]
   "powerline_symbol": "\uE0B0",
   "foreground": "#193549",
   "background": "#ffeb3b",
+  "background_templates": [
+    "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#FFEB3B{{ end }}",
+    "{{ if and (.Repo.Ahead gt 0) (.Repo.Behind gt 0) }}#FFCC80{{ end }}",
+    "{{ if .Repo.Ahead gt 0 }}#B388FF{{ end }}",
+    "{{ if .Repo.Behind gt 0 }}#B388FB{{ end }}"
+  ],
   "properties": {
-    "display_status": true,
-    "display_stash_count": true,
+    "fetch_status": true,
+    "fetch_stash_count": true,
     "display_upstream_icon": true
   }
 }
@@ -46,29 +52,31 @@ An alternative is to use the [Posh-Git segment][poshgit]
 
 ## Properties
 
-### Standard
+- template: `string` - A go [text/template][go-text-template] template extended with [sprig][sprig] utilizing the
+properties below. Defaults to empty.
+
+### Fetching information
+
+As doing multiple git calls can slow down the prompt experience, we do not fetch information by default.
+You can set the following properties to `true` to enable fetching additional information (and populate the template).
+
+- fetch_branch_status: `boolean` - fetch the branch status (rebase/merge/cherry-pick/...) - defaults to `true`
+- fetch_status: `boolean` - fetch the local changes - defaults to `false`
+- fetch_stash_count: `boolean` fetch stash count - defaults to `false`
+- fetch_worktree_count: `boolean` fetch worktree count - defaults to `false`
+
+### Icons
+
+#### Branch
 
 - branch_icon: `string` - the icon to use in front of the git branch name - defaults to `\uE0A0 `
-- display_branch_status: `boolean` - display the branch status or not - defaults to `true`
 - branch_identical_icon: `string` - the icon to display when remote and local are identical - defaults to `\u2261`
 - branch_ahead_icon: `string` - the icon to display when the local branch is ahead of its remote - defaults to `\u2191`
 - branch_behind_icon: `string` - the icon to display when the local branch is behind its remote - defaults to `\u2193`
 - branch_gone_icon: `string` - the icon to display when there's no remote branch - defaults to `\u2262`
 - branch_max_length: `int` - the max length for the displayed branch name where `0` implies full length - defaults to `0`
 
-### Status
-
-- display_status: `boolean` - display the local changes or not - defaults to `false`
-- display_status_detail: `boolean` - display the local changes in detail or not - defaults to `true`
-- display_stash_count: `boolean` show stash count or not - defaults to `false`
-- display_worktree_count: `boolean` show worktree count or not - defaults to `false`
-- status_separator_icon: `string` icon/text to display between staging and working area changes - defaults to ` |`
-- local_working_icon: `string` - the icon to display in front of the working area changes - defaults to `\uF044`
-- local_staged_icon: `string` - the icon to display in front of the staged area changes - defaults to `\uF046`
-- stash_count_icon: `string` icon/text to display before the stash context - defaults to `\uF692`
-- worktree_count_icon: `string` icon/text to display before the worktree context - defaults to `\uF1BB`
-
-### HEAD context
+#### HEAD
 
 - commit_icon: `string` - icon/text to display before the commit context (detached HEAD) - defaults to `\uF417`
 - tag_icon: `string` - icon/text to display before the tag context - defaults to `\uF412`
@@ -78,29 +86,38 @@ An alternative is to use the [Posh-Git segment][poshgit]
 - merge_icon: `string` icon/text to display before the merge context - defaults to `\uE727 `
 - no_commits_icon: `string` icon/text to display when there are no commits in the repo - defaults to `\uF594 `
 
-### Upstream context
+#### Upstream
 
-- display_upstream_icon: `boolean` - display upstream icon or not - defaults to `false`
+- display_upstream_icon: `boolean` - fetch upstream icon - defaults to `false`
 - github_icon: `string` - icon/text to display when the upstream is Github - defaults to `\uF408 `
 - gitlab_icon: `string` - icon/text to display when the upstream is Gitlab - defaults to `\uF296 `
 - bitbucket_icon: `string` - icon/text to display when the upstream is Bitbucket - defaults to `\uF171 `
 - azure_devops_icon: `string` - icon/text to display when the upstream is Azure DevOps - defaults to `\uFD03 `
 - git_icon: `string` - icon/text to display when the upstream is not known/mapped - defaults to `\uE5FB `
 
-### Colors
+## Template Properties
 
-- working_color: `string` [color][colors] - foreground color for the working area status - defaults to segment foreground
-- staging_color: `string` [color][colors] - foreground color for the staging area status - defaults to segment foreground
-- status_colors_enabled: `boolean` - color the segment based on the repository status - defaults to `false`
-- color_background: `boolean` - color background or foreground - defaults to `true`
-- local_changes_color: `string` [color][colors] - segment color when there are local changes - defaults to segment
-foreground/background (see `color_background`)
-- ahead_and_behind_color: `string` [color][colors] - segment color when the branch is ahead and behind -
-defaults to segment foreground/background (see `color_background`)
-- behind_color: `string` [color][colors] - segment color when the branch is behind - defaults to segment
-foreground/background (see `color_background`)
-- ahead_color: `string` [color][colors] - segment color when the branch is ahead - defaults to segment
-foreground/background (see `color_background`)
+- `.Repo.Working`: `GitStatus` - changes in the working tree (see below)
+- `.Repo.Staging`: `GitStatus` - staged changes in the work tree (see below)
+- `.Repo.HEAD`: `string` - the current HEAD context (branch/rebase/merge/...)
+- `.Repo.Behind`: `int` - commits behind of upstream
+- `.Repo.Ahead`: `int` - commits ahead of upstream
+- `.Repo.BranchStatus`: `string` - the current branch context (ahead/behind string representation)
+- `.Repo.Upstream`: `string` - the upstream name (remote)
+- `.Repo.UpstreamIcon`: `string` - the upstream icon (based on the icons above)
+- `.Repo.StashCount`: `int` - the stash count
+- `.Repo.WorktreeCount`: `int` - the worktree count
+- `.Repo.IsWorkTree`: `boolean` - if in a worktree repo or not
 
-[colors]: /docs/configure#colors
+### GitStatus
+
+- `.Unmerged`: `int` - number of unmerged changes
+- `.Deleted`: `int` - number of deleted changes
+- `.Added`: `int` - number of added changes
+- `.Modified`: `int` - number of modified changes
+- `.Changed`: `boolean` - if the status contains changes or not
+- `.String`: `string` - a string representation of the changes above
+
 [poshgit]: /docs/poshgit
+[go-text-template]: https://golang.org/pkg/text/template/
+[sprig]: https://masterminds.github.io/sprig/

--- a/docs/docs/segment-git.mdx
+++ b/docs/docs/segment-git.mdx
@@ -60,7 +60,6 @@ properties below. Defaults to empty.
 As doing multiple git calls can slow down the prompt experience, we do not fetch information by default.
 You can set the following properties to `true` to enable fetching additional information (and populate the template).
 
-- fetch_branch_status: `boolean` - fetch the branch status (rebase/merge/cherry-pick/...) - defaults to `true`
 - fetch_status: `boolean` - fetch the local changes - defaults to `false`
 - fetch_stash_count: `boolean` fetch stash count - defaults to `false`
 - fetch_worktree_count: `boolean` fetch worktree count - defaults to `false`

--- a/docs/docs/segment-nbgv.mdx
+++ b/docs/docs/segment-nbgv.mdx
@@ -18,7 +18,7 @@ The Nerdbank.GitVersioning CLI can be a bit slow causing the prompt to feel slow
 {
   "type": "nbgv",
   "style": "powerline",
-  "powerline_symbol": "",
+  "powerline_symbol": "\uE0B0",
   "foreground": "#ffffff",
   "background": "#3a579a",
   "properties": {

--- a/src/config.go
+++ b/src/config.go
@@ -199,8 +199,8 @@ func getDefaultConfig(info string) *Config {
 						Background:      "#fffb38",
 						Foreground:      "#193549",
 						Properties: map[Property]interface{}{
-							DisplayStashCount:   true,
-							DisplayUpstreamIcon: true,
+							FetchStashCount:   true,
+							FetchUpstreamIcon: true,
 						},
 					},
 					{

--- a/src/image_test.go
+++ b/src/image_test.go
@@ -32,8 +32,8 @@ func TestStringImageFileWithText(t *testing.T) {
 }
 
 func TestStringImageFileWithANSI(t *testing.T) {
-	prompt := `[38;2;0;55;218;49m[7m[m[0m[48;2;0;55;218m[38;2;255;255;255m oh-my-posh
-	 [0m[48;2;193;156;0m[38;2;0;55;218m[0m[48;2;193;156;0m[38;2;17;17;17m main ≡  ~4 -8 ?7 [0m[38;2;193;156;0m[0m
+	prompt := `[38;2;0;55;218;49m[7m\uE0B0[m[0m[48;2;0;55;218m[38;2;255;255;255m oh-my-posh
+	 [0m[48;2;193;156;0m[38;2;0;55;218m\uE0B0[0m[48;2;193;156;0m[38;2;17;17;17m main ≡  ~4 -8 ?7 [0m[38;2;193;156;0m\uE0B0[0m
 	[37m [0m[0m`
 	err := runImageTest(prompt)
 	assert.NoError(t, err)

--- a/src/segment_git.go
+++ b/src/segment_git.go
@@ -197,6 +197,11 @@ func (g *git) string() string {
 	if g.Repo.Upstream != "" && g.props.getBool(DisplayUpstreamIcon, false) {
 		g.Repo.UpstreamIcon = g.getUpstreamIcon()
 	}
+	if g.getBool(FetchStashCount, DisplayStashCount, false) {
+		g.Repo.StashCount = g.getStashContext()
+	}
+	if g.getBool(FetchWorktreeCount, DisplayWorktreeCount, false) {
+		g.Repo.WorktreeCount = g.getWorktreeContext()
 	}
 	// use template if available
 	segmentTemplate := g.props.getString(SegmentTemplate, "")
@@ -277,12 +282,7 @@ func (g *git) setGitStatus() {
 		}
 	}
 	g.Repo.HEAD = g.getGitHEADContext(status["local"])
-	if g.getBool(FetchStashCount, DisplayStashCount, false) {
-		g.Repo.StashCount = g.getStashContext()
-	}
-	if g.getBool(FetchWorktreeCount, DisplayWorktreeCount, false) {
-		g.Repo.WorktreeCount = g.getWorktreeContext()
-	}
+	g.Repo.BranchStatus = g.getBranchStatus()
 }
 
 func (g *git) getGitCommand() string {

--- a/src/segment_git.go
+++ b/src/segment_git.go
@@ -87,17 +87,17 @@ type git struct {
 }
 
 const (
-	// DisplayBranchStatus show branch status or not
-	DisplayBranchStatus Property = "display_branch_status"
-	// DisplayStatus shows the status of the repository
-	DisplayStatus Property = "display_status"
-	// DisplayStashCount show stash count or not
-	DisplayStashCount Property = "display_stash_count"
-	// DisplayWorktreeCount show worktree count or not
-	DisplayWorktreeCount Property = "display_worktree_count"
+	// FetchBranchStatus show branch status or not
+	FetchBranchStatus Property = "fetch_branch_status"
+	// FetchStatus shows the status of the repository
+	FetchStatus Property = "fetch_status"
+	// FetchStashCount show stash count or not
+	FetchStashCount Property = "fetch_stash_count"
+	// FetchWorktreeCount show worktree count or not
+	FetchWorktreeCount Property = "fetch_worktree_count"
+
 	// DisplayUpstreamIcon show or hide the upstream icon
 	DisplayUpstreamIcon Property = "display_upstream_icon"
-
 	// BranchMaxLength truncates the length of the branch name
 	BranchMaxLength Property = "branch_max_length"
 	// BranchIcon the icon to use as branch indicator
@@ -189,7 +189,7 @@ func (g *git) shouldIgnoreRootRepository(rootDir string) bool {
 
 func (g *git) string() string {
 	statusColorsEnabled := g.props.getBool(StatusColorsEnabled, false)
-	displayStatus := g.props.getBool(DisplayStatus, false)
+	displayStatus := g.getBool(FetchStatus, DisplayStatus, false)
 	if !displayStatus {
 		g.repo.HEAD = g.getPrettyHEADName()
 	}
@@ -199,7 +199,7 @@ func (g *git) string() string {
 	if g.repo.Upstream != "" && g.props.getBool(DisplayUpstreamIcon, false) {
 		g.repo.UpstreamIcon = g.getUpstreamIcon()
 	}
-	if g.props.getBool(DisplayBranchStatus, true) {
+	if g.getBool(FetchBranchStatus, DisplayBranchStatus, true) {
 		g.repo.BranchStatus = g.getBranchStatus()
 	}
 	// use template if available
@@ -281,10 +281,10 @@ func (g *git) setGitStatus() {
 		}
 	}
 	g.repo.HEAD = g.getGitHEADContext(status["local"])
-	if g.props.getBool(DisplayStashCount, false) {
+	if g.getBool(FetchStashCount, DisplayStashCount, false) {
 		g.repo.StashCount = g.getStashContext()
 	}
-	if g.props.getBool(DisplayWorktreeCount, false) {
+	if g.getBool(FetchWorktreeCount, DisplayWorktreeCount, false) {
 		g.repo.WorktreeCount = g.getWorktreeContext()
 	}
 }

--- a/src/segment_git.go
+++ b/src/segment_git.go
@@ -297,7 +297,7 @@ func (g *git) getGitCommand() string {
 }
 
 func (g *git) getGitCommandOutput(args ...string) string {
-	args = append([]string{"--no-optional-locks", "-c", "core.quotepath=false", "-c", "color.status=false"}, args...)
+	args = append([]string{"-C", strings.TrimSuffix(g.Repo.gitRootFolder, ".git"), "--no-optional-locks", "-c", "core.quotepath=false", "-c", "color.status=false"}, args...)
 	val, _ := g.env.runCommand(g.getGitCommand(), args...)
 	return val
 }

--- a/src/segment_git.go
+++ b/src/segment_git.go
@@ -87,8 +87,6 @@ type git struct {
 }
 
 const (
-	// FetchBranchStatus show branch status or not
-	FetchBranchStatus Property = "fetch_branch_status"
 	// FetchStatus shows the status of the repository
 	FetchStatus Property = "fetch_status"
 	// FetchStashCount show stash count or not
@@ -199,8 +197,6 @@ func (g *git) string() string {
 	if g.Repo.Upstream != "" && g.props.getBool(DisplayUpstreamIcon, false) {
 		g.Repo.UpstreamIcon = g.getUpstreamIcon()
 	}
-	if g.getBool(FetchBranchStatus, DisplayBranchStatus, true) {
-		g.Repo.BranchStatus = g.getBranchStatus()
 	}
 	// use template if available
 	segmentTemplate := g.props.getString(SegmentTemplate, "")

--- a/src/segment_git.go
+++ b/src/segment_git.go
@@ -87,15 +87,15 @@ type git struct {
 }
 
 const (
-	// FetchStatus shows the status of the repository
+	// FetchStatus fetches the status of the repository
 	FetchStatus Property = "fetch_status"
-	// FetchStashCount show stash count or not
+	// FetchStashCount fetches the stash count
 	FetchStashCount Property = "fetch_stash_count"
-	// FetchWorktreeCount show worktree count or not
+	// FetchWorktreeCount fetches the worktree count
 	FetchWorktreeCount Property = "fetch_worktree_count"
+	// FetchUpstreamIcon fetches the upstream icon
+	FetchUpstreamIcon Property = "fetch_upstream_icon"
 
-	// DisplayUpstreamIcon show or hide the upstream icon
-	DisplayUpstreamIcon Property = "display_upstream_icon"
 	// BranchMaxLength truncates the length of the branch name
 	BranchMaxLength Property = "branch_max_length"
 	// BranchIcon the icon to use as branch indicator
@@ -187,20 +187,20 @@ func (g *git) shouldIgnoreRootRepository(rootDir string) bool {
 
 func (g *git) string() string {
 	statusColorsEnabled := g.props.getBool(StatusColorsEnabled, false)
-	displayStatus := g.getBool(FetchStatus, DisplayStatus, false)
+	displayStatus := g.getBool(FetchStatus, DisplayStatus)
 	if !displayStatus {
 		g.Repo.HEAD = g.getPrettyHEADName()
 	}
 	if displayStatus || statusColorsEnabled {
 		g.setGitStatus()
 	}
-	if g.Repo.Upstream != "" && g.props.getBool(DisplayUpstreamIcon, false) {
+	if g.Repo.Upstream != "" && g.getBool(FetchUpstreamIcon, DisplayUpstreamIcon) {
 		g.Repo.UpstreamIcon = g.getUpstreamIcon()
 	}
-	if g.getBool(FetchStashCount, DisplayStashCount, false) {
+	if g.getBool(FetchStashCount, DisplayStashCount) {
 		g.Repo.StashCount = g.getStashContext()
 	}
-	if g.getBool(FetchWorktreeCount, DisplayWorktreeCount, false) {
+	if g.getBool(FetchWorktreeCount, DisplayWorktreeCount) {
 		g.Repo.WorktreeCount = g.getWorktreeContext()
 	}
 	// use template if available

--- a/src/segment_git_deprecated.go
+++ b/src/segment_git_deprecated.go
@@ -7,6 +7,15 @@ import (
 )
 
 const (
+	// DisplayBranchStatus show branch status or not
+	DisplayBranchStatus Property = "display_branch_status"
+	// DisplayStatus shows the status of the repository
+	DisplayStatus Property = "display_status"
+	// DisplayStashCount show stash count or not
+	DisplayStashCount Property = "display_stash_count"
+	// DisplayWorktreeCount show worktree count or not
+	DisplayWorktreeCount Property = "display_worktree_count"
+
 	// LocalWorkingIcon the icon to use as the local working area changes indicator
 	LocalWorkingIcon Property = "local_working_icon"
 	// LocalStagingIcon the icon to use as the local staging area changes indicator
@@ -34,6 +43,14 @@ const (
 	// StatusSeparatorIcon shows between staging and working area
 	StatusSeparatorIcon Property = "status_separator_icon"
 )
+
+func (g *git) getBool(property, legacyProperty Property, defaultValue bool) bool {
+	_, found := g.props.values[legacyProperty]
+	if found {
+		return g.props.getBool(legacyProperty, defaultValue)
+	}
+	return g.props.getBool(property, defaultValue)
+}
 
 func (g *git) renderDeprecatedString(statusColorsEnabled bool) string {
 	if statusColorsEnabled {

--- a/src/segment_git_deprecated.go
+++ b/src/segment_git_deprecated.go
@@ -58,28 +58,28 @@ func (g *git) renderDeprecatedString(statusColorsEnabled bool) string {
 	}
 	buffer := new(bytes.Buffer)
 	// remote (if available)
-	if len(g.repo.UpstreamIcon) != 0 {
-		fmt.Fprintf(buffer, "%s", g.repo.UpstreamIcon)
+	if len(g.Repo.UpstreamIcon) != 0 {
+		fmt.Fprintf(buffer, "%s", g.Repo.UpstreamIcon)
 	}
 	// branchName
-	fmt.Fprintf(buffer, "%s", g.repo.HEAD)
-	if len(g.repo.BranchStatus) != 0 {
-		buffer.WriteString(g.repo.BranchStatus)
+	fmt.Fprintf(buffer, "%s", g.Repo.HEAD)
+	if len(g.Repo.BranchStatus) != 0 {
+		buffer.WriteString(g.Repo.BranchStatus)
 	}
-	if g.repo.Staging.Changed {
-		fmt.Fprint(buffer, g.getStatusDetailString(g.repo.Staging, StagingColor, LocalStagingIcon, " \uF046"))
+	if g.Repo.Staging.Changed {
+		fmt.Fprint(buffer, g.getStatusDetailString(g.Repo.Staging, StagingColor, LocalStagingIcon, " \uF046"))
 	}
-	if g.repo.Staging.Changed && g.repo.Working.Changed {
+	if g.Repo.Staging.Changed && g.Repo.Working.Changed {
 		fmt.Fprint(buffer, g.props.getString(StatusSeparatorIcon, " |"))
 	}
-	if g.repo.Working.Changed {
-		fmt.Fprint(buffer, g.getStatusDetailString(g.repo.Working, WorkingColor, LocalWorkingIcon, " \uF044"))
+	if g.Repo.Working.Changed {
+		fmt.Fprint(buffer, g.getStatusDetailString(g.Repo.Working, WorkingColor, LocalWorkingIcon, " \uF044"))
 	}
-	if g.repo.StashCount != 0 {
-		fmt.Fprintf(buffer, " %s%d", g.props.getString(StashCountIcon, "\uF692 "), g.repo.StashCount)
+	if g.Repo.StashCount != 0 {
+		fmt.Fprintf(buffer, " %s%d", g.props.getString(StashCountIcon, "\uF692 "), g.Repo.StashCount)
 	}
-	if g.repo.WorktreeCount != 0 {
-		fmt.Fprintf(buffer, " %s%d", g.props.getString(WorktreeCountIcon, "\uf1bb "), g.repo.WorktreeCount)
+	if g.Repo.WorktreeCount != 0 {
+		fmt.Fprintf(buffer, " %s%d", g.props.getString(WorktreeCountIcon, "\uf1bb "), g.Repo.WorktreeCount)
 	}
 	return buffer.String()
 }
@@ -93,13 +93,13 @@ func (g *git) SetStatusColor() {
 }
 
 func (g *git) getStatusColor(defaultValue string) string {
-	if g.repo.Staging.Changed || g.repo.Working.Changed {
+	if g.Repo.Staging.Changed || g.Repo.Working.Changed {
 		return g.props.getColor(LocalChangesColor, defaultValue)
-	} else if g.repo.Ahead > 0 && g.repo.Behind > 0 {
+	} else if g.Repo.Ahead > 0 && g.Repo.Behind > 0 {
 		return g.props.getColor(AheadAndBehindColor, defaultValue)
-	} else if g.repo.Ahead > 0 {
+	} else if g.Repo.Ahead > 0 {
 		return g.props.getColor(AheadColor, defaultValue)
-	} else if g.repo.Behind > 0 {
+	} else if g.Repo.Behind > 0 {
 		return g.props.getColor(BehindColor, defaultValue)
 	}
 	return defaultValue

--- a/src/segment_git_deprecated.go
+++ b/src/segment_git_deprecated.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+)
+
+const (
+	// LocalWorkingIcon the icon to use as the local working area changes indicator
+	LocalWorkingIcon Property = "local_working_icon"
+	// LocalStagingIcon the icon to use as the local staging area changes indicator
+	LocalStagingIcon Property = "local_staged_icon"
+	// DisplayStatusDetail shows the detailed status of the repository
+	DisplayStatusDetail Property = "display_status_detail"
+	// WorkingColor if set, the color to use on the working area
+	WorkingColor Property = "working_color"
+	// StagingColor if set, the color to use on the staging area
+	StagingColor Property = "staging_color"
+	// StatusColorsEnabled enables status colors
+	StatusColorsEnabled Property = "status_colors_enabled"
+	// LocalChangesColor if set, the color to use when there are local changes
+	LocalChangesColor Property = "local_changes_color"
+	// AheadAndBehindColor if set, the color to use when the branch is ahead and behind the remote
+	AheadAndBehindColor Property = "ahead_and_behind_color"
+	// BehindColor if set, the color to use when the branch is ahead and behind the remote
+	BehindColor Property = "behind_color"
+	// AheadColor if set, the color to use when the branch is ahead and behind the remote
+	AheadColor Property = "ahead_color"
+	// BranchMaxLength truncates the length of the branch name
+	BranchMaxLength Property = "branch_max_length"
+	// WorktreeCountIcon shows before the worktree context
+	WorktreeCountIcon Property = "worktree_count_icon"
+)
+
+func (g *git) renderDeprecatedString(displayStatus bool) string {
+	if !displayStatus {
+		return g.getPrettyHEADName()
+	}
+	buffer := new(bytes.Buffer)
+	// remote (if available)
+	if len(g.repo.UpstreamIcon) != 0 {
+		fmt.Fprintf(buffer, "%s", g.repo.UpstreamIcon)
+	}
+	// branchName
+	fmt.Fprintf(buffer, "%s", g.repo.HEAD)
+	if g.props.getBool(DisplayBranchStatus, true) {
+		buffer.WriteString(g.getBranchStatus())
+	}
+	if g.repo.Staging.Changed {
+		fmt.Fprint(buffer, g.getStatusDetailString(g.repo.Staging, StagingColor, LocalStagingIcon, " \uF046"))
+	}
+	if g.repo.Staging.Changed && g.repo.Working.Changed {
+		fmt.Fprint(buffer, g.props.getString(StatusSeparatorIcon, " |"))
+	}
+	if g.repo.Working.Changed {
+		fmt.Fprint(buffer, g.getStatusDetailString(g.repo.Working, WorkingColor, LocalWorkingIcon, " \uF044"))
+	}
+	if g.repo.StashCount != 0 {
+		fmt.Fprintf(buffer, " %s%d", g.props.getString(StashCountIcon, "\uF692 "), g.repo.StashCount)
+	}
+	if g.repo.WorktreeCount != 0 {
+		fmt.Fprintf(buffer, " %s%d", g.props.getString(WorktreeCountIcon, "\uf1bb "), g.repo.WorktreeCount)
+	}
+	return buffer.String()
+}

--- a/src/segment_git_deprecated.go
+++ b/src/segment_git_deprecated.go
@@ -7,14 +7,14 @@ import (
 )
 
 const (
-	// DisplayBranchStatus show branch status or not
-	DisplayBranchStatus Property = "display_branch_status"
 	// DisplayStatus shows the status of the repository
 	DisplayStatus Property = "display_status"
 	// DisplayStashCount show stash count or not
 	DisplayStashCount Property = "display_stash_count"
 	// DisplayWorktreeCount show worktree count or not
 	DisplayWorktreeCount Property = "display_worktree_count"
+	// DisplayUpstreamIcon show or hide the upstream icon
+	DisplayUpstreamIcon Property = "display_upstream_icon"
 
 	// LocalWorkingIcon the icon to use as the local working area changes indicator
 	LocalWorkingIcon Property = "local_working_icon"
@@ -44,12 +44,12 @@ const (
 	StatusSeparatorIcon Property = "status_separator_icon"
 )
 
-func (g *git) getBool(property, legacyProperty Property, defaultValue bool) bool {
+func (g *git) getBool(property, legacyProperty Property) bool {
 	_, found := g.props.values[legacyProperty]
 	if found {
-		return g.props.getBool(legacyProperty, defaultValue)
+		return g.props.getBool(legacyProperty, false)
 	}
-	return g.props.getBool(property, defaultValue)
+	return g.props.getBool(property, false)
 }
 
 func (g *git) renderDeprecatedString(statusColorsEnabled bool) string {
@@ -63,7 +63,7 @@ func (g *git) renderDeprecatedString(statusColorsEnabled bool) string {
 	}
 	// branchName
 	fmt.Fprintf(buffer, "%s", g.Repo.HEAD)
-	if g.props.getBool(DisplayBranchStatus, false) {
+	if len(g.Repo.BranchStatus) > 0 {
 		buffer.WriteString(g.Repo.BranchStatus)
 	}
 	if g.Repo.Staging.Changed {

--- a/src/segment_git_deprecated.go
+++ b/src/segment_git_deprecated.go
@@ -63,7 +63,7 @@ func (g *git) renderDeprecatedString(statusColorsEnabled bool) string {
 	}
 	// branchName
 	fmt.Fprintf(buffer, "%s", g.Repo.HEAD)
-	if len(g.Repo.BranchStatus) != 0 {
+	if g.props.getBool(DisplayBranchStatus, false) {
 		buffer.WriteString(g.Repo.BranchStatus)
 	}
 	if g.Repo.Staging.Changed {

--- a/src/segment_git_deprecated.go
+++ b/src/segment_git_deprecated.go
@@ -32,10 +32,7 @@ const (
 	WorktreeCountIcon Property = "worktree_count_icon"
 )
 
-func (g *git) renderDeprecatedString(displayStatus bool) string {
-	if !displayStatus {
-		return g.getPrettyHEADName()
-	}
+func (g *git) renderDeprecatedString() string {
 	buffer := new(bytes.Buffer)
 	// remote (if available)
 	if len(g.repo.UpstreamIcon) != 0 {
@@ -43,8 +40,8 @@ func (g *git) renderDeprecatedString(displayStatus bool) string {
 	}
 	// branchName
 	fmt.Fprintf(buffer, "%s", g.repo.HEAD)
-	if g.props.getBool(DisplayBranchStatus, true) {
-		buffer.WriteString(g.getBranchStatus())
+	if len(g.repo.BranchStatus) != 0 {
+		buffer.WriteString(g.repo.BranchStatus)
 	}
 	if g.repo.Staging.Changed {
 		fmt.Fprint(buffer, g.getStatusDetailString(g.repo.Staging, StagingColor, LocalStagingIcon, " \uF046"))

--- a/src/segment_git_deprecated_test.go
+++ b/src/segment_git_deprecated_test.go
@@ -116,7 +116,7 @@ func TestGetStatusColorLocalChangesStaging(t *testing.T) {
 		},
 	}
 	g := &git{
-		repo: repo,
+		Repo: repo,
 		props: &properties{
 			values: map[Property]interface{}{
 				LocalChangesColor: expected,
@@ -135,7 +135,7 @@ func TestGetStatusColorLocalChangesWorking(t *testing.T) {
 		},
 	}
 	g := &git{
-		repo: repo,
+		Repo: repo,
 		props: &properties{
 			values: map[Property]interface{}{
 				LocalChangesColor: expected,
@@ -154,7 +154,7 @@ func TestGetStatusColorAheadAndBehind(t *testing.T) {
 		Behind:  3,
 	}
 	g := &git{
-		repo: repo,
+		Repo: repo,
 		props: &properties{
 			values: map[Property]interface{}{
 				AheadAndBehindColor: expected,
@@ -173,7 +173,7 @@ func TestGetStatusColorAhead(t *testing.T) {
 		Behind:  0,
 	}
 	g := &git{
-		repo: repo,
+		Repo: repo,
 		props: &properties{
 			values: map[Property]interface{}{
 				AheadColor: expected,
@@ -192,7 +192,7 @@ func TestGetStatusColorBehind(t *testing.T) {
 		Behind:  5,
 	}
 	g := &git{
-		repo: repo,
+		Repo: repo,
 		props: &properties{
 			values: map[Property]interface{}{
 				BehindColor: expected,
@@ -211,7 +211,7 @@ func TestGetStatusColorDefault(t *testing.T) {
 		Behind:  0,
 	}
 	g := &git{
-		repo: repo,
+		Repo: repo,
 		props: &properties{
 			values: map[Property]interface{}{
 				BehindColor: changesColor,
@@ -229,7 +229,7 @@ func TestSetStatusColorForeground(t *testing.T) {
 		},
 	}
 	g := &git{
-		repo: repo,
+		Repo: repo,
 		props: &properties{
 			values: map[Property]interface{}{
 				LocalChangesColor: changesColor,
@@ -251,7 +251,7 @@ func TestSetStatusColorBackground(t *testing.T) {
 		},
 	}
 	g := &git{
-		repo: repo,
+		Repo: repo,
 		props: &properties{
 			values: map[Property]interface{}{
 				LocalChangesColor: changesColor,

--- a/src/segment_git_deprecated_test.go
+++ b/src/segment_git_deprecated_test.go
@@ -1,0 +1,283 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetStatusDetailStringDefault(t *testing.T) {
+	expected := "icon +1"
+	status := &GitStatus{
+		Changed: true,
+		Added:   1,
+	}
+	g := &git{
+		props: &properties{
+			foreground: "#111111",
+		},
+	}
+	assert.Equal(t, expected, g.getStatusDetailString(status, WorkingColor, LocalWorkingIcon, "icon"))
+}
+
+func TestGetStatusDetailStringDefaultColorOverride(t *testing.T) {
+	expected := "<#123456>icon +1</>"
+	status := &GitStatus{
+		Changed: true,
+		Added:   1,
+	}
+	g := &git{
+		props: &properties{
+			values: map[Property]interface{}{
+				WorkingColor: "#123456",
+			},
+			foreground: "#111111",
+		},
+	}
+	assert.Equal(t, expected, g.getStatusDetailString(status, WorkingColor, LocalWorkingIcon, "icon"))
+}
+
+func TestGetStatusDetailStringDefaultColorOverrideAndIconColorOverride(t *testing.T) {
+	expected := "<#789123>work</> <#123456>+1</>"
+	status := &GitStatus{
+		Changed: true,
+		Added:   1,
+	}
+	g := &git{
+		props: &properties{
+			values: map[Property]interface{}{
+				WorkingColor:     "#123456",
+				LocalWorkingIcon: "<#789123>work</>",
+			},
+			foreground: "#111111",
+		},
+	}
+	assert.Equal(t, expected, g.getStatusDetailString(status, WorkingColor, LocalWorkingIcon, "icon"))
+}
+
+func TestGetStatusDetailStringDefaultColorOverrideNoIconColorOverride(t *testing.T) {
+	expected := "<#123456>work +1</>"
+	status := &GitStatus{
+		Changed: true,
+		Added:   1,
+	}
+	g := &git{
+		props: &properties{
+			values: map[Property]interface{}{
+				WorkingColor:     "#123456",
+				LocalWorkingIcon: "work",
+			},
+			foreground: "#111111",
+		},
+	}
+	assert.Equal(t, expected, g.getStatusDetailString(status, WorkingColor, LocalWorkingIcon, "icon"))
+}
+
+func TestGetStatusDetailStringNoStatus(t *testing.T) {
+	expected := "icon"
+	status := &GitStatus{
+		Changed: true,
+		Added:   1,
+	}
+	g := &git{
+		props: &properties{
+			values: map[Property]interface{}{
+				DisplayStatusDetail: false,
+			},
+			foreground: "#111111",
+		},
+	}
+	assert.Equal(t, expected, g.getStatusDetailString(status, WorkingColor, LocalWorkingIcon, "icon"))
+}
+
+func TestGetStatusDetailStringNoStatusColorOverride(t *testing.T) {
+	expected := "<#123456>icon</>"
+	status := &GitStatus{
+		Changed: true,
+		Added:   1,
+	}
+	g := &git{
+		props: &properties{
+			values: map[Property]interface{}{
+				DisplayStatusDetail: false,
+				WorkingColor:        "#123456",
+			},
+			foreground: "#111111",
+		},
+	}
+	assert.Equal(t, expected, g.getStatusDetailString(status, WorkingColor, LocalWorkingIcon, "icon"))
+}
+
+func TestGetStatusColorLocalChangesStaging(t *testing.T) {
+	expected := changesColor
+	repo := &Repo{
+		Staging: &GitStatus{
+			Changed: true,
+		},
+	}
+	g := &git{
+		repo: repo,
+		props: &properties{
+			values: map[Property]interface{}{
+				LocalChangesColor: expected,
+			},
+		},
+	}
+	assert.Equal(t, expected, g.getStatusColor("#fg1111"))
+}
+
+func TestGetStatusColorLocalChangesWorking(t *testing.T) {
+	expected := changesColor
+	repo := &Repo{
+		Staging: &GitStatus{},
+		Working: &GitStatus{
+			Changed: true,
+		},
+	}
+	g := &git{
+		repo: repo,
+		props: &properties{
+			values: map[Property]interface{}{
+				LocalChangesColor: expected,
+			},
+		},
+	}
+	assert.Equal(t, expected, g.getStatusColor("#fg1111"))
+}
+
+func TestGetStatusColorAheadAndBehind(t *testing.T) {
+	expected := changesColor
+	repo := &Repo{
+		Staging: &GitStatus{},
+		Working: &GitStatus{},
+		Ahead:   1,
+		Behind:  3,
+	}
+	g := &git{
+		repo: repo,
+		props: &properties{
+			values: map[Property]interface{}{
+				AheadAndBehindColor: expected,
+			},
+		},
+	}
+	assert.Equal(t, expected, g.getStatusColor("#fg1111"))
+}
+
+func TestGetStatusColorAhead(t *testing.T) {
+	expected := changesColor
+	repo := &Repo{
+		Staging: &GitStatus{},
+		Working: &GitStatus{},
+		Ahead:   1,
+		Behind:  0,
+	}
+	g := &git{
+		repo: repo,
+		props: &properties{
+			values: map[Property]interface{}{
+				AheadColor: expected,
+			},
+		},
+	}
+	assert.Equal(t, expected, g.getStatusColor("#fg1111"))
+}
+
+func TestGetStatusColorBehind(t *testing.T) {
+	expected := changesColor
+	repo := &Repo{
+		Staging: &GitStatus{},
+		Working: &GitStatus{},
+		Ahead:   0,
+		Behind:  5,
+	}
+	g := &git{
+		repo: repo,
+		props: &properties{
+			values: map[Property]interface{}{
+				BehindColor: expected,
+			},
+		},
+	}
+	assert.Equal(t, expected, g.getStatusColor("#fg1111"))
+}
+
+func TestGetStatusColorDefault(t *testing.T) {
+	expected := changesColor
+	repo := &Repo{
+		Staging: &GitStatus{},
+		Working: &GitStatus{},
+		Ahead:   0,
+		Behind:  0,
+	}
+	g := &git{
+		repo: repo,
+		props: &properties{
+			values: map[Property]interface{}{
+				BehindColor: changesColor,
+			},
+		},
+	}
+	assert.Equal(t, expected, g.getStatusColor(expected))
+}
+
+func TestSetStatusColorForeground(t *testing.T) {
+	expected := changesColor
+	repo := &Repo{
+		Staging: &GitStatus{
+			Changed: true,
+		},
+	}
+	g := &git{
+		repo: repo,
+		props: &properties{
+			values: map[Property]interface{}{
+				LocalChangesColor: changesColor,
+				ColorBackground:   false,
+			},
+			foreground: "#ffffff",
+			background: "#111111",
+		},
+	}
+	g.SetStatusColor()
+	assert.Equal(t, expected, g.props.foreground)
+}
+
+func TestSetStatusColorBackground(t *testing.T) {
+	expected := changesColor
+	repo := &Repo{
+		Staging: &GitStatus{
+			Changed: true,
+		},
+	}
+	g := &git{
+		repo: repo,
+		props: &properties{
+			values: map[Property]interface{}{
+				LocalChangesColor: changesColor,
+				ColorBackground:   true,
+			},
+			foreground: "#ffffff",
+			background: "#111111",
+		},
+	}
+	g.SetStatusColor()
+	assert.Equal(t, expected, g.props.background)
+}
+
+func TestStatusColorsWithoutDisplayStatus(t *testing.T) {
+	expected := changesColor
+	context := &detachedContext{
+		status: "## main...origin/main [ahead 33]\n M myfile",
+	}
+	g := setupHEADContextEnv(context)
+	g.props = &properties{
+		values: map[Property]interface{}{
+			DisplayStatus:       false,
+			StatusColorsEnabled: true,
+			LocalChangesColor:   expected,
+		},
+	}
+	g.string()
+	assert.Equal(t, expected, g.props.background)
+}

--- a/src/segment_git_test.go
+++ b/src/segment_git_test.go
@@ -757,6 +757,43 @@ func TestGitTemplateString(t *testing.T) {
 			},
 		},
 		{
+			Case:     "Working and staging area changes with separator",
+			Expected: "main \uF046 +5 ~1 | \uF044 +2 ~3",
+			Template: "{{ .HEAD }}{{ if .Staging.Changed }} \uF046 {{ .Staging.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Working.Changed }} \uF044 {{ .Working.String }}{{ end }}", //nolint:lll
+			Repo: &Repo{
+				HEAD: "main",
+				Working: &GitStatus{
+					Added:    2,
+					Modified: 3,
+					Changed:  true,
+				},
+				Staging: &GitStatus{
+					Added:    5,
+					Modified: 1,
+					Changed:  true,
+				},
+			},
+		},
+		{
+			Case:     "Working and staging area changes with separator and stash count",
+			Expected: "main \uF046 +5 ~1 | \uF044 +2 ~3 \uf692 3",
+			Template: "{{ .HEAD }}{{ if .Staging.Changed }} \uF046 {{ .Staging.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Working.Changed }} \uF044 {{ .Working.String }}{{ end }}{{ if gt .StashCount 0 }} \uF692 {{ .StashCount }}{{ end }}", //nolint:lll
+			Repo: &Repo{
+				HEAD: "main",
+				Working: &GitStatus{
+					Added:    2,
+					Modified: 3,
+					Changed:  true,
+				},
+				Staging: &GitStatus{
+					Added:    5,
+					Modified: 1,
+					Changed:  true,
+				},
+				StashCount: 3,
+			},
+		},
+		{
 			Case:     "No local changes",
 			Expected: "main",
 			Template: "{{ .HEAD }}{{ if .Staging.Changed }} \uF046{{ .Staging.String }}{{ end }}{{ if .Working.Changed }} \uF044{{ .Working.String }}{{ end }}",
@@ -777,25 +814,13 @@ func TestGitTemplateString(t *testing.T) {
 				UpstreamIcon: "GitHub",
 			},
 		},
-		{
-			Case:     "Branch status",
-			Expected: "from GitHub on main \u21912",
-			Template: "from {{ .UpstreamIcon }} on {{ .HEAD }} {{ .BranchStatus }}",
-			Repo: &Repo{
-				HEAD:         "main",
-				Staging:      &GitStatus{},
-				Working:      &GitStatus{},
-				UpstreamIcon: "GitHub",
-				BranchStatus: "\u21912",
-			},
-		},
 	}
 
 	for _, tc := range cases {
 		g := &git{
 			props: &properties{
 				values: map[Property]interface{}{
-					DisplayStatus: true,
+					FetchStatus: true,
 				},
 			},
 			repo: tc.Repo,

--- a/src/segment_git_test.go
+++ b/src/segment_git_test.go
@@ -37,7 +37,7 @@ func TestEnabledInWorkingDirectory(t *testing.T) {
 		env: env,
 	}
 	assert.True(t, g.enabled())
-	assert.Equal(t, fileInfo.path, g.repo.gitWorkingFolder)
+	assert.Equal(t, fileInfo.path, g.Repo.gitWorkingFolder)
 }
 
 func TestEnabledInWorkingTree(t *testing.T) {
@@ -56,7 +56,7 @@ func TestEnabledInWorkingTree(t *testing.T) {
 		env: env,
 	}
 	assert.True(t, g.enabled())
-	assert.Equal(t, "/dir/hello/burp/burp", g.repo.gitWorkingFolder)
+	assert.Equal(t, "/dir/hello/burp/burp", g.Repo.gitWorkingFolder)
 }
 
 func TestGetGitOutputForCommand(t *testing.T) {
@@ -129,7 +129,7 @@ func setupHEADContextEnv(context *detachedContext) *git {
 	env.On("getRuntimeGOOS", nil).Return("unix")
 	g := &git{
 		env: env,
-		repo: &Repo{
+		Repo: &Repo{
 			gitWorkingFolder: "",
 			Working:          &GitStatus{},
 			Staging:          &GitStatus{},
@@ -384,7 +384,7 @@ func TestGetStashContextZeroEntries(t *testing.T) {
 		env := new(MockedEnvironment)
 		env.On("getFileContent", "/logs/refs/stash").Return(tc.StashContent)
 		g := &git{
-			repo: &Repo{
+			Repo: &Repo{
 				gitWorkingFolder: "",
 			},
 			env: env,
@@ -567,7 +567,7 @@ func TestGitUpstream(t *testing.T) {
 		}
 		g := &git{
 			env: env,
-			repo: &Repo{
+			Repo: &Repo{
 				Upstream: "origin/main",
 			},
 			props: props,
@@ -603,7 +603,7 @@ func TestGetBranchStatus(t *testing.T) {
 					BranchGoneIcon:      "gone",
 				},
 			},
-			repo: &Repo{
+			Repo: &Repo{
 				Ahead:    tc.Ahead,
 				Behind:   tc.Behind,
 				Upstream: tc.Upstream,
@@ -708,7 +708,7 @@ func TestGitTemplateString(t *testing.T) {
 		{
 			Case:     "Only HEAD name",
 			Expected: "main",
-			Template: "{{ .HEAD }}",
+			Template: "{{ .Repo.HEAD }}",
 			Repo: &Repo{
 				HEAD:   "main",
 				Behind: 2,
@@ -717,7 +717,7 @@ func TestGitTemplateString(t *testing.T) {
 		{
 			Case:     "Working area changes",
 			Expected: "main \uF044 +2 ~3",
-			Template: "{{ .HEAD }}{{ if .Working.Changed }} \uF044 {{ .Working.String }}{{ end }}",
+			Template: "{{ .Repo.HEAD }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}",
 			Repo: &Repo{
 				HEAD: "main",
 				Working: &GitStatus{
@@ -730,7 +730,7 @@ func TestGitTemplateString(t *testing.T) {
 		{
 			Case:     "No working area changes",
 			Expected: "main",
-			Template: "{{ .HEAD }}{{ if .Working.Changed }} \uF044 {{ .Working.String }}{{ end }}",
+			Template: "{{ .Repo.HEAD }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}",
 			Repo: &Repo{
 				HEAD: "main",
 				Working: &GitStatus{
@@ -741,7 +741,7 @@ func TestGitTemplateString(t *testing.T) {
 		{
 			Case:     "Working and staging area changes",
 			Expected: "main \uF046 +5 ~1 \uF044 +2 ~3",
-			Template: "{{ .HEAD }}{{ if .Staging.Changed }} \uF046 {{ .Staging.String }}{{ end }}{{ if .Working.Changed }} \uF044 {{ .Working.String }}{{ end }}",
+			Template: "{{ .Repo.HEAD }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}",
 			Repo: &Repo{
 				HEAD: "main",
 				Working: &GitStatus{
@@ -759,7 +759,7 @@ func TestGitTemplateString(t *testing.T) {
 		{
 			Case:     "Working and staging area changes with separator",
 			Expected: "main \uF046 +5 ~1 | \uF044 +2 ~3",
-			Template: "{{ .HEAD }}{{ if .Staging.Changed }} \uF046 {{ .Staging.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Working.Changed }} \uF044 {{ .Working.String }}{{ end }}", //nolint:lll
+			Template: "{{ .Repo.HEAD }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}", //nolint:lll
 			Repo: &Repo{
 				HEAD: "main",
 				Working: &GitStatus{
@@ -777,7 +777,7 @@ func TestGitTemplateString(t *testing.T) {
 		{
 			Case:     "Working and staging area changes with separator and stash count",
 			Expected: "main \uF046 +5 ~1 | \uF044 +2 ~3 \uf692 3",
-			Template: "{{ .HEAD }}{{ if .Staging.Changed }} \uF046 {{ .Staging.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Working.Changed }} \uF044 {{ .Working.String }}{{ end }}{{ if gt .StashCount 0 }} \uF692 {{ .StashCount }}{{ end }}", //nolint:lll
+			Template: "{{ .Repo.HEAD }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}", //nolint:lll
 			Repo: &Repo{
 				HEAD: "main",
 				Working: &GitStatus{
@@ -796,7 +796,7 @@ func TestGitTemplateString(t *testing.T) {
 		{
 			Case:     "No local changes",
 			Expected: "main",
-			Template: "{{ .HEAD }}{{ if .Staging.Changed }} \uF046{{ .Staging.String }}{{ end }}{{ if .Working.Changed }} \uF044{{ .Working.String }}{{ end }}",
+			Template: "{{ .Repo.HEAD }}{{ if .Repo.Staging.Changed }} \uF046{{ .Repo.Staging.String }}{{ end }}{{ if .Repo.Working.Changed }} \uF044{{ .Repo.Working.String }}{{ end }}",
 			Repo: &Repo{
 				HEAD:    "main",
 				Staging: &GitStatus{},
@@ -806,7 +806,7 @@ func TestGitTemplateString(t *testing.T) {
 		{
 			Case:     "Upstream Icon",
 			Expected: "from GitHub on main",
-			Template: "from {{ .UpstreamIcon }} on {{ .HEAD }}",
+			Template: "from {{ .Repo.UpstreamIcon }} on {{ .Repo.HEAD }}",
 			Repo: &Repo{
 				HEAD:         "main",
 				Staging:      &GitStatus{},
@@ -823,7 +823,7 @@ func TestGitTemplateString(t *testing.T) {
 					FetchStatus: true,
 				},
 			},
-			repo: tc.Repo,
+			Repo: tc.Repo,
 		}
 		assert.Equal(t, tc.Expected, g.templateString(tc.Template), tc.Case)
 	}

--- a/src/segment_git_test.go
+++ b/src/segment_git_test.go
@@ -564,35 +564,35 @@ func bootstrapUpstreamTest(upstream string) *git {
 
 func TestGetUpstreamSymbolGitHub(t *testing.T) {
 	g := bootstrapUpstreamTest("github.com/test")
-	upstreamIcon := g.getUpstreamSymbol()
+	upstreamIcon := g.getUpstreamIcon()
 	assert.Equal(t, "GH", upstreamIcon)
 }
 
 func TestGetUpstreamSymbolGitLab(t *testing.T) {
 	g := bootstrapUpstreamTest("gitlab.com/test")
-	upstreamIcon := g.getUpstreamSymbol()
+	upstreamIcon := g.getUpstreamIcon()
 	assert.Equal(t, "GL", upstreamIcon)
 }
 
 func TestGetUpstreamSymbolBitBucket(t *testing.T) {
 	g := bootstrapUpstreamTest("bitbucket.org/test")
-	upstreamIcon := g.getUpstreamSymbol()
+	upstreamIcon := g.getUpstreamIcon()
 	assert.Equal(t, "BB", upstreamIcon)
 }
 
 func TestGetUpstreamSymbolAzureDevOps(t *testing.T) {
 	g := bootstrapUpstreamTest("dev.azure.com/test")
-	upstreamIcon := g.getUpstreamSymbol()
+	upstreamIcon := g.getUpstreamIcon()
 	assert.Equal(t, "AD", upstreamIcon)
 
 	g = bootstrapUpstreamTest("test.visualstudio.com")
-	upstreamIcon = g.getUpstreamSymbol()
+	upstreamIcon = g.getUpstreamIcon()
 	assert.Equal(t, "AD", upstreamIcon)
 }
 
 func TestGetUpstreamSymbolGit(t *testing.T) {
 	g := bootstrapUpstreamTest("gitstash.com/test")
-	upstreamIcon := g.getUpstreamSymbol()
+	upstreamIcon := g.getUpstreamIcon()
 	assert.Equal(t, "G", upstreamIcon)
 }
 

--- a/src/segment_git_test.go
+++ b/src/segment_git_test.go
@@ -60,7 +60,7 @@ func TestEnabledInWorkingTree(t *testing.T) {
 }
 
 func TestGetGitOutputForCommand(t *testing.T) {
-	args := []string{"--no-optional-locks", "-c", "core.quotepath=false", "-c", "color.status=false"}
+	args := []string{"-C", "test", "--no-optional-locks", "-c", "core.quotepath=false", "-c", "color.status=false"}
 	commandArgs := []string{"symbolic-ref", "--short", "HEAD"}
 	want := "je suis le output"
 	env := new(MockedEnvironment)
@@ -69,6 +69,9 @@ func TestGetGitOutputForCommand(t *testing.T) {
 	env.On("getRuntimeGOOS", nil).Return("unix")
 	g := &git{
 		env: env,
+		Repo: &Repo{
+			gitRootFolder: "test",
+		},
 	}
 	got := g.getGitCommandOutput(commandArgs...)
 	assert.Equal(t, want, got)
@@ -139,7 +142,7 @@ func setupHEADContextEnv(context *detachedContext) *git {
 }
 
 func (m *MockedEnvironment) mockGitCommand(returnValue string, args ...string) {
-	args = append([]string{"--no-optional-locks", "-c", "core.quotepath=false", "-c", "color.status=false"}, args...)
+	args = append([]string{"-C", "", "--no-optional-locks", "-c", "core.quotepath=false", "-c", "color.status=false"}, args...)
 	m.On("runCommand", "git", args).Return(returnValue, nil)
 }
 
@@ -554,7 +557,7 @@ func TestGitUpstream(t *testing.T) {
 	for _, tc := range cases {
 		env := &MockedEnvironment{}
 		env.On("isWsl", nil).Return(false)
-		env.On("runCommand", "git", []string{"--no-optional-locks", "-c", "core.quotepath=false", "-c", "color.status=false", "remote", "get-url", "origin"}).Return(tc.Upstream, nil)
+		env.On("runCommand", "git", []string{"-C", "", "--no-optional-locks", "-c", "core.quotepath=false", "-c", "color.status=false", "remote", "get-url", "origin"}).Return(tc.Upstream, nil) //nolint:lll
 		env.On("getRuntimeGOOS", nil).Return("unix")
 		props := &properties{
 			values: map[Property]interface{}{

--- a/src/segment_git_test.go
+++ b/src/segment_git_test.go
@@ -129,7 +129,7 @@ func setupHEADContextEnv(context *detachedContext) *git {
 	env.On("getRuntimeGOOS", nil).Return("unix")
 	g := &git{
 		env: env,
-		repo: &gitRepo{
+		repo: &Repo{
 			gitWorkingFolder: "",
 		},
 	}
@@ -382,7 +382,7 @@ func TestGetStashContextZeroEntries(t *testing.T) {
 		env := new(MockedEnvironment)
 		env.On("getFileContent", "/logs/refs/stash").Return(tc.StashContent)
 		g := &git{
-			repo: &gitRepo{
+			repo: &Repo{
 				gitWorkingFolder: "",
 			},
 			env: env,
@@ -450,24 +450,24 @@ func TestParseGitBranchInfoRemoteGone(t *testing.T) {
 
 func TestGitStatusUnmerged(t *testing.T) {
 	expected := " x1"
-	status := &gitStatus{
-		unmerged: 1,
+	status := &GitStatus{
+		Unmerged: 1,
 	}
 	assert.Equal(t, expected, status.string())
 }
 
 func TestGitStatusUnmergedModified(t *testing.T) {
 	expected := " ~3 x1"
-	status := &gitStatus{
-		unmerged: 1,
-		modified: 3,
+	status := &GitStatus{
+		Unmerged: 1,
+		Modified: 3,
 	}
 	assert.Equal(t, expected, status.string())
 }
 
 func TestGitStatusEmpty(t *testing.T) {
 	expected := ""
-	status := &gitStatus{}
+	status := &GitStatus{}
 	assert.Equal(t, expected, status.string())
 }
 
@@ -485,11 +485,11 @@ func TestParseGitStatsWorking(t *testing.T) {
 		" C change.go",
 	}
 	status := g.parseGitStats(output, true)
-	assert.Equal(t, 3, status.modified)
-	assert.Equal(t, 1, status.unmerged)
-	assert.Equal(t, 3, status.added)
-	assert.Equal(t, 1, status.deleted)
-	assert.True(t, status.changed)
+	assert.Equal(t, 3, status.Modified)
+	assert.Equal(t, 1, status.Unmerged)
+	assert.Equal(t, 3, status.Added)
+	assert.Equal(t, 1, status.Deleted)
+	assert.True(t, status.Changed)
 }
 
 func TestParseGitStatsStaging(t *testing.T) {
@@ -506,34 +506,34 @@ func TestParseGitStatsStaging(t *testing.T) {
 		"AC change.go",
 	}
 	status := g.parseGitStats(output, false)
-	assert.Equal(t, 1, status.modified)
-	assert.Equal(t, 0, status.unmerged)
-	assert.Equal(t, 1, status.added)
-	assert.Equal(t, 2, status.deleted)
-	assert.True(t, status.changed)
+	assert.Equal(t, 1, status.Modified)
+	assert.Equal(t, 0, status.Unmerged)
+	assert.Equal(t, 1, status.Added)
+	assert.Equal(t, 2, status.Deleted)
+	assert.True(t, status.Changed)
 }
 
 func TestParseGitStatsNoChanges(t *testing.T) {
 	g := &git{}
-	expected := &gitStatus{}
+	expected := &GitStatus{}
 	output := []string{
 		"## amazing-feat",
 	}
 	status := g.parseGitStats(output, false)
 	assert.Equal(t, expected, status)
-	assert.False(t, status.changed)
+	assert.False(t, status.Changed)
 }
 
 func TestParseGitStatsInvalidLine(t *testing.T) {
 	g := &git{}
-	expected := &gitStatus{}
+	expected := &GitStatus{}
 	output := []string{
 		"## amazing-feat",
 		"#",
 	}
 	status := g.parseGitStats(output, false)
 	assert.Equal(t, expected, status)
-	assert.False(t, status.changed)
+	assert.False(t, status.Changed)
 }
 
 func bootstrapUpstreamTest(upstream string) *git {
@@ -552,8 +552,8 @@ func bootstrapUpstreamTest(upstream string) *git {
 	}
 	g := &git{
 		env: env,
-		repo: &gitRepo{
-			upstream: "origin/main",
+		repo: &Repo{
+			Upstream: "origin/main",
 		},
 		props: props,
 	}
@@ -596,9 +596,9 @@ func TestGetUpstreamSymbolGit(t *testing.T) {
 
 func TestGetStatusColorLocalChangesStaging(t *testing.T) {
 	expected := changesColor
-	repo := &gitRepo{
-		staging: &gitStatus{
-			changed: true,
+	repo := &Repo{
+		Staging: &GitStatus{
+			Changed: true,
 		},
 	}
 	g := &git{
@@ -614,10 +614,10 @@ func TestGetStatusColorLocalChangesStaging(t *testing.T) {
 
 func TestGetStatusColorLocalChangesWorking(t *testing.T) {
 	expected := changesColor
-	repo := &gitRepo{
-		staging: &gitStatus{},
-		working: &gitStatus{
-			changed: true,
+	repo := &Repo{
+		Staging: &GitStatus{},
+		Working: &GitStatus{
+			Changed: true,
 		},
 	}
 	g := &git{
@@ -633,11 +633,11 @@ func TestGetStatusColorLocalChangesWorking(t *testing.T) {
 
 func TestGetStatusColorAheadAndBehind(t *testing.T) {
 	expected := changesColor
-	repo := &gitRepo{
-		staging: &gitStatus{},
-		working: &gitStatus{},
-		ahead:   1,
-		behind:  3,
+	repo := &Repo{
+		Staging: &GitStatus{},
+		Working: &GitStatus{},
+		Ahead:   1,
+		Behind:  3,
 	}
 	g := &git{
 		repo: repo,
@@ -652,11 +652,11 @@ func TestGetStatusColorAheadAndBehind(t *testing.T) {
 
 func TestGetStatusColorAhead(t *testing.T) {
 	expected := changesColor
-	repo := &gitRepo{
-		staging: &gitStatus{},
-		working: &gitStatus{},
-		ahead:   1,
-		behind:  0,
+	repo := &Repo{
+		Staging: &GitStatus{},
+		Working: &GitStatus{},
+		Ahead:   1,
+		Behind:  0,
 	}
 	g := &git{
 		repo: repo,
@@ -671,11 +671,11 @@ func TestGetStatusColorAhead(t *testing.T) {
 
 func TestGetStatusColorBehind(t *testing.T) {
 	expected := changesColor
-	repo := &gitRepo{
-		staging: &gitStatus{},
-		working: &gitStatus{},
-		ahead:   0,
-		behind:  5,
+	repo := &Repo{
+		Staging: &GitStatus{},
+		Working: &GitStatus{},
+		Ahead:   0,
+		Behind:  5,
 	}
 	g := &git{
 		repo: repo,
@@ -690,11 +690,11 @@ func TestGetStatusColorBehind(t *testing.T) {
 
 func TestGetStatusColorDefault(t *testing.T) {
 	expected := changesColor
-	repo := &gitRepo{
-		staging: &gitStatus{},
-		working: &gitStatus{},
-		ahead:   0,
-		behind:  0,
+	repo := &Repo{
+		Staging: &GitStatus{},
+		Working: &GitStatus{},
+		Ahead:   0,
+		Behind:  0,
 	}
 	g := &git{
 		repo: repo,
@@ -709,9 +709,9 @@ func TestGetStatusColorDefault(t *testing.T) {
 
 func TestSetStatusColorForeground(t *testing.T) {
 	expected := changesColor
-	repo := &gitRepo{
-		staging: &gitStatus{
-			changed: true,
+	repo := &Repo{
+		Staging: &GitStatus{
+			Changed: true,
 		},
 	}
 	g := &git{
@@ -731,9 +731,9 @@ func TestSetStatusColorForeground(t *testing.T) {
 
 func TestSetStatusColorBackground(t *testing.T) {
 	expected := changesColor
-	repo := &gitRepo{
-		staging: &gitStatus{
-			changed: true,
+	repo := &Repo{
+		Staging: &GitStatus{
+			Changed: true,
 		},
 	}
 	g := &git{
@@ -770,9 +770,9 @@ func TestStatusColorsWithoutDisplayStatus(t *testing.T) {
 
 func TestGetStatusDetailStringDefault(t *testing.T) {
 	expected := "icon +1"
-	status := &gitStatus{
-		changed: true,
-		added:   1,
+	status := &GitStatus{
+		Changed: true,
+		Added:   1,
 	}
 	g := &git{
 		props: &properties{
@@ -784,9 +784,9 @@ func TestGetStatusDetailStringDefault(t *testing.T) {
 
 func TestGetStatusDetailStringDefaultColorOverride(t *testing.T) {
 	expected := "<#123456>icon +1</>"
-	status := &gitStatus{
-		changed: true,
-		added:   1,
+	status := &GitStatus{
+		Changed: true,
+		Added:   1,
 	}
 	g := &git{
 		props: &properties{
@@ -801,9 +801,9 @@ func TestGetStatusDetailStringDefaultColorOverride(t *testing.T) {
 
 func TestGetStatusDetailStringDefaultColorOverrideAndIconColorOverride(t *testing.T) {
 	expected := "<#789123>work</><#123456> +1</>"
-	status := &gitStatus{
-		changed: true,
-		added:   1,
+	status := &GitStatus{
+		Changed: true,
+		Added:   1,
 	}
 	g := &git{
 		props: &properties{
@@ -819,9 +819,9 @@ func TestGetStatusDetailStringDefaultColorOverrideAndIconColorOverride(t *testin
 
 func TestGetStatusDetailStringDefaultColorOverrideNoIconColorOverride(t *testing.T) {
 	expected := "<#123456>work +1</>"
-	status := &gitStatus{
-		changed: true,
-		added:   1,
+	status := &GitStatus{
+		Changed: true,
+		Added:   1,
 	}
 	g := &git{
 		props: &properties{
@@ -837,9 +837,9 @@ func TestGetStatusDetailStringDefaultColorOverrideNoIconColorOverride(t *testing
 
 func TestGetStatusDetailStringNoStatus(t *testing.T) {
 	expected := "icon"
-	status := &gitStatus{
-		changed: true,
-		added:   1,
+	status := &GitStatus{
+		Changed: true,
+		Added:   1,
 	}
 	g := &git{
 		props: &properties{
@@ -854,9 +854,9 @@ func TestGetStatusDetailStringNoStatus(t *testing.T) {
 
 func TestGetStatusDetailStringNoStatusColorOverride(t *testing.T) {
 	expected := "<#123456>icon</>"
-	status := &gitStatus{
-		changed: true,
-		added:   1,
+	status := &GitStatus{
+		Changed: true,
+		Added:   1,
 	}
 	g := &git{
 		props: &properties{
@@ -896,10 +896,10 @@ func TestGetBranchStatus(t *testing.T) {
 					BranchGoneIcon:      "gone",
 				},
 			},
-			repo: &gitRepo{
-				ahead:    tc.Ahead,
-				behind:   tc.Behind,
-				upstream: tc.Upstream,
+			repo: &Repo{
+				Ahead:    tc.Ahead,
+				Behind:   tc.Behind,
+				Upstream: tc.Upstream,
 			},
 		}
 		assert.Equal(t, tc.Expected, g.getBranchStatus(), tc.Case)

--- a/themes/M365Princess.omp.json
+++ b/themes/M365Princess.omp.json
@@ -35,11 +35,11 @@
           "foreground": "#ffffff",
           "background": "#FCA17D",
           "properties": {
-            "display_stash_count": true,
+            "fetch_stash_count": true,
             "display_upstream_icon": true,
-            "status_colors_enabled": false,
             "branch_icon": "",
-            "display_status": false,
+            "fetch_status": false,
+            "template": "{{ .Repo.HEAD }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}",
             "prefix": " \u279C (",
             "postfix": ") "
           }

--- a/themes/M365Princess.omp.json
+++ b/themes/M365Princess.omp.json
@@ -36,10 +36,10 @@
           "background": "#FCA17D",
           "properties": {
             "fetch_stash_count": true,
-            "display_upstream_icon": true,
+            "fetch_upstream_icon": true,
             "branch_icon": "",
             "fetch_status": false,
-            "template": "{{ .Repo.HEAD }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}",
+            "template": "{{ .Repo.UpstreamIcon }}{{ .Repo.HEAD }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}",
             "prefix": " \u279C (",
             "postfix": ") "
           }

--- a/themes/agnoster.omp.json
+++ b/themes/agnoster.omp.json
@@ -25,11 +25,11 @@
           "powerline_symbol": "\uE0B0",
           "foreground": "#100e23",
           "background": "#91ddff",
-          "properties" : {
-              "home_icon": "\uF7DB",
-              "folder_icon": "\uF115",
-              "folder_separator_icon": " \uE0B1 ",
-              "style": "agnoster"
+          "properties": {
+            "home_icon": "\uF7DB",
+            "folder_icon": "\uF115",
+            "folder_separator_icon": " \uE0B1 ",
+            "style": "agnoster"
           }
         },
         {
@@ -37,7 +37,10 @@
           "style": "powerline",
           "powerline_symbol": "\uE0B0",
           "foreground": "#193549",
-          "background": "#95ffa4"
+          "background": "#95ffa4",
+          "properties": {
+            "template": "{{ .Repo.HEAD }}"
+          }
         },
         {
           "type": "python",

--- a/themes/agnosterplus.omp.json
+++ b/themes/agnosterplus.omp.json
@@ -34,11 +34,11 @@
           "powerline_symbol": "\uE0B0",
           "foreground": "#100e23",
           "background": "#91ddff",
-          "properties" : {
-              "home_icon": "\uF7DB",
-              "folder_icon": "\uF115",
-              "folder_separator_icon": " \uE0B1 ",
-              "style": "agnoster"
+          "properties": {
+            "home_icon": "\uF7DB",
+            "folder_icon": "\uF115",
+            "folder_separator_icon": " \uE0B1 ",
+            "style": "agnoster"
           }
         },
         {
@@ -46,7 +46,10 @@
           "style": "powerline",
           "powerline_symbol": "\uE0B0",
           "foreground": "#193549",
-          "background": "#95ffa4"
+          "background": "#95ffa4",
+          "properties": {
+            "template": "{{ .Repo.HEAD }}"
+          }
         }
       ]
     }

--- a/themes/aliens.omp.json
+++ b/themes/aliens.omp.json
@@ -28,18 +28,18 @@
           "style": "powerline",
           "powerline_symbol": "\uE0B0",
           "foreground": "#193549",
-          "background": "#95ffa4"
+          "background": "#95ffa4",
+          "properties": {
+            "template": "{{ .Repo.HEAD }}"
+          }
         },
         {
           "type": "python",
           "style": "diamond",
           "foreground": "#ffffff",
           "background": "#FF6471",
-          "leading_diamond": "",
-          "trailing_diamond": "\uE0B4",
-          "properties": {
-            "prefix": "<transparent>\uE0B0 </>"
-          }
+          "leading_diamond": "<transparent,background>\uE0B0</>",
+          "trailing_diamond": "\uE0B4"
         }
       ]
     }

--- a/themes/amro.omp.json
+++ b/themes/amro.omp.json
@@ -32,9 +32,9 @@
           "foreground": "#14A5AE",
           "properties": {
             "fetch_stash_count": true,
-            "display_upstream_icon": true,
+            "fetch_upstream_icon": true,
             "prefix": "",
-            "template": "{{ .Repo.HEAD }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
+            "template": "{{ .Repo.UpstreamIcon }}{{ .Repo.HEAD }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           }
         }
       ]

--- a/themes/amro.omp.json
+++ b/themes/amro.omp.json
@@ -31,9 +31,10 @@
           "powerline_symbol": "\uE0B0",
           "foreground": "#14A5AE",
           "properties": {
-            "display_stash_count": true,
+            "fetch_stash_count": true,
             "display_upstream_icon": true,
-            "prefix": ""
+            "prefix": "",
+            "template": "{{ .Repo.HEAD }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           }
         }
       ]

--- a/themes/avit.omp.json
+++ b/themes/avit.omp.json
@@ -17,7 +17,11 @@
         {
           "type": "git",
           "style": "plain",
-          "foreground": "#C2C206"
+          "foreground": "#C2C206",
+          "properties": {
+            "prefix": "",
+            "template": "{{ .Repo.HEAD }}"
+          }
         },
         {
           "type": "root",

--- a/themes/blue-owl.omp.json
+++ b/themes/blue-owl.omp.json
@@ -16,6 +16,7 @@
           "foreground": "#FFEB3B",
           "background": "#a313a8",
           "properties": {
+            "prefix": "",
             "root_icon": "⚡"
           }
         },
@@ -23,7 +24,10 @@
           "type": "os",
           "style": "plain",
           "foreground": "#ffffff",
-          "background": "transparent"
+          "background": "transparent",
+          "properties": {
+            "prefix": ""
+          }
         },
         {
           "type": "path",
@@ -45,14 +49,16 @@
           "powerline_symbol": "\uE0B0",
           "foreground": "#000000",
           "background": "#00C853",
+          "background_templates": [
+            "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#FFEB3B{{ end }}",
+            "{{ if and (.Repo.Ahead gt 0) (.Repo.Behind gt 0) }}#FFCC80{{ end }}",
+            "{{ if .Repo.Ahead gt 0 }}#B388FF{{ end }}",
+            "{{ if .Repo.Behind gt 0 }}#B388FF{{ end }}"
+          ],
           "properties": {
-            "display_stash_count": true,
-            "staging_color": "#FF6F00",
-            "status_colors_enabled": true,
-            "local_changes_color": "#FFEB3B",
-            "ahead_and_behind_color": "#FFCC80",
-            "behind_color": "#B388FF",
-            "ahead_color": "#B388FF"
+            "fetch_stash_count": true,
+            "fetch_status": true,
+            "template": "{{ .Repo.HEAD }}{{ if .Repo.Staging.Changed }}<#FF6F00> \uF046 {{ .Repo.Staging.String }}</>{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           }
         },
         {

--- a/themes/blue-owl.omp.json
+++ b/themes/blue-owl.omp.json
@@ -51,9 +51,9 @@
           "background": "#00C853",
           "background_templates": [
             "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#FFEB3B{{ end }}",
-            "{{ if and (.Repo.Ahead gt 0) (.Repo.Behind gt 0) }}#FFCC80{{ end }}",
-            "{{ if .Repo.Ahead gt 0 }}#B388FF{{ end }}",
-            "{{ if .Repo.Behind gt 0 }}#B388FF{{ end }}"
+            "{{ if and (gt .Repo.Ahead 0) (gt .Repo.Behind 0) }}#FFCC80{{ end }}",
+            "{{ if gt .Repo.Ahead 0 }}#B388FF{{ end }}",
+            "{{ if gt .Repo.Behind 0 }}#B388FF{{ end }}"
           ],
           "properties": {
             "fetch_stash_count": true,

--- a/themes/blueish.omp.json
+++ b/themes/blueish.omp.json
@@ -57,8 +57,9 @@
           "foreground": "#193549",
           "background": "#a2c4e0",
           "properties": {
-            "display_stash_count": true,
-            "display_upstream_icon": true
+            "fetch_stash_count": true,
+            "display_upstream_icon": true,
+            "template": "{{ .Repo.HEAD }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           }
         },
         {

--- a/themes/blueish.omp.json
+++ b/themes/blueish.omp.json
@@ -58,8 +58,8 @@
           "background": "#a2c4e0",
           "properties": {
             "fetch_stash_count": true,
-            "display_upstream_icon": true,
-            "template": "{{ .Repo.HEAD }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
+            "fetch_upstream_icon": true,
+            "template": "{{ .Repo.UpstreamIcon }}{{ .Repo.HEAD }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           }
         },
         {

--- a/themes/bubbles.omp.json
+++ b/themes/bubbles.omp.json
@@ -42,8 +42,8 @@
           "properties": {
             "prefix": "",
             "postfix": "",
-            "display_status_detail": false,
-            "branch_icon": ""
+            "branch_icon": "",
+            "template": "{{ .Repo.HEAD }}"
           }
         },
         {

--- a/themes/bubblesline.omp.json
+++ b/themes/bubblesline.omp.json
@@ -28,7 +28,7 @@
           "properties": {
             "prefix": "",
             "postfix": "",
-            "display_status_detail": false,
+            "template": "{{ .Repo.HEAD }}",
             "branch_icon": ""
           }
         },
@@ -136,7 +136,6 @@
     {
       "type": "prompt",
       "alignment": "left",
-      "newline": true,
       "segments": [
         {
           "type": "session",

--- a/themes/cert.omp.json
+++ b/themes/cert.omp.json
@@ -41,7 +41,7 @@
           "foreground": "#fff",
           "properties": {
             "branch_icon": "",
-            "display_status": false,
+            "template": "{{ .Repo.HEAD }}",
             "prefix": " git(",
             "postfix": ") "
           }

--- a/themes/cinnamon.omp.json
+++ b/themes/cinnamon.omp.json
@@ -38,7 +38,7 @@
             "foreground": "#ffffff",
             "background": "#491545",
             "properties": {
-              "prefix": "\uF9C6 ",
+              "prefix": " \uF9C6 ",
               "playing_icon": "\uE602 ",
               "paused_icon": "\uF8E3 ",
               "stopped_icon": "\uF04D ",
@@ -64,4 +64,4 @@
     ],
     "final_space": true
   }
-  
+

--- a/themes/cinnamon.omp.json
+++ b/themes/cinnamon.omp.json
@@ -28,8 +28,9 @@
             "foreground": "#ffffff",
             "background": "#de076f",
             "properties": {
-              "display_upstream_icon": true,
-              "branch_icon": ""
+              "fetch_upstream_icon": true,
+              "branch_icon": "",
+              "template": "{{ .Repo.UpstreamIcon }}{{ .Repo.HEAD }}"
             }
           },
           {

--- a/themes/craver.omp.json
+++ b/themes/craver.omp.json
@@ -62,8 +62,8 @@
           "properties": {
             "fetch_status": true,
             "fetch_stash_count": true,
-            "display_upstream_icon": true,
-            "template": "{{ .Repo.HEAD }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}",
+            "fetch_upstream_icon": true,
+            "template": "{{ .Repo.UpstreamIcon }}{{ .Repo.HEAD }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}",
             "prefix": ""
           }
         },

--- a/themes/craver.omp.json
+++ b/themes/craver.omp.json
@@ -60,9 +60,10 @@
           "foreground": "#3A86FF",
           "background": "#242424",
           "properties": {
-            "display_status": true,
-            "display_stash_count": true,
+            "fetch_status": true,
+            "fetch_stash_count": true,
             "display_upstream_icon": true,
+            "template": "{{ .Repo.HEAD }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}",
             "prefix": ""
           }
         },

--- a/themes/darkblood.omp.json
+++ b/themes/darkblood.omp.json
@@ -22,7 +22,8 @@
           "foreground": "#ffffff",
           "properties": {
             "prefix": "<#CB4B16>[</>",
-            "postfix": "<#CB4B16>]</>"
+            "postfix": "<#CB4B16>]</>",
+            "template": "{{ .Repo.HEAD }}"
           }
         },
         {

--- a/themes/emodipt.omp.json
+++ b/themes/emodipt.omp.json
@@ -34,7 +34,7 @@
           "style": "plain",
           "foreground": "#F3C267",
           "properties": {
-            "display_status": true,
+            "template": "{{ .Repo.HEAD }}",
             "branch_identical_icon": "\uF14A",
             "branch_gone_icon": "\u274E"
           }
@@ -53,11 +53,10 @@
           "foreground": "#E06C75",
           "properties": {
             "prefix": "",
-            "text": " \u276F"
+            "text": "\u276F"
           }
         }
       ]
     }
-  ],
-  "final_space": true
+  ]
 }

--- a/themes/fish.omp.json
+++ b/themes/fish.omp.json
@@ -43,7 +43,8 @@
           "background": "#007ACC",
           "properties": {
             "prefix": "<#ffffff>\uE0B1</> ",
-            "postfix": " "
+            "postfix": " ",
+            "template": "{{ .Repo.HEAD }}"
           }
         },
         {

--- a/themes/gmay.omp.json
+++ b/themes/gmay.omp.json
@@ -37,7 +37,7 @@
           "background": "#4caf50",
           "properties": {
             "time_format": "2006-01-02 15:04:05",
-            "prefix": ""
+            "prefix": " "
           }
         },
 
@@ -48,8 +48,9 @@
           "foreground": "#193549",
           "background": "#fffb38",
           "properties": {
-            "display_stash_count": true,
-            "display_upstream_icon": true
+            "fetch_stash_count": true,
+            "display_upstream_icon": true,
+            "template": "{{ .Repo.HEAD }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           }
         },
         {

--- a/themes/gmay.omp.json
+++ b/themes/gmay.omp.json
@@ -49,8 +49,8 @@
           "background": "#fffb38",
           "properties": {
             "fetch_stash_count": true,
-            "display_upstream_icon": true,
-            "template": "{{ .Repo.HEAD }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
+            "fetch_upstream_icon": true,
+            "template": "{{ .Repo.UpstreamIcon }}{{ .Repo.HEAD }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           }
         },
         {

--- a/themes/half-life.omp.json
+++ b/themes/half-life.omp.json
@@ -49,15 +49,8 @@
             "rebase_icon": "",
             "cherry_pick_icon": "",
             "revert_icon": "",
-            "working_color": "#D75F00",
-            "staging_color": "#87FF00",
-            "local_working_icon": " ●",
-            "local_staged_icon": " ●",
-            "status_separator_icon": "",
-            "display_status": true,
-            "display_status_detail": false,
-            "display_branch_status": false,
-            "display_stash_count": false
+            "template": "{{ .Repo.HEAD }}{{ if .Repo.Staging.Changed }}<#87FF00> ● {{ .Repo.Staging.String }}</>{{ end }}{{ if .Repo.Working.Changed }}<#D75F00> ● {{ .Repo.Working.String }}</>{{ end }}",
+            "fetch_status": true
           }
         },
         {

--- a/themes/honukai.omp.json
+++ b/themes/honukai.omp.json
@@ -31,7 +31,8 @@
           "style": "plain",
           "foreground": "#B8B80A",
           "properties": {
-            "prefix": "<#ffffff>on git:</>"
+            "prefix": "<#ffffff>on git:</>",
+            "template": "{{ .Repo.HEAD }}"
           }
         }
       ]
@@ -69,7 +70,7 @@
           "style": "plain",
           "foreground": "#100e23",
           "properties": {
-            "prefix": " \uE235 "
+            "prefix": "\uE235 "
           }
         },
         {

--- a/themes/hotstick.minimal.omp.json
+++ b/themes/hotstick.minimal.omp.json
@@ -10,7 +10,7 @@
       "type": "prompt",
       "alignment": "left",
       "segments": [
-        { 
+        {
           "type": "root",
           "style": "plain",
           "foreground": "yellow",
@@ -24,7 +24,7 @@
           "foreground": "black",
           "background": "lightBlue",
           "leading_diamond": "",
-          "trailing_diamond": "",
+          "trailing_diamond": "\uE0B0",
           "properties": {
             "style": "mixed"
           }
@@ -32,11 +32,15 @@
         {
           "type": "git",
           "style": "powerline",
-          "powerline_symbol": "",
+          "powerline_symbol": "\uE0B0",
           "foreground": "black",
           "background": "green",
+          "background_templates": [
+            "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}yellow{{ end }}"
+          ],
           "properties": {
-            "display_status_detail": true,
+            "fetch_status": true,
+            "template": "{{ .Repo.HEAD }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}",
             "branch_icon": " ",
             "branch_identical_icon": "≡",
             "branch_ahead_icon": "↑",
@@ -50,11 +54,7 @@
             "rebase_icon": "Ɫ ",
             "cherry_pick_icon": "✓ ",
             "merge_icon": "◴ ",
-            "no_commits_icon": "[no commits]",
-            "status_separator_icon": " │",
-            "status_colors_enabled": true,
-            "color_background": true,
-            "local_changes_color": "yellow"
+            "no_commits_icon": "[no commits]"
           }
         }
       ]

--- a/themes/hunk.omp.json
+++ b/themes/hunk.omp.json
@@ -65,9 +65,9 @@
             "{{ if .Repo.Behind gt 0 }}#f17c37{{ end }}"
           ],
           "properties": {
-            "display_upstream_icon": true,
+            "fetch_upstream_icon": true,
             "fetch_status": true,
-            "template": "{{ .Repo.HEAD }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}"
+            "template": "{{ .Repo.UpstreamIcon }}{{ .Repo.HEAD }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}"
           }
         }
       ]

--- a/themes/hunk.omp.json
+++ b/themes/hunk.omp.json
@@ -60,9 +60,9 @@
           "background": "#caffbf",
           "background_templates": [
             "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#FCA17D{{ end }}",
-            "{{ if and (.Repo.Ahead gt 0) (.Repo.Behind gt 0) }}#f26d50{{ end }}",
-            "{{ if .Repo.Ahead gt 0 }}#89d1dc{{ end }}",
-            "{{ if .Repo.Behind gt 0 }}#f17c37{{ end }}"
+            "{{ if and (gt .Repo.Ahead 0) (gt .Repo.Behind 0) }}#f26d50{{ end }}",
+            "{{ if gt .Repo.Ahead 0 }}#89d1dc{{ end }}",
+            "{{ if gt .Repo.Behind 0 }}#f17c37{{ end }}"
           ],
           "properties": {
             "fetch_upstream_icon": true,

--- a/themes/hunk.omp.json
+++ b/themes/hunk.omp.json
@@ -55,19 +55,19 @@
         {
           "type": "git",
           "style": "powerline",
-          "powerline_symbol": "",
+          "powerline_symbol": "\uE0B0",
           "foreground": "#ffffff",
           "background": "#caffbf",
+          "background_templates": [
+            "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#FCA17D{{ end }}",
+            "{{ if and (.Repo.Ahead gt 0) (.Repo.Behind gt 0) }}#f26d50{{ end }}",
+            "{{ if .Repo.Ahead gt 0 }}#89d1dc{{ end }}",
+            "{{ if .Repo.Behind gt 0 }}#f17c37{{ end }}"
+          ],
           "properties": {
-            "display_stash_count": false,
             "display_upstream_icon": true,
-            "status_colors_enabled": true,
-            "display_status": true,
-            "local_changes_color": "#FCA17D",
-            "ahead_and_behind_color": "#f26d50",
-            "behind_color": "#f17c37",
-            "ahead_color": "#89d1dc",
-            "stash_count_icon": "\uF692 "
+            "fetch_status": true,
+            "template": "{{ .Repo.HEAD }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}"
           }
         }
       ]

--- a/themes/huvix.omp.json
+++ b/themes/huvix.omp.json
@@ -48,7 +48,7 @@
               "foreground": "#56B6C2",
               "properties": {
                 "branch_icon": "",
-                "display_status": false,
+                "template": "{{ .Repo.HEAD }}",
                 "prefix": "<#E8CC97>git(</>",
                 "postfix": "<#E8CC97>) </>"
               }
@@ -86,7 +86,7 @@
               "charging_color": "#64B5F6",
               "discharging_color": "#E36464",
               "prefix": "\u005B",
-              "postfix": "\uF295\u005D ",
+              "postfix": "\uF295\u005D",
               "display_charging": true
             }
           }

--- a/themes/iterm2.omp.json
+++ b/themes/iterm2.omp.json
@@ -48,19 +48,19 @@
         {
           "type": "git",
           "style": "powerline",
-          "powerline_symbol": "",
+          "powerline_symbol": "\uE0B0",
           "foreground": "#193549",
           "background": "#d2ff5e",
+          "background_templates": [
+            "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#ff9248{{ end }}",
+            "{{ if and (.Repo.Ahead gt 0) (.Repo.Behind gt 0) }}#f26d50{{ end }}",
+            "{{ if .Repo.Ahead gt 0 }}#89d1dc{{ end }}",
+            "{{ if .Repo.Behind gt 0 }}#f17c37{{ end }}"
+          ],
           "properties": {
-            "display_stash_count": true,
-            "display_upstream_icon": true,
-            "status_colors_enabled": true,
-            "display_status": true,
-            "local_changes_color": "#ff9248",
-            "ahead_and_behind_color": "#f26d50",
-            "behind_color": "#f17c37",
-            "ahead_color": "#89d1dc",
-            "stash_count_icon": "\uF692 "
+            "fetch_status": true,
+            "fetch_stash_count": true,
+            "template": "{{ .Repo.HEAD }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           }
         },
         {

--- a/themes/iterm2.omp.json
+++ b/themes/iterm2.omp.json
@@ -53,9 +53,9 @@
           "background": "#d2ff5e",
           "background_templates": [
             "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#ff9248{{ end }}",
-            "{{ if and (.Repo.Ahead gt 0) (.Repo.Behind gt 0) }}#f26d50{{ end }}",
-            "{{ if .Repo.Ahead gt 0 }}#89d1dc{{ end }}",
-            "{{ if .Repo.Behind gt 0 }}#f17c37{{ end }}"
+            "{{ if and (gt .Repo.Ahead 0) (gt .Repo.Behind 0) }}#f26d50{{ end }}",
+            "{{ if gt .Repo.Ahead 0 }}#89d1dc{{ end }}",
+            "{{ if gt .Repo.Behind 0 }}#f17c37{{ end }}"
           ],
           "properties": {
             "fetch_status": true,

--- a/themes/jandedobbeleer.omp.json
+++ b/themes/jandedobbeleer.omp.json
@@ -37,9 +37,9 @@
           "background": "#fffb38",
           "background_templates": [
             "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#FF9248{{ end }}",
-            "{{ if and (.Repo.Ahead gt 0) (.Repo.Behind gt 0) }}#ff4500{{ end }}",
-            "{{ if .Repo.Ahead gt 0 }}#B388FF{{ end }}",
-            "{{ if .Repo.Behind gt 0 }}#B388FF{{ end }}"
+            "{{ if and (gt .Repo.Ahead 0) (gt .Repo.Behind 0) }}#ff4500{{ end }}",
+            "{{ if gt .Repo.Ahead 0 }}#B388FF{{ end }}",
+            "{{ if gt .Repo.Behind 0 }}#B388FF{{ end }}"
           ],
           "leading_diamond": "",
           "trailing_diamond": "",

--- a/themes/jandedobbeleer.omp.json
+++ b/themes/jandedobbeleer.omp.json
@@ -10,7 +10,7 @@
           "foreground": "#ffffff",
           "background": "#c386f1",
           "leading_diamond": "",
-          "trailing_diamond": "",
+          "trailing_diamond": "\uE0B0",
           "properties": {
             "postfix": " ",
             "display_host": false
@@ -19,7 +19,7 @@
         {
           "type": "path",
           "style": "powerline",
-          "powerline_symbol": "",
+          "powerline_symbol": "\uE0B0",
           "foreground": "#ffffff",
           "background": "#ff479c",
           "properties": {
@@ -32,24 +32,28 @@
         {
           "type": "git",
           "style": "powerline",
-          "powerline_symbol": "",
+          "powerline_symbol": "\uE0B0",
           "foreground": "#193549",
           "background": "#fffb38",
+          "background_templates": [
+            "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#ff8c00{{ end }}",
+            "{{ if and (.Repo.Ahead gt 0) (.Repo.Behind gt 0) }}#ff4500{{ end }}",
+            "{{ if .Repo.Ahead gt 0 }}#B388FF{{ end }}",
+            "{{ if .Repo.Behind gt 0 }}#B388FF{{ end }}"
+          ],
+          "leading_diamond": "",
+          "trailing_diamond": "",
           "properties": {
-            "display_stash_count": true,
-            "display_upstream_icon": true,
-            "status_colors_enabled": true,
-            "local_changes_color": "#ff9248",
-            "ahead_and_behind_color": "#f26d50",
-            "behind_color": "#f17c37",
-            "ahead_color": "#89d1dc",
-            "stash_count_icon": "\uF692 "
+            "fetch_status": true,
+            "fetch_stash_count": true,
+            "branch_max_length": 25,
+            "template": "{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           }
         },
         {
           "type": "node",
           "style": "powerline",
-          "powerline_symbol": "",
+          "powerline_symbol": "\uE0B0",
           "foreground": "#ffffff",
           "background": "#6CA35E",
           "properties": {
@@ -60,7 +64,7 @@
         {
           "type": "go",
           "style": "powerline",
-          "powerline_symbol": "",
+          "powerline_symbol": "\uE0B0",
           "foreground": "#111111",
           "background": "#8ED1F7",
           "properties": {
@@ -71,7 +75,7 @@
         {
           "type": "julia",
           "style": "powerline",
-          "powerline_symbol": "",
+          "powerline_symbol": "\uE0B0",
           "foreground": "#111111",
           "background": "#4063D8",
           "properties": {
@@ -82,7 +86,7 @@
         {
           "type": "python",
           "style": "powerline",
-          "powerline_symbol": "",
+          "powerline_symbol": "\uE0B0",
           "foreground": "#111111",
           "background": "#FFDE57",
           "properties": {
@@ -95,7 +99,7 @@
         {
           "type": "ruby",
           "style": "powerline",
-          "powerline_symbol": "",
+          "powerline_symbol": "\uE0B0",
           "foreground": "#ffffff",
           "background": "#AE1401",
           "properties": {
@@ -107,7 +111,7 @@
         {
           "type": "azfunc",
           "style": "powerline",
-          "powerline_symbol": "",
+          "powerline_symbol": "\uE0B0",
           "foreground": "#ffffff",
           "background": "#FEAC19",
           "properties": {
@@ -119,7 +123,7 @@
         {
           "type": "aws",
           "style": "powerline",
-          "powerline_symbol": "",
+          "powerline_symbol": "\uE0B0",
           "foreground": "#ffffff",
           "background_templates": [
             "{{if contains \"default\" .Profile}}#FFA400{{end}}",
@@ -133,7 +137,7 @@
         {
           "type": "root",
           "style": "powerline",
-          "powerline_symbol": "",
+          "powerline_symbol": "\uE0B0",
           "foreground": "#111111",
           "background": "#ffff66",
           "properties": {
@@ -149,7 +153,7 @@
           "trailing_diamond": "",
           "properties": {
             "always_enabled": true,
-            "prefix": "<transparent></> \ufa1e",
+            "prefix": "<transparent>\uE0B0</> \ufa1e",
             "postfix": "\u2800"
           }
         },
@@ -165,7 +169,7 @@
             "always_enabled": true,
             "error_color": "#f1184c",
             "color_background": true,
-            "prefix": "<#83769c></> "
+            "prefix": "<#83769c>\uE0B0</> "
           }
         }
       ]

--- a/themes/jandedobbeleer.omp.json
+++ b/themes/jandedobbeleer.omp.json
@@ -36,7 +36,7 @@
           "foreground": "#193549",
           "background": "#fffb38",
           "background_templates": [
-            "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#ff8c00{{ end }}",
+            "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#FF9248{{ end }}",
             "{{ if and (.Repo.Ahead gt 0) (.Repo.Behind gt 0) }}#ff4500{{ end }}",
             "{{ if .Repo.Ahead gt 0 }}#B388FF{{ end }}",
             "{{ if .Repo.Behind gt 0 }}#B388FF{{ end }}"
@@ -46,8 +46,9 @@
           "properties": {
             "fetch_status": true,
             "fetch_stash_count": true,
+            "fetch_upstream_icon": true,
             "branch_max_length": 25,
-            "template": "{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
+            "template": "{{ .Repo.UpstreamIcon }}{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           }
         },
         {

--- a/themes/jblab_2021.omp.json
+++ b/themes/jblab_2021.omp.json
@@ -50,9 +50,9 @@
           "foreground": "#FFFFFF",
           "background_templates": [
             "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#7621DE{{ end }}",
-            "{{ if and (.Repo.Ahead gt 0) (.Repo.Behind gt 0) }}#7621DE{{ end }}",
-            "{{ if .Repo.Ahead gt 0 }}#7621DE{{ end }}",
-            "{{ if .Repo.Behind gt 0 }}#7621DE{{ end }}"
+            "{{ if and (gt .Repo.Ahead 0) (gt .Repo.Behind 0) }}#7621DE{{ end }}",
+            "{{ if gt .Repo.Ahead 0 }}#7621DE{{ end }}",
+            "{{ if gt .Repo.Behind 0 }}#7621DE{{ end }}"
           ],
           "powerline_symbol": "\uE0B0",
           "properties": {

--- a/themes/jblab_2021.omp.json
+++ b/themes/jblab_2021.omp.json
@@ -58,9 +58,9 @@
           "properties": {
             "fetch_stash_count": true,
             "fetch_status": true,
-            "display_upstream_icon": true,
+            "fetch_upstream_icon": true,
             "prefix": " ",
-            "template": "{{ .Repo.HEAD }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
+            "template": "{{ .Repo.UpstreamIcon }}{{ .Repo.HEAD }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           },
           "style": "powerline",
           "type": "git"

--- a/themes/jblab_2021.omp.json
+++ b/themes/jblab_2021.omp.json
@@ -48,18 +48,19 @@
         {
           "background": "#280C2E",
           "foreground": "#FFFFFF",
+          "background_templates": [
+            "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#7621DE{{ end }}",
+            "{{ if and (.Repo.Ahead gt 0) (.Repo.Behind gt 0) }}#7621DE{{ end }}",
+            "{{ if .Repo.Ahead gt 0 }}#7621DE{{ end }}",
+            "{{ if .Repo.Behind gt 0 }}#7621DE{{ end }}"
+          ],
           "powerline_symbol": "\uE0B0",
           "properties": {
-            "ahead_and_behind_color": "#7621DE",
-            "ahead_color": "#7621DE",
-            "behind_color": "#7621DE",
-            "display_stash_count": true,
-            "display_status": true,
+            "fetch_stash_count": true,
+            "fetch_status": true,
             "display_upstream_icon": true,
-            "local_changes_color": "#7621DE",
             "prefix": " ",
-            "staging_color": "#7621DE",
-            "status_colors_enabled": true
+            "template": "{{ .Repo.HEAD }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           },
           "style": "powerline",
           "type": "git"

--- a/themes/jonnychipz.omp.json
+++ b/themes/jonnychipz.omp.json
@@ -126,10 +126,10 @@
           ],
           "properties": {
             "fetch_stash_count": true,
-            "display_upstream_icon": true,
+            "fetch_upstream_icon": true,
             "fetch_status": true,
             "prefix": "<#000000>\ue0b1 </>",
-            "template": "{{ .Repo.HEAD }}{{ if .Repo.Staging.Changed }}<#2FDA4E> \uF046 {{ .Repo.Staging.String }}</>{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Working.Changed }}<#E84855> \uF044 {{ .Repo.Working.String }}</>{{ end }}"
+            "template": "{{ .Repo.UpstreamIcon }}{{ .Repo.HEAD }}{{ if .Repo.Staging.Changed }}<#2FDA4E> \uF046 {{ .Repo.Staging.String }}</>{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Working.Changed }}<#E84855> \uF044 {{ .Repo.Working.String }}</>{{ end }}"
           }
         },
         {

--- a/themes/jonnychipz.omp.json
+++ b/themes/jonnychipz.omp.json
@@ -121,8 +121,8 @@
           "background": "#ffffff",
           "foreground_templates": [
             "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#ffea00{{ end }}",
-            "{{ if .Repo.Ahead gt 0 }}#2EC4B6{{ end }}",
-            "{{ if .Repo.Behind gt 0 }}#8A4FFF{{ end }}"
+            "{{ if gt .Repo.Ahead 0 }}#2EC4B6{{ end }}",
+            "{{ if gt .Repo.Behind 0 }}#8A4FFF{{ end }}"
           ],
           "properties": {
             "fetch_stash_count": true,

--- a/themes/jonnychipz.omp.json
+++ b/themes/jonnychipz.omp.json
@@ -119,18 +119,17 @@
           "style": "diamond",
           "foreground": "#000000",
           "background": "#ffffff",
+          "foreground_templates": [
+            "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#ffea00{{ end }}",
+            "{{ if .Repo.Ahead gt 0 }}#2EC4B6{{ end }}",
+            "{{ if .Repo.Behind gt 0 }}#8A4FFF{{ end }}"
+          ],
           "properties": {
-            "display_stash_count": true,
+            "fetch_stash_count": true,
             "display_upstream_icon": true,
-            "display_status": true,
-            "status_colors_enabled": true,
-            "color_background": false,
-            "local_changes_color": "#ffea00",
-            "working_color": "#E84855",
-            "staging_color": "#2FDA4E",
-            "ahead_color": "#2EC4B6",
-            "behind_color": "#8A4FFF",
-            "prefix": "<#ffffff>\ue0b1 </>"
+            "fetch_status": true,
+            "prefix": "<#000000>\ue0b1 </>",
+            "template": "{{ .Repo.HEAD }}{{ if .Repo.Staging.Changed }}<#2FDA4E> \uF046 {{ .Repo.Staging.String }}</>{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Working.Changed }}<#E84855> \uF044 {{ .Repo.Working.String }}</>{{ end }}"
           }
         },
         {

--- a/themes/jtracey93.omp.json
+++ b/themes/jtracey93.omp.json
@@ -29,7 +29,8 @@
           "background": "#25AFF3",
           "foreground": "#ffffff",
           "properties": {
-            "display_status": true,
+            "fetch_status": true,
+            "template": "{{ .Repo.HEAD }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}",
             "postfix": ") ",
             "prefix": " branch ("
           },
@@ -42,7 +43,7 @@
           "foreground": "#ffffff",
           "background": "#1BD760",
           "properties": {
-            "track_separator" : " - ",
+            "track_separator": " - ",
             "playing_icon": "",
             "stopped_icon": "",
             "paused_icon": ""
@@ -55,7 +56,7 @@
             "time_format": "15:04:05"
           },
           "style": "diamond",
-          "trailing_diamond": "",
+          "trailing_diamond": "\uE0B0",
           "type": "time"
         }
       ],

--- a/themes/jv_sitecorian.omp.json
+++ b/themes/jv_sitecorian.omp.json
@@ -6,21 +6,21 @@
   "console_title_template": "{{if .Root}}Admin: {{end}} {{.Folder}}",
   "blocks": [
     {
-        "type": "prompt",
-        "alignment": "left",
-        "newline": true,
-        "segments": [
-            {
-            "type": "text",
-            "style": "plain",
-            "foreground": "#ffffff",
-            "properties": {
+      "type": "prompt",
+      "alignment": "left",
+      "newline": true,
+      "segments": [
+        {
+          "type": "text",
+          "style": "plain",
+          "foreground": "#ffffff",
+          "properties": {
             "prefix": "",
             "text": "",
             "postfix": ""
           }
         }
-     ]
+      ]
     },
     {
       "type": "prompt",
@@ -30,7 +30,7 @@
           "type": "text",
           "style": "plain",
           "foreground": "#185F7B",
-            "properties": {
+          "properties": {
             "prefix": "\ue0c5",
             "text": "",
             "postfix": ""
@@ -42,7 +42,7 @@
           "powerline_symbol": "\ue0c4",
           "background": "#185F7B",
           "foreground": "#185F7B",
-            "properties": {
+          "properties": {
             "text": "",
             "prefix": "",
             "postfix": ""
@@ -59,27 +59,28 @@
             "style": "mixed",
             "home_icon": "\uf7dd  ",
             "prefix": "",
-            "postfix": " ",            
+            "postfix": " ",
             "enable_hyperlink": true
           }
         },
         {
-            "type": "git",
-            "style": "powerline",
-            "powerline_symbol": "\uE0B0",
-            "foreground": "#ffffff",
-            "background": "#6f42c1",
-            "properties": {
-              "display_stash_count": true,
-              "display_upstream_icon": true,
-              "status_colors_enabled": true,
-              "display_status": true,
-              "local_changes_color": "#176f2c",
-              "ahead_and_behind_color": "#f26d50",
-              "behind_color": "#f9c513",
-              "ahead_color": "#0366d6",
-              "stash_count_icon": "\uF692 "
-            }
+          "type": "git",
+          "style": "powerline",
+          "powerline_symbol": "\uE0B0",
+          "foreground": "#ffffff",
+          "background": "#6f42c1",
+          "backround_templates": [
+            "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#176f2c{{ end }}",
+            "{{ if and (.Repo.Ahead gt 0) (.Repo.Behind gt 0) }}#f26d50{{ end }}",
+            "{{ if .Repo.Ahead gt 0 }}#0366d6{{ end }}",
+            "{{ if .Repo.Behind gt 0 }}#f9c513{{ end }}"
+          ],
+          "properties": {
+            "fetch_stash_count": true,
+            "fetch_status": true,
+            "display_upstream_icon": true,
+            "template": "{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
+          }
         },
         {
           "type": "text",
@@ -104,15 +105,15 @@
             "success_icon": "\uf469 \u2665 ",
             "color_background": true,
             "error_icon": "\uf525 ",
-            "error_color": "red"          
+            "error_color": "red"
           }
         }
       ]
     },
     {
-        "type": "prompt",
-        "alignment": "right",
-        "segments": [
+      "type": "prompt",
+      "alignment": "right",
+      "segments": [
         {
           "type": "time",
           "style": "diamond",
@@ -127,18 +128,17 @@
           }
         },
         {
-            "type": "executiontime",
-            "style": "diamond",
-            "leading_diamond": "\ue0c5",
-            "trailing_diamond": "\ue0c4",
-            "invert_powerline": true,
-            "foreground": "#ffffff",
-            "background": "#2B2B2B",
-            "properties": {
-                "postfix": "<#ffffff> \uF252 </>",
-                "postfix": "<#ffffff> \ufbab </>",
-                "always_enabled": true
-            }
+          "type": "executiontime",
+          "style": "diamond",
+          "leading_diamond": "\ue0c5",
+          "trailing_diamond": "\ue0c4",
+          "invert_powerline": true,
+          "foreground": "#ffffff",
+          "background": "#2B2B2B",
+          "properties": {
+            "postfix": "<#ffffff> \uF252 </>",
+            "always_enabled": true
+          }
         }
       ]
     },
@@ -151,7 +151,7 @@
           "type": "text",
           "style": "plain",
           "foreground": "#2B2B2B",
-            "properties": {
+          "properties": {
             "prefix": "\ue0c5",
             "text": "",
             "postfix": ""
@@ -170,7 +170,7 @@
           "powerline_symbol": "\uE0B0",
           "foreground": "#FBD951",
           "background": "#2B2B2B",
-            "properties": {
+          "properties": {
             "prefix": ""
           }
         },
@@ -185,23 +185,23 @@
             "display_host": false
           }
         }
-     ]
-    },    
+      ]
+    },
     {
       "type": "rprompt",
       "alignment": "right",
       "segments": [
-      {
-        "type": "shell",
-        "style": "plain",
-        "foreground": "#666666",
-        "background": "#000000",
-        "properties": {
-          "prefix": " ",
-          "postfix": ""
+        {
+          "type": "shell",
+          "style": "plain",
+          "foreground": "#666666",
+          "background": "#000000",
+          "properties": {
+            "prefix": " ",
+            "postfix": ""
+          }
         }
-      }
-    ]
+      ]
     }
   ]
 }

--- a/themes/jv_sitecorian.omp.json
+++ b/themes/jv_sitecorian.omp.json
@@ -71,9 +71,9 @@
           "background": "#6f42c1",
           "backround_templates": [
             "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#176f2c{{ end }}",
-            "{{ if and (.Repo.Ahead gt 0) (.Repo.Behind gt 0) }}#f26d50{{ end }}",
-            "{{ if .Repo.Ahead gt 0 }}#0366d6{{ end }}",
-            "{{ if .Repo.Behind gt 0 }}#f9c513{{ end }}"
+            "{{ if and (gt .Repo.Ahead 0) (gt .Repo.Behind 0) }}#f26d50{{ end }}",
+            "{{ if gt .Repo.Ahead 0 }}#0366d6{{ end }}",
+            "{{ if gt .Repo.Behind 0 }}#f9c513{{ end }}"
           ],
           "properties": {
             "fetch_stash_count": true,

--- a/themes/jv_sitecorian.omp.json
+++ b/themes/jv_sitecorian.omp.json
@@ -78,8 +78,8 @@
           "properties": {
             "fetch_stash_count": true,
             "fetch_status": true,
-            "display_upstream_icon": true,
-            "template": "{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
+            "fetch_upstream_icon": true,
+            "template": "{{ .Repo.UpstreamIcon }}{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           }
         },
         {

--- a/themes/lambda.omp.json
+++ b/themes/lambda.omp.json
@@ -27,7 +27,8 @@
           "style": "plain",
           "foreground": "#B80101",
           "properties": {
-            "prefix": " <#F5F5F5>git:</>"
+            "prefix": " <#F5F5F5>git:</>",
+            "template": "{{ .Repo.HEAD }}"
           }
         }
       ]

--- a/themes/marcduiker.omp.json
+++ b/themes/marcduiker.omp.json
@@ -9,9 +9,9 @@
         {
           "background": "#feae34",
           "foreground": "#262b44",
-          "powerline_symbol": "",
+          "powerline_symbol": "\uE0B0",
           "leading_diamond": "",
-          "trailing_diamond": "",
+          "trailing_diamond": "\uE0B0",
           "properties": {
             "prefix": "  ",
             "style": "folder"
@@ -22,16 +22,18 @@
         {
           "background": "#fee761",
           "foreground": "#262b44",
-          "powerline_symbol": "",
+          "background_templates": [
+            "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#f77622{{ end }}",
+            "{{ if and (.Repo.Ahead gt 0) (.Repo.Behind gt 0) }}#e43b44{{ end }}",
+            "{{ if .Repo.Ahead gt 0 }}#2ce8f5{{ end }}",
+            "{{ if .Repo.Behind gt 0 }}#f77622{{ end }}"
+          ],
+          "powerline_symbol": "\uE0B0",
           "properties": {
-            "display_stash_count": true,
+            "fetch_status": true,
+            "fetch_stash_count": true,
             "display_upstream_icon": true,
-            "status_colors_enabled": true,
-            "local_changes_color": "#f77622",
-            "ahead_and_behind_color": "#e43b44",
-            "behind_color": "#f77622",
-            "ahead_color": "#2ce8f5",
-            "stash_count_icon": "\uF692 "
+            "template": "{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           },
           "style": "powerline",
           "type": "git"
@@ -39,14 +41,14 @@
         {
           "background": "#fee761",
           "foreground": "#262b44",
-          "powerline_symbol": "",
+          "powerline_symbol": "\uE0B0",
           "style": "powerline",
           "type": "root"
         },
         {
           "background": "#0095e9",
           "foreground": "#ffffff",
-          "leading_diamond": "<transparent, #0095e9></>",
+          "leading_diamond": "<transparent, #0095e9>\uE0B0</>",
           "properties": {
             "always_enabled": true,
             "color_background": true,

--- a/themes/marcduiker.omp.json
+++ b/themes/marcduiker.omp.json
@@ -24,9 +24,9 @@
           "foreground": "#262b44",
           "background_templates": [
             "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#f77622{{ end }}",
-            "{{ if and (.Repo.Ahead gt 0) (.Repo.Behind gt 0) }}#e43b44{{ end }}",
-            "{{ if .Repo.Ahead gt 0 }}#2ce8f5{{ end }}",
-            "{{ if .Repo.Behind gt 0 }}#f77622{{ end }}"
+            "{{ if and (gt .Repo.Ahead 0) (gt .Repo.Behind 0) }}#e43b44{{ end }}",
+            "{{ if gt .Repo.Ahead 0 }}#2ce8f5{{ end }}",
+            "{{ if gt .Repo.Behind 0 }}#f77622{{ end }}"
           ],
           "powerline_symbol": "\uE0B0",
           "properties": {

--- a/themes/marcduiker.omp.json
+++ b/themes/marcduiker.omp.json
@@ -32,8 +32,8 @@
           "properties": {
             "fetch_status": true,
             "fetch_stash_count": true,
-            "display_upstream_icon": true,
-            "template": "{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
+            "fetch_upstream_icon": true,
+            "template": "{{ .Repo.UpstreamIcon }}{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           },
           "style": "powerline",
           "type": "git"

--- a/themes/material.omp.json
+++ b/themes/material.omp.json
@@ -29,7 +29,8 @@
           "foreground": "#D0666F",
           "properties": {
             "branch_icon": "",
-            "display_status": false,
+            "fetch_status": false,
+            "template": "{{ .Repo.HEAD }}",
             "prefix": "<#5FAAE8>git:(</>",
             "postfix": "<#5FAAE8>)</>"
           }

--- a/themes/microverse-power.omp.json
+++ b/themes/microverse-power.omp.json
@@ -65,9 +65,10 @@
           "foreground": "#3A86FF",
           "background": "#242424",
           "properties": {
-            "display_stash_count": true,
+            "fetch_stash_count": true,
             "display_upstream_icon": true,
-            "prefix": ""
+            "prefix": "",
+            "template": "{{ .Repo.HEAD }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           }
         },
         {

--- a/themes/microverse-power.omp.json
+++ b/themes/microverse-power.omp.json
@@ -66,9 +66,9 @@
           "background": "#242424",
           "properties": {
             "fetch_stash_count": true,
-            "display_upstream_icon": true,
+            "fetch_upstream_icon": true,
             "prefix": "",
-            "template": "{{ .Repo.HEAD }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
+            "template": "{{ .Repo.UpstreamIcon }}{{ .Repo.HEAD }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           }
         },
         {

--- a/themes/mojada.omp.json
+++ b/themes/mojada.omp.json
@@ -72,9 +72,9 @@
           "background": "#fffb38",
           "background_templates": [
             "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#ff9248{{ end }}",
-            "{{ if and (.Repo.Ahead gt 0) (.Repo.Behind gt 0) }}#f26d50{{ end }}",
-            "{{ if .Repo.Ahead gt 0 }}#f17c37{{ end }}",
-            "{{ if .Repo.Behind gt 0 }}#89d1dc{{ end }}"
+            "{{ if and (gt .Repo.Ahead 0) (gt .Repo.Behind 0) }}#f26d50{{ end }}",
+            "{{ if gt .Repo.Ahead 0 }}#f17c37{{ end }}",
+            "{{ if gt .Repo.Behind 0 }}#89d1dc{{ end }}"
           ],
           "properties": {
             "fetch_status": true,

--- a/themes/mojada.omp.json
+++ b/themes/mojada.omp.json
@@ -79,8 +79,8 @@
           "properties": {
             "fetch_status": true,
             "fetch_stash_count": true,
-            "display_upstream_icon": true,
-            "template": "{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
+            "fetch_upstream_icon": true,
+            "template": "{{ .Repo.UpstreamIcon }}{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           }
         },
         {

--- a/themes/mojada.omp.json
+++ b/themes/mojada.omp.json
@@ -1,154 +1,159 @@
 {
-    "blocks": [{
-            "type": "prompt",
-            "alignment": "left",
-            "newline": true,
-            "segments": [{
-                    "type": "os",
-                    "style": "diamond",
-                    "leading_diamond": "\uE0B6",
-                    "trailing_diamond": "",
-                    "foreground": "#0077c2",
-                    "background": "#fbfbfb",
-                    "properties": {
-                        "postfix": " ",
-                        "macos": "\uEF179",
-                        "windows": "\uF17A",
-                        "linux": "\uF17C",
-                        "debian": "\uF306",
-                        "ubuntu": "\uF31B",
-                        "arch": "\uF303",
-                        "fedora": "\uF30A",
-                        "manjaro": "\uF312",
-                        "opensuse": "\uF314"
-                    }
-                },
-                {
-                    "type": "session",
-                    "style": "powerline",
-                    "foreground": "#0077c2",
-                    "background": "#fbfbfb",
-                    "powerline_symbol": "\uE0B0",
-                    "properties": {
-                        "prefix": "",
-                        "display_host": true,
-                        "host_color": "#e06c75",
-                        "user_info_separator": "<#000000>@</>"
-                    }
-                },
-                {
-                    "type": "root",
-                    "style": "powerline",
-                    "powerline_symbol": "\uE0B0",
-                    "foreground": "#ffffff",
-                    "background": "#e06c75",
-                    "properties": {
-                        "root_icon": "\uE799 ",
-                        "postfix": "\u2800"
-                    }
-                },
-                {
-                    "type": "path",
-                    "style": "powerline",
-                    "powerline_symbol": "\uE0B0",
-                    "foreground": "#ffffff",
-                    "background": "#0077c2",
-                    "properties": {
-                        "style": "letter",
-                        "folder_separator_icon": "/",
-                        "prefix": " \uE5FE ",
-                        "home_icon": "~",
-                        "enable_hyperlink": true,
-                        "max_depth": 2
-                    }
-                },
-                {
-                    "type": "git",
-                    "style": "powerline",
-                    "powerline_symbol": "\uE0B0",
-                    "foreground": "#193549",
-                    "background": "#fffb38",
-                    "properties": {
-                        "display_stash_count": true,
-                        "display_upstream_icon": true,
-                        "status_colors_enabled": true,
-                        "local_changes_color": "#ff9248",
-                        "ahead_and_behind_color": "#f26d50",
-                        "behind_color": "#f17c37",
-                        "ahead_color": "#89d1dc",
-                        "stash_count_icon": "\uF692 "
-                    }
-                },
-                {
-                    "type": "text",
-                    "style": "plain",
-                    "foreground": "#FFD54F",
-                    "properties": {
-                        "prefix": " ",
-                        "text": "{{if .Root}}#{{else}}${{end}}",
-                        "postfix": ""
-                    }
-                }
-            ]
+  "blocks": [
+    {
+      "type": "prompt",
+      "alignment": "left",
+      "newline": true,
+      "segments": [
+        {
+          "type": "os",
+          "style": "diamond",
+          "leading_diamond": "\uE0B6",
+          "trailing_diamond": "",
+          "foreground": "#0077c2",
+          "background": "#fbfbfb",
+          "properties": {
+            "postfix": " ",
+            "macos": "\uEF179",
+            "windows": "\uF17A",
+            "linux": "\uF17C",
+            "debian": "\uF306",
+            "ubuntu": "\uF31B",
+            "arch": "\uF303",
+            "fedora": "\uF30A",
+            "manjaro": "\uF312",
+            "opensuse": "\uF314"
+          }
         },
         {
-            "type": "rprompt",
-            "segments": [{
-                    "type": "exit",
-                    "style": "plain",
-                    "foreground": "#ffffff",
-                    "properties": {
-                        "display_exit_code": false,
-                        "always_enabled": true,
-                        "success_icon": "<#00ff00>\uF633</>",
-                        "error_icon": "<#ff0000>\uF659</>"
-                    }
-                },
-                {
-                    "type": "executiontime",
-                    "style": "plain",
-                    "foreground": "#ffffff",
-                    "properties": {
-                        "always_enabled": true,
-                        "prefix": ""
-                    }
-                },
-                {
-                    "type": "battery",
-                    "style": "powerline",
-                    "invert_powerline": true,
-                    "powerline_symbol": "\uE0B2",
-                    "foreground": "#ffffff",
-                    "background": "#f36943",
-                    "properties": {
-                        "battery_icon": "",
-                        "discharging_icon": "\uF57D ",
-                        "charging_icon": "\uF588 ",
-                        "charged_icon": "\uF583 ",
-                        "color_background": true,
-                        "charged_color": "#4caf50",
-                        "charging_color": "#40c4ff",
-                        "discharging_color": "#ff5722",
-                        "postfix": "% "
-                    }
-                },
-                {
-                    "type": "time",
-                    "style": "diamond",
-                    "invert_powerline": true,
-                    "leading_diamond": "",
-                    "trailing_diamond": "\uE0B4",
-                    "background": "#61afef",
-                    "foreground": "#ffffff",
-                    "properties": {
-                        "time_format": "15:04 (Mon)"
-                    }
-                }
-            ]
+          "type": "session",
+          "style": "powerline",
+          "foreground": "#0077c2",
+          "background": "#fbfbfb",
+          "powerline_symbol": "\uE0B0",
+          "properties": {
+            "prefix": "",
+            "display_host": true,
+            "host_color": "#e06c75",
+            "user_info_separator": "<#000000>@</>"
+          }
+        },
+        {
+          "type": "root",
+          "style": "powerline",
+          "powerline_symbol": "\uE0B0",
+          "foreground": "#ffffff",
+          "background": "#e06c75",
+          "properties": {
+            "root_icon": "\uE799 ",
+            "postfix": "\u2800"
+          }
+        },
+        {
+          "type": "path",
+          "style": "powerline",
+          "powerline_symbol": "\uE0B0",
+          "foreground": "#ffffff",
+          "background": "#0077c2",
+          "properties": {
+            "style": "letter",
+            "folder_separator_icon": "/",
+            "prefix": " \uE5FE ",
+            "home_icon": "~",
+            "enable_hyperlink": true,
+            "max_depth": 2
+          }
+        },
+        {
+          "type": "git",
+          "style": "powerline",
+          "powerline_symbol": "\uE0B0",
+          "foreground": "#193549",
+          "background": "#fffb38",
+          "background_templates": [
+            "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#ff9248{{ end }}",
+            "{{ if and (.Repo.Ahead gt 0) (.Repo.Behind gt 0) }}#f26d50{{ end }}",
+            "{{ if .Repo.Ahead gt 0 }}#f17c37{{ end }}",
+            "{{ if .Repo.Behind gt 0 }}#89d1dc{{ end }}"
+          ],
+          "properties": {
+            "fetch_status": true,
+            "fetch_stash_count": true,
+            "display_upstream_icon": true,
+            "template": "{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
+          }
+        },
+        {
+          "type": "text",
+          "style": "plain",
+          "foreground": "#FFD54F",
+          "properties": {
+            "prefix": " ",
+            "text": "{{if .Root}}#{{else}}${{end}}",
+            "postfix": ""
+          }
         }
-    ],
-    "final_space": true,
-    "console_title": true,
-    "console_title_style": "template",
-    "console_title_template": "{{.User}}@{{.Host}} : {{.Folder}}"
+      ]
+    },
+    {
+      "type": "rprompt",
+      "segments": [
+        {
+          "type": "exit",
+          "style": "plain",
+          "foreground": "#ffffff",
+          "properties": {
+            "display_exit_code": false,
+            "always_enabled": true,
+            "success_icon": "<#00ff00>\uF633</>",
+            "error_icon": "<#ff0000>\uF659</>"
+          }
+        },
+        {
+          "type": "executiontime",
+          "style": "plain",
+          "foreground": "#ffffff",
+          "properties": {
+            "always_enabled": true,
+            "prefix": ""
+          }
+        },
+        {
+          "type": "battery",
+          "style": "powerline",
+          "invert_powerline": true,
+          "powerline_symbol": "\uE0B2",
+          "foreground": "#ffffff",
+          "background": "#f36943",
+          "properties": {
+            "battery_icon": "",
+            "discharging_icon": "\uF57D ",
+            "charging_icon": "\uF588 ",
+            "charged_icon": "\uF583 ",
+            "color_background": true,
+            "charged_color": "#4caf50",
+            "charging_color": "#40c4ff",
+            "discharging_color": "#ff5722",
+            "postfix": "% "
+          }
+        },
+        {
+          "type": "time",
+          "style": "diamond",
+          "invert_powerline": true,
+          "leading_diamond": "",
+          "trailing_diamond": "\uE0B4",
+          "background": "#61afef",
+          "foreground": "#ffffff",
+          "properties": {
+            "time_format": "15:04 (Mon)"
+          }
+        }
+      ]
+    }
+  ],
+  "final_space": true,
+  "console_title": true,
+  "console_title_style": "template",
+  "console_title_template": "{{.User}}@{{.Host}} : {{.Folder}}"
 }

--- a/themes/mt.omp.json
+++ b/themes/mt.omp.json
@@ -37,9 +37,9 @@
           "properties": {
             "fetch_stash_count": true,
             "fetch_status": false,
-            "display_upstream_icon": true,
+            "fetch_upstream_icon": true,
             "branch_icon": "",
-            "template": "{{ .Repo.HEAD }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}",
+            "template": "{{ .Repo.UpstreamIcon }}{{ .Repo.HEAD }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}",
             "prefix": " \u279C (",
             "postfix": ") "
           }

--- a/themes/mt.omp.json
+++ b/themes/mt.omp.json
@@ -1,71 +1,71 @@
 {
-    "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
-    "final_space": true,
-    "blocks": [
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
+  "final_space": true,
+  "blocks": [
+    {
+      "type": "prompt",
+      "alignment": "left",
+      "segments": [
         {
-            "type": "prompt",
-            "alignment": "left",
-            "segments": [
-                {
-                    "type": "session",
-                    "style": "diamond",
-                    "foreground": "#ffffff",
-                    "background": "#B4009E",
-                    "leading_diamond": "\uE0B6",
-                    "trailing_diamond": "",
-                    "properties": {
-                        "prefix": "",
-                        "display_host": false
-                    }
-                },
-                {
-                    "type": "path",
-                    "style": "powerline",
-                    "powerline_symbol": "\uE0B0",
-                    "foreground": "#000000",
-                    "background": "#FFFF00",
-                    "properties": {
-                        "style": "folder"
-                    }
-                },
-                {
-                    "type": "git",
-                    "style": "powerline",
-                    "powerline_symbol": "\uE0B0",
-                    "foreground": "#ffffff",
-                    "background": "#4E44FF",
-                    "properties": {
-                        "display_stash_count": true,
-                        "display_upstream_icon": true,
-                        "status_colors_enabled": false,
-                        "branch_icon": "",
-                        "display_status": false,
-                        "prefix": " \u279C (",
-                        "postfix": ") "
-                    }
-                },
-                {
-                    "type": "node",
-                    "style": "powerline",
-                    "powerline_symbol": "\uE0B0",
-                    "foreground": "#ffffff",
-                    "background": "#4e903d",
-                    "properties": {
-                        "prefix": " \uE718 "
-                    }
-                },
-                {
-                    "type": "time",
-                    "style": "diamond",
-                    "trailing_diamond": "\uE0B0",
-                    "foreground": "#ffffff",
-                    "background": "#16C60C",
-                    "properties": {
-                        "prefix": " \u2665 ",
-                        "time_format": "15:04"
-                    }
-                }
-            ]
+          "type": "session",
+          "style": "diamond",
+          "foreground": "#ffffff",
+          "background": "#B4009E",
+          "leading_diamond": "\uE0B6",
+          "trailing_diamond": "",
+          "properties": {
+            "prefix": "",
+            "display_host": false
+          }
+        },
+        {
+          "type": "path",
+          "style": "powerline",
+          "powerline_symbol": "\uE0B0",
+          "foreground": "#000000",
+          "background": "#FFFF00",
+          "properties": {
+            "style": "folder"
+          }
+        },
+        {
+          "type": "git",
+          "style": "powerline",
+          "powerline_symbol": "\uE0B0",
+          "foreground": "#ffffff",
+          "background": "#4E44FF",
+          "properties": {
+            "fetch_stash_count": true,
+            "fetch_status": false,
+            "display_upstream_icon": true,
+            "branch_icon": "",
+            "template": "{{ .Repo.HEAD }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}",
+            "prefix": " \u279C (",
+            "postfix": ") "
+          }
+        },
+        {
+          "type": "node",
+          "style": "powerline",
+          "powerline_symbol": "\uE0B0",
+          "foreground": "#ffffff",
+          "background": "#4e903d",
+          "properties": {
+            "prefix": " \uE718 "
+          }
+        },
+        {
+          "type": "time",
+          "style": "diamond",
+          "trailing_diamond": "\uE0B0",
+          "foreground": "#ffffff",
+          "background": "#16C60C",
+          "properties": {
+            "prefix": " \u2665 ",
+            "time_format": "15:04"
+          }
         }
-    ]
+      ]
+    }
+  ]
 }

--- a/themes/negligible.omp.json
+++ b/themes/negligible.omp.json
@@ -1,119 +1,120 @@
 {
-    "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
-    "blocks": [
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
+  "blocks": [
+    {
+      "type": "prompt",
+      "alignment": "left",
+      "segments": [
         {
-            "type": "prompt",
-            "alignment": "left",
-            "segments": [
-                {
-                    "type": "os",
-                    "style": "powerline",
-                    "foreground": "cyan",
-                    "properties": {
-                        "prefix": "",
-                        "postfix": ""
-                    }
-                },
-                {
-                    "type": "path",
-                    "style": "plain",
-                    "foreground": "cyan",
-                    "properties": {
-                        "style": "full"
-                    }
-                },
-                {
-                    "type": "git",
-                    "style": "plain",
-                    "foreground": "#F1502F",
-                    "properties": {
-                        "prefix": ":: ",
-                        "display_status": true
-                    }
-                }
-            ]
+          "type": "os",
+          "style": "powerline",
+          "foreground": "cyan",
+          "properties": {
+            "prefix": "",
+            "postfix": ""
+          }
         },
         {
-            "type": "prompt",
-            "alignment": "right",
-            "segments": [
-                {
-                    "type": "root",
-                    "style": "plain",
-                    "foreground": "red",
-                    "properties": {
-                        "prefix": "| ",
-                        "root_icon": "root"
-                    }
-                },
-                {
-                    "type": "dart",
-                    "style": "powerline",
-                    "foreground": "#06A4CE",
-                    "properties": {
-                        "prefix": "| \uE798 "
-                    }
-                },
-                {
-                    "type": "node",
-                    "style": "powerline",
-                    "foreground": "#6CA35E",
-                    "properties": {
-                        "prefix": "| \uE718 "
-                    }
-                },
-                {
-                    "type": "python",
-                    "style": "plain",
-                    "foreground": "#4584b6",
-                    "properties": {
-                        "prefix": "| \uE235 ",
-                        "display_version": false,
-                        "display_mode": "context",
-                        "display_virtual_env": true
-                    }
-                },
-                {
-                    "type": "battery",
-                    "style": "powerline",
-                    "invert_powerline": true,
-                    "properties": {
-                        "charging_icon": " ",
-                        "charged_icon": "\uf00d ",
-                        "charged_color": "#ff0000",
-                        "charging_color": "#4caf50",
-                        "discharging_color": "#40c4ff",
-                        "prefix": "| ",
-                        "postfix": "  "
-                    }
-                },
-                {
-                    "type": "time",
-                    "style": "plain",
-                    "foreground": "lightGreen",
-                    "properties": {
-                        "prefix": "| "
-                    }
-                }
-            ]
+          "type": "path",
+          "style": "plain",
+          "foreground": "cyan",
+          "properties": {
+            "style": "full"
+          }
         },
         {
-            "type": "prompt",
-            "alignment": "left",
-            "newline": true,
-            "segments": [
-                {
-                    "type": "exit",
-                    "style": "powerline",
-                    "foreground": "lightGreen",
-                    "properties": {
-                        "display_exit_code": false,
-                        "always_enabled": true,
-                        "error_color": "red",
-                        "prefix": "\u279c"
-                    }
-                }
-            ]
+          "type": "git",
+          "style": "plain",
+          "foreground": "#F1502F",
+          "properties": {
+            "prefix": ":: ",
+            "fetch_status": true,
+            "template": "{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}"
+          }
         }
-    ]
+      ]
+    },
+    {
+      "type": "prompt",
+      "alignment": "right",
+      "segments": [
+        {
+          "type": "root",
+          "style": "plain",
+          "foreground": "red",
+          "properties": {
+            "prefix": "| ",
+            "root_icon": "root"
+          }
+        },
+        {
+          "type": "dart",
+          "style": "powerline",
+          "foreground": "#06A4CE",
+          "properties": {
+            "prefix": "| \uE798 "
+          }
+        },
+        {
+          "type": "node",
+          "style": "powerline",
+          "foreground": "#6CA35E",
+          "properties": {
+            "prefix": "| \uE718 "
+          }
+        },
+        {
+          "type": "python",
+          "style": "plain",
+          "foreground": "#4584b6",
+          "properties": {
+            "prefix": "| \uE235 ",
+            "display_version": false,
+            "display_mode": "context",
+            "display_virtual_env": true
+          }
+        },
+        {
+          "type": "battery",
+          "style": "powerline",
+          "invert_powerline": true,
+          "properties": {
+            "charging_icon": " ",
+            "charged_icon": "\uf00d ",
+            "charged_color": "#ff0000",
+            "charging_color": "#4caf50",
+            "discharging_color": "#40c4ff",
+            "prefix": "| ",
+            "postfix": "  "
+          }
+        },
+        {
+          "type": "time",
+          "style": "plain",
+          "foreground": "lightGreen",
+          "properties": {
+            "prefix": "| "
+          }
+        }
+      ]
+    },
+    {
+      "type": "prompt",
+      "alignment": "left",
+      "newline": true,
+      "segments": [
+        {
+          "type": "exit",
+          "style": "powerline",
+          "foreground": "lightGreen",
+          "properties": {
+            "display_exit_code": false,
+            "always_enabled": true,
+            "error_color": "red",
+            "prefix": "\u279c"
+          }
+        }
+      ]
+    }
+  ]
 }

--- a/themes/night-owl.omp.json
+++ b/themes/night-owl.omp.json
@@ -53,9 +53,9 @@
           "background": "#22da6e",
           "background_templates": [
             "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#ffeb95{{ end }}",
-            "{{ if and (.Repo.Ahead gt 0) (.Repo.Behind gt 0) }}#c5e478{{ end }}",
-            "{{ if .Repo.Ahead gt 0 }}#C792EA{{ end }}",
-            "{{ if .Repo.Behind gt 0 }}#C792EA{{ end }}"
+            "{{ if and (gt .Repo.Ahead 0) (gt .Repo.Behind 0) }}#c5e478{{ end }}",
+            "{{ if gt .Repo.Ahead 0 }}#C792EA{{ end }}",
+            "{{ if gt .Repo.Behind 0 }}#C792EA{{ end }}"
           ],
           "properties": {
             "branch_icon": "\ue725 ",

--- a/themes/night-owl.omp.json
+++ b/themes/night-owl.omp.json
@@ -60,8 +60,8 @@
           "properties": {
             "branch_icon": "\ue725 ",
             "fetch_status": true,
-            "display_upstream_icon": true,
-            "template": "{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }}<#ef5350> \uF046 {{ .Repo.Staging.String }}</>{{ end }}"
+            "fetch_upstream_icon": true,
+            "template": "{{ .Repo.UpstreamIcon }}{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }}<#ef5350> \uF046 {{ .Repo.Staging.String }}</>{{ end }}"
           }
         },
         {

--- a/themes/night-owl.omp.json
+++ b/themes/night-owl.omp.json
@@ -51,16 +51,17 @@
           "powerline_symbol": "\uE0B0",
           "foreground": "#011627",
           "background": "#22da6e",
+          "background_templates": [
+            "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#ffeb95{{ end }}",
+            "{{ if and (.Repo.Ahead gt 0) (.Repo.Behind gt 0) }}#c5e478{{ end }}",
+            "{{ if .Repo.Ahead gt 0 }}#C792EA{{ end }}",
+            "{{ if .Repo.Behind gt 0 }}#C792EA{{ end }}"
+          ],
           "properties": {
-            "branch_icon": " \ue725 ",
-            "display_status": true,
+            "branch_icon": "\ue725 ",
+            "fetch_status": true,
             "display_upstream_icon": true,
-            "staging_color": "#ef5350",
-            "status_colors_enabled": true,
-            "local_changes_color": "#ffeb95",
-            "ahead_and_behind_color": "#c5e478",
-            "behind_color": "#C792EA",
-            "ahead_color": "#C792EA"
+            "template": "{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }}<#ef5350> \uF046 {{ .Repo.Staging.String }}</>{{ end }}"
           }
         },
         {

--- a/themes/nu4a.omp.json
+++ b/themes/nu4a.omp.json
@@ -28,11 +28,11 @@
           "powerline_symbol": "\uE0B0",
           "foreground": "#100e23",
           "background": "#ec9706",
-          "properties" : {
-              "home_icon": "\uF7DB",
-              "folder_icon": "\uF115",
-              "folder_separator_icon": " \uE0B1 ",
-              "style": "full"
+          "properties": {
+            "home_icon": "\uF7DB",
+            "folder_icon": "\uF115",
+            "folder_separator_icon": " \uE0B1 ",
+            "style": "full"
           }
         },
         {
@@ -40,7 +40,10 @@
           "style": "powerline",
           "powerline_symbol": "\uE0B0",
           "foreground": "#193549",
-          "background": "#95ffa4"
+          "background": "#95ffa4",
+          "properties": {
+            "template": "{{ .Repo.HEAD }}"
+          }
         },
         {
           "type": "python",

--- a/themes/paradox.omp.json
+++ b/themes/paradox.omp.json
@@ -36,7 +36,10 @@
           "style": "powerline",
           "powerline_symbol": "\uE0B0",
           "foreground": "#193549",
-          "background": "#95ffa4"
+          "background": "#95ffa4",
+          "properties": {
+            "template": "{{ .Repo.HEAD }}"
+          }
         },
         {
           "type": "python",

--- a/themes/pararussel.omp.json
+++ b/themes/pararussel.omp.json
@@ -29,9 +29,9 @@
           "foreground": "#D0666F",
           "properties": {
             "branch_icon": "",
-            "display_status": false,
             "prefix": "<#5FAAE8>git:(</>",
-            "postfix": "<#5FAAE8>)</>"
+            "postfix": "<#5FAAE8>)</>",
+            "template": "{{ .Repo.HEAD }}"
           }
         },
         {

--- a/themes/patriksvensson.omp.json
+++ b/themes/patriksvensson.omp.json
@@ -44,11 +44,11 @@
           "properties": {
             "fetch_status": true,
             "fetch_stash_count": true,
-            "display_upstream_icon": true,
+            "fetch_upstream_icon": true,
             "prefix": " on ",
             "postfix": "",
             "github_icon": " ",
-            "template": "{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }}<red> \uF044 {{ .Repo.Working.String }}</>{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }}<yellow> \uF046 {{ .Repo.Staging.String }}</>{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
+            "template": "{{ .Repo.UpstreamIcon }}{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }}<red> \uF044 {{ .Repo.Working.String }}</>{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }}<yellow> \uF046 {{ .Repo.Staging.String }}</>{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           }
         },
         {

--- a/themes/patriksvensson.omp.json
+++ b/themes/patriksvensson.omp.json
@@ -37,9 +37,9 @@
           "foreground": "green",
           "foreground_templates": [
             "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}yellow{{ end }}",
-            "{{ if and (.Repo.Ahead gt 0) (.Repo.Behind gt 0) }}red{{ end }}",
-            "{{ if .Repo.Ahead gt 0 }}red{{ end }}",
-            "{{ if .Repo.Behind gt 0 }}green{{ end }}"
+            "{{ if and (gt .Repo.Ahead 0) (gt .Repo.Behind 0) }}red{{ end }}",
+            "{{ if gt .Repo.Ahead 0 }}red{{ end }}",
+            "{{ if gt .Repo.Behind 0 }}green{{ end }}"
           ],
           "properties": {
             "fetch_status": true,

--- a/themes/patriksvensson.omp.json
+++ b/themes/patriksvensson.omp.json
@@ -2,91 +2,90 @@
   "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh3/main/themes/schema.json",
   "final_space": true,
   "blocks": [
-      {
-          "type": "prompt",
-          "alignment": "left",
-          "newline": true,
-          "segments": [
-              {
-                  "type": "root",
-                  "style": "plain",
-                  "powerline_symbol": "\uE0B0",
-                  "foreground": "red",
-                  "properties": {
-                      "prefix": "",
-                      "postfix": " ",
-                      "root_icon": "\uF0E7"
-                  }
-              },
-              {
-                  "type": "path",
-                  "style": "plain",
-                  "foreground": "blue",
-                  "properties": {
-                      "prefix": "",
-                      "postfix": "",
-                      "home_icon": "\uF7DB",
-                      "folder_icon": "\uE5FF",
-                      "folder_separator_icon": "/",
-                      "style": "agnoster"
-                  }
-              },
-              {
-                  "type": "git",
-                  "style": "plain",
-                  "foreground": "green",
-                  "properties": {
-                      "display_status": true,
-                      "prefix": " on ",
-                      "postfix": "",
-                      "ahead_color": "red",
-                      "behind_color": "green",
-                      "working_color": "red",
-                      "staging_color": "yellow",
-                      "local_changes_color": "yellow",
-                      "ahead_and_behind_color": "red",
-                      "color_background": false,
-                      "display_stash_count": true,
-                      "display_upstream_icon": true,
-                      "status_colors_enabled": true,
-                      "github_icon": " "
-                  }
-              },
-              {
-                  "type": "dotnet",
-                  "style": "plain",
-                  "foreground": "magenta",
-                  "properties": {
-                    "prefix": " [.NET] "
-                  }
-                }
-          ]
-      },
-      {
-          "type": "prompt",
-          "alignment": "left",
-          "newline": true,
-          "segments": [
-              {
-                  "type": "time",
-                  "style": "plain",
-                  "foreground": "yellow",
-                  "properties": {
-                      "prefix": "",
-                      "time_format": "15:04:05"
-                  }
-              },
-              {
-                  "type": "text",
-                  "style": "plain",
-                  "foreground": "green",
-                  "properties": {
-                      "prefix": "",
-                      "postfix": "",
-                      "text": "\u276F"
-                  }
-              }
-          ]
-      }
+    {
+      "type": "prompt",
+      "alignment": "left",
+      "newline": true,
+      "segments": [
+        {
+          "type": "root",
+          "style": "plain",
+          "powerline_symbol": "\uE0B0",
+          "foreground": "red",
+          "properties": {
+            "prefix": "",
+            "postfix": " ",
+            "root_icon": "\uF0E7"
+          }
+        },
+        {
+          "type": "path",
+          "style": "plain",
+          "foreground": "blue",
+          "properties": {
+            "prefix": "",
+            "postfix": "",
+            "home_icon": "\uF7DB",
+            "folder_icon": "\uE5FF",
+            "folder_separator_icon": "/",
+            "style": "agnoster"
+          }
+        },
+        {
+          "type": "git",
+          "style": "plain",
+          "foreground": "green",
+          "foreground_templates": [
+            "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}yellow{{ end }}",
+            "{{ if and (.Repo.Ahead gt 0) (.Repo.Behind gt 0) }}red{{ end }}",
+            "{{ if .Repo.Ahead gt 0 }}red{{ end }}",
+            "{{ if .Repo.Behind gt 0 }}green{{ end }}"
+          ],
+          "properties": {
+            "fetch_status": true,
+            "fetch_stash_count": true,
+            "display_upstream_icon": true,
+            "prefix": " on ",
+            "postfix": "",
+            "github_icon": " ",
+            "template": "{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }}<red> \uF044 {{ .Repo.Working.String }}</>{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }}<yellow> \uF046 {{ .Repo.Staging.String }}</>{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
+          }
+        },
+        {
+          "type": "dotnet",
+          "style": "plain",
+          "foreground": "magenta",
+          "properties": {
+            "prefix": " [.NET] "
+          }
+        }
+      ]
+    },
+    {
+      "type": "prompt",
+      "alignment": "left",
+      "newline": true,
+      "segments": [
+        {
+          "type": "time",
+          "style": "plain",
+          "foreground": "yellow",
+          "properties": {
+            "prefix": "",
+            "time_format": "15:04:05"
+          }
+        },
+        {
+          "type": "text",
+          "style": "plain",
+          "foreground": "green",
+          "properties": {
+            "prefix": "",
+            "postfix": "",
+            "text": "\u276F"
+          }
+        }
+      ]
+    }
   ]
 }

--- a/themes/pixelrobots.omp.json
+++ b/themes/pixelrobots.omp.json
@@ -119,18 +119,17 @@
           "style": "diamond",
           "foreground": "#ffea00",
           "background": "#2f2f2f",
+          "foreground_templates": [
+            "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#ffea00{{ end }}",
+            "{{ if .Repo.Ahead gt 0 }}#2EC4B6{{ end }}",
+            "{{ if .Repo.Behind gt 0 }}#8A4FFF{{ end }}"
+          ],
           "properties": {
-            "display_stash_count": true,
+            "fetch_stash_count": true,
+            "fetch_status": true,
             "display_upstream_icon": true,
-            "display_status": true,
-            "status_colors_enabled": true,
-            "color_background": false,
-            "local_changes_color": "#ffea00",
-            "working_color": "#E84855",
-            "staging_color": "#2FDA4E",
-            "ahead_color": "#2EC4B6",
-            "behind_color": "#8A4FFF",
-            "prefix": "<#ffea00>\ue0b1 </>"
+            "prefix": "<#ffea00>\ue0b1 </>",
+            "template": "{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }}<#E84855> \uF044 {{ .Repo.Working.String }}</>{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }}<#2FDA4E> \uF046 {{ .Repo.Staging.String }}</>{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           }
         },
         {

--- a/themes/pixelrobots.omp.json
+++ b/themes/pixelrobots.omp.json
@@ -127,9 +127,9 @@
           "properties": {
             "fetch_stash_count": true,
             "fetch_status": true,
-            "display_upstream_icon": true,
+            "fetch_upstream_icon": true,
             "prefix": "<#ffea00>\ue0b1 </>",
-            "template": "{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }}<#E84855> \uF044 {{ .Repo.Working.String }}</>{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }}<#2FDA4E> \uF046 {{ .Repo.Staging.String }}</>{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
+            "template": "{{ .Repo.UpstreamIcon }}{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }}<#E84855> \uF044 {{ .Repo.Working.String }}</>{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }}<#2FDA4E> \uF046 {{ .Repo.Staging.String }}</>{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           }
         },
         {

--- a/themes/pixelrobots.omp.json
+++ b/themes/pixelrobots.omp.json
@@ -121,8 +121,8 @@
           "background": "#2f2f2f",
           "foreground_templates": [
             "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#ffea00{{ end }}",
-            "{{ if .Repo.Ahead gt 0 }}#2EC4B6{{ end }}",
-            "{{ if .Repo.Behind gt 0 }}#8A4FFF{{ end }}"
+            "{{ if gt .Repo.Ahead 0 }}#2EC4B6{{ end }}",
+            "{{ if gt .Repo.Behind 0 }}#8A4FFF{{ end }}"
           ],
           "properties": {
             "fetch_stash_count": true,

--- a/themes/plague.omp.json
+++ b/themes/plague.omp.json
@@ -42,8 +42,8 @@
           "background": "#fffb38",
           "properties": {
             "fetch_stash_count": true,
-            "display_upstream_icon": true,
-            "template": "{{ .Repo.HEAD }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
+            "fetch_upstream_icon": true,
+            "template": "{{ .Repo.UpstreamIcon }}{{ .Repo.HEAD }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           }
         },
         {

--- a/themes/plague.omp.json
+++ b/themes/plague.omp.json
@@ -41,8 +41,9 @@
           "foreground": "#193549",
           "background": "#fffb38",
           "properties": {
-            "display_stash_count": true,
-            "display_upstream_icon": true
+            "fetch_stash_count": true,
+            "display_upstream_icon": true,
+            "template": "{{ .Repo.HEAD }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           }
         },
         {

--- a/themes/powerlevel10k_classic.omp.json
+++ b/themes/powerlevel10k_classic.omp.json
@@ -36,7 +36,8 @@
           "foreground": "#D4E157",
           "background": "#546E7A",
           "properties": {
-            "prefix": "<#26C6DA>\uE0B1 </>"
+            "prefix": "<#26C6DA>\uE0B1 </>",
+            "template": "{{ .Repo.HEAD }}"
           }
         },
         {

--- a/themes/powerlevel10k_lean.omp.json
+++ b/themes/powerlevel10k_lean.omp.json
@@ -35,7 +35,8 @@
           "style": "plain",
           "foreground": "#FFE700",
           "properties": {
-            "prefix": ""
+            "prefix": "",
+            "template": "{{ .Repo.HEAD }}"
           }
         },
         {

--- a/themes/powerlevel10k_modern.omp.json
+++ b/themes/powerlevel10k_modern.omp.json
@@ -41,8 +41,8 @@
           "background": "#D4E157",
           "powerline_symbol": "\uE0B4",
           "properties": {
-            "style": "full",
-            "prefix": " "
+            "prefix": " ",
+            "template": "{{ .Repo.HEAD }}"
           }
         }
       ]

--- a/themes/powerlevel10k_rainbow.omp.json
+++ b/themes/powerlevel10k_rainbow.omp.json
@@ -40,8 +40,8 @@
             "branch_icon": "\uF126 ",
             "fetch_stash_count": true,
             "fetch_status": true,
-            "display_upstream_icon": true,
-            "template": "{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
+            "fetch_upstream_icon": true,
+            "template": "{{ .Repo.UpstreamIcon }}{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           }
         }
       ]

--- a/themes/powerlevel10k_rainbow.omp.json
+++ b/themes/powerlevel10k_rainbow.omp.json
@@ -32,9 +32,9 @@
           "background": "#4e9a06",
           "background_templates": [
             "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#c4a000{{ end }}",
-            "{{ if and (.Repo.Ahead gt 0) (.Repo.Behind gt 0) }}#f26d50{{ end }}",
-            "{{ if .Repo.Ahead gt 0 }}#89d1dc{{ end }}",
-            "{{ if .Repo.Behind gt 0 }}#4e9a06{{ end }}"
+            "{{ if and (gt .Repo.Ahead 0) (gt .Repo.Behind 0) }}#f26d50{{ end }}",
+            "{{ if gt .Repo.Ahead 0 }}#89d1dc{{ end }}",
+            "{{ if gt .Repo.Behind 0 }}#4e9a06{{ end }}"
           ],
           "properties": {
             "branch_icon": "\uF126 ",

--- a/themes/powerlevel10k_rainbow.omp.json
+++ b/themes/powerlevel10k_rainbow.omp.json
@@ -15,7 +15,7 @@
         {
           "type": "path",
           "style": "powerline",
-          "powerline_symbol": "",
+          "powerline_symbol": "\uE0B0",
           "foreground": "#e4e4e4",
           "background": "#3465a4",
           "properties": {
@@ -27,19 +27,21 @@
         {
           "type": "git",
           "style": "powerline",
-          "powerline_symbol": "",
+          "powerline_symbol": "\uE0B0",
           "foreground": "#000000",
           "background": "#4e9a06",
+          "background_templates": [
+            "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#c4a000{{ end }}",
+            "{{ if and (.Repo.Ahead gt 0) (.Repo.Behind gt 0) }}#f26d50{{ end }}",
+            "{{ if .Repo.Ahead gt 0 }}#89d1dc{{ end }}",
+            "{{ if .Repo.Behind gt 0 }}#4e9a06{{ end }}"
+          ],
           "properties": {
             "branch_icon": "\uF126 ",
-            "display_stash_count": true,
+            "fetch_stash_count": true,
+            "fetch_status": true,
             "display_upstream_icon": true,
-            "status_colors_enabled": true,
-            "local_changes_color": "#c4a000",
-            "ahead_and_behind_color": "#f26d50",
-            "behind_color": "#4e9a06",
-            "ahead_color": "#89d1dc",
-            "stash_count_icon": "\uF692 "
+            "template": "{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           }
         }
       ]
@@ -180,7 +182,7 @@
           "type": "time",
           "style": "diamond",
           "invert_powerline": true,
-          "trailing_diamond": "─╮",
+          "trailing_diamond": "\uE0B0─╮",
           "background": "#d3d7cf",
           "foreground": "#000000",
           "properties": {

--- a/themes/powerline.omp.json
+++ b/themes/powerline.omp.json
@@ -30,7 +30,10 @@
           "style": "powerline",
           "powerline_symbol": "\uE0B0",
           "foreground": "#193549",
-          "background": "#95ffa4"
+          "background": "#95ffa4",
+          "properties": {
+            "template": "{{ .Repo.HEAD }}"
+          }
         },
         {
           "type": "python",

--- a/themes/pure.omp.json
+++ b/themes/pure.omp.json
@@ -43,13 +43,13 @@
             "prefix": "",
             "fetch_stash_count": true,
             "fetch_status": true,
-            "display_upstream_icon": true,
+            "fetch_upstream_icon": true,
             "branch_icon": "",
             "github_icon": "",
             "branch_ahead_icon": "<#88C0D0>\u21e1 </>",
             "branch_behind_icon": "<#88C0D0>\u21e3 </>",
             "local_working_icon": "<#FFAFD7>\u002a</>",
-            "template": "{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
+            "template": "{{ .Repo.UpstreamIcon }}{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           }
         }
       ]

--- a/themes/pure.omp.json
+++ b/themes/pure.omp.json
@@ -41,15 +41,15 @@
           "foreground": "#6C6C6C",
           "properties": {
             "prefix": "",
-            "display_stash_count": true,
-            "display_status": true,
-            "display_status_detail": true,
+            "fetch_stash_count": true,
+            "fetch_status": true,
             "display_upstream_icon": true,
             "branch_icon": "",
             "github_icon": "",
             "branch_ahead_icon": "<#88C0D0>\u21e1 </>",
             "branch_behind_icon": "<#88C0D0>\u21e3 </>",
-            "local_working_icon": "<#FFAFD7>\u002a</>"
+            "local_working_icon": "<#FFAFD7>\u002a</>",
+            "template": "{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           }
         }
       ]

--- a/themes/remk.omp.json
+++ b/themes/remk.omp.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
-  "blocks":[
+  "blocks": [
     {
       "type": "prompt",
       "alignment": "left",
@@ -14,12 +14,12 @@
           "trailing_diamond": "",
           "properties": {
             "prefix": "",
-            "display_host":false
+            "display_host": false
           }
         },
         {
-          "type":"path",
-          "style":"plain",
+          "type": "path",
+          "style": "plain",
           "foreground": "#3f3f3f",
           "background": "lightYellow",
           "properties": {
@@ -33,9 +33,9 @@
           "background": "lightCyan",
           "properties": {
             "branch_icon": "",
-            "display_status": false,
             "prefix": " git(",
-            "postfix": ") "
+            "postfix": ") ",
+            "template": "{{ .Repo.HEAD }}"
           }
         },
         {

--- a/themes/robbyrussel.omp.json
+++ b/themes/robbyrussel.omp.json
@@ -1,4 +1,3 @@
-
 {
   "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
   "blocks": [
@@ -30,9 +29,9 @@
           "foreground": "#D0666F",
           "properties": {
             "branch_icon": "",
-            "display_status": false,
             "prefix": "<#5FAAE8>git:(</>",
-            "postfix": "<#5FAAE8>)</>"
+            "postfix": "<#5FAAE8>)</>",
+            "template": "{{ .Repo.HEAD }}"
           }
         },
         {

--- a/themes/rudolfs-dark.omp.json
+++ b/themes/rudolfs-dark.omp.json
@@ -21,7 +21,6 @@
             "wsl_separator": "",
             "prefix": " ",
             "postfix": " "
-
           }
         },
         {
@@ -54,19 +53,13 @@
           "foreground": "#ffffff",
           "background": "#256C9D",
           "properties": {
+            "fetch_status": true,
+            "fetch_stash_count": false,
             "branch_max_length": 30,
-            "display_stash_count": false,
             "display_upstream_icon": true,
-            "display_status": true,
-            "status_colors_enabled": false,
-            "color_background": true,
-            "local_changes_color": "#ffffff",
-            "working_color": "#ffffff",
-            "staging_color": "#ffffff",
-            "ahead_color": "#ffffff",
-            "behind_color": "#ffffff",
             "prefix": "[ ",
-            "postfix": " ]"
+            "postfix": " ]",
+            "template": "{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           }
         },
         {

--- a/themes/rudolfs-dark.omp.json
+++ b/themes/rudolfs-dark.omp.json
@@ -56,10 +56,10 @@
             "fetch_status": true,
             "fetch_stash_count": false,
             "branch_max_length": 30,
-            "display_upstream_icon": true,
+            "fetch_upstream_icon": true,
             "prefix": "[ ",
             "postfix": " ]",
-            "template": "{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
+            "template": "{{ .Repo.UpstreamIcon }}{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           }
         },
         {

--- a/themes/rudolfs-light.omp.json
+++ b/themes/rudolfs-light.omp.json
@@ -41,7 +41,7 @@
           "foreground": "#424242",
           "foreground_templates": [
             "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#053F22{{ end }}",
-            "{{ if or (.Repo.Ahead gt 0) (.Repo.Behind gt 0) }}#0A703E{{ end }}"
+            "{{ if or (gt .Repo.Ahead 0) (gt .Repo.Behind 0) }}#0A703E{{ end }}"
           ],
           "properties": {
             "fetch_status": true,

--- a/themes/rudolfs-light.omp.json
+++ b/themes/rudolfs-light.omp.json
@@ -21,7 +21,6 @@
             "wsl_separator": "",
             "prefix": " ",
             "postfix": " "
-
           }
         },
         {
@@ -34,26 +33,23 @@
             "prefix": "",
             "postfix": ""
           }
-        },        
+        },
         {
           "type": "git",
           "style": "plain",
           "background": "#E0E0E0",
           "foreground": "#424242",
+          "foreground_templates": [
+            "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#053F22{{ end }}",
+            "{{ if or (.Repo.Ahead gt 0) (.Repo.Behind gt 0) }}#0A703E{{ end }}"
+          ],
           "properties": {
-            "display_stash_count": false,
+            "fetch_status": true,
             "branch_max_length": 30,
             "display_upstream_icon": true,
-            "display_status": true,
-            "status_colors_enabled": true,
-            "color_background": false,
-            "local_changes_color": "#053F22",
-            "working_color": "#BD6200",
-            "staging_color": "#053F22",
-            "ahead_color": "#0A703E",
-            "behind_color": "#0A703E",
             "prefix": " [",
-            "postfix": "] "
+            "postfix": "] ",
+            "template": "{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }}<#BD6200> \uF044 {{ .Repo.Working.String }}</>{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }}<#053F22> \uF046 {{ .Repo.Staging.String }}</>{{ end }}"
           }
         },
         {

--- a/themes/rudolfs-light.omp.json
+++ b/themes/rudolfs-light.omp.json
@@ -46,10 +46,10 @@
           "properties": {
             "fetch_status": true,
             "branch_max_length": 30,
-            "display_upstream_icon": true,
+            "fetch_upstream_icon": true,
             "prefix": " [",
             "postfix": "] ",
-            "template": "{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }}<#BD6200> \uF044 {{ .Repo.Working.String }}</>{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }}<#053F22> \uF046 {{ .Repo.Staging.String }}</>{{ end }}"
+            "template": "{{ .Repo.UpstreamIcon }}{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }}<#BD6200> \uF044 {{ .Repo.Working.String }}</>{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }}<#053F22> \uF046 {{ .Repo.Staging.String }}</>{{ end }}"
           }
         },
         {

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -512,6 +512,9 @@
             "properties": {
               "properties": {
                 "properties": {
+                  "template": {
+                    "$ref": "#/definitions/template"
+                  },
                   "branch_icon": {
                     "type": "string",
                     "title": "Branch Icon",
@@ -554,12 +557,6 @@
                     "description": "Display the local changes or not",
                     "default": true
                   },
-                  "display_status_detail": {
-                    "type": "boolean",
-                    "title": "Display Status Detail",
-                    "description": "Display the local changes in detail or not",
-                    "default": true
-                  },
                   "display_stash_count": {
                     "type": "boolean",
                     "title": "Display Stash Count",
@@ -571,36 +568,6 @@
                     "title": "Display Worktree Count",
                     "description": "Display the worktree count or not",
                     "default": false
-                  },
-                  "status_separator_icon": {
-                    "type": "string",
-                    "title": "Status Separator Icon",
-                    "description": "Icon/text to display between staging and working area changes",
-                    "default": " | "
-                  },
-                  "local_working_icon": {
-                    "type": "string",
-                    "title": "Local Working Icon",
-                    "description": "The icon to display in front of the working area changes",
-                    "default": "\uF044"
-                  },
-                  "local_staged_icon": {
-                    "type": "string",
-                    "title": "Local Staged Icon",
-                    "description": "The icon to display in front of the staged area changes",
-                    "default": "\uF046"
-                  },
-                  "stash_count_icon": {
-                    "type": "string",
-                    "title": "Stash Count Icon",
-                    "description": "The icon to display before the stash context",
-                    "default": "\uF692 "
-                  },
-                  "worktree_count_icon": {
-                    "type": "string",
-                    "title": "Worktree Count Icon",
-                    "description": "The icon to display before the worktree context",
-                    "default": "\uF1bb "
                   },
                   "commit_icon": {
                     "type": "string",
@@ -680,28 +647,6 @@
                     "description": "Icon/text to display when the upstream is not known/mapped",
                     "default": "\uE5FB"
                   },
-                  "working_color": { "$ref": "#/definitions/color" },
-                  "staging_color": { "$ref": "#/definitions/color" },
-                  "status_colors_enabled": {
-                    "type": "boolean",
-                    "title": "Status Colors Enabled",
-                    "description": "Color the segment based on the repository status",
-                    "default": false
-                  },
-                  "color_background": {
-                    "type": "boolean",
-                    "title": "Color Background",
-                    "description": "Color the background or foreground",
-                    "default": true
-                  },
-                  "local_changes_color": {
-                    "$ref": "#/definitions/color"
-                  },
-                  "ahead_and_behind_color": {
-                    "$ref": "#/definitions/color"
-                  },
-                  "behind_color": { "$ref": "#/definitions/color" },
-                  "ahead_color": { "$ref": "#/definitions/color" },
                   "branch_max_length": {
                     "type": "integer",
                     "title": "Branch max length",

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -170,7 +170,7 @@
             "rust",
             "owm",
             "memory",
-            "angularcli",
+            "angular",
             "php"
           ]
         },
@@ -1695,12 +1695,12 @@
         {
           "if": {
             "properties": {
-              "type": { "const": "angularcli" }
+              "type": { "const": "angular" }
             }
           },
           "then": {
             "title": "Angular CLI Segment",
-            "description": "https://ohmyposh.dev/docs/angularcli",
+            "description": "https://ohmyposh.dev/docs/angular",
             "properties": {
               "properties": {
                 "properties": {

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -515,17 +515,35 @@
                   "template": {
                     "$ref": "#/definitions/template"
                   },
+                  "fetch_status": {
+                    "type": "boolean",
+                    "title": "Display Status",
+                    "description": "Display the local changes or not",
+                    "default": true
+                  },
+                  "fetch_stash_count": {
+                    "type": "boolean",
+                    "title": "Display Stash Count",
+                    "description": "Display the stash count or not",
+                    "default": false
+                  },
+                  "fetch_worktree_count": {
+                    "type": "boolean",
+                    "title": "Display Worktree Count",
+                    "description": "Display the worktree count or not",
+                    "default": false
+                  },
+                  "fetch_upstream_icon": {
+                    "type": "boolean",
+                    "title": "Display Upstream Icon",
+                    "description": "Display upstream icon or not",
+                    "default": false
+                  },
                   "branch_icon": {
                     "type": "string",
                     "title": "Branch Icon",
                     "description": "The icon to use in front of the git branch name",
                     "default": "\uE0A0 "
-                  },
-                  "display_branch_status": {
-                    "type": "boolean",
-                    "title": "Display Branch Status",
-                    "description": "Display the branch status or not",
-                    "default": true
                   },
                   "branch_identical_icon": {
                     "type": "string",
@@ -550,24 +568,6 @@
                     "title": "Branch Gone Icon",
                     "description": "The icon to display when there's no remote branch",
                     "default": "\u2262"
-                  },
-                  "display_status": {
-                    "type": "boolean",
-                    "title": "Display Status",
-                    "description": "Display the local changes or not",
-                    "default": true
-                  },
-                  "display_stash_count": {
-                    "type": "boolean",
-                    "title": "Display Stash Count",
-                    "description": "Display the stash count or not",
-                    "default": false
-                  },
-                  "display_worktree_count": {
-                    "type": "boolean",
-                    "title": "Display Worktree Count",
-                    "description": "Display the worktree count or not",
-                    "default": false
                   },
                   "commit_icon": {
                     "type": "string",
@@ -610,12 +610,6 @@
                     "title": "No Commits Icon",
                     "description": "Icon/text to display when there are no commits in the repo",
                     "default": "\uF594"
-                  },
-                  "fetch_upstream_icon": {
-                    "type": "boolean",
-                    "title": "Display Upstream Icon",
-                    "description": "Display upstream icon or not",
-                    "default": false
                   },
                   "github_icon": {
                     "type": "string",

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -611,7 +611,7 @@
                     "description": "Icon/text to display when there are no commits in the repo",
                     "default": "\uF594"
                   },
-                  "display_upstream_icon": {
+                  "fetch_upstream_icon": {
                     "type": "boolean",
                     "title": "Display Upstream Icon",
                     "description": "Display upstream icon or not",

--- a/themes/slim.omp.json
+++ b/themes/slim.omp.json
@@ -80,8 +80,8 @@
           "background": "#2f2f2f",
           "foreground_templates": [
             "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#ffeb3b{{ end }}",
-            "{{ if .Repo.Ahead gt 0 }}#2EC4B6{{ end }}",
-            "{{ if .Repo.Behind gt 0 }}#8A4FFF{{ end }}"
+            "{{ if gt .Repo.Ahead 0 }}#2EC4B6{{ end }}",
+            "{{ if gt .Repo.Behind 0 }}#8A4FFF{{ end }}"
           ],
           "properties": {
             "fetch_stash_count": true,

--- a/themes/slim.omp.json
+++ b/themes/slim.omp.json
@@ -78,18 +78,17 @@
           "style": "diamond",
           "foreground": "#ffeb3b",
           "background": "#2f2f2f",
+          "foreground_templates": [
+            "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#ffeb3b{{ end }}",
+            "{{ if .Repo.Ahead gt 0 }}#2EC4B6{{ end }}",
+            "{{ if .Repo.Behind gt 0 }}#8A4FFF{{ end }}"
+          ],
           "properties": {
-            "display_stash_count": true,
+            "fetch_stash_count": true,
+            "fetch_status": true,
             "display_upstream_icon": true,
-            "display_status": true,
-            "status_colors_enabled": true,
-            "color_background": false,
-            "local_changes_color": "#ffeb3b",
-            "working_color": "#E84855",
-            "staging_color": "#2FDA4E",
-            "ahead_color": "#2EC4B6",
-            "behind_color": "#8A4FFF",
-            "prefix": "<#7a7a7a>\ue0b1 </>"
+            "prefix": "<#7a7a7a>\ue0b1 </>",
+            "template": "{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }}<#E84855> \uF044 {{ .Repo.Working.String }}</>{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }}<#2FDA4E> \uF046 {{ .Repo.Staging.String }}</>{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           }
         },
         {

--- a/themes/slim.omp.json
+++ b/themes/slim.omp.json
@@ -86,9 +86,9 @@
           "properties": {
             "fetch_stash_count": true,
             "fetch_status": true,
-            "display_upstream_icon": true,
+            "fetch_upstream_icon": true,
             "prefix": "<#7a7a7a>\ue0b1 </>",
-            "template": "{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }}<#E84855> \uF044 {{ .Repo.Working.String }}</>{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }}<#2FDA4E> \uF046 {{ .Repo.Staging.String }}</>{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
+            "template": "{{ .Repo.UpstreamIcon }}{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }}<#E84855> \uF044 {{ .Repo.Working.String }}</>{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }}<#2FDA4E> \uF046 {{ .Repo.Staging.String }}</>{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           }
         },
         {

--- a/themes/slimfat.omp.json
+++ b/themes/slimfat.omp.json
@@ -76,18 +76,17 @@
           "style": "diamond",
           "foreground": "#ffeb3b",
           "background": "#2f2f2f",
+          "foreground_templates": [
+            "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#ffeb3b{{ end }}",
+            "{{ if .Repo.Ahead gt 0 }}#2EC4B6{{ end }}",
+            "{{ if .Repo.Behind gt 0 }}#8A4FFF{{ end }}"
+          ],
           "properties": {
-            "display_stash_count": true,
+            "fetch_stash_count": true,
+            "fetch_status": true,
             "display_upstream_icon": true,
-            "display_status": true,
-            "status_colors_enabled": true,
-            "color_background": false,
-            "local_changes_color": "#ffeb3b",
-            "working_color": "#E84855",
-            "staging_color": "#2FDA4E",
-            "ahead_color": "#2EC4B6",
-            "behind_color": "#8A4FFF",
-            "prefix": "<#7a7a7a>\ue0b1 </>"
+            "prefix": "<#7a7a7a>\ue0b1 </>",
+            "template": "{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }}<#E84855> \uF044 {{ .Repo.Working.String }}</>{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }}<#2FDA4E> \uF046 {{ .Repo.Staging.String }}</>{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           }
         },
         {

--- a/themes/slimfat.omp.json
+++ b/themes/slimfat.omp.json
@@ -78,8 +78,8 @@
           "background": "#2f2f2f",
           "foreground_templates": [
             "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#ffeb3b{{ end }}",
-            "{{ if .Repo.Ahead gt 0 }}#2EC4B6{{ end }}",
-            "{{ if .Repo.Behind gt 0 }}#8A4FFF{{ end }}"
+            "{{ if gt .Repo.Ahead 0 }}#2EC4B6{{ end }}",
+            "{{ if gt .Repo.Behind 0 }}#8A4FFF{{ end }}"
           ],
           "properties": {
             "fetch_stash_count": true,

--- a/themes/slimfat.omp.json
+++ b/themes/slimfat.omp.json
@@ -84,9 +84,9 @@
           "properties": {
             "fetch_stash_count": true,
             "fetch_status": true,
-            "display_upstream_icon": true,
+            "fetch_upstream_icon": true,
             "prefix": "<#7a7a7a>\ue0b1 </>",
-            "template": "{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }}<#E84855> \uF044 {{ .Repo.Working.String }}</>{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }}<#2FDA4E> \uF046 {{ .Repo.Staging.String }}</>{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
+            "template": "{{ .Repo.UpstreamIcon }}{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }}<#E84855> \uF044 {{ .Repo.Working.String }}</>{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }}<#2FDA4E> \uF046 {{ .Repo.Staging.String }}</>{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           }
         },
         {

--- a/themes/sorin.omp.json
+++ b/themes/sorin.omp.json
@@ -34,7 +34,8 @@
           "style": "plain",
           "foreground": "#C1C106",
           "properties": {
-            "prefix": "<#ffffff>git:</>"
+            "prefix": "<#ffffff>git:</>",
+            "template": "{{ .Repo.HEAD }}"
           }
         },
         {

--- a/themes/space.omp.json
+++ b/themes/space.omp.json
@@ -18,7 +18,7 @@
             "prefix": "",
             "postfix": "",
             "macos": "mac"
-        }
+          }
         },
         {
           "type": "session",
@@ -48,9 +48,9 @@
           "invert_powerline": false,
           "properties": {
             "branch_icon": "",
-            "display_stash_count": true,
-            "display_status": false,
-            "prefix": "<#ffffff>on</> "
+            "fetch_stash_count": true,
+            "prefix": "<#ffffff>on</> ",
+            "template": "{{ .Repo.HEAD }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           }
         },
         {
@@ -111,8 +111,8 @@
           "style": "plain",
           "foreground": "#FFD54F",
           "properties": {
-              "prefix": "",
-              "text": "\u276F"
+            "prefix": "",
+            "text": "\u276F"
           }
         }
       ]

--- a/themes/spaceship.omp.json
+++ b/themes/spaceship.omp.json
@@ -1,60 +1,60 @@
 {
   "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
-	"final_space": false,
-	"osc99": false,
-	"console_title": false,
-	"blocks": [
-		{
-			"type": "prompt",
-			"alignment": "left",
-			"horizontal_offset": 0,
-			"vertical_offset": 0,
-			"segments": [
-				{
-					"type": "session",
-					"style": "plain",
-					"invert_powerline": false,
-					"foreground": "lightYellow",
-					"properties": {
-						"display_host": false,
-						"prefix": "",
-						"user_info_separator": "",
-						"display_user": true
-					}
-				},
-				{
-					"type": "path",
-					"style": "plain",
-					"invert_powerline": false,
-					"foreground": "cyan",
-					"properties": {
+  "final_space": false,
+  "osc99": false,
+  "console_title": false,
+  "blocks": [
+    {
+      "type": "prompt",
+      "alignment": "left",
+      "horizontal_offset": 0,
+      "vertical_offset": 0,
+      "segments": [
+        {
+          "type": "session",
+          "style": "plain",
+          "invert_powerline": false,
+          "foreground": "lightYellow",
+          "properties": {
+            "display_host": false,
+            "prefix": "",
+            "user_info_separator": "",
+            "display_user": true
+          }
+        },
+        {
+          "type": "path",
+          "style": "plain",
+          "invert_powerline": false,
+          "foreground": "cyan",
+          "properties": {
             "prefix": "<#ffffff>in</> ",
-						"style": "folder"
-					}
-				},
-				{
-					"type": "git",
-					"style": "plain",
-					"invert_powerline": false,
-					"foreground": "#ff94df",
-					"properties": {
-						"branch_icon": " <#ff94df><b> </b></>",
-						"display_stash_count": true,
-						"display_status": false,
-						"prefix": "<#ffffff>on</> "
-					}
-				},
+            "style": "folder"
+          }
+        },
+        {
+          "type": "git",
+          "style": "plain",
+          "invert_powerline": false,
+          "foreground": "#ff94df",
+          "properties": {
+            "branch_icon": " <#ff94df><b> </b></>",
+            "fetch_stash_count": true,
+            "prefix": "<#ffffff>on</> ",
+            "template": "{{ .Repo.HEAD }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
+          }
+        },
 
-				{
-					"type": "text",
-					"style": "plain",
-					"foreground": "lightGreen",
-					"properties": {
-						"prefix": "",
-						"text": "\u276F"
-					}
-				}
-			]
-		}
-	]
+        {
+          "type": "text",
+          "style": "plain",
+          "foreground": "lightGreen",
+          "properties": {
+            "prefix": "",
+            "text": "\u276F"
+          }
+        }
+      ]
+    }
+  ]
 }

--- a/themes/star.omp.json
+++ b/themes/star.omp.json
@@ -30,7 +30,8 @@
           "foreground": "#C678DD",
           "properties": {
             "prefix": "<#ffffff>on</> ",
-            "display_status": true
+            "fetch_status": true,
+            "template": "{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}"
           }
         },
         {

--- a/themes/stelbent.minimal.omp.json
+++ b/themes/stelbent.minimal.omp.json
@@ -68,29 +68,29 @@
           "powerline_symbol": "\ue0b0",
           "foreground": "#100e23",
           "background": "#95ffa4",
+          "background_templates": [
+            "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#ff9248{{ end }}",
+            "{{ if and (.Repo.Ahead gt 0) (.Repo.Behind gt 0) }}#f26d50{{ end }}",
+            "{{ if .Repo.Ahead gt 0 }}#89d1dc{{ end }}",
+            "{{ if .Repo.Behind gt 0 }}#c5b6ad{{ end }}"
+          ],
           "properties": {
+            "fetch_status": true,
+            "fetch_stash_count": true,
             "branch_ahead_icon": "\u2191",
             "branch_behind_icon": "\u2193",
             "branch_gone": "\u2262",
             "branch_icon": "\ue0a0 ",
             "branch_identical_icon": "\u2261",
             "cherry_pick_icon": "\u2713 ",
-            "color_background": true,
             "commit_icon": "\u25b7 ",
-            "display_status_detail": true,
             "local_staged_icon": "",
             "local_working_icon": "",
             "merge_icon": "\u25f4 ",
             "no_commits_icon": "[no commits]",
             "rebase_icon": "\u2c62 ",
-            "stash_count_icon": "",
-            "status_colors_enabled": true,
-            "status_separator_icon": " \u2502",
             "tag_icon": "\u25b6 ",
-            "local_changes_color": "#ff9248",
-            "ahead_and_behind_color": "#f26d50",
-            "behind_color": "#f17c37",
-            "ahead_color": "#89d1dc"
+            "template": "{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} \u2502{{ end }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} {{ .Repo.StashCount }}{{ end }}"
           }
         },
         {

--- a/themes/stelbent.minimal.omp.json
+++ b/themes/stelbent.minimal.omp.json
@@ -70,9 +70,9 @@
           "background": "#95ffa4",
           "background_templates": [
             "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#ff9248{{ end }}",
-            "{{ if and (.Repo.Ahead gt 0) (.Repo.Behind gt 0) }}#f26d50{{ end }}",
-            "{{ if .Repo.Ahead gt 0 }}#89d1dc{{ end }}",
-            "{{ if .Repo.Behind gt 0 }}#c5b6ad{{ end }}"
+            "{{ if and (gt .Repo.Ahead 0) (gt .Repo.Behind 0) }}#f26d50{{ end }}",
+            "{{ if gt .Repo.Ahead 0 }}#89d1dc{{ end }}",
+            "{{ if gt .Repo.Behind 0 }}#c5b6ad{{ end }}"
           ],
           "properties": {
             "fetch_status": true,

--- a/themes/tonybaloney.omp.json
+++ b/themes/tonybaloney.omp.json
@@ -24,8 +24,8 @@
           "powerline_symbol": "\uE0B0",
           "properties": {
             "fetch_stash_count": true,
-            "display_upstream_icon": true,
-            "template": "{{ .Repo.HEAD }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
+            "fetch_upstream_icon": true,
+            "template": "{{ .Repo.UpstreamIcon }}{{ .Repo.HEAD }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           },
           "style": "powerline",
           "type": "git"

--- a/themes/tonybaloney.omp.json
+++ b/themes/tonybaloney.omp.json
@@ -9,9 +9,8 @@
         {
           "background": "#18354c",
           "foreground": "#ffc107",
-          "powerline_symbol": "",
           "leading_diamond": "",
-          "trailing_diamond": "",
+          "trailing_diamond": "\uE0B0",
           "properties": {
             "prefix": "  ",
             "style": "folder"
@@ -22,30 +21,30 @@
         {
           "background": "#18354c",
           "foreground": "#ffc107",
-          "powerline_symbol": "",
+          "powerline_symbol": "\uE0B0",
           "properties": {
-            "display_stash_count": true,
+            "fetch_stash_count": true,
             "display_upstream_icon": true,
-            "status_colors_enabled": false
+            "template": "{{ .Repo.HEAD }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           },
           "style": "powerline",
           "type": "git"
         },
         {
-            "type": "python",
-            "style": "powerline",
-            "powerline_symbol": "\uE0B0",
-            "foreground": "#18354c",
-            "background": "#ffc107",
-            "properties": {
-              "prefix": " \uE235 "
-            }
-          },
-          
+          "type": "python",
+          "style": "powerline",
+          "powerline_symbol": "\uE0B0",
+          "foreground": "#18354c",
+          "background": "#ffc107",
+          "properties": {
+            "prefix": " \uE235 "
+          }
+        },
+
         {
           "background": "#ffc107",
           "foreground": "#18354c",
-          "powerline_symbol": "",
+          "powerline_symbol": "\uE0B0",
           "style": "powerline",
           "type": "root"
         }

--- a/themes/unicorn.omp.json
+++ b/themes/unicorn.omp.json
@@ -49,8 +49,8 @@
           "properties": {
             "fetch_status": true,
             "fetch_stash_count": true,
-            "display_upstream_icon": true,
-            "template": "{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
+            "fetch_upstream_icon": true,
+            "template": "{{ .Repo.UpstreamIcon }}{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           }
         },
         {

--- a/themes/unicorn.omp.json
+++ b/themes/unicorn.omp.json
@@ -37,19 +37,20 @@
         {
           "type": "git",
           "style": "powerline",
-          "powerline_symbol": "",
+          "powerline_symbol": "\uE0B0",
           "foreground": "#193549",
           "background": "#d2ff5e",
+          "background_templates": [
+            "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#ff9248{{ end }}",
+            "{{ if and (.Repo.Ahead gt 0) (.Repo.Behind gt 0) }}#f26d50{{ end }}",
+            "{{ if .Repo.Ahead gt 0 }}#89d1dc{{ end }}",
+            "{{ if .Repo.Behind gt 0 }}#f17c37{{ end }}"
+          ],
           "properties": {
-            "display_stash_count": true,
+            "fetch_status": true,
+            "fetch_stash_count": true,
             "display_upstream_icon": true,
-            "status_colors_enabled": true,
-            "display_status": true,
-            "local_changes_color": "#ff9248",
-            "ahead_and_behind_color": "#f26d50",
-            "behind_color": "#f17c37",
-            "ahead_color": "#89d1dc",
-            "stash_count_icon": "\uF692 "
+            "template": "{{ .Repo.HEAD }}{{ .Repo.BranchStatus }}{{ if .Repo.Working.Changed }} \uF044 {{ .Repo.Working.String }}{{ end }}{{ if and (.Repo.Working.Changed) (.Repo.Staging.Changed) }} |{{ end }}{{ if .Repo.Staging.Changed }} \uF046 {{ .Repo.Staging.String }}{{ end }}{{ if gt .Repo.StashCount 0 }} \uF692 {{ .Repo.StashCount }}{{ end }}"
           }
         },
         {

--- a/themes/unicorn.omp.json
+++ b/themes/unicorn.omp.json
@@ -42,9 +42,9 @@
           "background": "#d2ff5e",
           "background_templates": [
             "{{ if or (.Repo.Working.Changed) (.Repo.Staging.Changed) }}#ff9248{{ end }}",
-            "{{ if and (.Repo.Ahead gt 0) (.Repo.Behind gt 0) }}#f26d50{{ end }}",
-            "{{ if .Repo.Ahead gt 0 }}#89d1dc{{ end }}",
-            "{{ if .Repo.Behind gt 0 }}#f17c37{{ end }}"
+            "{{ if and (gt .Repo.Ahead 0) (gt .Repo.Behind 0) }}#f26d50{{ end }}",
+            "{{ if gt .Repo.Ahead 0 }}#89d1dc{{ end }}",
+            "{{ if gt .Repo.Behind 0 }}#f17c37{{ end }}"
           ],
           "properties": {
             "fetch_status": true,

--- a/themes/wopian.omp.json
+++ b/themes/wopian.omp.json
@@ -1,116 +1,117 @@
 {
-    "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
-    "blocks": [
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
+  "blocks": [
+    {
+      "type": "prompt",
+      "alignment": "left",
+      "segments": [
         {
-            "type": "prompt",
-            "alignment": "left",
-            "segments": [
-                {
-                    "type": "os",
-                    "style": "powerline",
-                    "foreground": "cyan",
-                    "properties": {
-                        "prefix": "",
-                        "postfix": "",
-                        "wsl": "",
-                        "wsl_separator": ""
-                    }
-                },
-                {
-                    "type": "path",
-                    "style": "plain",
-                    "foreground": "cyan",
-                    "properties": {
-                        "style": "full"
-                    }
-                },
-                {
-                    "type": "git",
-                    "style": "plain",
-                    "foreground": "lightYellow",
-                    "properties": {
-                        "prefix": ":: <lightBlue>git(</>",
-                        "postfix": "<lightBlue>)</>"
-                    }
-                }
-            ]
+          "type": "os",
+          "style": "powerline",
+          "foreground": "cyan",
+          "properties": {
+            "prefix": "",
+            "postfix": "",
+            "wsl": "",
+            "wsl_separator": ""
+          }
         },
         {
-            "type": "prompt",
-            "alignment": "right",
-            "segments": [
-                {
-                    "type": "node",
-                    "style": "plain",
-                    "foreground": "#68a063",
-                    "properties": {
-                        "display_version": true,
-                        "prefix": " ",
-                        "postfix": "",
-                        "display_mode": "files",
-                        "display_package_manager": true,
-                        "yarn_icon": "/yarn",
-                        "npm_icon": "/npm"
-                    }
-                },
-                {
-                    "type": "crystal",
-                    "style": "plain",
-                    "foreground": "#4063D8",
-                    "properties": {
-                        "display_version": true,
-                        "display_mode": "files",
-                        "prefix": " ",
-                        "postfix": ""
-                    }
-                },
-                {
-                    "type": "ruby",
-                    "style": "plain",
-                    "foreground": "#DE3F24",
-                    "properties": {
-                        "display_version": true,
-                        "prefix": " ",
-                        "postfix": "",
-                        "display_mode": "files"
-                    }
-                },
-                {
-                    "type": "python",
-                    "style": "plain",
-                    "foreground": "#FED142",
-                    "properties": {
-                        "display_virtual_env": false,
-                        "display_version": true,
-                        "prefix": " ",
-                        "postfix": "",
-                        "display_mode": "context"
-                    }
-                },
-                {
-                    "type": "time",
-                    "style": "plain",
-                    "foreground": "lightGreen"
-                }
-            ]
+          "type": "path",
+          "style": "plain",
+          "foreground": "cyan",
+          "properties": {
+            "style": "full"
+          }
         },
         {
-            "type": "prompt",
-            "alignment": "left",
-            "newline": true,
-            "segments": [
-                {
-                    "type": "exit",
-                    "style": "powerline",
-                    "foreground": "lightGreen",
-                    "properties": {
-                        "display_exit_code": false,
-                        "always_enabled": true,
-                        "error_color": "red",
-                        "prefix": "\u279c"
-                    }
-                }
-            ]
+          "type": "git",
+          "style": "plain",
+          "foreground": "lightYellow",
+          "properties": {
+            "prefix": ":: <lightBlue>git(</>",
+            "postfix": "<lightBlue>)</>",
+            "template": "{{ .Repo.HEAD }}"
+          }
         }
-    ]
+      ]
+    },
+    {
+      "type": "prompt",
+      "alignment": "right",
+      "segments": [
+        {
+          "type": "node",
+          "style": "plain",
+          "foreground": "#68a063",
+          "properties": {
+            "display_version": true,
+            "prefix": " ",
+            "postfix": "",
+            "display_mode": "files",
+            "display_package_manager": true,
+            "yarn_icon": "/yarn",
+            "npm_icon": "/npm"
+          }
+        },
+        {
+          "type": "crystal",
+          "style": "plain",
+          "foreground": "#4063D8",
+          "properties": {
+            "display_version": true,
+            "display_mode": "files",
+            "prefix": " ",
+            "postfix": ""
+          }
+        },
+        {
+          "type": "ruby",
+          "style": "plain",
+          "foreground": "#DE3F24",
+          "properties": {
+            "display_version": true,
+            "prefix": " ",
+            "postfix": "",
+            "display_mode": "files"
+          }
+        },
+        {
+          "type": "python",
+          "style": "plain",
+          "foreground": "#FED142",
+          "properties": {
+            "display_virtual_env": false,
+            "display_version": true,
+            "prefix": " ",
+            "postfix": "",
+            "display_mode": "context"
+          }
+        },
+        {
+          "type": "time",
+          "style": "plain",
+          "foreground": "lightGreen"
+        }
+      ]
+    },
+    {
+      "type": "prompt",
+      "alignment": "left",
+      "newline": true,
+      "segments": [
+        {
+          "type": "exit",
+          "style": "powerline",
+          "foreground": "lightGreen",
+          "properties": {
+            "display_exit_code": false,
+            "always_enabled": true,
+            "error_color": "red",
+            "prefix": "\u279c"
+          }
+        }
+      ]
+    }
+  ]
 }

--- a/themes/xtoys.omp.json
+++ b/themes/xtoys.omp.json
@@ -37,9 +37,8 @@
           "properties": {
             "prefix": "HEAD:",
             "branch_icon": "",
-            "display_status": false,
             "display_upstream_icon": false,
-            "display_stash_count": false
+            "template": "{{ .Repo.HEAD }}"
           }
         },
         {

--- a/themes/xtoys.omp.json
+++ b/themes/xtoys.omp.json
@@ -37,8 +37,8 @@
           "properties": {
             "prefix": "HEAD:",
             "branch_icon": "",
-            "display_upstream_icon": false,
-            "template": "{{ .Repo.HEAD }}"
+            "fetch_upstream_icon": false,
+            "template": "{{ .Repo.UpstreamIcon }}{{ .Repo.HEAD }}"
           }
         },
         {

--- a/themes/ys.omp.json
+++ b/themes/ys.omp.json
@@ -1,107 +1,108 @@
 {
-    "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
-    "blocks": [
-      {
-        "type": "prompt",
-        "alignment": "left",
-        "segments": [
-          {
-            "type": "python",
-            "style": "plain",
-            "foreground": "white",
-            "properties": {
-              "prefix": "(",
-              "postfix": ")",
-              "display_version": false
-            }
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
+  "blocks": [
+    {
+      "type": "prompt",
+      "alignment": "left",
+      "segments": [
+        {
+          "type": "python",
+          "style": "plain",
+          "foreground": "white",
+          "properties": {
+            "prefix": "(",
+            "postfix": ")",
+            "display_version": false
           }
-        ]
-      },
-      {
-        "type": "prompt",
-        "alignment": "left",
-        "newline": true,
-        "segments": [
-          {
-            "type": "text",
-            "style": "plain",
-            "foreground": "lightBlue",
-            "properties": {
-              "prefix": "",
-              "text": "#"
-            }
-          },
-          {
-            "type": "root",
-            "style": "plain",
-            "foreground": "red",
-            "properties": {
-              "root_icon": "%"
-            }
-          },
-          {
-            "type": "session",
-            "style": "plain",
-            "properties": {
-              "user_info_separator": " <darkGray>@</> ",
-              "prefix": "",
-              "user_color": "cyan",
-              "host_color": "green"
-            }
-          },
-          {
-            "type": "path",
-            "style": "plain",
-            "foreground": "lightYellow",
-            "properties": {
-              "prefix": "<darkGray>in </>",
-              "style": "full"
-            }
-          },
-          {
-            "type": "git",
-            "style": "plain",
-            "properties": {
-              "prefix": "<darkGray>on</> <white>git:</>"
-            }
-          },
-          {
-            "type": "time",
-            "style": "plain",
-            "foreground": "darkGray",
-            "properties": {
-              "prefix": "[",
-              "postfix": "]"
-            }
-          },
-          {
-            "type": "exit",
-            "style": "plain",
-            "foreground": "red",
-            "properties": {
-              "prefix": " C:",
-              "always_numeric": true
-            }
+        }
+      ]
+    },
+    {
+      "type": "prompt",
+      "alignment": "left",
+      "newline": true,
+      "segments": [
+        {
+          "type": "text",
+          "style": "plain",
+          "foreground": "lightBlue",
+          "properties": {
+            "prefix": "",
+            "text": "#"
           }
-        ]
-      },
-      {
-        "type": "prompt",
-        "alignment": "left",
-        "newline": true,
-        "segments": [
-          {
-            "type": "text",
-            "style": "plain",
-            "foreground": "lightRed",
-            "properties": {
-              "prefix": "",
-              "text": "$",
-              "postfix": ""
-            }
+        },
+        {
+          "type": "root",
+          "style": "plain",
+          "foreground": "red",
+          "properties": {
+            "root_icon": "%"
           }
-        ]
-      }
-    ],
-    "final_space": true
-  }
+        },
+        {
+          "type": "session",
+          "style": "plain",
+          "properties": {
+            "user_info_separator": " <darkGray>@</> ",
+            "prefix": "",
+            "user_color": "cyan",
+            "host_color": "green"
+          }
+        },
+        {
+          "type": "path",
+          "style": "plain",
+          "foreground": "lightYellow",
+          "properties": {
+            "prefix": "<darkGray>in </>",
+            "style": "full"
+          }
+        },
+        {
+          "type": "git",
+          "style": "plain",
+          "properties": {
+            "prefix": "<darkGray>on</> <white>git:</>",
+            "template": "{{ .Repo.HEAD }}"
+          }
+        },
+        {
+          "type": "time",
+          "style": "plain",
+          "foreground": "darkGray",
+          "properties": {
+            "prefix": "[",
+            "postfix": "]"
+          }
+        },
+        {
+          "type": "exit",
+          "style": "plain",
+          "foreground": "red",
+          "properties": {
+            "prefix": " C:",
+            "always_numeric": true
+          }
+        }
+      ]
+    },
+    {
+      "type": "prompt",
+      "alignment": "left",
+      "newline": true,
+      "segments": [
+        {
+          "type": "text",
+          "style": "plain",
+          "foreground": "lightRed",
+          "properties": {
+            "prefix": "",
+            "text": "$",
+            "postfix": ""
+          }
+        }
+      ]
+    }
+  ],
+  "final_space": true
+}

--- a/themes/zash.omp.json
+++ b/themes/zash.omp.json
@@ -40,9 +40,9 @@
           "foreground": "#D4AAFC",
           "properties": {
             "branch_icon": "",
-            "display_status": false,
             "prefix": " <#DDB15F>git(</>",
-            "postfix": "<#DDB15F>)</>"
+            "postfix": "<#DDB15F>)</>",
+            "template": "{{ .Repo.HEAD }}"
           }
         },
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

Introduces templating functionality for the git segment.
As this can eventually resolve into removing quite a bit of switches, we can decide to do a major increment (BREAKING CHANGE)
or keep the "old way" supported but no longer offer support.

- refactor(git): add template capabilities
- refactor(git): allow status in template
- refactor(git): add upstream icon to repo
- refactor(git): add branch status to template
- refactor(git): move deprecated functions

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
