### PR TITLE
fix(git): worktree folder init

### DIFF
--- a/src/segment_git.go
+++ b/src/segment_git.go
@@ -143,7 +143,6 @@ func (g *git) enabled() bool {
 	if gitdir.isDir {
 		g.gitWorkingFolder = gitdir.path
 		g.gitRootFolder = gitdir.path
-		g.gitWorktreeFolder = strings.TrimSuffix(gitdir.path, ".git")
 		return true
 	}
 	// handle worktree


### PR DESCRIPTION
init worktreeFolder only when inside worktrees

### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

[Description of the change]

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
