### PR TITLE
fix(engine): osc99 support for windows terminal

### DIFF
--- a/src/engine.go
+++ b/src/engine.go
@@ -67,9 +67,6 @@ func (e *engine) render() string {
 		return e.print()
 	}
 	cwd := e.env.getcwd()
-	if e.env.isWsl() {
-		cwd, _ = e.env.runCommand("wslpath", "-m", cwd)
-	}
 	e.writeANSI(e.ansi.consolePwd(cwd))
 	return e.print()
 }


### PR DESCRIPTION
wsl conversion not needed anymore

### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

fix osc99 issue in wsl(zsh and pwsh). Keep current folder when duplicating tab.

I did not check yet why it's not working anymore.

Works in WSL/WSL2

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
