### PR TITLE
fix: sync Pwd()

### DIFF
--- a/src/environment/shell.go
+++ b/src/environment/shell.go
@@ -316,7 +316,9 @@ func (env *ShellEnvironment) Getenv(key string) string {
 
 func (env *ShellEnvironment) Pwd() string {
 	defer env.trace(time.Now(), "Pwd")
+	env.lock.Lock()
 	defer func() {
+		env.lock.Unlock()
 		env.log(Debug, "Pwd", env.cwd)
 	}()
 	if env.cwd != "" {
@@ -728,21 +730,8 @@ func (env *ShellEnvironment) TemplateCache() *TemplateCache {
 	return tmplCache
 }
 
-func (env *ShellEnvironment) DirMatchesOneOf(dir string, regexes []string) (match bool) {
-	// sometimes the function panics inside golang, we want to silence that error
-	// and assume that there's no match. Not perfect, but better than crashing
-	// for the time being until we figure out what the actual root cause is
-	defer func() {
-		if err := recover(); err != nil {
-			message := fmt.Sprintf("%s", err)
-			env.log(Error, "DirMatchesOneOf", message)
-			match = false
-		}
-	}()
-	env.lock.Lock()
-	defer env.lock.Unlock()
-	match = dirMatchesOneOf(dir, env.Home(), env.GOOS(), regexes)
-	return
+func (env *ShellEnvironment) DirMatchesOneOf(dir string, regexes []string) bool {
+	return dirMatchesOneOf(dir, env.Home(), env.GOOS(), regexes)
 }
 
 func dirMatchesOneOf(dir, home, goos string, regexes []string) bool {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

resolves #2038

Sync the `Pwd()` function as it seems to return invalid strings at times which could indicate a race condition.

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
