### PR TITLE
fix: node segment enable_version_mismatch

### DIFF
--- a/src/segment_node.go
+++ b/src/segment_node.go
@@ -61,5 +61,13 @@ func (n *node) matchesVersionFile() bool {
 	if len(fileVersion) == 0 {
 		return true
 	}
-	return fileVersion == n.language.activeCommand.version.Full
+
+	regex := fmt.Sprintf(
+		`(?im)^v?%s(\.?%s)?(\.?%s)?$`,
+		n.language.activeCommand.version.Major,
+		n.language.activeCommand.version.Minor,
+		n.language.activeCommand.version.Patch,
+	)
+
+	return matchString(regex, fileVersion)
 }

--- a/src/segment_node_test.go
+++ b/src/segment_node_test.go
@@ -7,15 +7,26 @@ import (
 )
 
 func TestNodeMatchesVersionFile(t *testing.T) {
+	nodeVersion := version{
+		Full:  "1.2.3",
+		Major: "1",
+		Minor: "2",
+		Patch: "3",
+	}
 	cases := []struct {
 		Case      string
 		Expected  bool
 		RCVersion string
-		Version   string
+		Version   version
 	}{
-		{Case: "no file context", Expected: true, RCVersion: "", Version: "durp"},
-		{Case: "version match", Expected: true, RCVersion: "durp", Version: "durp"},
-		{Case: "version mismatch", Expected: false, RCVersion: "werp", Version: "durp"},
+		{Case: "no file context", Expected: true, RCVersion: "", Version: nodeVersion},
+		{Case: "version match", Expected: true, RCVersion: "1.2.3", Version: nodeVersion},
+		{Case: "version mismatch", Expected: false, RCVersion: "3.2.1", Version: nodeVersion},
+		{Case: "version match in other format", Expected: true, RCVersion: "v1.2.3", Version: nodeVersion},
+		{Case: "version match without patch", Expected: true, RCVersion: "1.2", Version: nodeVersion},
+		{Case: "version match without patch in other format", Expected: true, RCVersion: "v1.2", Version: nodeVersion},
+		{Case: "version match without minor", Expected: true, RCVersion: "1", Version: nodeVersion},
+		{Case: "version match without minor in other format", Expected: true, RCVersion: "v1", Version: nodeVersion},
 	}
 
 	for _, tc := range cases {
@@ -25,9 +36,7 @@ func TestNodeMatchesVersionFile(t *testing.T) {
 			language: &language{
 				env: env,
 				activeCommand: &cmd{
-					version: &version{
-						Full: tc.Version,
-					},
+					version: &tc.Version,
 				},
 			},
 		}

--- a/src/segment_node_test.go
+++ b/src/segment_node_test.go
@@ -17,16 +17,15 @@ func TestNodeMatchesVersionFile(t *testing.T) {
 		Case      string
 		Expected  bool
 		RCVersion string
-		Version   version
 	}{
-		{Case: "no file context", Expected: true, RCVersion: "", Version: nodeVersion},
-		{Case: "version match", Expected: true, RCVersion: "1.2.3", Version: nodeVersion},
-		{Case: "version mismatch", Expected: false, RCVersion: "3.2.1", Version: nodeVersion},
-		{Case: "version match in other format", Expected: true, RCVersion: "v1.2.3", Version: nodeVersion},
-		{Case: "version match without patch", Expected: true, RCVersion: "1.2", Version: nodeVersion},
-		{Case: "version match without patch in other format", Expected: true, RCVersion: "v1.2", Version: nodeVersion},
-		{Case: "version match without minor", Expected: true, RCVersion: "1", Version: nodeVersion},
-		{Case: "version match without minor in other format", Expected: true, RCVersion: "v1", Version: nodeVersion},
+		{Case: "no file context", Expected: true, RCVersion: ""},
+		{Case: "version match", Expected: true, RCVersion: "1.2.3"},
+		{Case: "version mismatch", Expected: false, RCVersion: "3.2.1"},
+		{Case: "version match in other format", Expected: true, RCVersion: "v1.2.3"},
+		{Case: "version match without patch", Expected: true, RCVersion: "1.2"},
+		{Case: "version match without patch in other format", Expected: true, RCVersion: "v1.2"},
+		{Case: "version match without minor", Expected: true, RCVersion: "1"},
+		{Case: "version match without minor in other format", Expected: true, RCVersion: "v1"},
 	}
 
 	for _, tc := range cases {
@@ -36,7 +35,7 @@ func TestNodeMatchesVersionFile(t *testing.T) {
 			language: &language{
 				env: env,
 				activeCommand: &cmd{
-					version: &tc.Version,
+					version: &nodeVersion,
 				},
 			},
 		}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

The `.nvmrc` file can contain a node version in [different formats](https://github.com/nvm-sh/nvm#nvmrc), but currently this behavior is not supported. This fix adds more formats of `.nvmrc` file content.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
