### PR TITLE
fix: added spacing before os icon in craver theme

### DIFF
--- a/themes/craver.omp.json
+++ b/themes/craver.omp.json
@@ -17,7 +17,7 @@
           "foreground": "#3A86FF",
           "leading_diamond": " ",
           "style": "diamond",
-          "template": "{{ if .WSL }}WSL at {{ end }}{{.Icon}} ",
+          "template": " {{ if .WSL }}WSL at {{ end }}{{.Icon}} ",
           "type": "os"
         },
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

Before:
![image](https://user-images.githubusercontent.com/715417/164054496-64cbfe51-28d7-460e-ad26-8b555b4d3cb0.png)

After:
![image](https://user-images.githubusercontent.com/715417/164054533-0f57f02b-68ef-4954-951c-4eeda1d09281.png)



<!--TemplateBody-->

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
