### PR TITLE
fix: Kubernetes icon in cloud-native-azure theme is broken

### DIFF
--- a/themes/cloud-native-azure.omp.json
+++ b/themes/cloud-native-azure.omp.json
@@ -119,7 +119,7 @@
           "foreground": "#000000",
           "leading_diamond": "\ue0b6",
           "properties": {
-            "template": " \uefd31 Kubernetes {{.Context}} cluster {{if .Namespace}}- {{.Namespace}} namespace{{end}} "
+            "template": " \ufd31 Kubernetes {{.Context}} cluster {{if .Namespace}}- {{.Namespace}} namespace{{end}} "
           },
           "style": "diamond",
           "trailing_diamond": "\ue0b0",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description
Kubernetes icon in cloud-native-azure theme is broken and is fixed now.

<!--TemplateBody-->
**Before:**
![image](https://user-images.githubusercontent.com/4345663/157823445-7465375a-0c72-4d6b-92db-c6c85bbbd690.png)

**After:**
![image](https://user-images.githubusercontent.com/4345663/157823322-d85a9e55-2701-4d8e-a93b-7628e9c7286f.png)

