### PR TITLE
feat(init): remote config

### DIFF
--- a/docs/docs/install-homebrew.mdx
+++ b/docs/docs/install-homebrew.mdx
@@ -1,4 +1,4 @@
-A [Homebrew][brew] formula is available for easy installation. When installing Homebrew for Linux, be sure to follow *[Next steps][nextsteps]* instructions to add Homebrew to your PATH and to your bash shell profile script. 
+A [Homebrew][brew] formula is available for easy installation. When installing Homebrew for Linux, be sure to follow *[Next steps][nextsteps]* instructions to add Homebrew to your PATH and to your bash shell profile script.
 
 ```bash
 brew tap jandedobbeleer/oh-my-posh
@@ -29,9 +29,6 @@ brew update && brew upgrade && exec zsh
 :::
 
 ## Replace your existing prompt
-
-The guides below assume you copied the theme called `jandedobbeleer.omp.json` to your user's `$HOME` folder.
-When using brew, you can find this one at `$(brew --prefix oh-my-posh)/share/oh-my-posh/themes/jandedobbeleer.omp.json`.
 
 [brew]: https://brew.sh
 [nextsteps]: https://docs.brew.sh/Homebrew-on-Linux#install

--- a/docs/docs/install-linux.mdx
+++ b/docs/docs/install-linux.mdx
@@ -60,9 +60,6 @@ rm ~/.poshthemes/themes.zip
 
 ## Replace your existing prompt
 
-The guides below assume you copied the theme called `jandedobbeleer.omp.json` to your user's `$HOME` folder.
-When you've downloaded the themes, you can find this one at `~/.poshthemes/jandedobbeleer.omp.json`.
-
 </TabItem>
 </Tabs>
 

--- a/docs/docs/install-shells.mdx
+++ b/docs/docs/install-shells.mdx
@@ -41,7 +41,7 @@ Import-Module oh-my-posh
 :::
 
 ```powershell
-oh-my-posh --init --shell pwsh --config ~/jandedobbeleer.omp.json | Invoke-Expression
+oh-my-posh --init --shell pwsh --config https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/v$(oh-my-posh --version)/themes/jandedobbeleer.omp.json | Invoke-Expression
 ```
 
 Once added, reload your profile for the changes to take effect.
@@ -65,7 +65,7 @@ Use the full path to the config file, not the relative path.
 :::
 
 ```lua title="oh-my-posh.lua"
-load(io.popen('oh-my-posh --config="C:/Users/jan/jandedobbeleer.omp.json" --init --shell cmd'):read("*a"))()
+load(io.popen('oh-my-posh --config="https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/jandedobbeleer.omp.json" --init --shell cmd'):read("*a"))()
 ```
 
 Once added, restart cmd for the changes to take effect.
@@ -76,7 +76,7 @@ Once added, restart cmd for the changes to take effect.
 Add the following to `~/.zshrc`:
 
 ```bash
-eval "$(oh-my-posh --init --shell zsh --config ~/jandedobbeleer.omp.json)"
+eval "$(oh-my-posh --init --shell zsh --config https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/v$(oh-my-posh --version)/themes/jandedobbeleer.omp.json)"
 ```
 
 Once added, reload your profile for the changes to take effect.
@@ -91,7 +91,7 @@ source ~/.zshrc
 Add the following to `~/.bashrc` (could be `~/.profile` or `~/.bash_profile` depending on your environment):
 
 ```bash
-eval "$(oh-my-posh --init --shell bash --config ~/jandedobbeleer.omp.json)"
+eval "$(oh-my-posh --init --shell bash --config https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/v$(oh-my-posh --version)/themes/jandedobbeleer.omp.json)"
 ```
 
 Once added, reload your profile for the changes to take effect.
@@ -116,7 +116,7 @@ It's advised to be on the latest version of fish. Versions below 3.1.2 have issu
 Initialize Oh My Posh in `~/.config/fish/config.fish`:
 
 ```bash
-oh-my-posh --init --shell fish --config ~/jandedobbeleer.omp.json | source
+oh-my-posh --init --shell fish --config hhttps://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/v(oh-my-posh --version)/themes/jandedobbeleer.omp.json | source
 ```
 
 Once added, reload your config for the changes to take effect.
@@ -133,13 +133,13 @@ Set the prompt and restart nu shell:
 ### Nu < 0.32.0
 
 ```bash
-config set prompt  "= `{{$(oh-my-posh --config ~/jandedobbeleer.omp.json | str collect)}}`"
+config set prompt  "= `{{$(oh-my-posh --config https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/jandedobbeleer.omp.json | str collect)}}`"
 ```
 
 ### Nu >= 0.32.0
 
 ```bash
-config set prompt  "(oh-my-posh --config ~/jandedobbeleer.omp.json | str collect)"
+config set prompt  "(oh-my-posh --config https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/jandedobbeleer.omp.json | str collect)"
 ```
 
 Restart nu shell for the changes to take effect.

--- a/docs/docs/install-windows.mdx
+++ b/docs/docs/install-windows.mdx
@@ -164,8 +164,6 @@ when setting the prompt using the `--config` flag.
 </TabItem>
 </Tabs>
 
-The guides below assume you copied the theme called `jandedobbeleer.omp.json` to your user's `$HOME` folder.
-
 :::caution
 When using oh-my-posh inside the WSL, make sure to follow the [linux][linux] installation guide.
 :::

--- a/src/engine/image.go
+++ b/src/engine/image.go
@@ -302,7 +302,7 @@ func (ir *ImageRenderer) cleanContent() {
 		ir.AnsiString += fmt.Sprintf("_%s", strings.Repeat(" ", ir.CursorPadding))
 	}
 	// add watermarks
-	ir.AnsiString += "\n\n\x1b[1mhttps://ohmyposh.dev\x1b[22m"
+	ir.AnsiString += "\n\n\x1b[1mohmyposh.dev\x1b[22m"
 	if len(ir.Author) > 0 {
 		createdBy := fmt.Sprintf(" by \x1b[1m%s\x1b[22m", ir.Author)
 		ir.AnsiString += createdBy

--- a/src/engine/init.go
+++ b/src/engine/init.go
@@ -37,7 +37,7 @@ const (
 	plain       = "shell"
 )
 
-func getExecutablePath(shell string) (string, error) {
+func getExecutablePath(env environment.Environment) (string, error) {
 	executable, err := os.Executable()
 	if err != nil {
 		return "", err
@@ -46,7 +46,7 @@ func getExecutablePath(shell string) (string, error) {
 	// which uses unix style paths to resolve the executable's location.
 	// PowerShell knows how to resolve both, so we can swap this without any issue.
 	executable = strings.ReplaceAll(executable, "\\", "/")
-	switch shell {
+	switch *env.Args().Shell {
 	case bash, zsh:
 		executable = strings.ReplaceAll(executable, " ", "\\ ")
 		executable = strings.ReplaceAll(executable, "(", "\\(")
@@ -56,26 +56,29 @@ func getExecutablePath(shell string) (string, error) {
 	return executable, nil
 }
 
-func InitShell(shell, configFile string) string {
-	executable, err := getExecutablePath(shell)
+func InitShell(env environment.Environment) string {
+	executable, err := getExecutablePath(env)
 	if err != nil {
 		return noExe
 	}
+	shell := *env.Args().Shell
 	switch shell {
 	case pwsh, powershell5:
-		return fmt.Sprintf("(@(&\"%s\" --print-init --shell=%s --config=\"%s\") -join \"`n\") | Invoke-Expression", executable, shell, configFile)
+		return fmt.Sprintf("(@(&\"%s\" --print-init --shell=%s --config=\"%s\") -join \"`n\") | Invoke-Expression", executable, shell, *env.Args().Config)
 	case zsh, bash, fish, winCMD:
-		return PrintShellInit(shell, configFile)
+		return PrintShellInit(env)
 	default:
 		return fmt.Sprintf("echo \"No initialization script available for %s\"", shell)
 	}
 }
 
-func PrintShellInit(shell, configFile string) string {
-	executable, err := getExecutablePath(shell)
+func PrintShellInit(env environment.Environment) string {
+	executable, err := getExecutablePath(env)
 	if err != nil {
 		return noExe
 	}
+	shell := *env.Args().Shell
+	configFile := *env.Args().Config
 	switch shell {
 	case pwsh, powershell5:
 		return getShellInitScript(executable, configFile, pwshInit)

--- a/src/engine/init/omp.bash
+++ b/src/engine/init/omp.bash
@@ -46,5 +46,5 @@ function export_poshconfig() {
     if [ -z "$format" ]; then
       format="json"
     fi
-    ::OMP:: --config="$POSH_THEME" --print-config --config-format="$format" > $1
+    ::OMP:: --config="$POSH_THEME" --print-config --format="$format" > $1
 }

--- a/src/engine/init/omp.fish
+++ b/src/engine/init/omp.fish
@@ -42,5 +42,5 @@ function export_poshconfig
   if not test -n "$format"
     set format "json"
   end
-  ::OMP:: --config $POSH_THEME --print-config --config-format $format > $file_name
+  ::OMP:: --config $POSH_THEME --print-config --format $format > $file_name
 end

--- a/src/engine/init/omp.ps1
+++ b/src/engine/init/omp.ps1
@@ -149,7 +149,7 @@ function global:Export-PoshTheme {
 
     $config = $env:POSH_THEME
     $omp = "::OMP::"
-    $configString = @(&$omp --config="$config" --config-format="$Format" --print-config 2>&1)
+    $configString = @(&$omp --config="$config" --format="$Format" --print-config 2>&1)
     # if no path, copy to clipboard by default
     if ($FilePath -ne "") {
         #https://stackoverflow.com/questions/3038337/powershell-resolve-path-that-might-not-exist

--- a/src/engine/init/omp.zsh
+++ b/src/engine/init/omp.zsh
@@ -51,7 +51,7 @@ function export_poshconfig() {
     if [ -z "$format" ]; then
       format="json"
     fi
-    ::OMP:: --config="$POSH_THEME" --print-config --config-format="$format" > $1
+    ::OMP:: --config="$POSH_THEME" --print-config --format="$format" > $1
 }
 
 function self-insert() {

--- a/src/main.go
+++ b/src/main.go
@@ -167,12 +167,12 @@ func main() {
 		return
 	}
 	if *args.Init {
-		init := engine.InitShell(*args.Shell, *args.Config)
+		init := engine.InitShell(env)
 		fmt.Print(init)
 		return
 	}
 	if *args.PrintInit {
-		init := engine.PrintShellInit(*args.Shell, *args.Config)
+		init := engine.PrintShellInit(env)
 		fmt.Print(init)
 		return
 	}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

resolves #1803 

This change allows to initialise the prompt with a remote config that is stored locally per session.
We can decide to no longer ship the themes based on this as it's pretty straightforward to get started that way.

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
