### PR TITLE
docs(wifi): fix config block

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -3,3 +3,4 @@ MD014: false
 MD038: false
 line-length:
   line_length: 120
+  code_blocks: false

--- a/docs/docs/segment-wifi.md
+++ b/docs/docs/segment-wifi.md
@@ -21,13 +21,12 @@ Currently only supports Windows and WSL. Pull requests for Darwin and Linux supp
   "background": "#8822ee",
   "foreground": "#222222",
   "background_templates": [
-    "{{ if (not .Connected) }}#FF1111{{ end }}"
+    "{{ if (not .Connected) }}#FF1111{{ end }}",
     "{{ if (lt .Signal 60) }}#DDDD11{{ else if (lt .Signal 90) }}#DD6611{{ else }}#11CC11{{ end }}"
   ],
   "powerline_symbol": "\uE0B0",
   "properties": {
-    "template": "{{ if .Connected }}\uFAA8{{ else }}\uFAA9{{ end }}
-    {{ if .Connected }}{{ .SSID }} {{ .Signal }}% {{ .ReceiveRate }}Mbps{{ else }}{{ .State }}{{ end }}"
+    "template": "{{ if .Connected }}\uFAA8{{ else }}\uFAA9{{ end }} {{ if .Connected }}{{ .SSID }} {{ .Signal }}% {{ .ReceiveRate }}Mbps{{ else }}{{ .State }}{{ end }}"
   }
 }
 ```


### PR DESCRIPTION
disable md013 for code blocks(md)

### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

The config block fails if copy pasted(wifi) + disable line length check for code blocks(markdown)

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
