### PR TITLE
fix(az): add user to exposed model for pwsh

### DIFF
--- a/packages/inno/oh-my-posh.iss
+++ b/packages/inno/oh-my-posh.iss
@@ -3,12 +3,13 @@ AppName=Oh My Posh
 AppVersion=<VERSION>
 DefaultDirName={autopf}\oh-my-posh
 DefaultGroupName=Oh My Posh
-PrivilegesRequired=lowest
 AppPublisher=Jan De Dobbeleer
 AppPublisherURL=https://ohmyposh.dev
 AppSupportURL=https://github.com/JanDeDobbeleer/oh-my-posh/issues
 LicenseFile="bin\COPYING.txt"
 OutputBaseFilename=install
+PrivilegesRequired=lowest
+PrivilegesRequiredOverridesAllowed=commandline dialog
 
 [Files]
 Source: "bin\oh-my-posh.exe"; DestDir: "{app}\bin"

--- a/packages/winget/JanDeDobbeleer.OhMyPosh.installer.yaml
+++ b/packages/winget/JanDeDobbeleer.OhMyPosh.installer.yaml
@@ -7,8 +7,6 @@ InstallerType: inno
 Scope: user
 InstallModes:
 - interactive
-- silent
-- silentWithProgress
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v<VERSION>/install-amd64.exe

--- a/src/environment.go
+++ b/src/environment.go
@@ -164,6 +164,7 @@ type environment struct {
 
 func (env *environment) init(args *args) {
 	env.args = args
+	env.resolveConfigPath()
 	env.cmdCache = &commandCache{
 		commands: newConcurrentMap(),
 	}
@@ -173,6 +174,23 @@ func (env *environment) init(args *args) {
 	}
 	env.fileCache = &fileCache{}
 	env.fileCache.init(env.getCachePath())
+}
+
+func (env *environment) resolveConfigPath() {
+	if env.args == nil || env.args.Config == nil {
+		return
+	}
+	configFile := *env.args.Config
+	if strings.HasPrefix(configFile, "~") {
+		configFile = strings.TrimPrefix(configFile, "~")
+		configFile = filepath.Join(env.homeDir(), configFile)
+	}
+	if !filepath.IsAbs(configFile) {
+		if absConfigFile, err := filepath.Abs(configFile); err == nil {
+			configFile = absConfigFile
+		}
+	}
+	*env.args.Config = filepath.Clean(configFile)
 }
 
 func (env *environment) trace(start time.Time, function string, args ...string) {

--- a/src/segment_az.go
+++ b/src/segment_az.go
@@ -144,5 +144,8 @@ func (a *az) getAzureRmContext() bool {
 	a.ID = defaultContext.Subscription.ID
 	a.Name = defaultContext.Subscription.Name
 	a.State = defaultContext.Subscription.State
+	a.User = &AzureUser{
+		Name: defaultContext.Subscription.ExtendedProperties.Account,
+	}
 	return true
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

- Add the user to the Azure model when in PowerShell module mode
- Resolve the path for all shells before adding it to the config (relates to #867)
- Allow installation for all users on Windows (winget)

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
