### PR TITLE
fix(pwsh): restore pwsh 5 support

### DIFF
--- a/packages/powershell/oh-my-posh.psd1
+++ b/packages/powershell/oh-my-posh.psd1
@@ -21,7 +21,7 @@
     # Description of the functionality provided by this module
     Description       = 'A prompt theme engine for any shell'
     # Minimum version of the Windows PowerShell engine required by this module
-    PowerShellVersion = '6.0'
+    PowerShellVersion = '5.0'
     # List of all files packaged with this module
     FileList          = @()
     # Cmdlets to export from this module

--- a/packages/powershell/oh-my-posh.psm1
+++ b/packages/powershell/oh-my-posh.psm1
@@ -80,7 +80,7 @@ function Sync-PoshThemes {
     )
 
     Write-Host "Downloading oh-my-posh themes for $Version"
-    $tmp = New-TemporaryFile | Rename-Item -NewName { $_ -replace 'tmp$', 'zip' } –PassThru
+    $tmp = New-TemporaryFile | Rename-Item -NewName { $_ -replace 'tmp$', 'zip' } -PassThru
     $themesUrl = "https://github.com/jandedobbeleer/oh-my-posh/releases/download/v$Version/themes.zip"
     Invoke-WebRequest -OutFile $tmp $themesUrl
     $destination = $env:POSH_THEMES_PATH


### PR DESCRIPTION
In PowerShell 6+, the default encoding is UTF-8 without BOM on all platforms.
In Windows PowerShell, the default encoding is usually Windows-1252, an extension of latin-1, also known as ISO 8859-1.

### Prerequisites

- [ ] I have read and understood the `CONTRIBUTING` guide
- [ ] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

fix https://github.com/JanDeDobbeleer/oh-my-posh/issues/1346
answer https://github.com/JanDeDobbeleer/oh-my-posh/issues/1346#issuecomment-981929845

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
