### PR TITLE
docs(linux): Add instructions for a manual installation procedure for Linux

### DIFF
--- a/docs/docs/install-homebrew.mdx
+++ b/docs/docs/install-homebrew.mdx
@@ -1,5 +1,3 @@
-### Installation
-
 A [Homebrew][brew] formula is available for easy installation.
 
 ```bash

--- a/docs/docs/install-linux.mdx
+++ b/docs/docs/install-linux.mdx
@@ -16,7 +16,51 @@ import InstallHomebrew from "./install-homebrew.mdx";
 Oh My Posh uses ANSI color codes under the hood, these should work in every terminal,
 but you may have to set the environment variable `$TERM` to `xterm-256color` for it to work.
 
+### Installation
+<Tabs
+  defaultValue="homebrew"
+  groupId="install"
+  values={[
+    { label: 'homebrew', value: 'homebrew', },
+    { label: 'manual', value: 'manual', }
+  ]
+}>
+<TabItem value="homebrew">
 <InstallHomebrew />
+</TabItem>
+<TabItem value="manual">
+
+Oh My Posh can also be installed manually.
+
+#### Download the executable
+
+```bash
+sudo wget https://github.com/JanDeDobbeleer/oh-my-posh/releases/latest/download/posh-linux-amd64 -O /usr/local/bin/oh-my-posh
+sudo chmod +x /usr/local/bin/oh-my-posh
+```
+
+#### Download the themes
+
+```bash
+mkdir ~/.poshthemes
+wget https://github.com/JanDeDobbeleer/oh-my-posh/releases/latest/download/themes.zip -O ~/.poshthemes/themes.zip
+unzip ~/.poshthemes/themes.zip -d ~/.poshthemes
+chmod u+rw ~/.poshthemes/*.json
+rm ~/.poshthemes/themes.zip
+```
+
+#### Preview the themes
+
+```bash
+for file in ~/.poshthemes/*.omp.json; do echo "$file\n"; oh-my-posh --config $file --shell universal; echo "\n"; done;
+```
+
+### Replace your existing prompt
+
+The guides below assume you copied the theme called `jandedobbeleer.omp.json` to your user's `$HOME` folder.
+When you've downloaded the themes, you can find this one at `~/.poshthemes/jandedobbeleer.omp.json`.
+</TabItem>
+</Tabs>
 
 <Shells />
 

--- a/docs/docs/install-macos.mdx
+++ b/docs/docs/install-macos.mdx
@@ -16,6 +16,8 @@ import InstallHomebrew from "./install-homebrew.mdx";
 As the standard terminal has issues displaying the ANSI characters correctly, we advise using
 [iTerm2][iterm2] or any other modern day MacOS terminal that supports ANSI characters.
 
+### Installation
+
 <InstallHomebrew />
 
 <Shells />


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [ ] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

Add instructions for a manual installation procedure for Linux.
Recently, these were removed (#1317) and I think it should be kept for people who don't want to install homebrew just to install Oh My Posh.