### PR TITLE
docs: move template out of properties

### DIFF
--- a/docs/docs/config-segment.md
+++ b/docs/docs/config-segment.md
@@ -38,6 +38,7 @@ understand how to configure a segment.
 - invert_powerline: `boolean`
 - leading_diamond: `string`
 - trailing_diamond: `string`
+- template: `string` a go text/template [template][templates] to render the prompt
 - foreground: `string` [color][colors]
 - foreground_templates: foreground [color templates][color-templates]
 - background: `string` [color][colors]
@@ -101,7 +102,6 @@ You can use these on any segment, the engine is responsible for adding them corr
 
 - include_folders: `[]string`
 - exclude_folders: `[]string`
-- template: `string` - A go text/template [template][templates] to render the text
 
 #### Include / Exclude Folders
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

`template` was moved up to the segment level in ee3b1127. This catches up the docs.

<!--TemplateBody-->

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
