### PR TITLE
feature: wifi segment

### DIFF
--- a/docs/docs/segment-wifi.md
+++ b/docs/docs/segment-wifi.md
@@ -1,0 +1,47 @@
+---
+id: wifi
+title: WiFi
+sidebar_label: WiFi
+---
+
+## What
+
+Show details about the connected WiFi network.
+
+## Sample Configuration
+
+```json
+{
+  "type": "wifi",
+  "style": "powerline",
+  "background": "#8822ee",
+  "foreground": "#eeeeee",
+  "powerline_symbol": "\uE0B0",
+  "properties": {
+    "template": "{{if .Connectected}}\uFAA8{{else}}\uFAA9{{end}}{{if .Connected}}{{.SSID}} {{.Signal}}% {{.ReceiveRate}}Mbps{{else}}{{.State}}{{end}}"
+  }
+}
+```
+
+## Properties
+
+- connected_icon: `string` - the icon to use when WiFi is connected - defaults to `\uFAA8`
+- connected_icon: `string` - the icon to use when WiFi is disconnected - defaults to `\uFAA9`
+- template: `string` - A go [text/template][go-text-template] template extended with [sprig][sprig]
+utilizing the properties below -
+defaults to `{{if .Connectected}}\uFAA8{{else}}\uFAA9{{end}}{{if .Connected}}{{.SSID}} {{.Signal}}% {{.ReceiveRate}}Mbps{{else}}{{.State}}{{end}}`
+
+## Template Properties
+
+- `.Connected`: `bool` - if WiFi is currently connected
+- `.State`: `string` - WiFi connection status - e.g. connected or disconnected
+- `.SSID`: `string` - the SSID of the current wifi network
+- `.RadioType`: `string` - the radio type - e.g. 802.11ac, 802.11ax, 802.11n, etc.
+- `.Authentication`: `string` - the authentication type - e.g. WPA2-Personal, WPA2-Enterprise, etc.
+- `.Channel`: `int` - the current channel number
+- `.ReceiveRate`: `int` - the receive rate (Mbps)
+- `.TransmitRate`: `int` - the transmit rate (Mbps)
+- `.Signal`: `int` - the signal strength (%)
+
+[go-text-template]: https://golang.org/pkg/text/template/
+[sprig]: https://masterminds.github.io/sprig/

--- a/docs/docs/segment-wifi.md
+++ b/docs/docs/segment-wifi.md
@@ -6,7 +6,11 @@ sidebar_label: WiFi
 
 ## What
 
-Show details about the connected WiFi network.
+Show details about the currently connected WiFi network.
+
+::info
+Currently only supports Windows and WSL. Pull requests for Darwin and Linux support are welcome :)
+:::
 
 ## Sample Configuration
 
@@ -15,29 +19,30 @@ Show details about the connected WiFi network.
   "type": "wifi",
   "style": "powerline",
   "background": "#8822ee",
-  "foreground": "#eeeeee",
+  "foreground": "#222222",
+  "background_templates": [
+    "{{ if (not .Connected) }}#FF1111{{ end }}"
+    "{{ if (lt .Signal 60) }}#DDDD11{{ else if (lt .Signal 90) }}#DD6611{{ else }}#11CC11{{ end }}"
+  ],
   "powerline_symbol": "\uE0B0",
   "properties": {
-    "template": "{{if .Connectected}}\uFAA8{{else}}\uFAA9{{end}}{{if .Connected}}{{.SSID}} {{.Signal}}% {{.ReceiveRate}}Mbps{{else}}{{.State}}{{end}}"
+    "template": "{{ if .Connected }}\uFAA8{{ else }}\uFAA9{{ end }}
+    {{ if .Connected }}{{ .SSID }} {{ .Signal }}% {{ .ReceiveRate }}Mbps{{ else }}{{ .State }}{{ end }}"
   }
 }
 ```
 
 ## Properties
 
-- connected_icon: `string` - the icon to use when WiFi is connected - defaults to `\uFAA8`
-- connected_icon: `string` - the icon to use when WiFi is disconnected - defaults to `\uFAA9`
-- template: `string` - A go [text/template][go-text-template] template extended with [sprig][sprig]
-utilizing the properties below -
-defaults to `{{if .Connectected}}\uFAA8{{else}}\uFAA9{{end}}{{if .Connected}}{{.SSID}} {{.Signal}}% {{.ReceiveRate}}Mbps{{else}}{{.State}}{{end}}`
+- template: `string` - A go [text/template][go-text-template]  extended with [sprig][sprig] using the properties below
 
 ## Template Properties
 
 - `.Connected`: `bool` - if WiFi is currently connected
-- `.State`: `string` - WiFi connection status - e.g. connected or disconnected
+- `.State`: `string` - WiFi connection status - _e.g. connected or disconnected_
 - `.SSID`: `string` - the SSID of the current wifi network
-- `.RadioType`: `string` - the radio type - e.g. 802.11ac, 802.11ax, 802.11n, etc.
-- `.Authentication`: `string` - the authentication type - e.g. WPA2-Personal, WPA2-Enterprise, etc.
+- `.RadioType`: `string` - the radio type - _e.g. 802.11ac, 802.11ax, 802.11n, etc._
+- `.Authentication`: `string` - the authentication type - _e.g. WPA2-Personal, WPA2-Enterprise, etc._
 - `.Channel`: `int` - the current channel number
 - `.ReceiveRate`: `int` - the receive rate (Mbps)
 - `.TransmitRate`: `int` - the transmit rate (Mbps)

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -71,6 +71,7 @@ module.exports = {
         "terraform",
         "text",
         "time",
+        "wifi",
         "ytm",
       ],
     },

--- a/src/segment.go
+++ b/src/segment.go
@@ -130,6 +130,8 @@ const (
 	Angular SegmentType = "angular"
 	// PHP writes which php version is currently active
 	PHP SegmentType = "php"
+	// WiFi writes details about the current WiFi connection
+	WiFi SegmentType = "wifi"
 )
 
 func (segment *Segment) string() string {
@@ -263,6 +265,7 @@ func (segment *Segment) mapSegmentWithWriter(env environmentInfo) error {
 		SysInfo:       &sysinfo{},
 		Angular:       &angular{},
 		PHP:           &php{},
+		WiFi:          &wifi{},
 	}
 	if writer, ok := functions[segment.Type]; ok {
 		props := &properties{

--- a/src/segment_wifi.go
+++ b/src/segment_wifi.go
@@ -50,7 +50,8 @@ func (w *wifi) enabled() bool {
 }
 
 func (w *wifi) string() string {
-	const defaultTemplate string = "{{ if .Connected }}\uFAA8{{ else }}\uFAA9{{ end }}{{ if .Connected }}{{ .SSID }} {{ .Signal }}% {{ .ReceiveRate }}Mbps{{ else }}{{ .State }}{{ end }}"
+	const defaultTemplate string = "{{ if .Connected }}\uFAA8{{ else }}\uFAA9{{ end }}" +
+		"{{ if .Connected }}{{ .SSID }} {{ .Signal }}% {{ .ReceiveRate }}Mbps{{ else }}{{ .State }}{{ end }}"
 
 	segmentTemplate := w.props.getString(SegmentTemplate, defaultTemplate)
 	template := &textTemplate{
@@ -63,7 +64,7 @@ func (w *wifi) string() string {
 		return err.Error()
 	}
 
-	return fmt.Sprintf("%s", text)
+	return text
 }
 
 func (w *wifi) init(props *properties, env environmentInfo) {

--- a/src/segment_wifi.go
+++ b/src/segment_wifi.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type wifi struct {
+	props          *properties
+	env            environmentInfo
+	Connected      bool
+	State          string
+	SSID           string
+	RadioType      string
+	Authentication string
+	Channel        int
+	ReceiveRate    int
+	TransmitRate   int
+	Signal         int
+}
+
+func (w *wifi) enabled() bool {
+	// This segment only supports Windows/WSL for now
+	if w.env.getPlatform() != windowsPlatform && !w.env.isWsl() {
+		return false
+	}
+
+	// Bail out of no netsh command found
+	cmd := "netsh.exe"
+	if !w.env.hasCommand(cmd) {
+		return false
+	}
+
+	// Attempt to retrieve output from netsh command
+	cmdResult, err := w.env.runCommand(cmd, "wlan", "show", "interfaces")
+	displayError := w.props.getBool(DisplayError, false)
+	if err != nil && displayError {
+		w.State = fmt.Sprintf("WIFI ERR: %s", err)
+		return true
+	}
+	if err != nil {
+		return false
+	}
+
+	// Extract data from netsh cmdResult
+	parseNetshCmdResult(cmdResult, w)
+
+	return true
+}
+
+func (w *wifi) string() string {
+	const defaultTemplate string = "{{ if .Connected }}\uFAA8{{ else }}\uFAA9{{ end }}{{ if .Connected }}{{ .SSID }} {{ .Signal }}% {{ .ReceiveRate }}Mbps{{ else }}{{ .State }}{{ end }}"
+
+	segmentTemplate := w.props.getString(SegmentTemplate, defaultTemplate)
+	template := &textTemplate{
+		Template: segmentTemplate,
+		Context:  w,
+		Env:      w.env,
+	}
+	text, err := template.render()
+	if err != nil {
+		return err.Error()
+	}
+
+	return fmt.Sprintf("%s", text)
+}
+
+func (w *wifi) init(props *properties, env environmentInfo) {
+	w.props = props
+	w.env = env
+}
+
+func parseNetshCmdResult(netshCmdResult string, w *wifi) {
+	lines := strings.Split(netshCmdResult, "\n")
+	for _, line := range lines {
+		matches := strings.Split(line, " : ")
+		if len(matches) != 2 {
+			continue
+		}
+		name := strings.TrimSpace(matches[0])
+		value := strings.TrimSpace(matches[1])
+
+		switch name {
+		case "State":
+			w.State = value
+			w.Connected = value == "connected"
+		case "SSID":
+			w.SSID = value
+		case "Radio type":
+			w.RadioType = value
+		case "Authentication":
+			w.Authentication = value
+		case "Channel":
+			if intValue, err := strconv.Atoi(value); err == nil {
+				w.Channel = intValue
+			}
+		case "Receive rate (Mbps)":
+			if intValue, err := strconv.Atoi(strings.Split(value, ".")[0]); err == nil {
+				w.ReceiveRate = intValue
+			}
+		case "Transmit rate (Mbps)":
+			if intValue, err := strconv.Atoi(strings.Split(value, ".")[0]); err == nil {
+				w.TransmitRate = intValue
+			}
+		case "Signal":
+			if intValue, err := strconv.Atoi(strings.TrimRight(value, "%")); err == nil {
+				w.Signal = intValue
+			}
+		}
+	}
+}

--- a/src/segment_wifi_test.go
+++ b/src/segment_wifi_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type netshStringArgs struct {
+	state          string
+	ssid           string
+	radioType      string
+	authentication string
+	channel        int
+	receiveRate    int
+	transmitRate   int
+	signal         int
+}
+
+func getNetshString(args *netshStringArgs) string {
+	const netshString string = `
+	There is 1 interface on the system:
+
+	Name                   : Wi-Fi
+	Description            : Intel(R) Wireless-AC 9560 160MHz
+	GUID                   : 6bb8def2-9af2-4bd4-8be2-6bd54e46bdc9
+	Physical address       : d4:3b:04:e6:10:40
+	State                  : %s
+	SSID                   : %s
+	BSSID                  : 5c:7d:7d:82:c5:73
+	Network type           : Infrastructure
+	Radio type             : %s
+	Authentication         : %s
+	Cipher                 : CCMP
+	Connection mode        : Profile
+	Channel                : %d
+	Receive rate (Mbps)    : %d
+	Transmit rate (Mbps)   : %d
+	Signal                 : %d%%
+	Profile                : ohsiggy
+
+	Hosted network status  : Not available`
+
+	return fmt.Sprintf(netshString, args.state, args.ssid, args.radioType, args.authentication, args.channel, args.receiveRate, args.transmitRate, args.signal)
+}
+
+func TestWiFiSegment(t *testing.T) {
+	cases := []struct {
+		Case            string
+		ExpectedString  string
+		ExpectedEnabled bool
+		CommandNotFound bool
+		CommandOutput   string
+		CommandError    error
+		DisplayError    bool
+		Template        string
+		ExpectedState   string
+	}{
+		{
+			Case:            "not enabled on windows when netsh command not found",
+			ExpectedEnabled: false,
+			ExpectedString:  "",
+			CommandNotFound: true,
+		},
+		{
+			Case:            "not enabled on windows when netsh command fails",
+			ExpectedEnabled: false,
+			ExpectedString:  "",
+			CommandError:    errors.New("intentional testing failure"),
+		},
+		{
+			Case:            "enabled on windows with DisplayError=true",
+			ExpectedEnabled: true,
+			ExpectedString:  "WIFI ERR: intentional testing failure",
+			CommandError:    errors.New("intentional testing failure"),
+			DisplayError:    true,
+			Template:        "{{.State}}",
+		},
+		{
+			Case:            "enabled on windows with every property in template",
+			ExpectedEnabled: true,
+			ExpectedString:  "connected testing 802.11ac WPA2-Personal 99 500 400 80",
+			CommandOutput: getNetshString(&netshStringArgs{
+				state:          "connected",
+				ssid:           "testing",
+				radioType:      "802.11ac",
+				authentication: "WPA2-Personal",
+				channel:        99,
+				receiveRate:    500.0,
+				transmitRate:   400.0,
+				signal:         80,
+			}),
+			Template: "{{.State}} {{.SSID}} {{.RadioType}} {{.Authentication}} {{.Channel}} {{.ReceiveRate}} {{.TransmitRate}} {{.Signal}}",
+		},
+		{
+			Case:            "enabled on windows but wifi not connected",
+			ExpectedEnabled: true,
+			ExpectedString:  "disconnected",
+			CommandOutput: getNetshString(&netshStringArgs{
+				state: "disconnected",
+			}),
+			Template: "{{if not .Connected}}{{.State}}{{end}}",
+		},
+		{
+			Case:            "enabled on windows but template is invalid",
+			ExpectedEnabled: true,
+			ExpectedString:  "unable to create text based on template",
+			CommandOutput:   getNetshString(&netshStringArgs{}),
+			Template:        "{{.DoesNotExist}}",
+		},
+	}
+
+	for _, tc := range cases {
+		env := new(MockedEnvironment)
+		env.On("getPlatform", nil).Return(windowsPlatform)
+		env.On("isWsl", nil).Return(false)
+		env.On("hasCommand", "netsh.exe").Return(!tc.CommandNotFound)
+		env.On("runCommand", mock.Anything, mock.Anything).Return(tc.CommandOutput, tc.CommandError)
+
+		props := &properties{
+			values: map[Property]interface{}{
+				DisplayError:    tc.DisplayError,
+				SegmentTemplate: tc.Template,
+			},
+		}
+
+		w := &wifi{
+			env:   env,
+			props: props,
+		}
+
+		assert.Equal(t, tc.ExpectedEnabled, w.enabled(), tc.Case)
+		assert.Equal(t, tc.ExpectedString, w.string(), tc.Case)
+	}
+}

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -180,7 +180,8 @@
             "owm",
             "sysinfo",
             "angular",
-            "php"
+            "php",
+            "wifi"
           ]
         },
         "style": {
@@ -1692,6 +1693,26 @@
                   },
                   "display_mode": {
                     "$ref": "#/definitions/display_mode"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": { "const": "wifi" }
+            }
+          },
+          "then": {
+            "title": "WiFi Segment",
+            "description": "https://ohmyposh.dev/docs/wifi",
+            "properties": {
+              "properties": {
+                "properties": {
+                  "template": {
+                    "$ref": "#/definitions/template"
                   }
                 }
               }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

This is a WiFi segment to display details of the current WiFi connection. I've only tested it so far on Windows, but the `netsh` command that makes it work there, also works in WSL. So I am pretty sure it will work in WSL too, but obviously need to test.

Any suggestions for how to do that? I was thinking I'd just re-clone the repo in WSL and install another Go environment there, build it, and test.

Also, for the Linux functionality, I tried to use the Dev Container in this project, but after much Googling it turns out virtual environments like that don't actually have a WiFi network interface. The data should be in `/proc/net/wireless`, but as I don't have a physical Linux machine to test with, I cannot develop this functionality. So I'm hoping it's cool to submit this with just Windows and WSL for now. And perhaps a kind contributor could help with the Linux and Darwin code!

Please let me know what you think of the PR. I am very happy to make any changes you request.

Here's a sample of what it looks like with the default template (yes that's my actual SSID):

![image](https://user-images.githubusercontent.com/811177/142752960-9b45254f-1b76-4f2b-afc8-b409d3f75c8d.png)


[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
