### PR TITLE
docs: Specify where the export goes

### DIFF
--- a/docs/docs/share-theme.mdx
+++ b/docs/docs/share-theme.mdx
@@ -23,7 +23,7 @@ the output a little bit.
 }>
 <TabItem value="powershell">
 
-You can make use of the `Export-PoshImage` function to export your current theme configuration.
+You can make use of the `Export-PoshImage` function to export your current theme configuration to the current directory location.
 
 ```powershell
 Export-PoshImage -CursorPadding 50
@@ -39,7 +39,7 @@ There are a couple of parameters you can use to tweak the image rendering:
 </TabItem>
 <TabItem value="others">
 
-The oh-my-posh executable has the `--export-png` switch to export your current theme configuration.
+The oh-my-posh executable has the `--export-png` switch to export your current theme configuration to the current directory location.
 
 ```powershell
 oh-my-posh --shell shell --config ~/.mytheme.omp.json --export-png --cursor-padding 50

--- a/docs/docs/share-theme.mdx
+++ b/docs/docs/share-theme.mdx
@@ -23,7 +23,7 @@ the output a little bit.
 }>
 <TabItem value="powershell">
 
-You can make use of the `Export-PoshImage` function to export your current theme configuration to the current directory location.
+You can make use of the `Export-PoshImage` function to export your current theme configuration to the current directory.
 
 ```powershell
 Export-PoshImage -CursorPadding 50
@@ -39,7 +39,7 @@ There are a couple of parameters you can use to tweak the image rendering:
 </TabItem>
 <TabItem value="others">
 
-The oh-my-posh executable has the `--export-png` switch to export your current theme configuration to the current directory location.
+The oh-my-posh executable has the `--export-png` switch to export your current theme configuration to the current directory.
 
 ```powershell
 oh-my-posh --shell shell --config ~/.mytheme.omp.json --export-png --cursor-padding 50


### PR DESCRIPTION
At first I thought the output would go to an OMP-specific folder, then realized it went in the current directory.

### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

<!--TemplateBody-->

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
