### PR TITLE
docs: add npm to sidebar

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -77,6 +77,7 @@ module.exports = {
         "kubectl",
         "nbgv",
         "nightscout",
+        "npm",
         "node",
         "os",
         "owm",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

Seems I forgot to add `npm` to the sidebar. This PR should fix it.
