### PR TITLE
PowerShell path env: use the correct path separator depending on the OS

### DIFF
--- a/packages/powershell/oh-my-posh.psm1
+++ b/packages/powershell/oh-my-posh.psm1
@@ -1,6 +1,6 @@
 $env:POSH_PATH = "$((Get-Item $MyInvocation.MyCommand.ScriptBlock.Module.ModuleBase).Parent.FullName)"
 $env:POSH_THEMES_PATH = $env:POSH_PATH + "/themes"
-$env:PATH = "$env:POSH_PATH;$env:PATH"
+$env:PATH = $env:POSH_PATH + [System.IO.Path]::PathSeparator + $env:PATH
 
 function Get-PoshDownloadUrl {
     param(


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [ ] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

Currently oh-my-posh PowerShell module modifies the PATH environment variable. It does however not use the correct path separator on Linux and MacOs. This PR solves that by getting the correct path separator via dotnet io.path PathSeparator static method

Current behavior:
![image](https://user-images.githubusercontent.com/10071039/146354139-490f8f72-b120-4dec-9b8b-59e94251a74a.png)

Post fix behavior:
![image](https://user-images.githubusercontent.com/10071039/146354481-57d88dae-3fc5-4614-97c3-84c75c2da47a.png)


<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
