### PR TITLE
fix(pwsh): alert when we can't download dependencies

### DIFF
--- a/packages/powershell/oh-my-posh.psm1
+++ b/packages/powershell/oh-my-posh.psm1
@@ -113,8 +113,21 @@ function Sync-PoshArtifacts {
     Sync-PoshThemes -Version $Version
 }
 
-$moduleVersion = Split-Path -Leaf $MyInvocation.MyCommand.ScriptBlock.Module.ModuleBase
-Sync-PoshArtifacts -Version $moduleVersion
+try {
+    $moduleVersion = Split-Path -Leaf $MyInvocation.MyCommand.ScriptBlock.Module.ModuleBase
+    Sync-PoshArtifacts -Version $moduleVersion
+}
+catch {
+    $message = @'
+Oh My Posh is unable to download and store the latest version.
+In case you installed using AllUsers and are a non-admin user,
+please run the following command as an administrator:
+
+Import-Module oh-my-posh
+'@
+    Write-Error $message
+    exit 1
+}
 
 # Legacy functions
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

resolves #1382

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
