### PR TITLE
theme: correct typo in schema

### DIFF
--- a/themes/schema.json
+++ b/themes/schema.json
@@ -1135,7 +1135,7 @@
                   "folder_icon": {
                     "type": "string",
                     "title": "Folder Icon",
-                    "description": "The con to use as a folder indication",
+                    "description": "The icon to use as a folder indication",
                     "default": ".."
                   },
                   "windows_registry_icon": {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines

### Description

Correct a typo in `themes/schema.json`: `con` -> `icon`.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
