### PR TITLE
docs: distinguish between "setup" (noun) and "set up" (verb) in docs

### DIFF
--- a/docs/docs/contributing-plastic.md
+++ b/docs/docs/contributing-plastic.md
@@ -8,7 +8,7 @@ When changing the `segment_plastic.go` file, you may need to test your changes a
 [Plastic SCM][plastic]. This doc should bring you up to speed with Plastic SCM.
 
 In the [contributing doc][contributing] there is a section about [dev containers & codespaces][devcontainer].
-You can setup Plastic SCM inside these as well.
+You can set up Plastic SCM inside these as well.
 
 ## Server Setup
 
@@ -87,7 +87,7 @@ sudo apt-get install plasticscm-client-core
 
 ### Client configuration
 
-To connect the client to the server and setup an account run:
+To connect the client to the server and set up an account run:
 
 ```bash
 clconfigureclient 
@@ -111,7 +111,7 @@ cm li
 
 ## Testing stuff
 
-Now to the fun part! The server is automatically setup to host a `default` repo with the branch `/main`.
+Now to the fun part! The server is automatically set up to host a `default` repo with the branch `/main`.
 
 The Plastic SCM CLI command is: `cm`
 

--- a/docs/docs/install-linux.mdx
+++ b/docs/docs/install-linux.mdx
@@ -8,7 +8,7 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import InstallHomebrew from "./install-homebrew.mdx";
 
-## Setup your terminal
+## Set up your terminal
 
 Oh My Posh uses ANSI color codes under the hood, these should work in every terminal,
 but you may have to set the environment variable `$TERM` to `xterm-256color` for it to work.

--- a/docs/docs/install-macos.mdx
+++ b/docs/docs/install-macos.mdx
@@ -8,7 +8,7 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import InstallHomebrew from "./install-homebrew.mdx";
 
-## Setup your terminal
+## Set up your terminal
 
 As the standard terminal has issues displaying the ANSI characters correctly, we advise using
 [iTerm2][iterm2] or any other modern day MacOS terminal that supports ANSI characters.

--- a/docs/docs/install-windows.mdx
+++ b/docs/docs/install-windows.mdx
@@ -7,7 +7,7 @@ sidebar_label: ⊞ Windows
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-## Setup your terminal
+## Set up your terminal
 
 While Oh My Posh works on the standard terminal, we advise using the [Windows Terminal][wt].
 

--- a/src/cli/prompt.go
+++ b/src/cli/prompt.go
@@ -11,8 +11,8 @@ import (
 // promptCmd represents the prompt command
 var promptCmd = &cobra.Command{
 	Use:   "prompt",
-	Short: "Setup the prompt for your shell",
-	Long: `Setup the prompt for your shell
+	Short: "Set up the prompt for your shell",
+	Long: `Set up the prompt for your shell
 Allows to initialize one of the supported shells, or to set the prompt manually for a custom shell.`,
 	Run: func(cmd *cobra.Command, args []string) {},
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

"setup" is a noun and "set up" is a verb. This PR changes documentation where
the use of "setup" appears to require a verb rather than a noun.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
