### PR TITLE
fix(yaml): try int parsing before fallback

### DIFF
--- a/src/properties.go
+++ b/src/properties.go
@@ -89,12 +89,17 @@ func (p properties) getFloat64(property Property, defaultValue float64) float64 
 		return defaultValue
 	}
 
-	floatValue, ok := val.(float64)
+	if floatValue, ok := val.(float64); ok {
+		return floatValue
+	}
+
+	// config parser parses an int
+	intValue, ok := val.(int)
 	if !ok {
 		return defaultValue
 	}
 
-	return floatValue
+	return float64(intValue)
 }
 
 func (p properties) getInt(property Property, defaultValue int) int {
@@ -107,7 +112,7 @@ func (p properties) getInt(property Property, defaultValue int) int {
 		return intValue
 	}
 
-	// json parses a float
+	// config parser parses a float
 	intValue, ok := val.(float64)
 	if !ok {
 		return defaultValue


### PR DESCRIPTION
json and yaml returns 2 different types
float64 vs int

### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

(https://github.com/JanDeDobbeleer/oh-my-posh/issues/1421)](https://github.com/JanDeDobbeleer/oh-my-posh/issues/1421)
It's not the first time there's an issue in types being different between config parsers.

[Description of the change]

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
