### PR TITLE
Bugfix for themes schema.json definition reference

### DIFF
--- a/themes/schema.json
+++ b/themes/schema.json
@@ -30,7 +30,7 @@
       "description": "https://ohmyposh.dev/docs/config-overview#foreground-templates",
       "default": [],
       "items": {
-        "$ref": "#/definitions/template"
+        "$ref": "#/definitions/segment/properties/template"
       }
     },
     "fetch_version": {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

As the commit message states, ee3b1127dec3abd9edbc4c8aceea38000e7fcd10 moved `#/definitions/templates` to `#/definitions/segment/properties/template`, but seemingly one reference has been forgotten.
This PR simply updates the definition path for the reference under `#/definitions/color_templates/items`

Still a bit new to JSON schemas & I'm not sure if this templating schema is wanted for that property, as the URLs for `foreground_templates` and `background_templates` are non-existing, so I hope this is correct.

<!--TemplateBody-->

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
