### PR TITLE
chore: Add Kind cluster to doc publishing for cloud-native-azure theme

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,13 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.17
+        # Create Kind cluster to have a Kubernetes context for cloud-native-azure theme
+        # Images are defined on every Kind release
+        # See https://github.com/kubernetes-sigs/kind/releases
+      - name: Create k8s v1.23 Kind Cluster
+        uses: helm/kind-action@v1.2.0
+        with:
+          node_image: kindest/node:v1.23.4@sha256:0e34f0d0fd448aa2f2819cfd74e99fe5793a6e4938b328f657c8e3f81ee0dfb9
       - name: Build oh-my-posh 🔧
         run: |
           cd src


### PR DESCRIPTION
Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>

### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the conventional commits guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

Add Kind cluster to doc publishing workflow to create a Kubernetes context.

This is "required" for the `cloud-native-azure` theme to fully show the value.

Today, it looks as following:
![image](https://user-images.githubusercontent.com/4345663/157826503-5ee18bec-ecb0-420d-91c2-1ff8dd53e705.png)

While it's missing some added-value:
![image](https://user-images.githubusercontent.com/4345663/157826567-a5d2b176-511c-4f72-b707-abdd84eda208.png)


