### PR TITLE
Brewfather: fix missing doc link from sidebar

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -41,6 +41,7 @@ module.exports = {
         "az",
         "azfunc",
         "battery",
+        "brewfather",
         "command",
         "crystal",
         "dart",


### PR DESCRIPTION
### Prerequisites

- [X] I have read and understood the `CONTRIBUTING` guide
- [X] The commit message follows the [conventional commits][cc] guidelines
- [X] Tests for the changes have been added (for bug fixes/features)
- [X] Docs have been added / updated (for bug fixes/features)

### Description

docs(brewfather) add "brewfather" to sidebars.js

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary