### PR TITLE
docs: direct references to --config remote configs

### DIFF
--- a/docs/docs/config-overview.md
+++ b/docs/docs/config-overview.md
@@ -50,11 +50,18 @@ theme.
 :::
 
 ```bash
-oh-my-posh --config sample.json --shell uni
+oh-my-posh prompt print primary --config sample.json --shell uni
 ```
 
 If all goes according to plan, you should see the prompt being printed out on the line below. In case you see a lot of
 boxes with question marks, set up your terminal to use a [supported font][font] before continuing.
+
+:::tip
+The `--config` flag can accept either a local filepath or a remotely hosted config file.
+
+For example, the following is a valid `--config` flag:
+`--config 'https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/jandedobbeleer.omp.json'`
+:::
 
 ## General Settings
 

--- a/docs/docs/install-customize.mdx
+++ b/docs/docs/install-customize.mdx
@@ -110,6 +110,13 @@ Once adjusted, reload your config for the changes to take effect.
 </TabItem>
 </Tabs>
 
+:::tip
+The `--config` flag can accept either a local filepath or remotely hosted JSON.
+
+For example, the following is a valid `--config` flag:  
+`--config 'https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/jandedobbeleer.omp.json'`
+:::
+
 
 [themes]: themes.md
 [configuration]: config-overview.md


### PR DESCRIPTION
Entirely possible that you want different phrasing/formatting on this. I just figured it should be stated somewhere rather than implied (by looking at the examples).

I used a tip box because shoehorning it into the nearby paragraphs was rather disastrous.

### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

<!--TemplateBody-->

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
