### PR TITLE
feat: parse azure config files

### DIFF
--- a/docs/docs/segment-az.md
+++ b/docs/docs/segment-az.md
@@ -8,11 +8,6 @@ sidebar_label: Azure
 
 Display the currently active Azure subscription information.
 
-:::caution
-PowerShell offers support for the `Az.Accounts` module, but it is disabled by default.
-To enable this, set `$env:AZ_ENABLED = $true` in your `$PROFILE`.
-:::
-
 ## Sample Configuration
 
 ```json
@@ -35,10 +30,6 @@ To enable this, set `$env:AZ_ENABLED = $true` in your `$PROFILE`.
 properties below - defaults to `{{.Name}}`
 
 ## Template Properties
-
-:::caution
-When using the PowerShell module, only `.EnvironmentName`, `.ID`, `.Name` and `.User.Name` are available.
-:::
 
 - `.EnvironmentName`: `string` - the account environment name
 - `.HomeTenantID`: `string` - the home tenant id

--- a/src/init/omp.ps1
+++ b/src/init/omp.ps1
@@ -15,10 +15,6 @@ $env:POWERLINE_COMMAND = "oh-my-posh"
 $env:CONDA_PROMPT_MODIFIER = $false
 
 # specific module support (disabled by default)
-$omp_value = $env:AZ_ENABLED
-if ($null -eq $omp_value) {
-    $env:AZ_ENABLED = $false
-}
 $omp_value = $env:POSH_GIT_ENABLED
 if ($null -eq $omp_value) {
     $env:POSH_GIT_ENABLED = $false
@@ -49,24 +45,6 @@ function global:Initialize-ModuleSupport {
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSProvideCommentHelp', '', Justification = 'Variable used later(not in this scope)')]
         $global:GitStatus = Get-GitStatus
         $env:POSH_GIT_STATUS = Write-GitStatus -Status $global:GitStatus
-    }
-
-    $env:AZ_ENVIRONMENT_NAME = $null
-    $env:AZ_USER_NAME = $null
-    $env:AZ_SUBSCRIPTION_ID = $null
-    $env:AZ_ACCOUNT_NAME = $null
-
-    if ($env:AZ_ENABLED -eq $true) {
-        try {
-            $context = Get-AzContext
-            if ($null -ne $context) {
-                $env:AZ_ENVIRONMENT_NAME = $context.Environment.Name
-                $env:AZ_USER_NAME = $context.Account.Id
-                $env:AZ_SUBSCRIPTION_ID = $context.Subscription.Id
-                $env:AZ_ACCOUNT_NAME = $context.Subscription.Name
-            }
-        }
-        catch {}
     }
 }
 

--- a/src/segment_az_test.go
+++ b/src/segment_az_test.go
@@ -1,7 +1,8 @@
 package main
 
 import (
-	"fmt"
+	"io/ioutil"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,141 +10,59 @@ import (
 
 func TestAzSegment(t *testing.T) {
 	cases := []struct {
-		Case               string
-		ExpectedEnabled    bool
-		ExpectedString     string
-		EnvEnvironmentName string
-		EnvUserName        string
-		AccountName        string
-		EnvSubscriptionID  string
-		CLIExists          bool
-		CLIEnvironmentname string
-		CLISubscriptionID  string
-		CLIAccountName     string
-		CLIUserName        string
-		Template           string
+		Case            string
+		ExpectedEnabled bool
+		ExpectedString  string
+		HasCLI          bool
+		HasPowerShell   bool
+		Template        string
 	}{
 		{
-			Case:               "display account name",
-			ExpectedEnabled:    true,
-			ExpectedString:     "foobar",
-			CLIExists:          true,
-			CLIEnvironmentname: "foo",
-			CLISubscriptionID:  "bar",
-			CLIAccountName:     "foobar",
-			Template:           "{{.Name}}",
-		},
-		{
-			Case:               "envvars present",
-			ExpectedEnabled:    true,
-			ExpectedString:     "foo$bar",
-			EnvEnvironmentName: "foo",
-			EnvUserName:        "bar",
-			CLIExists:          false,
-			Template:           "{{.EnvironmentName}}${{.User.Name}}",
-		},
-		{
-			Case:               "envvar environment name present",
-			ExpectedEnabled:    true,
-			ExpectedString:     "foo",
-			EnvEnvironmentName: "foo",
-			CLIExists:          false,
-			Template:           "{{.EnvironmentName}}",
-		},
-		{
-			Case:            "envvar user name present",
-			ExpectedEnabled: true,
-			ExpectedString:  "bar",
-			EnvUserName:     "bar",
-			CLIExists:       false,
-			Template:        "{{.User.Name}}",
-		},
-		{
-			Case:              "envvar subscription id",
-			ExpectedEnabled:   true,
-			ExpectedString:    "foobar",
-			EnvSubscriptionID: "foobar",
-			EnvUserName:       "bar",
-			CLIExists:         false,
-			Template:          "{{.ID}}",
-		},
-		{
-			Case:            "cli not found",
+			Case:            "no config files found",
 			ExpectedEnabled: false,
-			ExpectedString:  "",
-			CLIExists:       false,
 		},
 		{
-			Case:               "cli contains data",
-			ExpectedEnabled:    true,
-			ExpectedString:     "foo$bar",
-			CLIExists:          true,
-			CLIEnvironmentname: "foo",
-			CLISubscriptionID:  "bar",
-			Template:           "{{.EnvironmentName}}${{.ID}}",
+			Case:            "Az CLI Profile",
+			ExpectedEnabled: true,
+			ExpectedString:  "AzureCliCloud",
+			Template:        "{{ .EnvironmentName }}",
+			HasCLI:          true,
 		},
 		{
-			Case:               "print only environment ame",
-			ExpectedEnabled:    true,
-			ExpectedString:     "foo",
-			CLIExists:          true,
-			CLIEnvironmentname: "foo",
-			CLISubscriptionID:  "bar",
-			Template:           "{{.EnvironmentName}}",
+			Case:            "Az Pwsh Profile",
+			ExpectedEnabled: true,
+			ExpectedString:  "AzurePoshCloud",
+			Template:        "{{ .EnvironmentName }}",
+			HasPowerShell:   true,
 		},
 		{
-			Case:               "print only id",
-			ExpectedEnabled:    true,
-			ExpectedString:     "bar",
-			CLIExists:          true,
-			CLIEnvironmentname: "foo",
-			CLISubscriptionID:  "bar",
-			Template:           "{{.ID}}",
-		},
-		{
-			Case:               "print none",
-			ExpectedEnabled:    true,
-			CLIExists:          true,
-			CLIEnvironmentname: "foo",
-			CLISubscriptionID:  "bar",
-		},
-		{
-			Case:               "update needed",
-			ExpectedEnabled:    true,
-			ExpectedString:     updateMessage,
-			CLIExists:          true,
-			CLIEnvironmentname: "Do you want to continue? (Y/n): Visual Studio Enterprise",
+			Case:            "Faulty template",
+			ExpectedEnabled: true,
+			ExpectedString:  incorrectTemplate,
+			Template:        "{{ .Burp }}",
+			HasPowerShell:   true,
 		},
 	}
 
 	for _, tc := range cases {
 		env := new(MockedEnvironment)
-		env.On("getenv", "AZ_ENVIRONMENT_NAME").Return(tc.EnvEnvironmentName)
-		env.On("getenv", "AZ_USER_NAME").Return(tc.EnvUserName)
-		env.On("getenv", "AZ_SUBSCRIPTION_ID").Return(tc.EnvSubscriptionID)
-		env.On("getenv", "AZ_ACCOUNT_NAME").Return(tc.AccountName)
-		env.On("hasCommand", "az").Return(tc.CLIExists)
-		env.On("runCommand", "az", []string{"account", "show"}).Return(
-			fmt.Sprintf(`{
-				"environmentName": "%s",
-				"homeTenantId": "8d934305-ac9f-46fe-b0e7-50fd32ad2acf",
-				"id": "%s",
-				"isDefault": true,
-				"managedByTenants": [],
-				"name": "%s",
-				"state": "Enabled",
-				"tenantId": "8d934305-ac9f-46fe-b0e7-50fd32ad2acf",
-				"user": {
-				  "name": "%s",
-				  "type": "user"
-				}
-			  }`, tc.CLIEnvironmentname, tc.CLISubscriptionID, tc.CLIAccountName, tc.CLIUserName),
-			nil,
-		)
+		home := "/Users/posh"
+		env.On("homeDir", nil).Return(home)
+		var azureProfile, azureRmContext string
+		if tc.HasCLI {
+			content, _ := ioutil.ReadFile("./test/azureProfile.json")
+			azureProfile = string(content)
+		}
+		if tc.HasPowerShell {
+			content, _ := ioutil.ReadFile("./test/AzureRmContext.json")
+			azureRmContext = string(content)
+		}
+		env.On("getFileContent", filepath.Join(home, ".azure/azureProfile.json")).Return(azureProfile)
+		env.On("getFileContent", filepath.Join(home, ".azure/AzureRmContext.json")).Return(azureRmContext)
+
 		var props properties = map[Property]interface{}{
 			SegmentTemplate: tc.Template,
 		}
-
 		az := &az{
 			env:   env,
 			props: props,

--- a/src/segment_git.go
+++ b/src/segment_git.go
@@ -310,7 +310,10 @@ func (g *git) getGitCommand() string {
 
 func (g *git) getGitCommandOutput(args ...string) string {
 	args = append([]string{"-C", g.gitRealFolder, "--no-optional-locks", "-c", "core.quotepath=false", "-c", "color.status=false"}, args...)
-	val, _ := g.env.runCommand(g.getGitCommand(), args...)
+	val, err := g.env.runCommand(g.getGitCommand(), args...)
+	if err != nil {
+		return ""
+	}
 	return val
 }
 

--- a/src/template.go
+++ b/src/template.go
@@ -50,7 +50,7 @@ func (t *textTemplate) render() (string, error) {
 	if err != nil {
 		return "", errors.New(invalidTemplate)
 	}
-	if strings.Contains(t.Template, ".Env") {
+	if strings.Contains(t.Template, ".Env.") {
 		t.loadEnvVars()
 	}
 	buffer := new(bytes.Buffer)

--- a/src/test/AzureRmContext.json
+++ b/src/test/AzureRmContext.json
@@ -1,0 +1,81 @@
+{
+  "DefaultContextKey": "My Azure Subscription (subscription_id) - tenant_id - user_name",
+  "EnvironmentTable": {},
+  "Contexts": {
+    "My Azure Subscription (subscription_id) - tenant_id - user_name": {
+      "Account": {
+        "Id": "232-232-232-232",
+        "Type": "User",
+        "TenantMap": {},
+        "ExtendedProperties": {
+          "Subscriptions": "subscription_ids",
+          "Tenants": "tenants_ids",
+          "HomeAccountId": "tenants_ids"
+        }
+      },
+      "Tenant": {
+        "Id": "4777-4777-4777-4777",
+        "Directory": null,
+        "IsHome": true,
+        "ExtendedProperties": {}
+      },
+      "Subscription": {
+        "Id": "97hkk-97hkk-97hkk-97hkk",
+        "Name": "AzurePosh",
+        "State": "Poshfull",
+        "ExtendedProperties": {
+          "HomeTenant": "688ab8f8-d8d8-4c8b-b8b8-b8b8b8b8b8b8",
+          "AuthorizationSource": "Legacy",
+          "SubscriptionPolices": "{\"locationPlacementId\":\"Public_2014-09-01\",\"quotaId\":\"MSDN_2014-09-01\",\"spendingLimit\":\"On\"}",
+          "Tenants": "4777-4777-4777-4777",
+          "Account": "Bill",
+          "Environment": "AzurePoshCloud"
+        }
+      },
+      "Environment": {
+        "Name": "AzurePoshCloud",
+        "Type": "Built-in",
+        "OnPremise": false,
+        "ServiceManagementUrl": "https://management.core.windows.net/",
+        "ResourceManagerUrl": "https://management.azure.com/",
+        "ManagementPortalUrl": "https://portal.azure.com/",
+        "PublishSettingsFileUrl": "https://go.microsoft.com/fwlink/?LinkID=301775",
+        "ActiveDirectoryAuthority": "https://login.microsoftonline.com/",
+        "GalleryUrl": "https://gallery.azure.com/",
+        "GraphUrl": "https://graph.windows.net/",
+        "ActiveDirectoryServiceEndpointResourceId": "https://management.core.windows.net/",
+        "StorageEndpointSuffix": "core.windows.net",
+        "SqlDatabaseDnsSuffix": ".database.windows.net",
+        "TrafficManagerDnsSuffix": "trafficmanager.net",
+        "AzureKeyVaultDnsSuffix": "vault.azure.net",
+        "AzureKeyVaultServiceEndpointResourceId": "https://vault.azure.net",
+        "GraphEndpointResourceId": "https://graph.windows.net/",
+        "DataLakeEndpointResourceId": "https://datalake.azure.net/",
+        "BatchEndpointResourceId": "https://batch.core.windows.net/",
+        "AzureDataLakeAnalyticsCatalogAndJobEndpointSuffix": "azuredatalakeanalytics.net",
+        "AzureDataLakeStoreFileSystemEndpointSuffix": "azuredatalakestore.net",
+        "AdTenant": "Common",
+        "ContainerRegistryEndpointSuffix": "azurecr.io",
+        "VersionProfiles": [],
+        "ExtendedProperties": {
+          "OperationalInsightsEndpoint": "https://api.loganalytics.io/v1",
+          "OperationalInsightsEndpointResourceId": "https://api.loganalytics.io",
+          "AzureAnalysisServicesEndpointSuffix": "asazure.windows.net",
+          "AnalysisServicesEndpointResourceId": "https://region.asazure.windows.net",
+          "AzureAttestationServiceEndpointSuffix": "attest.azure.net",
+          "AzureAttestationServiceEndpointResourceId": "https://attest.azure.net",
+          "AzureSynapseAnalyticsEndpointSuffix": "dev.azuresynapse.net",
+          "AzureSynapseAnalyticsEndpointResourceId": "https://dev.azuresynapse.net",
+          "ManagedHsmServiceEndpointResourceId": "https://managedhsm.azure.net",
+          "ManagedHsmServiceEndpointSuffix": "managedhsm.azure.net",
+          "MicrosoftGraphEndpointResourceId": "https://graph.microsoft.com/",
+          "MicrosoftGraphUrl": "https://graph.microsoft.com"
+        }
+      },
+      "VersionProfile": null,
+      "TokenCache": { "CacheData": null },
+      "ExtendedProperties": {}
+    }
+  },
+  "ExtendedProperties": {}
+}

--- a/src/test/azureProfile.json
+++ b/src/test/azureProfile.json
@@ -1,0 +1,16 @@
+{
+  "installationId": "8d2919ac-a393-11eb-9100-acde48001122",
+  "subscriptions": [
+    {
+      "id": "g51ds77-a393-11eb-9100-acde48001122",
+      "name": "AzureCli",
+      "state": "Powerfull",
+      "user": { "name": "Melinda", "type": "user" },
+      "isDefault": true,
+      "tenantId": "6js98d-a393-11eb-9100-acde48001122",
+      "environmentName": "AzureCliCloud",
+      "homeTenantId": "8d934305-ac9f-46fe-b0e7-50fd32ad2acf",
+      "managedByTenants": []
+    }
+  ]
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

Resolves #1473

If the following is true, this change could allow for the CLI parsing to be removed as
well as specific support for the PowerShell module.

- AZ CLI: you have a ~/.azure/azureProfile.json file
- AZ pwsh module: you have a ~/.azure/AzureRmContext.json

Both files should contain all info needed to populate the segment.

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
