### PR TITLE
fix: Apply consistent casing for drive letters and only drive letters

### DIFF
--- a/src/environment.go
+++ b/src/environment.go
@@ -186,7 +186,7 @@ func (env *environment) getcwd() string {
 	correctPath := func(pwd string) string {
 		// on Windows, and being case sensitive and not consistent and all, this gives silly issues
 		driveLetter := getCompiledRegex(`^[a-z]:`)
-		return driveLetter.ReplaceAllStringFunc(pwd, func(letter string) string {return strings.ToUpper(letter)})
+		return driveLetter.ReplaceAllStringFunc(pwd, strings.ToUpper)
 	}
 	if env.args != nil && *env.args.PWD != "" {
 		env.cwd = correctPath(*env.args.PWD)

--- a/src/environment.go
+++ b/src/environment.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"sync"
@@ -185,7 +186,8 @@ func (env *environment) getcwd() string {
 	}
 	correctPath := func(pwd string) string {
 		// on Windows, and being case sensitive and not consistent and all, this gives silly issues
-		return strings.Replace(pwd, "c:", "C:", 1)
+		driveLetter := regexp.MustCompile(`^[a-z]:`)
+		return driveLetter.ReplaceAllStringFunc(pwd, func(letter string) string {return strings.ToUpper(letter)})
 	}
 	if env.args != nil && *env.args.PWD != "" {
 		env.cwd = correctPath(*env.args.PWD)

--- a/src/environment.go
+++ b/src/environment.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"runtime"
 	"strings"
 	"sync"
@@ -186,7 +185,7 @@ func (env *environment) getcwd() string {
 	}
 	correctPath := func(pwd string) string {
 		// on Windows, and being case sensitive and not consistent and all, this gives silly issues
-		driveLetter := regexp.MustCompile(`^[a-z]:`)
+		driveLetter := getCompiledRegex(`^[a-z]:`)
 		return driveLetter.ReplaceAllStringFunc(pwd, func(letter string) string {return strings.ToUpper(letter)})
 	}
 	if env.args != nil && *env.args.PWD != "" {

--- a/src/environment_test.go
+++ b/src/environment_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"flag"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,30 +21,3 @@ func TestHostNameWithLan(t *testing.T) {
 	cleanHostName := cleanHostName(hostName)
 	assert.Equal(t, "hello", cleanHostName)
 }
-
-func TestPathWithDriveLetter(t *testing.T) {
-	args := &args{
-		Debug: flag.Bool(
-			"debug",
-			false,
-			"Print debug information"),
-		PWD: flag.String(
-			"pwd",
-			"",
-			"the path you are working in"),
-	}
-
-	testPath := func(t *testing.T, inputPath string, expectedResult string)  {
-		env := &environment{}
-		env.init(args)
-		env.args.PWD = &inputPath
-		assert.Equal(t, env.getcwd(), expectedResult)
-	}
-	testPath(t, `C:\Windows\`, `C:\Windows\`)
-	testPath(t, `c:\Windows\`, `C:\Windows\`)
-	testPath(t, `p:\other\`, `P:\other\`)
-	testPath(t, `other:\other\`, `other:\other\`)
-	testPath(t, `src:\source\`, `src:\source\`)
-	testPath(t, `HKLM:\SOFTWARE\magnetic:test\`, `HKLM:\SOFTWARE\magnetic:test\`)
-}
-

--- a/src/environment_test.go
+++ b/src/environment_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,3 +22,30 @@ func TestHostNameWithLan(t *testing.T) {
 	cleanHostName := cleanHostName(hostName)
 	assert.Equal(t, "hello", cleanHostName)
 }
+
+func TestPathWithDriveLetter(t *testing.T) {
+	args := &args{
+		Debug: flag.Bool(
+			"debug",
+			false,
+			"Print debug information"),
+		PWD: flag.String(
+			"pwd",
+			"",
+			"the path you are working in"),
+	}
+
+	testPath := func(t *testing.T, inputPath string, expectedResult string)  {
+		env := &environment{}
+		env.init(args)
+		env.args.PWD = &inputPath
+		assert.Equal(t, env.getcwd(), expectedResult)
+	}
+	testPath(t, `C:\Windows\`, `C:\Windows\`)
+	testPath(t, `c:\Windows\`, `C:\Windows\`)
+	testPath(t, `p:\other\`, `P:\other\`)
+	testPath(t, `other:\other\`, `other:\other\`)
+	testPath(t, `src:\source\`, `src:\source\`)
+	testPath(t, `HKLM:\SOFTWARE\magnetic:test\`, `HKLM:\SOFTWARE\magnetic:test\`)
+}
+

--- a/src/segment_path_test.go
+++ b/src/segment_path_test.go
@@ -671,6 +671,62 @@ func TestWritePathInfoWindowsOutsideHomeOneLevels(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
+func TestWritePathInfoWindowsLowerCaseDriveLetter(t *testing.T) {
+	home := homeBillWindows
+	want := "C: > Windows"
+	got := testWritePathInfo(home, "c:\\Windows\\", "\\")
+	assert.Equal(t, want, got)
+}
+
+func TestWritePathInfoWindowsOtherDriveLetters(t *testing.T) {
+	home := homeBillWindows
+	want := "P: > Other"
+	got := testWritePathInfo(home, "P:\\Other\\", "\\")
+	assert.Equal(t, want, got)
+}
+
+func TestWritePathInfoWindowsOtherDriveLettersLowerCase(t *testing.T) {
+	home := homeBillWindows
+	want := "P: > Other"
+	got := testWritePathInfo(home, "p:\\Other\\", "\\")
+	assert.Equal(t, want, got)
+}
+
+func TestWritePathInfoWindowsCustomDrive(t *testing.T) {
+	home := homeBillWindows
+	want := "other: > other"
+	got := testWritePathInfo(home, "other:\\other\\", "\\")
+	assert.Equal(t, want, got)
+}
+
+func TestWritePathInfoWindowsCustomDriveEndingWithC(t *testing.T) {
+	home := homeBillWindows
+	want := "src: > source"
+	got := testWritePathInfo(home, "src:\\source\\", "\\")
+	assert.Equal(t, want, got)
+}
+
+func TestWritePathInfoWindowsCustomDriveEndingWithCArbitraryCasing(t *testing.T) {
+	home := homeBillWindows
+	want := "sRc: > source"
+	got := testWritePathInfo(home, "sRc:\\source\\", "\\")
+	assert.Equal(t, want, got)
+}
+
+func TestWritePathInfoWindowsRegistryDrives(t *testing.T) {
+	home := homeBillWindows
+	want := "\uf013 > f > magnetic:test"
+	got := testWritePathInfo(home, "HKLM:\\SOFTWARE\\magnetic:test\\", "\\")
+	assert.Equal(t, want, got)
+}
+
+func TestWritePathInfoWindowsRegistryDrivePreserveCase(t *testing.T) {
+	home := homeBillWindows
+	want := "\uf013 > f > magnetic:TOAST"
+	got := testWritePathInfo(home, "HKLM:\\SOFTWARE\\magnetic:TOAST\\", "\\")
+	assert.Equal(t, want, got)
+}
+
 func TestWritePathInfoUnixOutsideHome(t *testing.T) {
 	home := homeJan
 	want := "mnt > f > f > location"


### PR DESCRIPTION
resolved #1173

### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

Apply proper casing for all drive letters, not just `C:`. Also, ignores anything that's not really a pure drive letter, such as all the rest of the custom PSDrives (it was only by luck that none of the default non-drive-letters PSDrives end in `c`), and `c:` in the middle of the path.
