### PR TITLE
feat(python): support pyenv .python-version files

### DIFF
--- a/docs/docs/segment-python.md
+++ b/docs/docs/segment-python.md
@@ -26,6 +26,7 @@ Supports conda, virtualenv and pyenv.
 
 - home_enabled: `boolean` - display the segment in the HOME folder or not - defaults to `false`
 - fetch_virtual_env: `boolean` - fetch the name of the virtualenv or not - defaults to `true`
+- use_python_version_file: `boolean` - Use pyenv `.python-version` files to determine virtual env - defaults to `false`
 - display_default: `boolean` - show the name of the virtualenv when it's default (`system`, `base`)
 or not - defaults to `true`
 - fetch_version: `boolean` - fetch the python version - defaults to `true`

--- a/src/segments/python.go
+++ b/src/segments/python.go
@@ -3,6 +3,8 @@ package segments
 import (
 	"oh-my-posh/environment"
 	"oh-my-posh/properties"
+	"oh-my-posh/regex"
+	"strings"
 )
 
 type Python struct {
@@ -13,7 +15,8 @@ type Python struct {
 
 const (
 	// FetchVirtualEnv fetches the virtual env
-	FetchVirtualEnv properties.Property = "fetch_virtual_env"
+	FetchVirtualEnv      properties.Property = "fetch_virtual_env"
+	UsePythonVersionFile properties.Property = "use_python_version_file"
 )
 
 func (p *Python) Template() string {
@@ -66,6 +69,15 @@ func (p *Python) loadContext() {
 		if p.canUseVenvName(name) {
 			p.Venv = name
 			break
+		}
+	}
+	if !p.language.props.GetBool(UsePythonVersionFile, false) {
+		return
+	}
+	if f, err := p.language.env.HasParentFilePath(".python-version"); err == nil {
+		contents := strings.Split(p.language.env.FileContent(f.Path), "\n")
+		if contents[0] != "" && regex.MatchString("[0-9]+.[0-9]+.[0-9]", contents[0]) == false && p.canUseVenvName(contents[0]) {
+			p.Venv = contents[0]
 		}
 	}
 }


### PR DESCRIPTION
Pyenv will use .python-version files up the file heirarchy when
determining the active Python version or virtual environment to use
based on which folder your shell is in.  This change will read the file,
and if the first line does not look like a Python version, set the Venv
to that string for display.

This feature is gated behind the `use_python_version_file` Property


### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description
Read .python-version files to determine virtualenv if environment variable search turns up empty.
Note:  Does not read $PYENV_ROOT/version -- should we?
Question:  Would it be better to just parse `pyenv version` directly to determine the first environment?
Finally:  I'm using regex to try to not display a global python version as the python virtualenv -- my first thought was to compare the returned string to `python.language.version.Full`, but apparently that's not populated when we're detecting the Venv.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
