### PR TITLE
docs(homebrew): correct path of themes

### DIFF
--- a/docs/docs/install-homebrew.mdx
+++ b/docs/docs/install-homebrew.mdx
@@ -1,7 +1,6 @@
 A [Homebrew][brew] formula is available for easy installation. When installing Homebrew for Linux, be sure to follow *[Next steps][nextsteps]* instructions to add Homebrew to your PATH and to your bash shell profile script.
 
 ```bash
-brew tap jandedobbeleer/oh-my-posh
 brew install jandedobbeleer/oh-my-posh/oh-my-posh
 ```
 
@@ -10,7 +9,7 @@ This installs two things:
 - `oh-my-posh` - Executable, added to `$(brew --prefix)/bin`
 - `themes` - The latest Oh My Posh [themes][themes]
 
-If you want to use a standard theme, you can find them in `$(brew --prefix)/oh-my-posh/themes`, referencing them as such
+If you want to use a standard theme, you can find them in `$(brew --prefix oh-my-posh)/themes`, referencing them as such
 will always keep them compatible when updating Oh My Posh.
 
 ## Update


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines

### Description

- Simplify the command for installing via Homebrew, as running only a line of `brew install jandedobbeleer/oh-my-posh/oh-my-posh` is fairly straightforward.

- Correct the path of installed themes to the original `$(brew --prefix oh-my-posh)/themes`. Related: https://github.com/JanDeDobbeleer/homebrew-oh-my-posh/issues/8#issuecomment-1100933240.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
