### PR TITLE
feat: set default kubernetes namespace for doc publishing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,12 @@ jobs:
         with:
           node_image: kindest/node:v1.23.4@sha256:0e34f0d0fd448aa2f2819cfd74e99fe5793a6e4938b328f657c8e3f81ee0dfb9
           cluster_name: posh
+      - name: Create Kubernetes namespace
+        run: |
+          kubectl create ns demo
+      - name: Set default Kubernetes namespace
+        run: |
+          kubectl config set-context posh --namespace demo
       - uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

Set default kubernetes namespace for doc publishing so that `cloud-native-azure` theme preview screenshot includes a namespace.
