### PR TITLE
fix: typo in numerous version url templates

### DIFF
--- a/src/segments/dotnet.go
+++ b/src/segments/dotnet.go
@@ -29,7 +29,7 @@ func (d *Dotnet) Init(props properties.Properties, env environment.Environment) 
 					`(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?))`,
 			},
 		},
-		versionURLTemplate: "https://github.com/dotnet/core/blob/master/release-notes/{{ .Major }}.{{ .Minor }}/{{ .Major }}.{{ .Minor }}.{{ .Patch }}/{{ .Major }}.{{ .Minor }}.{{ .Patch }}.md)", // nolint: lll
+		versionURLTemplate: "https://github.com/dotnet/core/blob/master/release-notes/{{ .Major }}.{{ .Minor }}/{{ .Major }}.{{ .Minor }}.{{ .Patch }}/{{ .Major }}.{{ .Minor }}.{{ .Patch }}.md", // nolint: lll
 	}
 }
 

--- a/src/segments/golang.go
+++ b/src/segments/golang.go
@@ -35,7 +35,7 @@ func (g *Golang) Init(props properties.Properties, env environment.Environment) 
 				regex:      `(?:go(?P<version>((?P<major>[0-9]+).(?P<minor>[0-9]+)(.(?P<patch>[0-9]+))?)))`,
 			},
 		},
-		versionURLTemplate: "https://golang.org/doc/go{{ .Major }}.{{ .Minor }})",
+		versionURLTemplate: "https://golang.org/doc/go{{ .Major }}.{{ .Minor }}",
 	}
 }
 

--- a/src/segments/julia.go
+++ b/src/segments/julia.go
@@ -25,7 +25,7 @@ func (j *Julia) Init(props properties.Properties, env environment.Environment) {
 				regex:      `julia version (?P<version>((?P<major>[0-9]+).(?P<minor>[0-9]+).(?P<patch>[0-9]+)))`,
 			},
 		},
-		versionURLTemplate: "https://github.com/JuliaLang/julia/releases/tag/v{{ .Full }})",
+		versionURLTemplate: "https://github.com/JuliaLang/julia/releases/tag/v{{ .Full }}",
 	}
 }
 

--- a/src/segments/kotlin.go
+++ b/src/segments/kotlin.go
@@ -25,7 +25,7 @@ func (k *Kotlin) Init(props properties.Properties, env environment.Environment) 
 				regex:      `Kotlin version (?P<version>((?P<major>[0-9]+).(?P<minor>[0-9]+).(?P<patch>[0-9]+)))`,
 			},
 		},
-		versionURLTemplate: "https://github.com/JetBrains/kotlin/releases/tag/v{{ .Full }})",
+		versionURLTemplate: "https://github.com/JetBrains/kotlin/releases/tag/v{{ .Full }}",
 	}
 }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

Removed trailing `)` in a few `versionURLTemplate`

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
