### PR TITLE
docs: Fix export flag example

### DIFF
--- a/docs/docs/install-customize.mdx
+++ b/docs/docs/install-customize.mdx
@@ -137,7 +137,7 @@ which can be used to tweak and store as your own custom theme.
 
 
 ```bash
-oh-my-posh config export --output ~/.mytheme.omp.yml
+oh-my-posh config export --config ~/.mytheme.omp.yml
 ```
 
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description


v7.41, must use `--config` as flag
`--output` is not valid


```
> oh-my-posh config export --output ~/.mytheme.omp.yml
Error: unknown flag: --output
```


<!--TemplateBody-->

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
