### PR TITLE
fix(wsl): get correct distro name

### DIFF
--- a/src/environment/unix.go
+++ b/src/environment/unix.go
@@ -65,8 +65,8 @@ func (env *ShellEnvironment) Platform() string {
 		env.Cache().Set(key, platform, -1)
 	}()
 	if wsl := env.Getenv("WSL_DISTRO_NAME"); len(wsl) != 0 {
-		platform = strings.ToLower(wsl)
-		return strings.Split(platform, "-")[0]
+		platform = strings.Split(strings.ToLower(wsl), "-")[0]
+		return platform
 	}
 	platform, _, _, _ = host.PlatformInformation()
 	if platform == "arch" {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines

### Description

Store the correct distro name of WSL into `omp.cache` so that in the "OS" segment, an icon of WSL distro will be rendered instead of a generic one. Related issue: #1766.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
