### PR TITLE
docs: remove `cache-path` from `help get` usage

### DIFF
--- a/src/cli/get.go
+++ b/src/cli/get.go
@@ -14,7 +14,7 @@ import (
 
 // getCmd represents the get command
 var getCmd = &cobra.Command{
-	Use:   "get [shell|cache-path|millies]",
+	Use:   "get [shell|millies]",
 	Short: "Get a value from oh-my-posh",
 	Long: `Get a value from oh-my-posh.
 This command is used to get the value of the following variables:


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

<!--TemplateBody-->
Closes #1986. Removed `cache-path` from Usage on `oh-my-posh help get`.
<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
