### PR TITLE
fix: Set .Mismatch flag for node segment

### DIFF
--- a/src/segments/node.go
+++ b/src/segments/node.go
@@ -45,7 +45,12 @@ func (n *Node) Init(props properties.Properties, env environment.Environment) {
 }
 
 func (n *Node) Enabled() bool {
-	return n.language.Enabled()
+	if n.language.Enabled() {
+		n.Mismatch = !n.matchesVersionFile()
+		return true
+	}
+
+	return false
 }
 
 func (n *Node) loadContext() {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

Hi, version mismatch for node segment broken with one of the latest updates. This fix brings it back to working.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
