### PR TITLE
fix: add back missing space character

### DIFF
--- a/themes/stelbent.minimal.omp.json
+++ b/themes/stelbent.minimal.omp.json
@@ -114,7 +114,7 @@
         {
           "foreground": "#757575",
           "properties": {
-            "template": "\u2514"
+            "template": "\u2514 "
           },
           "style": "plain",
           "type": "text"


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] ~Tests for the changes have been added (for bug fixes/features)~
- [ ] ~Docs have been added / updated (for bug fixes/features)~

### Description

Add back space character gone missing in https://github.com/JanDeDobbeleer/oh-my-posh/commit/86db860fe6bc49d364f9fc176ac15c18132b1013.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
