### PR TITLE
docs(faq): add a section on text decoration

### DIFF
--- a/docs/docs/faq.mdx
+++ b/docs/docs/faq.mdx
@@ -143,7 +143,7 @@ conda config --set changeps1 False
 Virtual environments created with `venv` add the active environment's name to the prompt automatically.
 To disable this behaviour, set `VIRTUAL_ENV_DISABLE_PROMPT` environment variable to `1` on your system. Example files:
 
-Note: Tilde (~) in paths refers to your user's home directory.
+Note: Tilde (~) in paths refers to your user's home directory. 
 
 <Tabs
   defaultValue="powershell"
@@ -157,8 +157,7 @@ Note: Tilde (~) in paths refers to your user's home directory.
 <TabItem value="powershell">
 
 ```powershell
-# ~\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1 (PowerShell v5.1 & below)
-# ~\Documents\PowerShell\Microsoft.PowerShell_profile.ps1 (PowerShell 7+)
+# Your PowerShell $PROFILE
 $env:VIRTUAL_ENV_DISABLE_PROMPT=1
 ```
 

--- a/docs/docs/faq.mdx
+++ b/docs/docs/faq.mdx
@@ -157,7 +157,8 @@ Note: Tilde (~) in paths refers to your user's home directory.
 <TabItem value="powershell">
 
 ```powershell
-# ~/Documents/WindowsPowerShell/profile.ps1
+# ~\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1 (PowerShell v5.1 & below)
+# ~\Documents\PowerShell\Microsoft.PowerShell_profile.ps1 (PowerShell 7+)
 $env:VIRTUAL_ENV_DISABLE_PROMPT=1
 ```
 

--- a/docs/docs/faq.mdx
+++ b/docs/docs/faq.mdx
@@ -180,6 +180,15 @@ export VIRTUAL_ENV_DISABLE_PROMPT=1
 </TabItem>
 </Tabs>
 
+### Text decoration styles like bold and dimmed don't work
+The text decoration styles are based on your terminal's capabilities.
+
+A quick way to check if your terminal supports the specific style escape sequence is to take a look at the `terminfo` database, on Linux.
+Refer [this page on ArchWiki](https://wiki.archlinux.org/title/Bash/Prompt_customization#Terminfo_escape_sequences).
+
+If you are on Windows, use Windows Terminal. It closely copies the `xterm-256color` capabilities.
+See the [PowerShell docs] and [this GitHub comment](https://github.com/microsoft/terminal/issues/6045#issuecomment-631743728).
+
 [git-gc]: https://git-scm.com/docs/git-gc
 [new-issue]: https://github.com/JanDeDobbeleer/oh-my-posh/issues/new/choose
 [latest]: https://github.com/JanDeDobbeleer/oh-my-posh/releases/latest


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description
- Added a section on text decoration styles not working for some terminals.
- Updated locations for PowerShell profiles according to respective versions.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
