### PR TITLE
fix(cli): check for empty args(cache/get)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -122,6 +122,16 @@
       "request": "attach",
       "port": 9229,
       "preDebugTask": "func: host start"
-    }
+    },
+    {
+      "name": "Debug CLI(cache)",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceRoot}/src",
+      "args": [
+        "cache",
+      ]
+    },
   ]
 }

--- a/src/cli/cache.go
+++ b/src/cli/cache.go
@@ -32,6 +32,10 @@ You can do the following:
 	},
 	Args: cobra.OnlyValidArgs,
 	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			_ = cmd.Help()
+			return
+		}
 		env := &environment.ShellEnvironment{
 			Version: cliVersion,
 		}

--- a/src/cli/get.go
+++ b/src/cli/get.go
@@ -27,6 +27,10 @@ This command is used to get the value of the following variables:
 	},
 	Args: cobra.OnlyValidArgs,
 	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			_ = cmd.Help()
+			return
+		}
 		env := &environment.ShellEnvironment{
 			Version: cliVersion,
 		}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

calling `oh-my-posh cache` or `oh-my-posh get` without parameters crashes

<img width="719" alt="image" src="https://user-images.githubusercontent.com/1829553/159209913-0d598c20-231f-4de9-925b-636a82a10fe5.png">


<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
