### PR TITLE
feat(dotnet): template + semver regex

### DIFF
--- a/docs/docs/segment-dotnet.md
+++ b/docs/docs/segment-dotnet.md
@@ -36,3 +36,18 @@ Display the currently active .NET SDK version.
   or `*.fsproj` files are present (default)
 - unsupported_version_icon: `string` - text/icon that is displayed when the active .NET SDK version (e.g., one specified
   by `global.json`) is not installed/supported - defaults to `\uf071` (X in a rectangle box)
+- template: `string` - A go [text/template][go-text-template] template extended with [sprig][sprig] utilizing the
+properties below. Defaults does nothing(backward compatibility).
+- version_url_template: `string` - A go [text/template][go-text-template] template extended
+with [sprig][sprig] utilizing the properties below. Defaults does nothing(backward compatibility).
+
+### Template Properties
+
+- `.Major`: `string` - is the major version
+- `.Minor`: `string` - is the minor version
+- `.Patch`: `string` - is the patch version
+- `.Prerelease`: `string` - is the prerelease version
+- `.BuildMetadata`: `string` - is the build metadata
+
+[go-text-template]: https://golang.org/pkg/text/template/
+[sprig]: https://masterminds.github.io/sprig/

--- a/src/properties.go
+++ b/src/properties.go
@@ -29,6 +29,8 @@ const (
 	AlwaysEnabled Property = "always_enabled"
 	// SegmentTemplate is the template to use to render the information
 	SegmentTemplate Property = "template"
+	// VersionURLTemplate is the template to use when building language segment hyperlink
+	VersionURLTemplate Property = "version_url_template"
 	// DisplayError to display when an error occurs or not
 	DisplayError Property = "display_error"
 	// DisplayDefault hides or shows the default

--- a/src/segment_dotnet.go
+++ b/src/segment_dotnet.go
@@ -30,7 +30,8 @@ func (d *dotnet) init(props *properties, env environmentInfo) {
 			{
 				executable: "dotnet",
 				args:       []string{"--version"},
-				regex:      `(?:(?P<version>((?P<major>[0-9]+).(?P<minor>[0-9]+).(?:\d{2})(?P<patch>[0-9]{1}))))`,
+				regex: `(?P<version>((?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)` +
+					`(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?))`,
 			},
 		},
 		versionURLTemplate: "[%1s](https://github.com/dotnet/core/blob/master/release-notes/%[2]s.%[3]s/%[2]s.%[3]s.%[4]s/%[2]s.%[3]s.%[4]s.md)",

--- a/src/segment_node.go
+++ b/src/segment_node.go
@@ -61,5 +61,5 @@ func (n *node) matchesVersionFile() bool {
 	if len(fileVersion) == 0 {
 		return true
 	}
-	return fileVersion == n.language.activeCommand.version.full
+	return fileVersion == n.language.activeCommand.version.Full
 }

--- a/src/segment_node_test.go
+++ b/src/segment_node_test.go
@@ -26,7 +26,7 @@ func TestNodeMatchesVersionFile(t *testing.T) {
 				env: env,
 				activeCommand: &cmd{
 					version: &version{
-						full: tc.Version,
+						Full: tc.Version,
 					},
 				},
 			},


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

WIP  
New regex to extract rc part + template 

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
