### PR TITLE
fix(cli): avoid panicking when no argument is given

### DIFF
--- a/src/cli/init.go
+++ b/src/cli/init.go
@@ -30,6 +30,10 @@ See the documentation to initialize your shell: https://ohmyposh.dev/docs/prompt
 		},
 		Args: cobra.OnlyValidArgs,
 		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) == 0 {
+				_ = cmd.Help()
+				return
+			}
 			runInit(args[0])
 		},
 	}

--- a/src/cli/print.go
+++ b/src/cli/print.go
@@ -45,6 +45,10 @@ var printCmd = &cobra.Command{
 	},
 	Args: cobra.OnlyValidArgs,
 	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			_ = cmd.Help()
+			return
+		}
 		env := &environment.ShellEnvironment{
 			Version: cliVersion,
 			CmdFlags: &environment.Flags{


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines

### Description

The command `init` and `prompt` will raise a panicking when no argument is given. Typically, the help text should be printed.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
