### PR TITLE
Updated wrong lua script for cmd

### DIFF
--- a/docs/docs/install-prompt.mdx
+++ b/docs/docs/install-prompt.mdx
@@ -71,7 +71,7 @@ Use the full path to the config file, not the relative path.
 :::
 
 ```lua title="oh-my-posh.lua"
-load(io.popen('oh-my-posh init cmd'):read("*a"))()
+load(io.popen('oh-my-posh --init --shell cmd'):read("*a"))()
 ```
 
 Once added, restart cmd for the changes to take effect.


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description


Lua script given for the clink + cmd prompt wasn't working so I have updated it to the working script.

With the script given in Docs
![WhatsApp Image 2022-04-14 at 8 44 56 PM](https://user-images.githubusercontent.com/71957060/163420605-d1b42a3d-a042-40ce-a50b-ad2551903a0b.jpg)

After updated script
![Screenshot 2022-04-14 204411](https://user-images.githubusercontent.com/71957060/163420742-589d67b1-bf12-4951-8962-ea5ad987db0a.jpg)
<!--TemplateBody-->

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
