### PR TITLE
feat: add hide root to agnoster short

### DIFF
--- a/docs/docs/segment-path.md
+++ b/docs/docs/segment-path.md
@@ -35,7 +35,9 @@ Display the current path.
 - style: `enum` - how to display the current path
 - mixed_threshold: `number` - the maximum length of a path segment that will be displayed when using `Mixed` -
   defaults to `4`
-- max_depth: `number` - maximum path depth to display before shortening when using `Agnoster Short` - defaults to `1`
+- max_depth: `number` - maximum path depth to display before shortening when using `agnoster_short` - defaults to `1`
+- hide_root_location: `boolean` -  hides the root location if it doesn't fit in the last `max_depth` folders, when using
+  `agnoster_short` - defaults to `false`
 
 ## Mapped Locations
 
@@ -91,8 +93,8 @@ Renders each folder name separated by the `folder_separator_icon`.
 
 ### Agnoster Short
 
-When more than `max_depth` levels deep, it renders one `folder_icon` followed by the names of the last `max_depth` folders,
-separated by the `folder_separator_icon`.
+When more than `max_depth` levels deep, it renders one `folder_icon` (if `hide_root_location` is `false`) followed by
+the names of the last `max_depth` folders, separated by the `folder_separator_icon`.
 
 ### Agnoster Left
 

--- a/src/segments/path_test.go
+++ b/src/segments/path_test.go
@@ -170,6 +170,7 @@ func TestAgnosterPathStyles(t *testing.T) {
 		Style               string
 		GOOS                string
 		MaxDepth            int
+		HideRootLocation    bool
 	}{
 		{Style: AgnosterFull, Expected: "usr > location > whatever", HomePath: "/usr/home", Pwd: "/usr/location/whatever", PathSeparator: "/", FolderSeparatorIcon: " > "},
 		{Style: AgnosterShort, Expected: "usr > .. > man", HomePath: "/usr/home", Pwd: "/usr/location/whatever/man", PathSeparator: "/", FolderSeparatorIcon: " > "},
@@ -224,6 +225,30 @@ func TestAgnosterPathStyles(t *testing.T) {
 		{Style: AgnosterFull, Expected: "PSDRIVE: | src", HomePath: homeBillWindows, Pwd: "/foo", Pswd: "PSDRIVE:/src", PathSeparator: "/", FolderSeparatorIcon: " | "},
 		{Style: AgnosterShort, Expected: "PSDRIVE: | .. | init", HomePath: homeBillWindows, Pwd: "/foo", Pswd: "PSDRIVE:/src/init", PathSeparator: "/", FolderSeparatorIcon: " | "},
 
+		{Style: AgnosterShort, Expected: "src | init", HomePath: homeBillWindows, Pwd: "/foo", Pswd: "PSDRIVE:/src/init", PathSeparator: "/", FolderSeparatorIcon: " | ", MaxDepth: 2,
+			HideRootLocation: true},
+		{Style: AgnosterShort, Expected: "PSDRIVE: | src", HomePath: homeBillWindows, Pwd: "/foo", Pswd: "PSDRIVE:/src", PathSeparator: "/", FolderSeparatorIcon: " | ", MaxDepth: 2,
+			HideRootLocation: true},
+		{Style: AgnosterShort, Expected: "~", HomePath: homeBillWindows, Pwd: homeBillWindows, PathSeparator: "\\", FolderSeparatorIcon: " > ", MaxDepth: 1, HideRootLocation: true},
+		{Style: AgnosterShort, Expected: "foo", HomePath: homeBillWindows, Pwd: homeBillWindows + "\\foo", PathSeparator: "\\", FolderSeparatorIcon: "\\", MaxDepth: 1,
+			HideRootLocation: true},
+		{Style: AgnosterShort, Expected: "~\\foo", HomePath: homeBillWindows, Pwd: homeBillWindows + "\\foo", PathSeparator: "\\", FolderSeparatorIcon: "\\", MaxDepth: 2,
+			HideRootLocation: true},
+		{Style: AgnosterShort, Expected: "~", HomePath: "/usr/home", Pwd: "/usr/home", PathSeparator: "/", FolderSeparatorIcon: " > ", MaxDepth: 1, HideRootLocation: true},
+		{Style: AgnosterShort, Expected: "foo", HomePath: "/usr/home", Pwd: "/usr/home/foo", PathSeparator: "/", FolderSeparatorIcon: "/", MaxDepth: 1, HideRootLocation: true},
+		{Style: AgnosterShort, Expected: "bar > man", HomePath: "/usr/home", Pwd: "/usr/foo/bar/man", PathSeparator: "/", FolderSeparatorIcon: " > ", MaxDepth: 2,
+			HideRootLocation: true},
+		{Style: AgnosterShort, Expected: "foo > bar > man", HomePath: "/usr/home", Pwd: "/usr/foo/bar/man", PathSeparator: "/", FolderSeparatorIcon: " > ", MaxDepth: 3,
+			HideRootLocation: true},
+		{Style: AgnosterShort, Expected: "~ > foo", HomePath: "/usr/home", Pwd: "/usr/home/foo", PathSeparator: "/", FolderSeparatorIcon: " > ", MaxDepth: 2, HideRootLocation: true},
+		{Style: AgnosterShort, Expected: "~ > foo > bar > man", HomePath: "/usr/home", Pwd: "/usr/home/foo/bar/man", PathSeparator: "/", FolderSeparatorIcon: " > ", MaxDepth: 4,
+			HideRootLocation: true},
+		{Style: AgnosterShort, Expected: "C:", HomePath: "/usr/home", Pwd: "/mnt/c", Pswd: "C:", PathSeparator: "/", FolderSeparatorIcon: " | ", MaxDepth: 2, HideRootLocation: true},
+		{Style: AgnosterShort, Expected: "~ | space foo", HomePath: "/usr/home", Pwd: "/usr/home/space foo", PathSeparator: "/", FolderSeparatorIcon: " | ", MaxDepth: 2,
+			HideRootLocation: true},
+		{Style: AgnosterShort, Expected: "space foo", HomePath: "/usr/home", Pwd: "/usr/home/space foo", PathSeparator: "/", FolderSeparatorIcon: " | ", MaxDepth: 1,
+			HideRootLocation: true},
+
 		{Style: Mixed, Expected: "~ > .. > man", HomePath: "/usr/home", Pwd: "/usr/home/whatever/man", PathSeparator: "/", FolderSeparatorIcon: " > "},
 		{Style: Mixed, Expected: "~ > ab > .. > man", HomePath: "/usr/home", Pwd: "/usr/home/ab/whatever/man", PathSeparator: "/", FolderSeparatorIcon: " > "},
 
@@ -261,6 +286,7 @@ func TestAgnosterPathStyles(t *testing.T) {
 				FolderSeparatorIcon: tc.FolderSeparatorIcon,
 				properties.Style:    tc.Style,
 				MaxDepth:            tc.MaxDepth,
+				HideRootLocation:    tc.HideRootLocation,
 			},
 		}
 		_ = path.Enabled()

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -1157,6 +1157,12 @@
                     "title": "Mixed threshold",
                     "description": "The maximum length of a path segment that will be displayed when using mixed style.",
                     "default": 4
+                  },
+                  "hide_root_location": {
+                    "type": "boolean",
+                    "title": "Hide the root location",
+                    "description": "Hides the root location, when using agnoster_short style, if it doesn't fit in the last max_depth folders.",
+                    "default": false
                   }
                 }
               }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

Adds the `hide_root_location` toggle to Agnoster Short preventing it from displaying the root directory if it exceeds the `max_depth`. 

With `hide_root_location` true and `max_depth` of 2:
![image](https://user-images.githubusercontent.com/85419773/156113600-8775e115-7f63-4d07-8cb1-7d4fac7fe671.png)


Kind Regards,
Jed

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
