### PR TITLE
feat: adjust var names for consistency

### DIFF
--- a/docs/docs/config-title.md
+++ b/docs/docs/config-title.md
@@ -37,8 +37,8 @@ offers a few standard properties to work with.
 - `.PWD`: `string` - the current working directory
 - `.Folder`: `string` - the current working folder
 - `.Shell`: `string` - the current shell name
-- `.User`: `string` - the current user name
-- `.Host`: `string` - the host name
+- `.UserName`: `string` - the current user name
+- `.HostName`: `string` - the host name
 - `.Env.VarName`: `string` - Any environment variable where `VarName` is the environment variable name
 
 A `boolean` can be used for conditional display purposes, a `string` can be displayed.
@@ -54,7 +54,7 @@ the current working directory is `/usr/home/omp` and the shell is `zsh`.
     // when root == true: omp :: root :: zsh
     "console_title_template": "{{.Folder}}", // outputs: omp
     "console_title_template": "{{.Shell}} in {{.PWD}}", // outputs: zsh in /usr/home/omp
-    "console_title_template": "{{.User}}@{{.Host}} {{.Shell}} in {{.PWD}}", // outputs: MyUser@MyMachine zsh in /usr/home/omp
+    "console_title_template": "{{.UserName}}@{{.HostName}} {{.Shell}} in {{.PWD}}", // outputs: MyUser@MyMachine zsh in /usr/home/omp
     "console_title_template": "{{.Env.USERDOMAIN}} {{.Shell}} in {{.PWD}}", // outputs: MyCompany zsh in /usr/home/omp
 }
 ```

--- a/docs/docs/config-transient.mdx
+++ b/docs/docs/config-transient.mdx
@@ -55,8 +55,8 @@ properties below - defaults to `{{ .Shell }}> `
 - `.Path`: `string` - the current working directory
 - `.Folder`: `string` - the current working folder
 - `.Shell`: `string` - the current shell name
-- `.User`: `string` - the current user name
-- `.Host`: `string` - the host name
+- `.UserName`: `string` - the current user name
+- `.HostName`: `string` - the host name
 - `.Env.VarName`: `string` - Any environment variable where `VarName` is the environment variable name
 
 ## Enable the feature

--- a/docs/docs/segment-kubectl.md
+++ b/docs/docs/segment-kubectl.md
@@ -36,7 +36,7 @@ performance - defaults to `false`
 
 - `.Context`: `string` - the current kubectl context
 - `.Namespace`: `string` - the current kubectl context namespace
-- `.UserName`: `string` - the current kubectl context user
+- `.User`: `string` - the current kubectl context user
 - `.Cluster`: `string` - the current kubectl context cluster
 
 ## Tips

--- a/docs/docs/segment-session.md
+++ b/docs/docs/segment-session.md
@@ -13,7 +13,7 @@ Show the current user and host name.
 ```json
 {
   "type": "session",
-  "style": "diamond", 
+  "style": "diamond",
   "foreground": "#ffffff",
   "background": "#c386f1",
   "leading_diamond": "\uE0B6",
@@ -32,7 +32,7 @@ properties below.
 ## Template Properties
 
 - `.UserName`: `string` - the current user's name
-- `.ComputerName`: `string` - the current computer's name
+- `.HostName`: `string` - the current computer's name
 - `.SSHSession`: `boolean` - active SSH session or not
 - `.Root`: `boolean` - are you a root/admin user or not
 

--- a/docs/docs/segment-text.md
+++ b/docs/docs/segment-text.md
@@ -46,8 +46,8 @@ with [sprig][sprig] utilizing the properties below.
 - `.Path`: `string` - the current working directory
 - `.Folder`: `string` - the current working folder
 - `.Shell`: `string` - the current shell name
-- `.User`: `string` - the current user name
-- `.Host`: `string` - the host name
+- `.UserName`: `string` - the current user name
+- `.HostName`: `string` - the host name
 - `.Env.VarName`: `string` - Any environment variable where `VarName` is the environment variable name
 
 [coloring]: /docs/config-colors

--- a/src/console_title_test.go
+++ b/src/console_title_test.go
@@ -39,7 +39,7 @@ func TestGetConsoleTitle(t *testing.T) {
 		},
 		{
 			Style:         Template,
-			Template:      "{{.User}}@{{.Host}}{{if .Root}} :: Admin{{end}} :: {{.Shell}}",
+			Template:      "{{.UserName}}@{{.HostName}}{{if .Root}} :: Admin{{end}} :: {{.Shell}}",
 			Root:          true,
 			User:          "MyUser",
 			PathSeperator: "\\",
@@ -88,7 +88,7 @@ func TestGetConsoleTitleIfGethostnameReturnsError(t *testing.T) {
 	}{
 		{
 			Style:         Template,
-			Template:      "Not using Host only {{.User}} and {{.Shell}}",
+			Template:      "Not using Host only {{.UserName}} and {{.Shell}}",
 			User:          "MyUser",
 			PathSeperator: "\\",
 			ShellName:     "PowerShell",
@@ -96,7 +96,7 @@ func TestGetConsoleTitleIfGethostnameReturnsError(t *testing.T) {
 		},
 		{
 			Style:         Template,
-			Template:      "{{.User}}@{{.Host}} :: {{.Shell}}",
+			Template:      "{{.UserName}}@{{.HostName}} :: {{.Shell}}",
 			User:          "MyUser",
 			PathSeperator: "\\",
 			ShellName:     "PowerShell",

--- a/src/segment_az.go
+++ b/src/segment_az.go
@@ -21,7 +21,7 @@ type AzureConfig struct {
 
 type AzureSubscription struct {
 	ID               string        `json:"id"`
-	UserName         string        `json:"name"`
+	Name             string        `json:"name"`
 	State            string        `json:"state"`
 	User             *AzureUser    `json:"user"`
 	IsDefault        bool          `json:"isDefault"`
@@ -153,7 +153,7 @@ func (a *az) getAzureRmContext() bool {
 	a.EnvironmentName = defaultContext.Environment.Name
 	a.TenantID = defaultContext.Tenant.ID
 	a.ID = defaultContext.Subscription.ID
-	a.UserName = defaultContext.Subscription.Name
+	a.Name = defaultContext.Subscription.Name
 	a.State = defaultContext.Subscription.State
 	a.User = &AzureUser{
 		Name: defaultContext.Subscription.ExtendedProperties.Account,

--- a/src/segment_deprecated.go
+++ b/src/segment_deprecated.go
@@ -284,14 +284,14 @@ func (s *session) getDefaultUser() string {
 
 func (s *session) legacyEnabled() bool {
 	if s.props.getBool(DisplayUser, true) {
-		s.UserName = s.getUserName()
+		s.userName = s.getUserName()
 	}
 	if s.props.getBool(DisplayHost, true) {
-		s.ComputerName = s.getComputerName()
+		s.hostName = s.getComputerName()
 	}
 	s.DefaultUserName = s.getDefaultUser()
 	showDefaultUser := s.props.getBool(DisplayDefault, true)
-	if !showDefaultUser && s.DefaultUserName == s.UserName {
+	if !showDefaultUser && s.DefaultUserName == s.userName {
 		return false
 	}
 	return true
@@ -310,15 +310,15 @@ func (s *session) getFormattedText() string {
 	userColor := s.props.getColor(UserColor, defaulColor)
 	hostColor := s.props.getColor(HostColor, defaulColor)
 	if len(userColor) > 0 && len(hostColor) > 0 {
-		return fmt.Sprintf("%s<%s>%s</>%s<%s>%s</>", sshIcon, userColor, s.UserName, separator, hostColor, s.ComputerName)
+		return fmt.Sprintf("%s<%s>%s</>%s<%s>%s</>", sshIcon, userColor, s.userName, separator, hostColor, s.hostName)
 	}
 	if len(userColor) > 0 {
-		return fmt.Sprintf("%s<%s>%s</>%s%s", sshIcon, userColor, s.UserName, separator, s.ComputerName)
+		return fmt.Sprintf("%s<%s>%s</>%s%s", sshIcon, userColor, s.userName, separator, s.hostName)
 	}
 	if len(hostColor) > 0 {
-		return fmt.Sprintf("%s%s%s<%s>%s</>", sshIcon, s.UserName, separator, hostColor, s.ComputerName)
+		return fmt.Sprintf("%s%s%s<%s>%s</>", sshIcon, s.userName, separator, hostColor, s.hostName)
 	}
-	return fmt.Sprintf("%s%s%s%s", sshIcon, s.UserName, separator, s.ComputerName)
+	return fmt.Sprintf("%s%s%s%s", sshIcon, s.userName, separator, s.hostName)
 }
 
 // Language

--- a/src/segment_kubectl.go
+++ b/src/segment_kubectl.go
@@ -26,7 +26,7 @@ type KubeConfig struct {
 
 type KubeContext struct {
 	Cluster   string `yaml:"cluster"`
-	UserName  string `yaml:"user"`
+	User      string `yaml:"user"`
 	Namespace string `yaml:"namespace"`
 }
 
@@ -139,6 +139,6 @@ func (k *kubectl) setError(message string) {
 		k.Context = message
 	}
 	k.Namespace = message
-	k.UserName = message
+	k.User = message
 	k.Cluster = message
 }

--- a/src/segment_kubectl_test.go
+++ b/src/segment_kubectl_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const testKubectlAllInfoTemplate = "{{.Context}} :: {{.Namespace}} :: {{.UserName}} :: {{.Cluster}}"
+const testKubectlAllInfoTemplate = "{{.Context}} :: {{.Namespace}} :: {{.User}} :: {{.Cluster}}"
 
 func TestKubectlSegment(t *testing.T) {
 	standardTemplate := "{{.Context}}{{if .Namespace}} :: {{.Namespace}}{{end}}"

--- a/src/segment_session.go
+++ b/src/segment_session.go
@@ -7,10 +7,9 @@ type session struct {
 	env   Environment
 	text  string
 
-	UserName     string
-	ComputerName string
-	SSHSession   bool
-	Root         bool
+	userName   string
+	hostName   string
+	SSHSession bool
 
 	// Deprecated
 	DefaultUserName string
@@ -22,9 +21,6 @@ func (s *session) enabled() bool {
 	if segmentTemplate == "" {
 		return s.legacyEnabled()
 	}
-	s.UserName = s.getUserName()
-	s.ComputerName = s.getComputerName()
-	s.Root = s.env.isRunningAsRoot()
 	template := &textTemplate{
 		Template: segmentTemplate,
 		Context:  s,

--- a/src/segment_session_test.go
+++ b/src/segment_session_test.go
@@ -23,7 +23,7 @@ func TestSessionSegmentTemplate(t *testing.T) {
 			ExpectedString:  "john@company-laptop",
 			ComputerName:    "company-laptop",
 			UserName:        "john",
-			Template:        "{{.UserName}}@{{.ComputerName}}",
+			Template:        "{{.UserName}}@{{.HostName}}",
 			ExpectedEnabled: true,
 		},
 		{
@@ -39,7 +39,7 @@ func TestSessionSegmentTemplate(t *testing.T) {
 			UserName:        "john",
 			SSHSession:      true,
 			ComputerName:    "remote",
-			Template:        "{{.UserName}}{{if .SSHSession}} on {{.ComputerName}}{{end}}",
+			Template:        "{{.UserName}}{{if .SSHSession}} on {{.HostName}}{{end}}",
 			ExpectedEnabled: true,
 		},
 		{
@@ -48,7 +48,7 @@ func TestSessionSegmentTemplate(t *testing.T) {
 			UserName:        "john",
 			SSHSession:      false,
 			ComputerName:    "remote",
-			Template:        "{{.UserName}}{{if .SSHSession}} on {{.ComputerName}}{{end}}",
+			Template:        "{{.UserName}}{{if .SSHSession}} on {{.HostName}}{{end}}",
 			ExpectedEnabled: true,
 		},
 		{
@@ -58,7 +58,7 @@ func TestSessionSegmentTemplate(t *testing.T) {
 			SSHSession:      true,
 			ComputerName:    "remote",
 			Root:            true,
-			Template:        "{{if .Root}}super {{end}}{{.UserName}}{{if .SSHSession}} on {{.ComputerName}}{{end}}",
+			Template:        "{{if .Root}}super {{end}}{{.UserName}}{{if .SSHSession}} on {{.HostName}}{{end}}",
 			ExpectedEnabled: true,
 		},
 		{

--- a/src/segment_text_test.go
+++ b/src/segment_text_test.go
@@ -17,7 +17,7 @@ func TestTextSegment(t *testing.T) {
 		{Case: "template text with env var", ExpectedString: "hello world", Text: "{{ .Env.HELLO }} world"},
 		{Case: "template text with shell name", ExpectedString: "hello world from terminal", Text: "{{ .Env.HELLO }} world from {{ .Shell }}"},
 		{Case: "template text with folder", ExpectedString: "hello world in posh", Text: "{{ .Env.HELLO }} world in {{ .Folder }}"},
-		{Case: "template text with user", ExpectedString: "hello Posh", Text: "{{ .Env.HELLO }} {{ .User }}"},
+		{Case: "template text with user", ExpectedString: "hello Posh", Text: "{{ .Env.HELLO }} {{ .UserName }}"},
 		{Case: "empty text", Text: "", ExpectedDisabled: true},
 		{Case: "empty template result", Text: "{{ .Env.WORLD }}", ExpectedDisabled: true},
 	}

--- a/src/template.go
+++ b/src/template.go
@@ -26,15 +26,15 @@ type textTemplate struct {
 type Data interface{}
 
 type Context struct {
-	Root   bool
-	PWD    string
-	Folder string
-	Shell  string
-	User   string
-	Host   string
-	Code   int
-	Env    map[string]string
-	OS     string
+	Root     bool
+	PWD      string
+	Folder   string
+	Shell    string
+	UserName string
+	HostName string
+	Code     int
+	Env      map[string]string
+	OS       string
 
 	// Simple container to hold ANY object
 	Data
@@ -51,9 +51,9 @@ func (c *Context) init(t *textTemplate) {
 	c.PWD = pwd
 	c.Folder = base(c.PWD, t.Env)
 	c.Shell = t.Env.getShellName()
-	c.User = t.Env.getCurrentUser()
+	c.UserName = t.Env.getCurrentUser()
 	if host, err := t.Env.getHostName(); err == nil {
-		c.Host = host
+		c.HostName = host
 	}
 	c.Code = t.Env.lastErrorCode()
 	c.Env = t.Env.environ()
@@ -104,7 +104,7 @@ func (t *textTemplate) cleanTemplate() {
 		*knownVariables = append(*knownVariables, splitted[0])
 		return splitted[0], true
 	}
-	knownVariables := []string{"Root", "PWD", "Folder", "Shell", "User", "Host", "Env", "Data", "Code", "OS"}
+	knownVariables := []string{"Root", "PWD", "Folder", "Shell", "UserName", "HostName", "Env", "Data", "Code", "OS"}
 	matches := findAllNamedRegexMatch(`(?: |{)(?P<var>(\.[a-zA-Z_][a-zA-Z0-9]*)+)`, t.Template)
 	for _, match := range matches {
 		if variable, OK := unknownVariable(match["var"], &knownVariables); OK {

--- a/themes/agnoster.omp.json
+++ b/themes/agnoster.omp.json
@@ -19,7 +19,7 @@
           "foreground": "#100e23",
           "background": "#ffffff",
           "properties": {
-            "template": "{{ .UserName }}@{{ .ComputerName }}"
+            "template": "{{ .UserName }}@{{ .HostName }}"
           }
         },
         {

--- a/themes/agnosterplus.omp.json
+++ b/themes/agnosterplus.omp.json
@@ -28,7 +28,7 @@
           "foreground": "#100e23",
           "background": "#ffffff",
           "properties": {
-            "template": "{{ .UserName }}@{{ .ComputerName }}"
+            "template": "{{ .UserName }}@{{ .HostName }}"
           }
         },
         {

--- a/themes/aliens.omp.json
+++ b/themes/aliens.omp.json
@@ -13,7 +13,7 @@
           "leading_diamond": "\uE0B6",
           "trailing_diamond": "\uE0B0",
           "properties": {
-            "template": "{{ .UserName }}@{{ .ComputerName }}"
+            "template": "{{ .UserName }}@{{ .HostName }}"
           }
         },
         {

--- a/themes/atomicBit.omp.json
+++ b/themes/atomicBit.omp.json
@@ -13,7 +13,7 @@
           "properties": {
             "prefix": "╭─[",
             "postfix": "]─",
-            "template": "<#ffff55>{{ .UserName }}</><#ff5555>@</><#55ff55>{{ .ComputerName }}</>"
+            "template": "<#ffff55>{{ .UserName }}</><#ff5555>@</><#55ff55>{{ .HostName }}</>"
           }
         },
         {

--- a/themes/blue-owl.omp.json
+++ b/themes/blue-owl.omp.json
@@ -4,7 +4,7 @@
   "osc99": true,
   "console_title": true,
   "console_title_style": "template",
-  "console_title_template": "{{if .Root}} ⚡ {{end}}{{.Folder | replace \"~\" \"🏚\" }} @ {{.Host}}",
+  "console_title_template": "{{if .Root}} ⚡ {{end}}{{.Folder | replace \"~\" \"🏚\" }} @ {{.HostName}}",
   "blocks": [
     {
       "type": "prompt",
@@ -101,7 +101,7 @@
           "properties": {
             "postfix": "",
             "prefix": "  ",
-            "template": "{{ .UserName }}<transparent> / </>{{ .ComputerName }}"
+            "template": "{{ .UserName }}<transparent> / </>{{ .HostName }}"
           }
         },
         {

--- a/themes/blueish.omp.json
+++ b/themes/blueish.omp.json
@@ -24,7 +24,7 @@
           "background": "#546E7A",
           "powerline_symbol": "\uE0B0",
           "properties": {
-            "template": "{{ .UserName }}@{{ .ComputerName }}"
+            "template": "{{ .UserName }}@{{ .HostName }}"
           }
         },
         {

--- a/themes/capr4n.omp.json
+++ b/themes/capr4n.omp.json
@@ -3,7 +3,7 @@
   "final_space": true,
   "console_title": true,
   "console_title_style": "template",
-  "console_title_template": "{{if .Root}} ⚡ {{end}}{{.User}} ➔ 📁{{.Folder}}",
+  "console_title_template": "{{if .Root}} ⚡ {{end}}{{.UserName}} ➔ 📁{{.Folder}}",
   "blocks": [
     {
       "type": "rprompt",

--- a/themes/cinnamon.omp.json
+++ b/themes/cinnamon.omp.json
@@ -12,7 +12,7 @@
             "background": "#07585c",
             "leading_diamond": "\uE0B6",
             "properties": {
-              "template": "{{ .UserName }}@{{ .ComputerName }}"
+              "template": "{{ .UserName }}@{{ .HostName }}"
             }
           },
           {

--- a/themes/fish.omp.json
+++ b/themes/fish.omp.json
@@ -24,7 +24,7 @@
           "style": "plain",
           "foreground": "#ffffff",
           "properties": {
-            "template": "{{ .UserName }}@{{ .ComputerName }}"
+            "template": "{{ .UserName }}@{{ .HostName }}"
           }
         },
         {

--- a/themes/gmay.omp.json
+++ b/themes/gmay.omp.json
@@ -18,7 +18,7 @@
           "foreground": "#ffffff",
           "background": "#3A86FF",
           "properties": {
-            "template": "{{ .UserName }}@{{ .ComputerName }}"
+            "template": "{{ .UserName }}@{{ .HostName }}"
           }
         },
         {

--- a/themes/grandpa-style.omp.json
+++ b/themes/grandpa-style.omp.json
@@ -4,7 +4,7 @@
     "osc99": true,
     "console_title": true,
     "console_title_style": "template",
-    "console_title_template": "{{if .Root}} ⚡ {{end}}{{.Folder | replace \"~\" \"🏚\" }} @ {{.Host}}",
+    "console_title_template": "{{if .Root}} ⚡ {{end}}{{.Folder | replace \"~\" \"🏚\" }} @ {{.HostName}}",
     "blocks": [
         {
             "type": "prompt",

--- a/themes/honukai.omp.json
+++ b/themes/honukai.omp.json
@@ -11,7 +11,7 @@
           "foreground": "#FFFFFF",
           "properties": {
             "prefix": "<#0377C8># </>",
-            "template": "<#0377C8>{{ .UserName }}</> <#ffffff>in</> <#4A9207>{{ .ComputerName }}</>"
+            "template": "<#0377C8>{{ .UserName }}</> <#ffffff>in</> <#4A9207>{{ .HostName }}</>"
           }
         },
         {

--- a/themes/jblab_2021.omp.json
+++ b/themes/jblab_2021.omp.json
@@ -4,7 +4,7 @@
   "osc99": true,
   "console_title": true,
   "console_title_style": "template",
-  "console_title_template": "{{if .Root}} ⚡ {{end}}{{.Folder | replace \"~\" \"🏠\"}} @ {{.Host}}",
+  "console_title_template": "{{if .Root}} ⚡ {{end}}{{.Folder | replace \"~\" \"🏠\"}} @ {{.HostName}}",
   "blocks": [
     {
       "type": "prompt",

--- a/themes/jonnychipz.omp.json
+++ b/themes/jonnychipz.omp.json
@@ -29,7 +29,7 @@
           "leading_diamond": "\uE0B6",
           "trailing_diamond": "\uE0B0",
           "properties": {
-            "template": "{{ .UserName }}@{{ .ComputerName }}"
+            "template": "{{ .UserName }}@{{ .HostName }}"
           }
         },
         {

--- a/themes/mojada.omp.json
+++ b/themes/mojada.omp.json
@@ -33,7 +33,7 @@
           "properties": {
             "prefix": "",
             "display_host": true,
-            "template": "{{ .UserName }}<#000000>@</><#e06c75>{{ .ComputerName }}</>"
+            "template": "{{ .UserName }}<#000000>@</><#e06c75>{{ .HostName }}</>"
           }
         },
         {
@@ -150,5 +150,5 @@
   "final_space": true,
   "console_title": true,
   "console_title_style": "template",
-  "console_title_template": "{{.User}}@{{.Host}} : {{.Folder}}"
+  "console_title_template": "{{.UserName}}@{{.HostName}} : {{.Folder}}"
 }

--- a/themes/nu4a.omp.json
+++ b/themes/nu4a.omp.json
@@ -4,7 +4,7 @@
   "osc99": false,
   "console_title": true,
   "console_title_style": "template",
-  "console_title_template": "{{if .Root}} ⚡ {{end}}{{.User}} ➔ 📁{{.Folder}}",
+  "console_title_template": "{{if .Root}} ⚡ {{end}}{{.UserName}} ➔ 📁{{.Folder}}",
   "blocks": [
     {
       "type": "prompt",

--- a/themes/paradox.omp.json
+++ b/themes/paradox.omp.json
@@ -19,7 +19,7 @@
           "foreground": "#100e23",
           "background": "#ffffff",
           "properties": {
-            "template": "{{ .UserName }}@{{ .ComputerName }}"
+            "template": "{{ .UserName }}@{{ .HostName }}"
           }
         },
         {

--- a/themes/plague.omp.json
+++ b/themes/plague.omp.json
@@ -13,7 +13,7 @@
           "leading_diamond": "\uE0B6",
           "trailing_diamond": "\uE0B0",
           "properties": {
-            "template": "{{ .UserName }}@{{ .ComputerName }}"
+            "template": "{{ .UserName }}@{{ .HostName }}"
           }
         },
         {

--- a/themes/powerlevel10k_classic.omp.json
+++ b/themes/powerlevel10k_classic.omp.json
@@ -64,7 +64,7 @@
           "leading_diamond": "\uE0B2",
           "properties": {
             "postfix": " <#26C6DA>\uE0B3</> ",
-            "template": "{{ .UserName }}@{{ .ComputerName }}"
+            "template": "{{ .UserName }}@{{ .HostName }}"
           }
         },
         {

--- a/themes/powerline.omp.json
+++ b/themes/powerline.omp.json
@@ -15,7 +15,7 @@
           "style": "plain",
           "foreground": "#ffffff",
           "properties": {
-            "template": "{{ .UserName }}@{{ .ComputerName }}"
+            "template": "{{ .UserName }}@{{ .HostName }}"
           }
         },
         {

--- a/themes/slim.omp.json
+++ b/themes/slim.omp.json
@@ -43,7 +43,7 @@
           "background": "#2f2f2f",
           "properties": {
             "postfix": "<#7a7a7a> \ue0b1</>",
-            "template": "{{ if ne .Env.POSH_SESSION_DEFAULT_USER .UserName }}<#77f5d6>{{ .UserName }}</><#7a7a7a>\uf1fa</><#2EEFBF>{{ end }}{{ .ComputerName }}</>"
+            "template": "{{ if ne .Env.POSH_SESSION_DEFAULT_USER .UserName }}<#77f5d6>{{ .UserName }}</><#7a7a7a>\uf1fa</><#2EEFBF>{{ end }}{{ .HostName }}</>"
           }
         },
         {

--- a/themes/slimfat.omp.json
+++ b/themes/slimfat.omp.json
@@ -43,7 +43,7 @@
           "background": "#2f2f2f",
           "properties": {
             "postfix": "<#7a7a7a> \ue0b1</>",
-            "template": "{{ if ne .Env.POSH_SESSION_DEFAULT_USER .UserName }}<#77f5d6>{{ .UserName }}</><#7a7a7a>\uf1fa</><#2EEFBF>{{ .ComputerName }}{{ end }}</>"
+            "template": "{{ if ne .Env.POSH_SESSION_DEFAULT_USER .UserName }}<#77f5d6>{{ .UserName }}</><#7a7a7a>\uf1fa</><#2EEFBF>{{ .HostName }}{{ end }}</>"
           }
         },
         {

--- a/themes/sorin.omp.json
+++ b/themes/sorin.omp.json
@@ -24,7 +24,7 @@
           "foreground": "#FFFFFF",
           "properties": {
             "prefix": "",
-            "template": "{{ .UserName }}@{{ .ComputerName }}"
+            "template": "{{ .UserName }}@{{ .HostName }}"
           }
         },
         {

--- a/themes/stelbent.minimal.omp.json
+++ b/themes/stelbent.minimal.omp.json
@@ -48,7 +48,7 @@
           "foreground": "#757575",
           "properties": {
             "prefix": "\u250c ",
-            "template": "{{ .UserName }}@{{ .ComputerName }}"
+            "template": "{{ .UserName }}@{{ .HostName }}"
           }
         },
         {

--- a/themes/thecyberden.omp.json
+++ b/themes/thecyberden.omp.json
@@ -18,7 +18,7 @@
                     "trailing_diamond": "",
                     "properties": {
                         "prefix": "\uFCBE ",
-                        "template": "{{ .ComputerName }}"
+                        "template": "{{ .HostName }}"
                     }
                 },
                 {

--- a/themes/unicorn.omp.json
+++ b/themes/unicorn.omp.json
@@ -3,7 +3,7 @@
   "final_space": true,
   "console_title": true,
   "console_title_style": "template",
-  "console_title_template": "{{.User}}@{{.Host}} in {{ .Path }}",
+  "console_title_template": "{{.UserName}}@{{.HostName}} in {{ .Path }}",
   "blocks": [
     {
       "type": "prompt",

--- a/themes/xtoys.omp.json
+++ b/themes/xtoys.omp.json
@@ -19,7 +19,7 @@
           "style": "plain",
           "properties": {
             "prefix": "",
-            "template": "{{ .UserName }}@{{ .ComputerName }}"
+            "template": "{{ .UserName }}@{{ .HostName }}"
           }
         },
         {

--- a/themes/ys.omp.json
+++ b/themes/ys.omp.json
@@ -44,7 +44,7 @@
           "style": "plain",
           "properties": {
             "prefix": "",
-            "template": "<cyan>{{ .UserName }}</> <darkGray>@</> <green>{{ .ComputerName }}</>"
+            "template": "<cyan>{{ .UserName }}</> <darkGray>@</> <green>{{ .HostName }}</>"
           }
         },
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

BREAKING CHANGE: adjusts the way some segment work for templates.

Mapping the var names as following will resolve the issue.
- session/title/general purpose
    - .Host -> .HostName
    - .User -> .UserName
- az
    - .UserName -> .Name
- kubectl
    - .UserName -> .User


<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
