### PR TITLE
fix(battery): ignore UnknownChargeRate error

### DIFF
--- a/docs/docs/segment-battery.md
+++ b/docs/docs/segment-battery.md
@@ -48,7 +48,8 @@ properties below - defaults to `{{.Icon}}{{ if not .Error }}{{.Percentage}}{{ en
 - `.Full`: `float64` - Last known full capacity (in mWh)
 - `.Design`: `float64` - Reported design capacity (in mWh)
 - `.ChargeRate`: `float64` - Current (momentary) charge rate (in mW). It is always non-negative, consult .State
-field to check whether it means charging or discharging
+field to check whether it means charging or discharging (on some systems this might be always `0` if the battery
+doesn't support it)
 - `.Voltage`: `float64` - Current voltage (in V)
 - `.DesignVoltage`: `float64` - Design voltage (in V). Some systems (e.g. macOS) do not provide a separate
 value for this. In such cases, or if getting this fails, but getting `Voltage` succeeds, this field will have

--- a/src/environment.go
+++ b/src/environment.go
@@ -403,25 +403,25 @@ func (env *environment) getBatteryInfo() ([]*battery.Battery, error) {
 	unableToRetrieveBatteryInfo := "A device which does not exist was specified."
 	unknownChargeRate := "Unknown value received"
 	var fatalErr battery.Errors
-	ignoreErr := func(err error) error {
+	ignoreErr := func(err error) bool {
 		if e, ok := err.(battery.ErrPartial); ok {
-			// ignore errors unknown charge rate value
+			// ignore unknown charge rate value error
 			if e.Current == nil &&
 				e.Design == nil &&
 				e.DesignVoltage == nil &&
 				e.Full == nil &&
 				e.State == nil &&
 				e.Voltage == nil &&
+				e.ChargeRate != nil &&
 				e.ChargeRate.Error() == unknownChargeRate {
-				return nil
+				return true
 			}
 		}
-		return err
+		return false
 	}
 	if batErr, ok := err.(battery.Errors); ok {
 		for _, err := range batErr {
-			err = ignoreErr(err)
-			if err != nil {
+			if !ignoreErr(err) {
 				fatalErr = append(fatalErr, err)
 			}
 		}


### PR DESCRIPTION
This error is returned when Windows can't get the charge rate from the battery

### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

On some Windows systems the battery doesn't supply a `charge rate value`. Then an error is returned by the `battery` lib.
This error can be ignored. The battery stats are still correct.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
