### PR TITLE
docs: add instructions to disable venv prompt (python)

### DIFF
--- a/docs/docs/faq.mdx
+++ b/docs/docs/faq.mdx
@@ -138,6 +138,15 @@ To solely rely on Oh My Posh to set the prompt, you can configure the follwing s
 conda config --set changeps1 False
 ```
 
+### Python venv: Prompt is changed to display the environment name
+Upon activation, virtual environments created with `venv` change the prompt to add the activated environment's name.
+To disable this behaviour, set `VIRTUAL_ENV_DISABLE_PROMPT` environment variable to `1` on your system.
+You can add the following line to your Powershell profile:
+
+```powershell
+$env:VIRTUAL_ENV_DISABLE_PROMPT=1
+```
+
 [new-issue]: https://github.com/JanDeDobbeleer/oh-my-posh/issues/new/choose
 [latest]: https://github.com/JanDeDobbeleer/oh-my-posh/releases/latest
 [wt-glyph]: https://github.com/microsoft/terminal/issues/3546

--- a/docs/docs/faq.mdx
+++ b/docs/docs/faq.mdx
@@ -140,7 +140,9 @@ conda config --set changeps1 False
 
 ### Python venv: Prompt is changed to display the environment name
 Upon activation, virtual environments created with `venv` change the prompt to add the activated environment's name.
-To disable this behaviour, set `VIRTUAL_ENV_DISABLE_PROMPT` environment variable to `1` on your system. Example commands to run (with probable file locations you'll have to put them in for auto-loading):
+To disable this behaviour, set `VIRTUAL_ENV_DISABLE_PROMPT` environment variable to `1` on your system. Example commands to run, with probable file locations you'll have to put them in for auto-loading:
+
+Note: Tilde (~) in paths here refers to your user's home directory.
 
 ```powershell
 # powershell - ~/Documents/WindowsPowerShell/profile.ps1

--- a/docs/docs/faq.mdx
+++ b/docs/docs/faq.mdx
@@ -140,11 +140,19 @@ conda config --set changeps1 False
 
 ### Python venv: Prompt is changed to display the environment name
 Upon activation, virtual environments created with `venv` change the prompt to add the activated environment's name.
-To disable this behaviour, set `VIRTUAL_ENV_DISABLE_PROMPT` environment variable to `1` on your system.
-You can add the following line to your Powershell profile:
+To disable this behaviour, set `VIRTUAL_ENV_DISABLE_PROMPT` environment variable to `1` on your system. Example commands to run (with probable file locations you'll have to put them in for auto-loading):
 
 ```powershell
+# powershell - ~/Documents/WindowsPowerShell/profile.ps1
 $env:VIRTUAL_ENV_DISABLE_PROMPT=1
+```
+```bash
+# bash, zsh - ~/bashrc or ~/.zprofile ~/.zshrc
+export VIRTUAL_ENV_DISABLE_PROMPT=1
+```
+```fish
+#fish - ~/.config/fish/config.fish
+set -x VIRTUAL_ENV_DISABLE_PROMPT 1
 ```
 
 [new-issue]: https://github.com/JanDeDobbeleer/oh-my-posh/issues/new/choose


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

Oh My Posh docs only contain directions to disable the Conda automatic prompt. This PR introduces directions to disable the automatic `venv` prompt change as well for the Python users.

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
