### PR TITLE
fix(env): remove defer on platform

### DIFF
--- a/src/environment_unix.go
+++ b/src/environment_unix.go
@@ -58,7 +58,9 @@ func (env *environment) getPlatform() string {
 		return val
 	}
 	var platform string
-	defer env.cache().set(key, platform, -1)
+	defer func() {
+		env.cache().set(key, platform, -1)
+	}()
 	if wsl := env.getenv("WSL_DISTRO_NAME"); len(wsl) != 0 {
 		platform = strings.ToLower(wsl)
 		return platform


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description
This is a small fix to actually store the value. Arguments to defers are apparently evaluated immediately so platform will always be an empty string.
Remove the defer and make sure the value is correctly assigned, before caching it.

<!--TemplateBody-->

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
