### PR TITLE
docs(faq): add missing PS docs link

### DIFF
--- a/docs/docs/faq.mdx
+++ b/docs/docs/faq.mdx
@@ -183,11 +183,11 @@ export VIRTUAL_ENV_DISABLE_PROMPT=1
 ### Text decoration styles like bold and dimmed don't work
 The text decoration styles are based on your terminal's capabilities.
 
-A quick way to check if your terminal supports the specific style escape sequence is to take a look at the `terminfo` database, on Linux.
+A quick way to check if your terminal supports a specific style escape sequence is to take a look at the `terminfo` database, on Linux.
 Refer [this page on ArchWiki](https://wiki.archlinux.org/title/Bash/Prompt_customization#Terminfo_escape_sequences).
 
 If you are on Windows, use Windows Terminal. It closely copies the `xterm-256color` capabilities.
-See the [PowerShell docs] and [this GitHub comment](https://github.com/microsoft/terminal/issues/6045#issuecomment-631743728).
+See the [PowerShell docs](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_ansi_terminals?view=powershell-7.2) and [this GitHub comment](https://github.com/microsoft/terminal/issues/6045#issuecomment-631743728).
 
 [git-gc]: https://git-scm.com/docs/git-gc
 [new-issue]: https://github.com/JanDeDobbeleer/oh-my-posh/issues/new/choose

--- a/docs/docs/faq.mdx
+++ b/docs/docs/faq.mdx
@@ -181,14 +181,17 @@ export VIRTUAL_ENV_DISABLE_PROMPT=1
 </Tabs>
 
 ### Text decoration styles like bold and dimmed don't work
-The text decoration styles are based on your terminal's capabilities.
+The text decoration styles are based on your terminal emulator's capabilities.
 
 A quick way to check if your terminal supports a specific style escape sequence is to take a look at the `terminfo` database, on Linux.
-Refer [this page on ArchWiki](https://wiki.archlinux.org/title/Bash/Prompt_customization#Terminfo_escape_sequences).
+Refer [this page on ArchWiki][arch-terminfo].
 
 If you are on Windows, use Windows Terminal. It closely copies the `xterm-256color` capabilities.
-See the [PowerShell docs](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_ansi_terminals?view=powershell-7.2) and [this GitHub comment](https://github.com/microsoft/terminal/issues/6045#issuecomment-631743728).
+See the [PowerShell docs on terminal support][ps-ansi-docs] and [this GitHub comment][xterm-gh-comment].
 
+[arch-terminfo]: https://wiki.archlinux.org/title/Bash/Prompt_customization#Terminfo_escape_sequences
+[ps-ansi-docs]: https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_ansi_terminals?view=powershell-7.2
+[xterm-gh-comment]: https://github.com/microsoft/terminal/issues/6045#issuecomment-631743728
 [git-gc]: https://git-scm.com/docs/git-gc
 [new-issue]: https://github.com/JanDeDobbeleer/oh-my-posh/issues/new/choose
 [latest]: https://github.com/JanDeDobbeleer/oh-my-posh/releases/latest


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description
Added missing link to the PowerShell docs for terminal support reference.
