### PR TITLE
feat: Julian Date format segment

### DIFF
--- a/docs/docs/segment-juliandate.md
+++ b/docs/docs/segment-juliandate.md
@@ -1,0 +1,49 @@
+---
+id: juliandate
+title: Julian Date
+sidebar_label: Julian Date
+---
+
+## What
+
+The Julian date format is used in some industries. This is usually in the format *YYDDD* where:
+
+- *YY* : is the year
+- *DDD* : is the day of the year
+
+### Example
+
+For the gregorian calendar date 6th December 2021. We would take the year to be 21 and the day of the year to be 340
+(31 days in January then keep counting until 6th December)
+which results in 21340 as the julian date
+
+## Sample Configuration
+
+```json
+        {
+          "type": "juliandate",
+          "style": "diamond",
+          "foreground": "#ffffff",
+          "background": "#0000ff",
+          "leading_diamond": "\uE0B2",
+          "trailing_diamond": "\uE0B0",
+          "properties": {
+            "template": "\uf5f5 {{.Year}}{{.DayOfYear}}"
+          }
+        },
+```
+
+## Properties
+
+- template: `string` - You can add your own icon into the template if you wish as in the example, otherwise the
+segment will just display the YYDDD as default if no template property is provided
+
+## Template Properties
+
+- .Year: `string` - The two digit year value (for 2021 will be 21)
+- .DayOfYear: `string` - The three digit day of the year value (this is padded by 0's for numbers less than 100,
+for example, 1st January will be 001)
+
+[go-text-template]: https://golang.org/pkg/text/template/
+[sprig]: https://masterminds.github.io/sprig/
+[nightscout]: http://www.nightscout.info/

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -53,6 +53,7 @@ module.exports = {
         "golang",
         "java",
         "julia",
+        "juliandate",
         "kubectl",
         "nbgv",
         "nightscout",

--- a/src/environment.go
+++ b/src/environment.go
@@ -90,6 +90,7 @@ type environmentInfo interface {
 	cache() cache
 	close()
 	logs() string
+	getTimeNow() time.Time
 }
 
 type commandCache struct {
@@ -414,6 +415,10 @@ func (env *environment) getBatteryInfo() ([]*battery.Battery, error) {
 	}
 	// everything is fine
 	return validBatteries, nil
+}
+
+func (env *environment) getTimeNow() time.Time {
+	return time.Now()
 }
 
 func (env *environment) getShellName() string {

--- a/src/segment.go
+++ b/src/segment.go
@@ -135,6 +135,8 @@ const (
 	WiFi SegmentType = "wifi"
 	// WinReg queries the Windows registry.
 	WinReg SegmentType = "winreg"
+	// JulianDate writes the current date in julian format
+	JulianDate SegmentType = "juliandate"
 )
 
 func (segment *Segment) string() string {
@@ -265,6 +267,7 @@ func (segment *Segment) mapSegmentWithWriter(env environmentInfo) error {
 		Nightscout:    &nightscout{},
 		WiFi:          &wifi{},
 		WinReg:        &winreg{},
+		JulianDate:    &juliandate{},
 	}
 	if segment.Properties == nil {
 		segment.Properties = make(properties)

--- a/src/segment_juliandate.go
+++ b/src/segment_juliandate.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+)
+
+type juliandate struct {
+	props properties
+	env   environmentInfo
+
+	DayOfYear string
+	Year      string
+}
+
+func (j *juliandate) enabled() bool {
+	now := j.env.getTimeNow()
+	// returns the last two digits of the year, for example year 2021 will return 21, and 2009 returns 09
+	j.Year = fmt.Sprintf("%02d", now.Year()%100)
+	// returns the day of the year, in the range [001,365] for non-leap years, and [001,366] in leap years.
+	j.DayOfYear = fmt.Sprintf("%03d", now.YearDay())
+
+	return true
+}
+
+func (j *juliandate) string() string {
+	segmentTemplate := j.props.getString(SegmentTemplate, "{{.Year}}{{.DayOfYear}}")
+	template := &textTemplate{
+		Template: segmentTemplate,
+		Context:  j,
+		Env:      j.env,
+	}
+
+	text, err := template.render()
+	if err != nil {
+		return err.Error()
+	}
+
+	return text
+}
+
+func (j *juliandate) init(props properties, env environmentInfo) {
+	j.props = props
+	j.env = env
+}

--- a/src/segment_juliandate_test.go
+++ b/src/segment_juliandate_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJulianDateSegment(t *testing.T) {
+	cases := []struct {
+		Case            string
+		TestDate        time.Time
+		ExpectedString  string
+		ExpectedEnabled bool
+		Template        string
+		Error           error
+	}{
+		{
+			Case:            "6th December 2021",
+			TestDate:        time.Date(2021, time.Month(12), 6, 1, 10, 30, 0, time.UTC),
+			Template:        "{{.Year}}{{.DayOfYear}}",
+			ExpectedString:  "21340",
+			ExpectedEnabled: true,
+		},
+		{
+			Case:            "2nd January 2009 requires some padding",
+			TestDate:        time.Date(2009, time.Month(1), 2, 1, 10, 30, 0, time.UTC),
+			Template:        "{{.Year}}{{.DayOfYear}}",
+			ExpectedString:  "09002",
+			ExpectedEnabled: true,
+		},
+		{
+			Case:            "20th March 2031",
+			TestDate:        time.Date(2031, time.Month(3), 20, 1, 10, 30, 0, time.UTC),
+			Template:        "{{.Year}}{{.DayOfYear}}",
+			ExpectedString:  "31079",
+			ExpectedEnabled: true,
+		},
+		{
+			Case:            "Faulty template",
+			TestDate:        time.Date(2021, time.Month(2), 21, 1, 10, 30, 0, time.UTC),
+			Template:        "{{.DayOfYear}}{{.DoesntExist}}",
+			ExpectedString:  incorrectTemplate,
+			ExpectedEnabled: true,
+		},
+	}
+
+	for _, tc := range cases {
+		env := &MockedEnvironment{}
+		var props properties = map[Property]interface{}{}
+		env.On("getTimeNow").Return(tc.TestDate)
+
+		if tc.Template != "" {
+			props[SegmentTemplate] = tc.Template
+		}
+
+		jd := &juliandate{
+			props: props,
+			env:   env,
+		}
+
+		enabled := jd.enabled()
+		assert.Equal(t, tc.ExpectedEnabled, enabled, tc.Case)
+		if !enabled {
+			continue
+		}
+
+		assert.Equal(t, tc.ExpectedString, jd.string(), tc.Case)
+	}
+}

--- a/src/segment_path_test.go
+++ b/src/segment_path_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"github.com/distatus/battery"
 	"github.com/gookit/config/v2"
@@ -102,6 +103,11 @@ func (env *MockedEnvironment) lastErrorCode() int {
 func (env *MockedEnvironment) executionTime() float64 {
 	args := env.Called(nil)
 	return float64(args.Int(0))
+}
+
+func (env *MockedEnvironment) getTimeNow() time.Time {
+	args := env.Called()
+	return args.Get(0).(time.Time)
 }
 
 func (env *MockedEnvironment) isRunningAsRoot() bool {

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -167,6 +167,7 @@
             "terraform",
             "go",
             "julia",
+            "juliandate",
             "ruby",
             "ytm",
             "executiontime",
@@ -1695,10 +1696,30 @@
                     "default": ""
                   },
                   "fallback": {
-                    "type":"string",
-                    "title":"Fallback value",
-                    "description":"Value to display if registry value cannot be retrieved",
-                    "default":""
+                    "type": "string",
+                    "title": "Fallback value",
+                    "description": "Value to display if registry value cannot be retrieved",
+                    "default": ""
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": { "const": "juliandate" }
+            }
+          },
+          "then": {
+            "title": "Display the Julian Date",
+            "description": "https://ohmyposh.dev/docs/juliandate",
+            "properties": {
+              "properties": {
+                "properties": {
+                  "template": {
+                    "$ref": "#/definitions/template"
                   }
                 }
               }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

The Julian date format is used in some industries. This is usually in the format *YYDDD* where:

- *YY*: is the year
- *DDD*: is the day of the year

<img width="527" alt="Screenshot 2021-12-06 at 16 21 49" src="https://user-images.githubusercontent.com/72079589/144883182-7c1cfd8e-82ed-4143-96bf-a63121d5bb79.png">

