### PR TITLE
docs: segment nightscout mmol template

### DIFF
--- a/docs/docs/segment-nightscout.md
+++ b/docs/docs/segment-nightscout.md
@@ -53,7 +53,7 @@ if that color is visible against any of your backgrounds.
 Or display in mmol/l (instead of the default mg/dl) with the following template:
 
 ```json
-    "template": " {{ if eq (mod .Sgv 18) 0 }} {{ div .Sgv 18 }}.0 {{ else }} {{ round (divf .Sgv 18) 1 }} {{ end }} {{.TrendIcon}}"
+    "template": " {{ if eq (mod .Sgv 18) 0 }}{{divf .Sgv 18}}.0{{ else }} {{ round (divf .Sgv 18) 1 }}{{ end }}{{.TrendIcon}}"
 ```
 
 ## Properties

--- a/docs/docs/segment-nightscout.md
+++ b/docs/docs/segment-nightscout.md
@@ -53,7 +53,7 @@ if that color is visible against any of your backgrounds.
 Or display in mmol/l (instead of the default mg/dl) with the following template:
 
 ```json
-    "template": " {{divf (floor (mulf 10 (divf .Sgv 18))) 10}} {{.TrendIcon}}"
+    "template": " {{ if eq (mod .Sgv 18) 0 }} {{ div .Sgv 18 }}.0 {{ else }} {{ round (divf .Sgv 18) 1 }} {{ end }} {{.TrendIcon}}"
 ```
 
 ## Properties


### PR DESCRIPTION
### Prerequisites

- [X] I have read and understood the `CONTRIBUTING` guide
- [X] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

For displaying the sugar glucose value as mmol/L, with one digit after the decimal point. It's better to use the round function. It's also important to always display one digit after the decimal point, even it is a zero.