### PR TITLE
docs(wifi): missed a colon

### DIFF
--- a/docs/docs/segment-wifi.md
+++ b/docs/docs/segment-wifi.md
@@ -8,7 +8,7 @@ sidebar_label: WiFi
 
 Show details about the currently connected WiFi network.
 
-::info
+:::info
 Currently only supports Windows and WSL. Pull requests for Darwin and Linux support are welcome :)
 :::
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

The info admonition is missing a `:` in its opening tag.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
