### PR TITLE
fix(zsh): adjust prompt commands to standard

### DIFF
--- a/src/engine/init/omp.zsh
+++ b/src/engine/init/omp.zsh
@@ -5,11 +5,11 @@ export CONDA_PROMPT_MODIFIER=false
 # set secondary prompt
 PS2="$(::OMP:: --config="$POSH_THEME" --shell=zsh --print-secondary)"
 
-function _omp-preexec() {
+function prompt_ohmyposh_preexec() {
   omp_start_time=$(::OMP:: --millis)
 }
 
-function _omp-precmd() {
+function prompt_ohmyposh_precmd() {
   omp_last_error=$?
   omp_stack_count=${#dirstack[@]}
   omp_elapsed=-1
@@ -27,18 +27,18 @@ function _omp-precmd() {
 
 function _install-omp-hooks() {
   for s in "${preexec_functions[@]}"; do
-    if [ "$s" = "_omp-preexec" ]; then
+    if [ "$s" = "prompt_ohmyposh_preexec" ]; then
       return
     fi
   done
-  preexec_functions+=(_omp-preexec)
+  preexec_functions+=(prompt_ohmyposh_preexec)
 
   for s in "${precmd_functions[@]}"; do
-    if [ "$s" = "_omp-precmd" ]; then
+    if [ "$s" = "prompt_ohmyposh_precmd" ]; then
       return
     fi
   done
-  precmd_functions+=(_omp-precmd)
+  precmd_functions+=(prompt_ohmyposh_precmd)
 }
 
 if [ "$TERM" != "linux" ]; then


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

relates to #1881

Theoretically, when following the support trail at starhip, renaming the current commands should
allow us to initialize the shell with these commands:

```shell
znap eval ohmyposh 'oh-my-posh --shell zsh --print-init --config=myconfig.omp.json'
znap prompt
```

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
