### PR TITLE
docs(homebrew): adjust details about installation

### DIFF
--- a/docs/docs/install-homebrew.mdx
+++ b/docs/docs/install-homebrew.mdx
@@ -2,12 +2,12 @@ A [Homebrew][brew] formula is available for easy installation. When installing H
 
 ```bash
 brew tap jandedobbeleer/oh-my-posh
-brew install oh-my-posh
+brew install jandedobbeleer/oh-my-posh/oh-my-posh
 ```
 
 This installs two things:
 
-- `oh-my-posh` - Executable, added to `$(brew --prefix)`
+- `oh-my-posh` - Executable, added to `$(brew --prefix)/bin`
 - `themes` - The latest Oh My Posh [themes][themes]
 
 If you want to use a standard theme, you can find them in `$(brew --prefix)/oh-my-posh/themes`, referencing them as such


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines

### Description

This may help to prevent other Homebrew users from getting the same confusion as I got in #2023. ~~The Way **#B** to install OMP could be more friendly to non-Gophers.~~

**P.S.** I had ever thought that _**homebrew-oh-my-posh**_ could provide a way of installing from binary releases (e.g., [go-task](https://github.com/go-task/homebrew-tap/blob/master/Formula/go-task.rb), which uses [GoReleaser](https://github.com/goreleaser/goreleaser)) since this could be more friendly to non-Gophers. However, _**homebrew-core**_ already provides the way of installing from bottles, so now I think it appears to be non-essential.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
