### PR TITLE
fish: support for additional prompts

### DIFF
--- a/docs/docs/config-tooltips.mdx
+++ b/docs/docs/config-tooltips.mdx
@@ -8,7 +8,7 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
 :::info
-Due to limitations (or not having found a way just yet), this feature only works in `zsh`, `powershell` and `cmd` (as of [clink][clink] version v1.2.46) for
+Due to limitations (or not having found a way just yet), this feature only works in `fish`, `zsh`, `powershell` and `cmd` (as of [clink][clink] version v1.2.46) for
 the time being.
 :::
 
@@ -61,6 +61,7 @@ are being explored.
   values={[
     { label: 'powershell', value: 'pwsh', },
     { label: 'zsh', value: 'zsh', },
+    { label: 'fish', value: 'fish', },
   ]
 }>
 <TabItem value="pwsh">
@@ -91,6 +92,17 @@ enable_poshtooltips
 ```
 
 Restart your shell or reload `.zshrc` using `exec zsh` for the changes to take effect.
+
+</TabItem>
+<TabItem value="fish">
+
+Invoke Oh My Posh in `~/.config/fish/config.fish` and add the following line below:
+
+```bash
+enable_poshtooltips
+```
+
+Restart your shell or reload fish using `exec fish` for the changes to take effect.
 
 </TabItem>
 </Tabs>

--- a/docs/docs/config-transient.mdx
+++ b/docs/docs/config-transient.mdx
@@ -8,7 +8,7 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
 :::info
-This feature only works in `zsh`, `powershell` and `cmd` for the time being.
+This feature only works in `fish`, `zsh`, `powershell` and `cmd` for the time being.
 :::
 
 Transient prompt, when enabled, replaces the prompt with a simpler one to allow more screen real estate.
@@ -68,6 +68,7 @@ properties below - defaults to `{{ .Shell }}> `
     { label: 'powershell', value: 'pwsh', },
     { label: 'cmd', value: 'cmd', },
     { label: 'zsh', value: 'zsh', },
+    { label: 'fish', value: 'fish', },
   ]
 }>
 <TabItem value="pwsh">
@@ -109,6 +110,17 @@ enable_poshtransientprompt
 ```
 
 Restart your shell or reload `.zshrc` using `exec zsh` for the changes to take effect.
+
+</TabItem>
+<TabItem value="fish">
+
+Invoke Oh My Posh in `~/.config/fish/config.fish` and add the following line below:
+
+```bash
+enable_poshtransientprompt
+```
+
+Restart your shell or reload fish using `exec fish` for the changes to take effect.
 
 </TabItem>
 </Tabs>

--- a/docs/docs/install-prompt.mdx
+++ b/docs/docs/install-prompt.mdx
@@ -128,7 +128,7 @@ oh-my-posh prompt init fish | source
 Once added, reload your config for the changes to take effect.
 
 ```bash
-. ~/.config/fish/config.fish
+exec fish
 ```
 
 </TabItem>

--- a/src/engine/engine.go
+++ b/src/engine/engine.go
@@ -332,7 +332,7 @@ func (e *Engine) PrintExtraPrompt(promptType ExtraPromptType) string {
 			return prompt
 		}
 		return str
-	case shell.PWSH, shell.PWSH5, shell.CMD, shell.BASH:
+	case shell.PWSH, shell.PWSH5, shell.CMD, shell.BASH, shell.FISH:
 		str, _ := e.Writer.String()
 		return str
 	}

--- a/src/engine/engine.go
+++ b/src/engine/engine.go
@@ -253,7 +253,7 @@ func (e *Engine) PrintTooltip(tip string) string {
 		Segments:  []*Segment{tooltip},
 	}
 	switch e.Env.Shell() {
-	case shell.ZSH, shell.CMD:
+	case shell.ZSH, shell.CMD, shell.FISH:
 		block.init(e.Env, e.Writer, e.Ansi)
 		text, _ := block.renderSegments()
 		return text
@@ -266,7 +266,7 @@ func (e *Engine) PrintTooltip(tip string) string {
 		e.write(text)
 		return e.string()
 	}
-	return ""
+	return " "
 }
 
 type ExtraPromptType int

--- a/src/shell/scripts/omp.fish
+++ b/src/shell/scripts/omp.fish
@@ -1,6 +1,7 @@
 set -g POSH_THEME "::CONFIG::"
 set -g POWERLINE_COMMAND "oh-my-posh"
 set -g CONDA_PROMPT_MODIFIER false
+set -g omp_tooltip_command ""
 
 function fish_prompt
     set -g omp_status_cache $status
@@ -22,6 +23,11 @@ function fish_prompt
 end
 
 function fish_right_prompt
+    if test -n "$omp_tooltip_command"
+      ::OMP:: prompt print tooltip --config $POSH_THEME --shell fish --command $omp_tooltip_command
+      set omp_tooltip_command ""
+      return
+    end
     ::OMP:: prompt print right --config $POSH_THEME --shell fish --error $omp_status_cache --execution-time $omp_duration --stack-count $omp_stack_count
 end
 
@@ -29,4 +35,16 @@ function postexec_omp --on-event fish_postexec
   # works with fish <3.2
   # pre and postexec not fired for empty command in fish >=3.2
   set -gx omp_lastcommand $argv
+end
+
+# tooltip
+
+function _render_tooltip
+  set omp_tooltip_command (commandline --current-buffer | string collect)
+  commandline --insert " "
+  commandline --function repaint
+end
+
+function enable_poshtooltips
+  bind \x20 _render_tooltip
 end


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

- feat(fish): tooltip support
- feat(fish): transient prompt


<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
