### PR TITLE
docs:  homebrew: add missing subfolder path

### DIFF
--- a/docs/docs/install-homebrew.mdx
+++ b/docs/docs/install-homebrew.mdx
@@ -31,7 +31,7 @@ brew update && brew upgrade && exec zsh
 ## Replace your existing prompt
 
 The guides below assume you copied the theme called `jandedobbeleer.omp.json` to your user's `$HOME` folder.
-When using brew, you can find this one at `$(brew --prefix oh-my-posh)/share/themes/jandedobbeleer.omp.json`.
+When using brew, you can find this one at `$(brew --prefix oh-my-posh)/share/oh-my-posh/themes/jandedobbeleer.omp.json`.
 
 [brew]: https://brew.sh
 [nextsteps]: https://docs.brew.sh/Homebrew-on-Linux#install

--- a/docs/docs/install-homebrew.mdx
+++ b/docs/docs/install-homebrew.mdx
@@ -31,7 +31,7 @@ brew update && brew upgrade && exec zsh
 ## Replace your existing prompt
 
 The guides below assume you copied the theme called `jandedobbeleer.omp.json` to your user's `$HOME` folder.
-When using brew, you can find this one at `$(brew --prefix oh-my-posh)/themes/jandedobbeleer.omp.json`.
+When using brew, you can find this one at `$(brew --prefix oh-my-posh)/share/themes/jandedobbeleer.omp.json`.
 
 [brew]: https://brew.sh
 [nextsteps]: https://docs.brew.sh/Homebrew-on-Linux#install


### PR DESCRIPTION
Adds share folder to homebrew installation when referencing example themes; currently causes error with most recent version.

### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

<!--TemplateBody-->

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
