### PR TITLE
fix: remove redundant segment

### DIFF
--- a/themes/marcduiker.omp.json
+++ b/themes/marcduiker.omp.json
@@ -37,16 +37,6 @@
           "type": "git"
         },
         {
-          "background": "#fee761",
-          "foreground": "#262b44",
-          "powerline_symbol": "\ue0b0",
-          "properties": {
-            "template": " \uf0e7 "
-          },
-          "style": "powerline",
-          "type": "root"
-        },
-        {
           "background": "#0095e9",
           "background_templates": [
             "{{ if gt .Code 0 }}#ff0044{{ end }}"


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

There was a redundant segment in the theme that I never spotted until I just reinstalled it from scratch 😬 .

<!--TemplateBody-->

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
