### PR TITLE
Updated documentation to show how to skip loading for the built-in Te…

### DIFF
--- a/docs/docs/install-macos.mdx
+++ b/docs/docs/install-macos.mdx
@@ -11,7 +11,7 @@ import InstallHomebrew from "./install-homebrew.mdx";
 ## Set up your terminal
 
 As the standard terminal has issues displaying the ANSI characters correctly, we advise using
-[iTerm2][iterm2] or any other modern day MacOS terminal that supports ANSI characters.
+[iTerm2][iterm2] or any other modern day macOS terminal that supports ANSI characters.
 
 :::info
 To display all icons, we recommend the use of a [Nerd Font][fonts].

--- a/docs/docs/install-prompt.mdx
+++ b/docs/docs/install-prompt.mdx
@@ -85,6 +85,18 @@ Add the following to `~/.zshrc`:
 eval "$(oh-my-posh init zsh)"
 ```
 
+:::tip
+As the standard terminal has issues displaying the ANSI characters correctly, you might want to skip loading just for that terminal and instead of the line above, place this in your `~/.zshrc`:
+
+```bash
+if [ $TERM_PROGRAM != "Apple_Terminal" ]; then
+  eval "$(oh-my-posh init zsh)"
+fi
+```
+
+Note this will still load Oh My Posh for [iTerm2][iterm2] or any other modern day macOS terminal that supports ANSI characters.
+:::
+
 Once added, reload your profile for the changes to take effect.
 
 ```bash
@@ -161,3 +173,4 @@ Restart nu shell for the changes to take effect.
 </Tabs>
 
 [clink]: https://chrisant996.github.io/clink/
+[iterm2]: https://www.iterm2.com/


### PR DESCRIPTION

### Prerequisites

- [ ] I have read and understood the `CONTRIBUTING` guide
- [ ] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

Updated documentation to show how to skip loading for the built-in Terminal app on macOS.