### PR TITLE
Path segment: add support for template property

### DIFF
--- a/src/segment_path.go
+++ b/src/segment_path.go
@@ -10,6 +10,17 @@ import (
 type path struct {
 	props properties
 	env   environmentInfo
+
+	// Full displays the full path
+	Full   string
+	Folder string
+	Letter string
+	Mixed  string
+
+	FolderSeparatorIcon string
+	HomeIcon            string
+	FolderIcon          string
+	WindowsRegistryIcon string
 }
 
 const (
@@ -53,9 +64,39 @@ func (pt *path) enabled() bool {
 	return true
 }
 
+func (pt *path) templateString(segmentTemplate string) string {
+	pt.Full = pt.getFullPath()
+	pt.Folder = pt.getFolderPath()
+	pt.Letter = pt.getLetterPath()
+	pt.Mixed = pt.getMixedPath()
+
+	pt.FolderSeparatorIcon = pt.props.getString(FolderSeparatorIcon, "")
+	pt.HomeIcon = pt.props.getString(HomeIcon, "")
+	pt.FolderIcon = pt.props.getString(FolderIcon, "")
+	pt.WindowsRegistryIcon = pt.props.getString(WindowsRegistryIcon, "")
+
+	template := &textTemplate{
+		Template: segmentTemplate,
+		Context:  pt,
+		Env:      pt.env,
+	}
+	text, err := template.render()
+	if err != nil {
+		return err.Error()
+	}
+	return text
+}
+
 func (pt *path) string() string {
 	cwd := pt.env.getcwd()
 	var formattedPath string
+
+	segmentTemplate := pt.props.getString(SegmentTemplate, "")
+	if len(segmentTemplate) > 0 {
+		formattedPath = pt.templateString(segmentTemplate)
+		return formattedPath
+	}
+
 	switch style := pt.props.getString(Style, Agnoster); style {
 	case Agnoster:
 		formattedPath = pt.getAgnosterPath()


### PR DESCRIPTION
_I'm opening this as a draft to verify the approach and get feedback before I go too far._

### Prerequisites

Not all of these are done, but I'll complete them iteratively in the PR.

- [x] I have read and understood the `CONTRIBUTING` guide
- [ ] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

This PR adds support for a `template` property in the Path segment. See #885 for more context.

#### Template properties

The template receives the following properties:

These four properties contain the string values of the path with various styles:

- Full
- Folder
- Letter
- Mixed

The `style` property is ignored. Instead, the strings passed to the template take into account the other properties that affect how the styles are rendered. For example, this path configuration produces the following:

```json
{
  "type": "path",
  "style": "plain",
  "foreground": "#ffffff",
  "background": "#ff479c",
  "properties": {
    "style": "agnoster",
    "folder_separator_icon": ">",
    "template": "<b>{{ .Full }} {{ .Folder }} {{ .Letter }} {{ .Mixed }}</b>"
  }
}
```

![image](https://user-images.githubusercontent.com/19589/145626447-232fbc56-0863-4e9c-962a-d1a191a66dad.png)

These four properties contain icons (as strings):

- FolderSeparatorIcon
- HomeIcon
- FolderIcon
- WindowsRegistryIcon

#### Behavior notes

When the template property is provided, the `style` property is ignored since the strings for all styles are passed to the template. This is consistent with other segments that support a template property. It should also be backwards-compatible. Existing themes won't have a template property and thus will continue to work as they do today. Users can opt into the template by adding it to their theme.

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
