### PR TITLE
fix(winreg): fallback value on error or empty

### DIFF
--- a/docs/docs/segment-winreg.md
+++ b/docs/docs/segment-winreg.md
@@ -34,7 +34,8 @@ Supported registry key types:
 ## Properties
 
 - path: `string` - registry path to the desired key using backslashes and with a valid root HKEY name.
-- key: `string` - the key to read from the `path location.  If `""`, will read the default value.
+- key: `string` - the key to read from the `path` location.
+- fallback: `string` - the value to fall back to if no entry is found
 - template: `string` - a go [text/template][go-text-template] template extended
   with [sprig][sprig] utilizing the properties below.
 

--- a/src/segment_winreg.go
+++ b/src/segment_winreg.go
@@ -12,6 +12,8 @@ const (
 	RegistryPath Property = "path"
 	// key within full reg path formed from two above
 	RegistryKey Property = "key"
+	// Fallback is the text to display if the key is not found
+	Fallback Property = "fallback"
 )
 
 func (wr *winreg) init(props *properties, env environmentInfo) {
@@ -26,10 +28,15 @@ func (wr *winreg) enabled() bool {
 
 	registryPath := wr.props.getString(RegistryPath, "")
 	registryKey := wr.props.getString(RegistryKey, "")
+	fallback := wr.props.getString(Fallback, "")
 
 	var err error
 	wr.Value, err = wr.env.getWindowsRegistryKeyValue(registryPath, registryKey)
-	return err == nil
+	if len(fallback) > 0 && (err != nil || len(wr.Value) == 0) {
+		wr.Value = fallback
+		return true
+	}
+	return err == nil && len(wr.Value) > 0
 }
 
 func (wr *winreg) string() string {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

Allow a fallback value when using the winreg segment.

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
