### PR TITLE
feat: add prefix to omp.ps1 prompt variables

### DIFF
--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -62,7 +62,7 @@ function global:Initialize-ModuleSupport {
     $omp = "::OMP::"
     $config, $cleanPWD, $cleanPSWD = Get-PoshContext
     if ($env:POSH_TRANSIENT -eq $true) {
-        $standardOut = @(&$omp print transient --error="$global:ERRORCODE" --pwd="$cleanPWD" --pswd="$cleanPSWD" --execution-time="$global:EXECUTIONTIME" --config="$config" 2>&1)
+        $standardOut = @(&$omp print transient --error="$global:OMP_ERRORCODE" --pwd="$cleanPWD" --pswd="$cleanPSWD" --execution-time="$global:OMP_EXECUTIONTIME" --config="$config" 2>&1)
         $standardOut -join "`n"
         $env:POSH_TRANSIENT = $false
         return
@@ -72,16 +72,16 @@ function global:Initialize-ModuleSupport {
         $standardOut -join "`n"
         return
     }
-    $global:ERRORCODE = 0
+    $global:OMP_ERRORCODE = 0
     Initialize-ModuleSupport
     Set-PoshContext
     if ($lastCommandSuccess -eq $false) {
         #native app exit code
         if ($realLASTEXITCODE -is [int] -and $realLASTEXITCODE -gt 0) {
-            $global:ERRORCODE = $realLASTEXITCODE
+            $global:OMP_ERRORCODE = $realLASTEXITCODE
         }
         else {
-            $global:ERRORCODE = 1
+            $global:OMP_ERRORCODE = 1
         }
     }
 
@@ -94,14 +94,14 @@ function global:Initialize-ModuleSupport {
     }
     catch {}
 
-    $global:EXECUTIONTIME = -1
+    $global:OMP_EXECUTIONTIME = -1
     $history = Get-History -ErrorAction Ignore -Count 1
     if ($null -ne $history -and $null -ne $history.EndExecutionTime -and $null -ne $history.StartExecutionTime -and $global:omp_lastHistoryId -ne $history.Id) {
-        $global:EXECUTIONTIME = ($history.EndExecutionTime - $history.StartExecutionTime).TotalMilliseconds
+        $global:OMP_EXECUTIONTIME = ($history.EndExecutionTime - $history.StartExecutionTime).TotalMilliseconds
         $global:omp_lastHistoryId = $history.Id
     }
     $terminalWidth = $Host.UI.RawUI.WindowSize.Width
-    $standardOut = @(&$omp print primary --error="$global:ERRORCODE" --pwd="$cleanPWD" --pswd="$cleanPSWD" --execution-time="$global:EXECUTIONTIME" --stack-count="$stackCount" --config="$config" --terminal-width=$terminalWidth 2>&1)
+    $standardOut = @(&$omp print primary --error="$global:OMP_ERRORCODE" --pwd="$cleanPWD" --pswd="$cleanPSWD" --execution-time="$global:OMP_EXECUTIONTIME" --stack-count="$stackCount" --config="$config" --terminal-width=$terminalWidth 2>&1)
     # make sure PSReadLine knows we have a multiline prompt
     $extraLines = $standardOut.Count - 1
     if ($extraLines -gt 0) {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

<!--TemplateBody-->
Closes #1987. "OMP" string added to `$global:ERRORCODE` and
`$global:EXECUTIONTIME` variables within the init
script for powershell (e.g. omp.ps1 )
<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
