### PR TITLE
feat(git): --separate-git-dir support

### DIFF
--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -190,6 +190,15 @@ func (g *Git) shouldDisplay() bool {
 			return true
 		}
 
+		// check for separate git folder(--separate-git-dir)
+		// check if the folder contains a HEAD file
+		if g.env.HasFilesInDir(g.gitWorkingFolder, "HEAD") {
+			gitFolder := strings.TrimSuffix(g.gitRootFolder, ".git")
+			g.gitRootFolder = g.gitWorkingFolder
+			g.gitWorkingFolder = gitFolder
+			g.gitRealFolder = gitFolder
+			return true
+		}
 		return false
 	}
 	return false


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

<!--TemplateBody-->
https://github.com/JanDeDobbeleer/oh-my-posh/issues/2074

should not break existing code: new fallback added after worktree and submodule if a gitdir ending with ".git" is found.
**Still have to reboot to test it with wsl/wsl2.**

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
