### PR TITLE
expose code in transient prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -241,3 +241,5 @@ $RECYCLE.BIN/
 cosign.key
 
 *.omp.json.bak
+
+__debug_bin

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -43,6 +43,7 @@
         "transient",
         "--config=${workspaceRoot}/themes/jandedobbeleer.omp.json",
         "--shell=pwsh",
+        "--error=1"
       ]
     },
     {

--- a/docs/docs/config-colors.md
+++ b/docs/docs/config-colors.md
@@ -25,6 +25,34 @@ Oh My Posh supports multiple different color references, being:
 
   `darkGray` `lightRed` `lightGreen` `lightYellow` `lightBlue` `lightMagenta` `lightCyan` `lightWhite`
 
+## Color templates
+
+Array of string templates to define the color based on the current context.
+Under the hood this uses go's [text/template][go-text-template] feature extended with [sprig][sprig] and
+offers a few standard properties to work with. For segments, you can look at the **Template Properties**
+section in the documentation. The general template properties are listed [here][template-properties].
+
+The following sample is based on the [AWS Segment][aws].
+
+```json
+{
+  "type": "aws",
+  "style": "powerline",
+  "powerline_symbol": "\uE0B0",
+  "foreground": "#ffffff",
+  "background": "#111111",
+  "foreground_templates": [
+    "{{if contains \"default\" .Profile}}#FFA400{{end}}",
+    "{{if contains \"jan\" .Profile}}#f1184c{{end}}"
+  ]
+}
+```
+
+The logic is as follows: when `foreground_templates` contains an array, we will check every template line until there's
+one that returns a non-empty string. So, when the contents of `.Profile` contain the word `default`, the first template
+returns `#FFA400` and that's the color that will be used. If it contains `jan`, it returns `#f1184c`. When none of the
+templates returns a value, the foreground value `#ffffff` is used as a fallback value.
+
 ## Color overrides
 
 You have the ability to override the foreground and/or background color for text in any property that accepts it.
@@ -164,3 +192,5 @@ For example, `p:foreground` and `p:background` will be correctly set to "#CAF0F8
 [ansicolors]: https://htmlcolorcodes.com/color-chart/material-design-color-chart/
 [git]: /docs/segment-git
 [battery]: /docs/segment-battery
+[template-properties]: /docs/config-templates#global-properties
+[aws]: /docs/aws

--- a/docs/docs/config-segment.md
+++ b/docs/docs/config-segment.md
@@ -39,9 +39,9 @@ understand how to configure a segment.
 - leading_diamond: `string`
 - trailing_diamond: `string`
 - foreground: `string` [color][colors]
-- foreground_templates: `array` of `string` values
+- foreground_templates: foreground [color templates][color-templates]
 - background: `string` [color][colors]
-- background_templates: `array` of `string` values
+- background_templates: background [color templates][color-templates]
 - properties: `array` of `Property`: `string`
 
 ## Type
@@ -88,46 +88,6 @@ its foreground color.
 ## Trailing diamond
 
 Text character to use at the end of the segment. Will take the background color of the segment as its foreground color.
-
-## Foreground
-
-[Color][colors] to use as the segment text foreground color. Also supports transparency using the `transparent` keyword.
-
-## Foreground Templates
-
-Array if string templates to define the foreground color for the given Segment based on the Segment's Template Properties.
-Under the hood this uses go's [text/template][go-text-template] feature extended with [sprig][sprig] and
-offers a few standard properties to work with. For supported Segments, look for the **Template Properties** section in
-the documentation.
-
-The following sample is based on the [AWS Segment][aws].
-
-```json
-{
-  "type": "aws",
-  "style": "powerline",
-  "powerline_symbol": "\uE0B0",
-  "foreground": "#ffffff",
-  "background": "#111111",
-  "foreground_templates": [
-    "{{if contains \"default\" .Profile}}#FFA400{{end}}",
-    "{{if contains \"jan\" .Profile}}#f1184c{{end}}"
-  ]
-}
-```
-
-The logic is as follows: when `background_templates` contains an array, we will check every template line until there's
-one that returns a non-empty string. So, when the contents of `.Profile` contain the word `default`, the first template
-returns `#FFA400` and that's the color that will be used. If it contains `jan`, it returns `#f1184c`. When none of the
-templates returns a value, the foreground value `#ffffff` is used.
-
-## Background
-
-[Color][colors] to use as the segment text background color. Also supports transparency using the `transparent` keyword.
-
-## Background Templates
-
-Same as [Foreground Templates][fg-templ] but for the background color.
 
 ## Properties
 
@@ -198,7 +158,6 @@ This means that for user Bill, who has a user account `Bill` on Windows and `bil
 [colors]: /docs/config-colors
 [go-text-template]: https://golang.org/pkg/text/template/
 [sprig]: https://masterminds.github.io/sprig/
-[fg-templ]: /docs/config-overview#foreground-templates
 [regex]: https://www.regular-expressions.info/tutorial.html
-[aws]: /docs/aws
 [templates]: /docs/config-templates
+[color-templates]: /docs/config-colors#color-templates

--- a/docs/docs/config-transient.mdx
+++ b/docs/docs/config-transient.mdx
@@ -44,8 +44,10 @@ You need to extend or create a custom theme with your transient prompt. For exam
 
 The configuration has the following properties:
 
-- background: `string` [color][colors]
 - foreground: `string` [color][colors]
+- foreground_templates: foreground [color templates][color-templates]
+- background: `string` [color][colors]
+- background_templates: background [color templates][color-templates]
 - template: `string` - A go [text/template][go-text-template] template extended with [sprig][sprig] utilizing the
 properties below - defaults to `{{ .Shell }}> `
 
@@ -131,3 +133,4 @@ Restart your shell or reload fish using `exec fish` for the changes to take effe
 [sprig]: https://masterminds.github.io/sprig/
 [clink]: https://chrisant996.github.io/clink/
 [templates]: /docs/config-templates
+[color-templates]: /docs/config-colors#color-templates

--- a/src/color/templates.go
+++ b/src/color/templates.go
@@ -1,0 +1,27 @@
+package color
+
+import (
+	"oh-my-posh/environment"
+	"oh-my-posh/template"
+)
+
+type Templates []string
+
+func (t Templates) Resolve(context interface{}, env environment.Environment, defaultColor string) string {
+	if len(t) == 0 {
+		return defaultColor
+	}
+	txtTemplate := &template.Text{
+		Context: context,
+		Env:     env,
+	}
+	for _, tmpl := range t {
+		txtTemplate.Template = tmpl
+		value, err := txtTemplate.Render()
+		if err != nil || value == "" {
+			continue
+		}
+		return value
+	}
+	return defaultColor
+}

--- a/src/engine/config.go
+++ b/src/engine/config.go
@@ -59,9 +59,11 @@ func (cfg *Config) MakeColors(env environment.Environment) color.AnsiColors {
 }
 
 type ExtraPrompt struct {
-	Template   string `json:"template,omitempty"`
-	Background string `json:"background,omitempty"`
-	Foreground string `json:"foreground,omitempty"`
+	Template            string          `json:"template,omitempty"`
+	Foreground          string          `json:"foreground,omitempty"`
+	ForegroundTemplates color.Templates `json:"foreground_templates,omitempty"`
+	Background          string          `json:"background,omitempty"`
+	BackgroundTemplates color.Templates `json:"background_templates,omitempty"`
 }
 
 func (cfg *Config) print(message string) {

--- a/src/engine/engine.go
+++ b/src/engine/engine.go
@@ -294,7 +294,7 @@ func (e *Engine) PrintExtraPrompt(promptType ExtraPromptType) string {
 		prompt = e.Config.SecondaryPrompt
 	}
 	if prompt == nil {
-		return ""
+		prompt = &ExtraPrompt{}
 	}
 	getTemplate := func(template string) string {
 		if len(template) != 0 {

--- a/src/engine/engine.go
+++ b/src/engine/engine.go
@@ -319,8 +319,10 @@ func (e *Engine) PrintExtraPrompt(promptType ExtraPromptType) string {
 	if err != nil {
 		promptText = err.Error()
 	}
-	e.Writer.SetColors(prompt.Background, prompt.Foreground)
-	e.Writer.Write(prompt.Background, prompt.Foreground, promptText)
+	foreground := prompt.ForegroundTemplates.Resolve(nil, e.Env, prompt.Foreground)
+	background := prompt.BackgroundTemplates.Resolve(nil, e.Env, prompt.Background)
+	e.Writer.SetColors(background, foreground)
+	e.Writer.Write(background, foreground, promptText)
 	switch e.Env.Shell() {
 	case shell.ZSH:
 		// escape double quotes contained in the prompt

--- a/src/environment/shell.go
+++ b/src/environment/shell.go
@@ -261,11 +261,30 @@ func (env *ShellEnvironment) resolveConfigPath() {
 }
 
 func (env *ShellEnvironment) getConfigPath(location string) {
+	configFileName := fmt.Sprintf("%s.omp.json", env.Version)
+	configPath := filepath.Join(env.CachePath(), configFileName)
+	if env.HasFilesInDir(env.CachePath(), configFileName) {
+		env.CmdFlags.Config = configPath
+		return
+	}
+	// clean old config files
+	cleanCacheDir := func() {
+		dir, err := ioutil.ReadDir(env.CachePath())
+		if err != nil {
+			return
+		}
+		for _, file := range dir {
+			if strings.HasSuffix(file.Name(), ".omp.json") {
+				os.Remove(filepath.Join(env.CachePath(), file.Name()))
+			}
+		}
+	}
+	cleanCacheDir()
+
 	cfg, err := env.HTTPRequest(location, 5000)
 	if err != nil {
 		return
 	}
-	configPath := filepath.Join(env.CachePath(), "config.omp.json")
 	out, err := os.Create(configPath)
 	if err != nil {
 		return

--- a/src/environment/shell.go
+++ b/src/environment/shell.go
@@ -9,7 +9,6 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"net/url"
 	"oh-my-posh/regex"
 	"os"
 	"os/exec"
@@ -239,9 +238,8 @@ func (env *ShellEnvironment) resolveConfigPath() {
 	if len(env.CmdFlags.Config) == 0 {
 		env.CmdFlags.Config = fmt.Sprintf("https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/v%s/themes/default.omp.json", env.Version)
 	}
-	location, err := url.ParseRequestURI(env.CmdFlags.Config)
-	if err == nil {
-		env.getConfigPath(location.String())
+	if strings.HasPrefix(env.CmdFlags.Config, "https://") {
+		env.getConfigPath(env.CmdFlags.Config)
 		return
 	}
 	// Cygwin path always needs the full path as we're on Windows but not really.

--- a/src/environment/windows.go
+++ b/src/environment/windows.go
@@ -483,7 +483,7 @@ func (env *ShellEnvironment) parseNetworkInterface(network *WLAN_INTERFACE_INFO,
 
 type WLAN_INTERFACE_INFO_LIST struct { // nolint: revive
 	dwNumberOfItems uint32
-	dwIndex         uint32 // nolint: structcheck,unused
+	dwIndex         uint32
 	InterfaceInfo   [1]WLAN_INTERFACE_INFO
 }
 
@@ -494,9 +494,9 @@ type WLAN_INTERFACE_INFO struct { // nolint: revive
 }
 
 type WLAN_CONNECTION_ATTRIBUTES struct { // nolint: revive
-	isState                   uint32      // nolint: structcheck,unused
-	wlanConnectionMode        uint32      // nolint: structcheck,unused
-	strProfileName            [256]uint16 // nolint: structcheck,unused
+	isState                   uint32
+	wlanConnectionMode        uint32
+	strProfileName            [256]uint16
 	wlanAssociationAttributes WLAN_ASSOCIATION_ATTRIBUTES
 	wlanSecurityAttributes    WLAN_SECURITY_ATTRIBUTES
 }
@@ -504,9 +504,9 @@ type WLAN_CONNECTION_ATTRIBUTES struct { // nolint: revive
 type WLAN_ASSOCIATION_ATTRIBUTES struct { // nolint: revive
 	dot11Ssid         DOT11_SSID
 	dot11BssType      uint32
-	dot11Bssid        [6]uint8 // nolint: structcheck,unused
+	dot11Bssid        [6]uint8
 	dot11PhyType      uint32
-	uDot11PhyIndex    uint32 // nolint: structcheck,unused
+	uDot11PhyIndex    uint32
 	wlanSignalQuality uint32
 	ulRxRate          uint32
 	ulTxRate          uint32
@@ -514,7 +514,7 @@ type WLAN_ASSOCIATION_ATTRIBUTES struct { // nolint: revive
 
 type WLAN_SECURITY_ATTRIBUTES struct { // nolint: revive
 	bSecurityEnabled     uint32
-	bOneXEnabled         uint32 // nolint: structcheck,unused
+	bOneXEnabled         uint32
 	dot11AuthAlgorithm   uint32
 	dot11CipherAlgorithm uint32
 }

--- a/src/shell/scripts/omp.fish
+++ b/src/shell/scripts/omp.fish
@@ -5,11 +5,12 @@ set --global omp_tooltip_command ""
 set --global omp_transient 0
 
 function fish_prompt
+    set --local omp_status_cache_temp $status
     if test "$omp_transient" = "1"
-      ::OMP:: prompt print transient --config $POSH_THEME --shell fish
+      ::OMP:: prompt print transient --config $POSH_THEME --shell fish --error $omp_status_cache --execution-time $omp_duration --stack-count $omp_stack_count
       return
     end
-    set --global omp_status_cache $status
+    set --global omp_status_cache $omp_status_cache_temp
     set --global omp_stack_count (count $dirstack)
     set --global omp_duration "$CMD_DURATION$cmd_duration"
     # check if variable set, < 3.2 case

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -20,9 +20,6 @@ function prompt_ohmyposh_precmd() {
   eval "$(::OMP:: prompt print primary --config="$POSH_THEME" --error="$omp_last_error" --execution-time="$omp_elapsed" --stack-count="$omp_stack_count" --eval --shell=zsh)"
   unset omp_start_time
   unset omp_now
-  unset omp_elapsed
-  unset omp_last_error
-  unset omp_stack_count
 }
 
 function _install-omp-hooks() {
@@ -73,7 +70,7 @@ _posh-zle-line-init() {
     local -i ret=$?
     (( $+zle_bracketed_paste )) && print -r -n - $zle_bracketed_paste[2]
 
-    eval "$(::OMP:: prompt print transient --config="$POSH_THEME" --eval --shell=zsh)"
+    eval "$(::OMP:: prompt print transient --error="$omp_last_error" --execution-time="$omp_elapsed" --stack-count="$omp_stack_count" --config="$POSH_THEME" --eval --shell=zsh)"
     zle .reset-prompt
 
     # If we received EOT, we exit the shell

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -72,8 +72,10 @@
           "type": "string",
           "title": "Prompt Template"
         },
+        "foreground": { "$ref": "#/definitions/color" },
+        "foreground_templates": { "$ref": "#/definitions/color_templates" },
         "background": { "$ref": "#/definitions/color" },
-        "foreground": { "$ref": "#/definitions/color" }
+        "background_templates": { "$ref": "#/definitions/color_templates" }
       }
     },
     "block": {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

- feat(pwsh): expose errorcode to transient prompt
- feat(transient): color template support
- refactor: download config on new version only


<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
