### PR TITLE
Fix trailing diamond colour in Java block

### DIFF
--- a/themes/night-owl.omp.json
+++ b/themes/night-owl.omp.json
@@ -148,7 +148,7 @@
           "type": "java",
           "style": "diamond",
           "leading_diamond": "\uE0B2",
-          "trailing_diamond": "<transparent,#0e8ac8>\uE0B2</>",
+          "trailing_diamond": "<transparent,#ffffff>\uE0B2</>",
           "foreground": "#ec2729",
           "background": "#ffffff",
           "properties": {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

Updates colour for the trailing diamond in the Java block so that it is the same as the colour of the background attribute. Mentioned in #1634.

<!--TemplateBody-->

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
