### PR TITLE
fix: typo `hhttps` to `https`

### DIFF
--- a/docs/docs/install-shells.mdx
+++ b/docs/docs/install-shells.mdx
@@ -116,7 +116,7 @@ It's advised to be on the latest version of fish. Versions below 3.1.2 have issu
 Initialize Oh My Posh in `~/.config/fish/config.fish`:
 
 ```bash
-oh-my-posh --init --shell fish --config hhttps://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/v(oh-my-posh --version)/themes/jandedobbeleer.omp.json | source
+oh-my-posh --init --shell fish --config https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/v(oh-my-posh --version)/themes/jandedobbeleer.omp.json | source
 ```
 
 Once added, reload your config for the changes to take effect.


### PR DESCRIPTION
### Prerequisites

- [X] I have read and understood the `CONTRIBUTING` guide
- [X] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [X] Docs have been added / updated (for bug fixes/features)

### Description

<!--TemplateBody-->
This commit will fix small typo `hhttps` to `https` in `install-shells.mdx` file
<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
