### PR TITLE
fix: change default az segment template

### DIFF
--- a/src/segment_az.go
+++ b/src/segment_az.go
@@ -78,7 +78,7 @@ type AzurePowerShellSubscription struct {
 }
 
 func (a *az) string() string {
-	segmentTemplate := a.props.getString(SegmentTemplate, "{{ .EnvironmentName }}")
+	segmentTemplate := a.props.getString(SegmentTemplate, "{{ .Name }}")
 	template := &textTemplate{
 		Template: segmentTemplate,
 		Context:  a,


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

Docs mention that by default the az segment should show the name, but it was showing the environment.
Fixes #1543 
