### PR TITLE
feat(m365princess): update m365princess to include pnp posh envt variables

### DIFF
--- a/themes/M365Princess.omp.json
+++ b/themes/M365Princess.omp.json
@@ -29,11 +29,10 @@
           "template": "{{ if .Env.PNPPSSITE }}\u00A0{{ end }}"
         }
       ],
-      "type": "prompt"
+      "type": "rprompt"
     },
     {
       "alignment": "left",
-      "newline": true,
       "segments": [
         {
           "background": "#9A348E",

--- a/themes/M365Princess.omp.json
+++ b/themes/M365Princess.omp.json
@@ -5,6 +5,37 @@
       "alignment": "left",
       "segments": [
         {
+          "type": "text",
+          "style": "diamond",
+          "leading_diamond": "\ue0b6",
+          "foreground": "#ffffff",
+          "background": "#cc3802",
+          "template": "{{ if .Env.PNPPSHOST }} \uf8c5 {{ .Env.PNPPSHOST }} {{ end }}"
+        },
+        {
+          "type": "text",
+          "style": "powerline",
+          "foreground": "#ffffff",
+          "background": "#047e84",
+          "powerline_symbol": "\ue0b0",
+          "template": "{{ if .Env.PNPPSSITE }} \uf672 {{ .Env.PNPPSSITE }}{{ end }}"
+        },
+        {
+          "type": "text",
+          "style": "diamond",
+          "trailing_diamond": "\ue0b4",
+          "foreground": "#ffffff",
+          "background": "#047e84",
+          "template": "{{ if .Env.PNPPSSITE }}\u00A0{{ end }}"
+        }
+      ],
+      "type": "prompt"
+    },
+    {
+      "alignment": "left",
+      "newline": true,
+      "segments": [
+        {
           "background": "#9A348E",
           "foreground": "#ffffff",
           "leading_diamond": "\ue0b6",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

This PR contains an update to the `M365Princess` theme to show a couple of environment variables.

When interacting with Microsoft 365, most of the times we use the PnP community driven PowerShell module called [PnP PowerShell](https://pnp.github.io/powershell/). One of the first commands we execute while using PnP PowerShell, is `Connect-PnPOnline` to connect to a SharePoint site. With the update added in this PR, we can which SharePoint site we are connected and which Microsoft 365 tenant is the SharePoint site in. 
These are displayed with the help of a couple of environment variables that are set by PnP PowerShell after running the `Connect-PnPOnline` command.

In the preview below, the connected SharePoint site is `/sites/yoursite` which is in the tenant named `yourtenant.sharepoint.com`

![image](https://user-images.githubusercontent.com/9694225/163199255-af4dcc79-19cf-41ff-a20d-6fc31d3c59e3.png)

I have shown this PR to the author of the theme @LuiseFreese and she is happy with the implementation.

The original idea to show these details was from Erwin van Hunen ([@erwinvanhunen](https://github.com/erwinvanhunen)) the person who created PnP PowerShell.