### PR TITLE
fix: broken title paths

### DIFF
--- a/themes/pure.omp.json
+++ b/themes/pure.omp.json
@@ -82,6 +82,6 @@
   ],
   "console_title": true,
   "console_title_style": "template",
-  "console_title_template": "{{if .Root}}(Admin){{end}} {{.Path}}",
+  "console_title_template": "{{if .Root}}(Admin){{end}} {{.PWD}}",
   "version": 1
 }

--- a/themes/unicorn.omp.json
+++ b/themes/unicorn.omp.json
@@ -97,7 +97,7 @@
   ],
   "console_title": true,
   "console_title_style": "template",
-  "console_title_template": "{{.UserName}}@{{.HostName}} in {{ .Path }}",
+  "console_title_template": "{{.UserName}}@{{.HostName}} in {{ .PWD }}",
   "final_space": true,
   "version": 1
 }


### PR DESCRIPTION
Before:
![image_103](https://user-images.githubusercontent.com/18603393/152467518-92041e6c-60d5-4bcb-a2b4-66dd05b40b42.png)


After:
![image_104](https://user-images.githubusercontent.com/18603393/152467547-8c55a4cf-63b0-4995-9b72-ea6f6d207545.png)


### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

<!--TemplateBody-->
An update broke the custom titles for 2 themes, and I decided to fix them
<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
