### PR TITLE
update installation documentation for nu 0.60.0

### DIFF
--- a/docs/docs/install-customize.mdx
+++ b/docs/docs/install-customize.mdx
@@ -108,6 +108,7 @@ config set prompt  "(oh-my-posh prompt print primary --config ~/.jandedobbeleer.
 
 ```bash
 let-env PROMPT_COMMAND = { oh-my-posh prompt print primary --config ~/.jandedobbeleer.omp.json }
+let-env PROMPT_COMMAND_RIGHT = { oh-my-posh prompt print right --config ~/.jandedobbeleer.omp.json }
 ```
 
 Once altered, restart nu shell for the changes to take effect.

--- a/docs/docs/install-customize.mdx
+++ b/docs/docs/install-customize.mdx
@@ -104,6 +104,12 @@ config set prompt  "= `{{$(oh-my-posh prompt print primary --config ~/.jandedobb
 config set prompt  "(oh-my-posh prompt print primary --config ~/.jandedobbeleer.omp.json | str collect)"
 ```
 
+**Nu >= 0.60.0**
+
+```bash
+let-env PROMPT_COMMAND = { oh-my-posh prompt print primary --config ~/.jandedobbeleer.omp.json }
+```
+
 Once altered, restart nu shell for the changes to take effect.
 
 </TabItem>

--- a/docs/docs/install-prompt.mdx
+++ b/docs/docs/install-prompt.mdx
@@ -152,6 +152,7 @@ config set prompt  "(oh-my-posh prompt print primary | str collect)"
 
 ```bash
 let-env PROMPT_COMMAND = { oh-my-posh prompt print primary }
+let-env PROMPT_COMMAND_RIGHT = { oh-my-posh prompt print right }
 ```
 
 Restart nu shell for the changes to take effect.

--- a/docs/docs/install-prompt.mdx
+++ b/docs/docs/install-prompt.mdx
@@ -148,6 +148,12 @@ config set prompt  "= `{{$(oh-my-posh prompt print primary | str collect)}}`"
 config set prompt  "(oh-my-posh prompt print primary | str collect)"
 ```
 
+**Nu >= 0.60.0**
+
+```bash
+let-env PROMPT_COMMAND = { oh-my-posh prompt print primary }
+```
+
 Restart nu shell for the changes to take effect.
 
 </TabItem>


### PR DESCRIPTION
### Prerequisites

- [ x] I have read and understood the `CONTRIBUTING` guide
- [x ] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x ] Docs have been added / updated (for bug fixes/features)

### Description

<!--TemplateBody-->
Nushell has been updated to `0.60.0`. This update is large and brings a large amount of breaking changes. When setting up oh-my-posh within the new-and-improved Nushell, I noticed the prompt install instructions had been deprecated by this most recent update due to the changes to the configuration system. I figured I might as well help out the next person on the same journey :^).
<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
