### PR TITLE
fix: hyperlink regex

### DIFF
--- a/src/regex/regex.go
+++ b/src/regex/regex.go
@@ -11,7 +11,7 @@ var (
 )
 
 const (
-	LINK = `(?P<STR>\x1b]8;;(file|https)(.+)\x1b\\(?P<TEXT>.+)\x1b]8;;\x1b\\)`
+	LINK = `(?P<STR>\x1b]8;;(.+)\x1b\\(?P<TEXT>.+)\x1b]8;;\x1b\\)`
 )
 
 func GetCompiledRegex(pattern string) *regexp.Regexp {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [ ] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

The hyperlink text is not replaced correctly so the length calculation is wrong

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
