### PR TITLE
feat(wifi): read wifi state on non-englisch systems

### DIFF
--- a/docs/docs/segment-wifi.md
+++ b/docs/docs/segment-wifi.md
@@ -21,24 +21,22 @@ Currently only supports Windows and WSL. Pull requests for Darwin and Linux supp
   "background": "#8822ee",
   "foreground": "#222222",
   "background_templates": [
-    "{{ if (not .Connected) }}#FF1111{{ end }}",
     "{{ if (lt .Signal 60) }}#DDDD11{{ else if (lt .Signal 90) }}#DD6611{{ else }}#11CC11{{ end }}"
   ],
   "powerline_symbol": "\uE0B0",
   "properties": {
-    "template": "{{ if .Connected }}\uFAA8{{ else }}\uFAA9{{ end }} {{ if .Connected }}{{ .SSID }} {{ .Signal }}% {{ .ReceiveRate }}Mbps{{ else }}{{ .State }}{{ end }}"
+    "template": "\uFAA8 {{ .SSID }} {{ .Signal }}% {{ .ReceiveRate }}Mbps"
   }
 }
 ```
 
 ## Properties
 
-- template: `string` - A go [text/template][go-text-template]  extended with [sprig][sprig] using the properties below
+- template: `string` - A go [text/template][go-text-template]  extended with [sprig][sprig] using the properties below.
+Defaults to `{{ if .Error }}{{ .Error }}{{ else }}\uFAA8 {{ .SSID }} {{ .Signal }}% {{ .ReceiveRate }}Mbps{{ end }}`
 
 ## Template Properties
 
-- `.Connected`: `bool` - if WiFi is currently connected
-- `.State`: `string` - WiFi connection status - _e.g. connected or disconnected_
 - `.SSID`: `string` - the SSID of the current wifi network
 - `.RadioType`: `string` - the radio type - _e.g. 802.11ac, 802.11ax, 802.11n, etc._
 - `.Authentication`: `string` - the authentication type - _e.g. WPA2-Personal, WPA2-Enterprise, etc._

--- a/src/constants_windows.go
+++ b/src/constants_windows.go
@@ -1,0 +1,33 @@
+package main
+
+const (
+	FHSS   WifiType = "FHSS"
+	DSSS   WifiType = "DSSS"
+	IR     WifiType = "IR"
+	A      WifiType = "802.11a"
+	HRDSSS WifiType = "HRDSSS"
+	G      WifiType = "802.11g"
+	N      WifiType = "802.11n"
+	AC     WifiType = "802.11ac"
+
+	Infrastructure WifiType = "Infrastructure"
+	Independent    WifiType = "Independent"
+	Any            WifiType = "Any"
+
+	OpenSystem WifiType = "802.11 Open System"
+	SharedKey  WifiType = "802.11 Shared Key"
+	WPA        WifiType = "WPA"
+	WPAPSK     WifiType = "WPA PSK"
+	WPANone    WifiType = "WPA NONE"
+	WPA2       WifiType = "WPA2"
+	WPA2PSK    WifiType = "WPA2 PSK"
+	Disabled   WifiType = "disabled"
+	Unknown    WifiType = "Unknown"
+
+	None   WifiType = "None"
+	WEP40  WifiType = "WEP40"
+	TKIP   WifiType = "TKIP"
+	CCMP   WifiType = "CCMP"
+	WEP104 WifiType = "WEP104"
+	WEP    WifiType = "WEP"
+)

--- a/src/environment.go
+++ b/src/environment.go
@@ -72,6 +72,21 @@ type windowsRegistryValue struct {
 	str       string
 }
 
+type wifiInfo struct {
+	SSID         string
+	Connected    bool
+	State        string
+	Interface    string
+	BSSType      string
+	PhysType     string
+	Auth         string
+	Cipher       string
+	Channel      int
+	ReceiveRate  int
+	TransmitRate int
+	Signal       int
+}
+
 type environmentInfo interface {
 	getenv(key string) string
 	getcwd() string
@@ -110,6 +125,7 @@ type environmentInfo interface {
 	inWSLSharedDrive() bool
 	convertToLinuxPath(path string) string
 	convertToWindowsPath(path string) string
+	getWifiNetworks() (*wifiInfo, error)
 }
 
 type commandCache struct {
@@ -137,12 +153,13 @@ const (
 )
 
 type environment struct {
-	args       *args
-	cwd        string
-	cmdCache   *commandCache
-	fileCache  *fileCache
-	logBuilder strings.Builder
-	debug      bool
+	args           *args
+	cwd            string
+	cmdCache       *commandCache
+	fileCache      *fileCache
+	logBuilder     strings.Builder
+	debug          bool
+	comInitialized bool
 }
 
 func (env *environment) init(args *args) {

--- a/src/environment.go
+++ b/src/environment.go
@@ -72,19 +72,20 @@ type windowsRegistryValue struct {
 	str       string
 }
 
+type WifiType string
+
 type wifiInfo struct {
-	SSID         string
-	Connected    bool
-	State        string
-	Interface    string
-	BSSType      string
-	PhysType     string
-	Auth         string
-	Cipher       string
-	Channel      int
-	ReceiveRate  int
-	TransmitRate int
-	Signal       int
+	SSID           string
+	Interface      string
+	RadioType      WifiType
+	PhysType       WifiType
+	Authentication WifiType
+	Cipher         WifiType
+	Channel        int
+	ReceiveRate    int
+	TransmitRate   int
+	Signal         int
+	Error          string
 }
 
 type environmentInfo interface {
@@ -125,7 +126,7 @@ type environmentInfo interface {
 	inWSLSharedDrive() bool
 	convertToLinuxPath(path string) string
 	convertToWindowsPath(path string) string
-	getWifiNetworks() (*wifiInfo, error)
+	getWifiNetwork() (*wifiInfo, error)
 }
 
 type commandCache struct {
@@ -153,13 +154,12 @@ const (
 )
 
 type environment struct {
-	args           *args
-	cwd            string
-	cmdCache       *commandCache
-	fileCache      *fileCache
-	logBuilder     strings.Builder
-	debug          bool
-	comInitialized bool
+	args       *args
+	cwd        string
+	cmdCache   *commandCache
+	fileCache  *fileCache
+	logBuilder strings.Builder
+	debug      bool
 }
 
 func (env *environment) init(args *args) {

--- a/src/environment_unix.go
+++ b/src/environment_unix.go
@@ -93,3 +93,7 @@ func (env *environment) convertToLinuxPath(path string) string {
 	}
 	return path
 }
+
+func (env *environment) getWifiNetwork() (*wifiInfo, error) {
+	return nil, errors.New("not implemented")
+}

--- a/src/environment_windows.go
+++ b/src/environment_windows.go
@@ -262,14 +262,16 @@ func (env *environment) convertToLinuxPath(path string) string {
 	return path
 }
 
-func (env *environment) getWifiNetworks() (*wifiInfo, error) {
-	hapi := syscall.NewLazyDLL("wlanapi.dll")
-	hWlanOpenHandle := hapi.NewProc("WlanOpenHandle")
-	hWlanCloseHandle := hapi.NewProc("WlanCloseHandle")
-	//hWlanFreeMemory := hapi.NewProc("WlanFreeMemory")
-	hWlanEnumInterfaces := hapi.NewProc("WlanEnumInterfaces")
-	hWlanQueryInterface := hapi.NewProc("WlanQueryInterface")
+var (
+	hapi                = syscall.NewLazyDLL("wlanapi.dll")
+	hWlanOpenHandle     = hapi.NewProc("WlanOpenHandle")
+	hWlanCloseHandle    = hapi.NewProc("WlanCloseHandle")
+	hWlanEnumInterfaces = hapi.NewProc("WlanEnumInterfaces")
+	hWlanQueryInterface = hapi.NewProc("WlanQueryInterface")
+)
 
+func (env *environment) getWifiNetwork() (*wifiInfo, error) {
+	env.trace(time.Now(), "getWifiNetwork")
 	// Open handle
 	var pdwNegotiatedVersion uint32
 	var phClientHandle uint32
@@ -279,9 +281,11 @@ func (env *environment) getWifiNetworks() (*wifiInfo, error) {
 	}
 
 	// defer closing handle
-	defer hWlanCloseHandle.Call(uintptr(phClientHandle), uintptr(unsafe.Pointer(nil)))
+	defer func() {
+		_, _, _ = hWlanCloseHandle.Call(uintptr(phClientHandle), uintptr(unsafe.Pointer(nil)))
+	}()
 
-	// enum interfaces
+	// list interfaces
 	var interfaceList *WLAN_INTERFACE_INFO_LIST
 	e, _, err = hWlanEnumInterfaces.Call(uintptr(phClientHandle), uintptr(unsafe.Pointer(nil)), uintptr(unsafe.Pointer(&interfaceList)))
 	if e != 0 {
@@ -289,203 +293,182 @@ func (env *environment) getWifiNetworks() (*wifiInfo, error) {
 	}
 
 	// use first interface that is connected
-	var info wifiInfo
-	interfaces := make([]WLAN_INTERFACE_INFO, int(interfaceList.dwNumberOfItems))
+	numberOfInterfaces := int(interfaceList.dwNumberOfItems)
 	infoSize := unsafe.Sizeof(interfaceList.InterfaceInfo[0])
-	for i := 0; i < int(interfaceList.dwNumberOfItems); i++ {
-		interfaces[i] = *(*WLAN_INTERFACE_INFO)(unsafe.Pointer(uintptr(unsafe.Pointer(&interfaceList.InterfaceInfo[0])) + uintptr(i)*infoSize))
-
-		info = wifiInfo{}
-		info.Interface = strings.TrimRight(string(utf16.Decode(interfaces[i].strInterfaceDescription[:])), "\x00")
-
-		// see https://docs.microsoft.com/en-us/windows/win32/api/wlanapi/ne-wlanapi-wlan_interface_state-r1
-		switch interfaces[i].isState {
-		case 0:
-			info.State = "Not ready"
-		case 1:
-			info.State = "Connected"
-			info.Connected = true
-		case 2:
-			info.State = "Ad-hoc network formed"
-		case 3:
-			info.State = "Disconnecting"
-		case 4:
-			info.State = "Disconnected"
-		case 5:
-			info.State = "Associating"
-		case 6:
-			info.State = "Discovering"
-		case 7:
-			info.State = "Authenticating"
-		default:
-			info.State = "Unknown"
-		}
-
-		if !info.Connected {
+	for i := 0; i < numberOfInterfaces; i++ {
+		network := (*WLAN_INTERFACE_INFO)(unsafe.Pointer(uintptr(unsafe.Pointer(&interfaceList.InterfaceInfo[0])) + uintptr(i)*infoSize))
+		if network.isState != 1 {
 			continue
 		}
+		return env.parseNetworkInterface(network, phClientHandle)
+	}
+	return nil, errors.New("Not connected")
+}
 
-		// Query wifi connection state
-		var dataSize uint16
-		var wlanAttr *WLAN_CONNECTION_ATTRIBUTES
-		e, _, err = hWlanQueryInterface.Call(uintptr(phClientHandle),
-			uintptr(unsafe.Pointer(&interfaces[i].InterfaceGuid)),
-			uintptr(7), // wlan_intf_opcode_current_connection
-			uintptr(unsafe.Pointer(nil)),
-			uintptr(unsafe.Pointer(&dataSize)),
-			uintptr(unsafe.Pointer(&wlanAttr)),
-			uintptr(unsafe.Pointer(nil)))
-		if e != 0 {
-			return &info, err
-		}
+func (env *environment) parseNetworkInterface(network *WLAN_INTERFACE_INFO, clientHandle uint32) (*wifiInfo, error) {
+	info := wifiInfo{}
+	info.Interface = strings.TrimRight(string(utf16.Decode(network.strInterfaceDescription[:])), "\x00")
 
-		// SSID
-		ssid := wlanAttr.wlanAssociationAttributes.dot11Ssid
-		if ssid.uSSIDLength > 0 {
-			info.SSID = string(ssid.ucSSID[0:ssid.uSSIDLength])
-		}
+	// Query wifi connection state
+	var dataSize uint16
+	var wlanAttr *WLAN_CONNECTION_ATTRIBUTES
+	e, _, err := hWlanQueryInterface.Call(uintptr(clientHandle),
+		uintptr(unsafe.Pointer(&network.InterfaceGuid)),
+		uintptr(7), // wlan_intf_opcode_current_connection
+		uintptr(unsafe.Pointer(nil)),
+		uintptr(unsafe.Pointer(&dataSize)),
+		uintptr(unsafe.Pointer(&wlanAttr)),
+		uintptr(unsafe.Pointer(nil)))
+	if e != 0 {
+		env.log(Error, "parseNetworkInterface", "wlan_intf_opcode_current_connection error")
+		return &info, err
+	}
 
-		// see https://docs.microsoft.com/en-us/windows/win32/nativewifi/dot11-phy-type
-		switch wlanAttr.wlanAssociationAttributes.dot11PhyType {
-		case 1:
-			info.PhysType = "FHSS"
-		case 2:
-			info.PhysType = "DSSS"
-		case 3:
-			info.PhysType = "IR"
-		case 4:
-			info.PhysType = "802.11a"
-		case 5:
-			info.PhysType = "HRDSSS"
-		case 6:
-			info.PhysType = "802.11g"
-		case 7:
-			info.PhysType = "802.11n"
-		case 8:
-			info.PhysType = "802.11ac"
-		default:
-			info.PhysType = "Unknown"
-		}
+	// SSID
+	ssid := wlanAttr.wlanAssociationAttributes.dot11Ssid
+	if ssid.uSSIDLength > 0 {
+		info.SSID = string(ssid.ucSSID[0:ssid.uSSIDLength])
+	}
 
-		// see https://docs.microsoft.com/en-us/windows/win32/nativewifi/dot11-bss-type
-		switch wlanAttr.wlanAssociationAttributes.dot11BssType {
-		case 1:
-			info.BSSType = "Infrastructure"
-		case 2:
-			info.BSSType = "Independent"
-		default:
-			info.BSSType = "Any"
-		}
+	// see https://docs.microsoft.com/en-us/windows/win32/nativewifi/dot11-phy-type
+	switch wlanAttr.wlanAssociationAttributes.dot11PhyType {
+	case 1:
+		info.PhysType = FHSS
+	case 2:
+		info.PhysType = DSSS
+	case 3:
+		info.PhysType = IR
+	case 4:
+		info.PhysType = A
+	case 5:
+		info.PhysType = HRDSSS
+	case 6:
+		info.PhysType = G
+	case 7:
+		info.PhysType = N
+	case 8:
+		info.PhysType = AC
+	default:
+		info.PhysType = Unknown
+	}
 
-		if wlanAttr.wlanSecurityAttributes.bSecurityEnabled > 0 {
-			// see https://docs.microsoft.com/en-us/windows/win32/nativewifi/dot11-auth-algorithm
-			switch wlanAttr.wlanSecurityAttributes.dot11AuthAlgorithm {
-			case 1:
-				info.Auth = "802.11 Open System"
-			case 2:
-				info.Auth = "802.11 Shared Key"
-			case 3:
-				info.Auth = "WPA"
-			case 4:
-				info.Auth = "WPA PSK"
-			case 5:
-				info.Auth = "WPA NONE"
-			case 6:
-				info.Auth = "WPA2"
-			case 7:
-				info.Auth = "WPA2 PSK"
-			default:
-				info.Auth = "Unknown"
-			}
+	// see https://docs.microsoft.com/en-us/windows/win32/nativewifi/dot11-bss-type
+	switch wlanAttr.wlanAssociationAttributes.dot11BssType {
+	case 1:
+		info.RadioType = Infrastructure
+	case 2:
+		info.RadioType = Independent
+	default:
+		info.RadioType = Any
+	}
 
-			// see https://docs.microsoft.com/en-us/windows/win32/nativewifi/dot11-cipher-algorithm
-			switch wlanAttr.wlanSecurityAttributes.dot11CipherAlgorithm {
-			case 0:
-				info.Cipher = "None"
-			case 0x1:
-				info.Cipher = "WEP40"
-			case 0x2:
-				info.Cipher = "TKIP"
-			case 0x4:
-				info.Cipher = "CCMP"
-			case 0x5:
-				info.Cipher = "WEP104"
-			case 0x100:
-				info.Cipher = "WPA"
-			case 0x101:
-				info.Cipher = "WEP"
-			default:
-				info.Cipher = "Unknown"
-			}
-		} else {
-			info.Auth = "Disabled"
-		}
+	info.Signal = int(wlanAttr.wlanAssociationAttributes.wlanSignalQuality)
+	info.TransmitRate = int(wlanAttr.wlanAssociationAttributes.ulTxRate) / 1024
+	info.ReceiveRate = int(wlanAttr.wlanAssociationAttributes.ulRxRate) / 1024
 
-		info.Signal = int(wlanAttr.wlanAssociationAttributes.wlanSignalQuality)
-		info.TransmitRate = int(wlanAttr.wlanAssociationAttributes.ulTxRate)
-		info.ReceiveRate = int(wlanAttr.wlanAssociationAttributes.ulRxRate)
+	// Query wifi channel
+	dataSize = 0
+	var channel *uint32
+	e, _, err = hWlanQueryInterface.Call(uintptr(clientHandle),
+		uintptr(unsafe.Pointer(&network.InterfaceGuid)),
+		uintptr(8), // wlan_intf_opcode_channel_number
+		uintptr(unsafe.Pointer(nil)),
+		uintptr(unsafe.Pointer(&dataSize)),
+		uintptr(unsafe.Pointer(&channel)),
+		uintptr(unsafe.Pointer(nil)))
+	if e != 0 {
+		env.log(Error, "parseNetworkInterface", "wlan_intf_opcode_channel_number error")
+		return &info, err
+	}
+	info.Channel = int(*channel)
 
-		// Query wifi channel
-		dataSize = 0
-		var channel *uint32
-		e, _, err = hWlanQueryInterface.Call(uintptr(phClientHandle),
-			uintptr(unsafe.Pointer(&interfaces[i].InterfaceGuid)),
-			uintptr(8), // wlan_intf_opcode_channel_number
-			uintptr(unsafe.Pointer(nil)),
-			uintptr(unsafe.Pointer(&dataSize)),
-			uintptr(unsafe.Pointer(&channel)),
-			uintptr(unsafe.Pointer(nil)))
-		if e != 0 {
-			return &info, err
-		}
-
-		info.Channel = int(*channel)
-
+	if wlanAttr.wlanSecurityAttributes.bSecurityEnabled <= 0 {
+		info.Authentication = Disabled
 		return &info, nil
+	}
+
+	// see https://docs.microsoft.com/en-us/windows/win32/nativewifi/dot11-auth-algorithm
+	switch wlanAttr.wlanSecurityAttributes.dot11AuthAlgorithm {
+	case 1:
+		info.Authentication = OpenSystem
+	case 2:
+		info.Authentication = SharedKey
+	case 3:
+		info.Authentication = WPA
+	case 4:
+		info.Authentication = WPAPSK
+	case 5:
+		info.Authentication = WPANone
+	case 6:
+		info.Authentication = WPA2
+	case 7:
+		info.Authentication = WPA2PSK
+	default:
+		info.Authentication = Unknown
+	}
+
+	// see https://docs.microsoft.com/en-us/windows/win32/nativewifi/dot11-cipher-algorithm
+	switch wlanAttr.wlanSecurityAttributes.dot11CipherAlgorithm {
+	case 0:
+		info.Cipher = None
+	case 0x1:
+		info.Cipher = WEP40
+	case 0x2:
+		info.Cipher = TKIP
+	case 0x4:
+		info.Cipher = CCMP
+	case 0x5:
+		info.Cipher = WEP104
+	case 0x100:
+		info.Cipher = WPA
+	case 0x101:
+		info.Cipher = WEP
+	default:
+		info.Cipher = Unknown
 	}
 
 	return &info, nil
 }
 
-type WLAN_INTERFACE_INFO_LIST struct {
+type WLAN_INTERFACE_INFO_LIST struct { // nolint: revive
 	dwNumberOfItems uint32
-	dwIndex         uint32
+	dwIndex         uint32 // nolint: structcheck,unused
 	InterfaceInfo   [1]WLAN_INTERFACE_INFO
 }
 
-type WLAN_INTERFACE_INFO struct {
-	InterfaceGuid           syscall.GUID
+type WLAN_INTERFACE_INFO struct { // nolint: revive
+	InterfaceGuid           syscall.GUID // nolint: revive
 	strInterfaceDescription [256]uint16
 	isState                 uint32
 }
 
-type WLAN_CONNECTION_ATTRIBUTES struct {
-	isState                   uint32
-	wlanConnectionMode        uint32
-	strProfileName            [256]uint16
+type WLAN_CONNECTION_ATTRIBUTES struct { // nolint: revive
+	isState                   uint32      // nolint: structcheck,unused
+	wlanConnectionMode        uint32      // nolint: structcheck,unused
+	strProfileName            [256]uint16 // nolint: structcheck,unused
 	wlanAssociationAttributes WLAN_ASSOCIATION_ATTRIBUTES
 	wlanSecurityAttributes    WLAN_SECURITY_ATTRIBUTES
 }
 
-type WLAN_ASSOCIATION_ATTRIBUTES struct {
+type WLAN_ASSOCIATION_ATTRIBUTES struct { // nolint: revive
 	dot11Ssid         DOT11_SSID
 	dot11BssType      uint32
-	dot11Bssid        [6]uint8
+	dot11Bssid        [6]uint8 // nolint: structcheck,unused
 	dot11PhyType      uint32
-	uDot11PhyIndex    uint32
+	uDot11PhyIndex    uint32 // nolint: structcheck,unused
 	wlanSignalQuality uint32
 	ulRxRate          uint32
 	ulTxRate          uint32
 }
 
-type WLAN_SECURITY_ATTRIBUTES struct {
+type WLAN_SECURITY_ATTRIBUTES struct { // nolint: revive
 	bSecurityEnabled     uint32
-	bOneXEnabled         uint32
+	bOneXEnabled         uint32 // nolint: structcheck,unused
 	dot11AuthAlgorithm   uint32
 	dot11CipherAlgorithm uint32
 }
 
-type DOT11_SSID struct {
+type DOT11_SSID struct { // nolint: revive
 	uSSIDLength uint32
 	ucSSID      [32]uint8
 }

--- a/src/segment_path_test.go
+++ b/src/segment_path_test.go
@@ -198,6 +198,11 @@ func (env *MockedEnvironment) convertToLinuxPath(path string) string {
 	return args.String(0)
 }
 
+func (env *MockedEnvironment) getWifiNetworks() (*wifiInfo, error) {
+	args := env.Called(nil)
+	return args.Get(0).(*wifiInfo), args.Error(1)
+}
+
 const (
 	homeBill        = "/home/bill"
 	homeJan         = "/usr/home/jan"

--- a/src/segment_path_test.go
+++ b/src/segment_path_test.go
@@ -198,7 +198,7 @@ func (env *MockedEnvironment) convertToLinuxPath(path string) string {
 	return args.String(0)
 }
 
-func (env *MockedEnvironment) getWifiNetworks() (*wifiInfo, error) {
+func (env *MockedEnvironment) getWifiNetwork() (*wifiInfo, error) {
 	args := env.Called(nil)
 	return args.Get(0).(*wifiInfo), args.Error(1)
 }

--- a/src/segment_wifi_test.go
+++ b/src/segment_wifi_test.go
@@ -2,114 +2,41 @@ package main
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
-
-type netshStringArgs struct {
-	state          string
-	ssid           string
-	radioType      string
-	authentication string
-	channel        int
-	receiveRate    int
-	transmitRate   int
-	signal         int
-}
-
-func getNetshString(args *netshStringArgs) string {
-	const netshString string = `
-	There is 1 interface on the system:
-
-	Name                   : Wi-Fi
-	Description            : Intel(R) Wireless-AC 9560 160MHz
-	GUID                   : 6bb8def2-9af2-4bd4-8be2-6bd54e46bdc9
-	Physical address       : d4:3b:04:e6:10:40
-	State                  : %s
-	SSID                   : %s
-	BSSID                  : 5c:7d:7d:82:c5:73
-	Network type           : Infrastructure
-	Radio type             : %s
-	Authentication         : %s
-	Cipher                 : CCMP
-	Connection mode        : Profile
-	Channel                : %d
-	Receive rate (Mbps)    : %d
-	Transmit rate (Mbps)   : %d
-	Signal                 : %d%%
-	Profile                : ohsiggy
-
-	Hosted network status  : Not available`
-
-	return fmt.Sprintf(netshString, args.state, args.ssid, args.radioType, args.authentication, args.channel, args.receiveRate, args.transmitRate, args.signal)
-}
 
 func TestWiFiSegment(t *testing.T) {
 	cases := []struct {
 		Case            string
 		ExpectedString  string
 		ExpectedEnabled bool
-		CommandNotFound bool
-		CommandOutput   string
-		CommandError    error
+		Network         *wifiInfo
+		WifiError       error
 		DisplayError    bool
-		Template        string
-		ExpectedState   string
 	}{
 		{
-			Case:            "not enabled on windows when netsh command not found",
-			ExpectedEnabled: false,
-			ExpectedString:  "",
-			CommandNotFound: true,
+			Case: "No error and nil network",
 		},
 		{
-			Case:            "not enabled on windows when netsh command fails",
-			ExpectedEnabled: false,
-			ExpectedString:  "",
-			CommandError:    errors.New("intentional testing failure"),
+			Case:      "Error and nil network",
+			WifiError: errors.New("oh noes"),
 		},
 		{
-			Case:            "enabled on windows with DisplayError=true",
-			ExpectedEnabled: true,
-			ExpectedString:  "WIFI ERR: intentional testing failure",
-			CommandError:    errors.New("intentional testing failure"),
+			Case:            "Display error and nil network",
+			WifiError:       errors.New("oh noes"),
+			ExpectedString:  "oh noes",
 			DisplayError:    true,
-			Template:        "{{.State}}",
+			ExpectedEnabled: true,
 		},
 		{
-			Case:            "enabled on windows with every property in template",
+			Case:            "Display wifi state",
+			ExpectedString:  "pretty fly for a wifi",
 			ExpectedEnabled: true,
-			ExpectedString:  "connected testing 802.11ac WPA2-Personal 99 500 400 80",
-			CommandOutput: getNetshString(&netshStringArgs{
-				state:          "connected",
-				ssid:           "testing",
-				radioType:      "802.11ac",
-				authentication: "WPA2-Personal",
-				channel:        99,
-				receiveRate:    500.0,
-				transmitRate:   400.0,
-				signal:         80,
-			}),
-			Template: "{{.State}} {{.SSID}} {{.RadioType}} {{.Authentication}} {{.Channel}} {{.ReceiveRate}} {{.TransmitRate}} {{.Signal}}",
-		},
-		{
-			Case:            "enabled on windows but wifi not connected",
-			ExpectedEnabled: true,
-			ExpectedString:  "disconnected",
-			CommandOutput: getNetshString(&netshStringArgs{
-				state: "disconnected",
-			}),
-			Template: "{{if not .Connected}}{{.State}}{{end}}",
-		},
-		{
-			Case:            "enabled on windows but template is invalid",
-			ExpectedEnabled: true,
-			ExpectedString:  "unable to create text based on template",
-			CommandOutput:   getNetshString(&netshStringArgs{}),
-			Template:        "{{.DoesNotExist}}",
+			Network: &wifiInfo{
+				SSID: "pretty fly for a wifi",
+			},
 		},
 	}
 
@@ -117,18 +44,19 @@ func TestWiFiSegment(t *testing.T) {
 		env := new(MockedEnvironment)
 		env.On("getPlatform", nil).Return(windowsPlatform)
 		env.On("isWsl", nil).Return(false)
-		env.On("hasCommand", "netsh.exe").Return(!tc.CommandNotFound)
-		env.On("runCommand", mock.Anything, mock.Anything).Return(tc.CommandOutput, tc.CommandError)
+		env.On("getWifiNetwork", nil).Return(tc.Network, tc.WifiError)
 
 		w := &wifi{
 			env: env,
 			props: map[Property]interface{}{
 				DisplayError:    tc.DisplayError,
-				SegmentTemplate: tc.Template,
+				SegmentTemplate: "{{ if .Error }}{{ .Error }}{{ else }}{{ .SSID }}{{ end }}",
 			},
 		}
 
 		assert.Equal(t, tc.ExpectedEnabled, w.enabled(), tc.Case)
-		assert.Equal(t, tc.ExpectedString, w.string(), tc.Case)
+		if tc.Network != nil || tc.DisplayError {
+			assert.Equal(t, tc.ExpectedString, w.string(), tc.Case)
+		}
 	}
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

This fixes issue #1405 and makes the `wifi` segment work on non-englisch systems.
It's kind of a mess though. I used this article a lot:
https://medium.com/@justen.walker/breaking-all-the-rules-using-go-to-call-windows-api-2cbfd8c79724

Feel free to suggest changes to clean this up a little ;)
