### PR TITLE
fix(language): version url templates fix

### DIFF
--- a/src/segments/dotnet.go
+++ b/src/segments/dotnet.go
@@ -29,7 +29,7 @@ func (d *Dotnet) Init(props properties.Properties, env environment.Environment) 
 					`(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?))`,
 			},
 		},
-		versionURLTemplate: "https://github.com/dotnet/core/blob/master/release-notes/{{ .Major }}.{{ .Minor }}/{{ .Major }}.{{ .Minor }}.{{ .Patch }}/{{ .Major }}.{{ .Minor }}.{{ .Patch }}.md", // nolint: lll
+		versionURLTemplate: "https://github.com/dotnet/core/blob/master/release-notes/{{ .Major }}.{{ .Minor }}/{{ .Major }}.{{ .Minor }}.{{ substr 0 1 .Patch }}/{{ .Major }}.{{ .Minor }}.{{ substr 0 1 .Patch }}.md", // nolint: lll
 	}
 }
 

--- a/src/segments/node.go
+++ b/src/segments/node.go
@@ -38,7 +38,7 @@ func (n *Node) Init(props properties.Properties, env environment.Environment) {
 				regex:      `(?:v(?P<version>((?P<major>[0-9]+).(?P<minor>[0-9]+).(?P<patch>[0-9]+))))`,
 			},
 		},
-		versionURLTemplate: "[%[1]s](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V%[2]s.md#%[1]s)",
+		versionURLTemplate: "https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V{{ .Major }}.md#{{ .Full }}",
 		matchesVersionFile: n.matchesVersionFile,
 		loadContext:        n.loadContext,
 	}

--- a/src/segments/npm.go
+++ b/src/segments/npm.go
@@ -29,6 +29,6 @@ func (n *Npm) Init(props properties.Properties, env environment.Environment) {
 				regex:      `(?P<version>((?P<major>[0-9]+).(?P<minor>[0-9]+).(?P<patch>[0-9]+)))`,
 			},
 		},
-		versionURLTemplate: "https://github.com/npm/npm/releases/tag/v{{ .Full }}",
+		versionURLTemplate: "https://github.com/npm/cli/releases/tag/v{{ .Full }}",
 	}
 }

--- a/src/segments/php.go
+++ b/src/segments/php.go
@@ -25,7 +25,7 @@ func (p *Php) Init(props properties.Properties, env environment.Environment) {
 				regex:      `(?:PHP (?P<version>((?P<major>[0-9]+).(?P<minor>[0-9]+).(?P<patch>[0-9]+))))`,
 			},
 		},
-		versionURLTemplate: "[%[1]s](https://www.php.net/ChangeLog-%[2]s.php#PHP_%[2]s_%[3]s)",
+		versionURLTemplate: "https://www.php.net/ChangeLog-{{ .Major }}.php#PHP_{{ .Major }}_{{ .Minor }}",
 	}
 }
 

--- a/src/segments/python.go
+++ b/src/segments/python.go
@@ -39,7 +39,7 @@ func (p *Python) Init(props properties.Properties, env environment.Environment) 
 				regex:      `(?:Python (?P<version>((?P<major>[0-9]+).(?P<minor>[0-9]+).(?P<patch>[0-9]+))))`,
 			},
 		},
-		versionURLTemplate: "[%s](https://www.python.org/downloads/release/python-%s%s%s/)",
+		versionURLTemplate: "https://docs.python.org/release/{{ .Major }}.{{ .Minor }}.{{ .Patch }}/whatsnew/changelog.html#python-{{ .Major }}-{{ .Minor }}-{{ .Patch }}",
 		displayMode:        props.GetString(DisplayMode, DisplayModeEnvironment),
 		homeEnabled:        props.GetBool(HomeEnabled, true),
 	}

--- a/src/template/link.go
+++ b/src/template/link.go
@@ -5,7 +5,11 @@ import (
 	link "net/url"
 )
 
+// url builds an hyperlink if url is not empty, otherwise returns the text only
 func url(text, url string) (string, error) {
+	if url == "" {
+		return text, nil
+	}
 	_, err := link.ParseRequestURI(url)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
dotnet + node + npm + php + python
url helper: returns plain text if url is empty instead of failing

### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

Languages version url template fixed(new format)
url helper: don't fail if url param is empty, return the text only (so we can set url .Full .URL without having to check with an if/else .URL is empty

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
