### PR TITLE
refactor(pwsh): purify global scope and environment

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
         "prompt",
         "print",
         "primary",
-        "--config==${workspaceRoot}/themes/cinnamon.omp.json",
+        "--config=${workspaceRoot}/themes/cinnamon.omp.json",
         "--shell=pwsh",
         "--terminal-width=200",
       ]

--- a/packages/powershell/oh-my-posh.psm1
+++ b/packages/powershell/oh-my-posh.psm1
@@ -185,7 +185,7 @@ function Set-PoshPrompt {
     # Workaround for get-location/push-location/pop-location from within a module
     # https://github.com/PowerShell/PowerShell/issues/12868
     # https://github.com/JanDeDobbeleer/oh-my-posh2/issues/113
-    $global:omp_global_sessionstate = $PSCmdlet.SessionState
+    $global:OMP_GLOBAL_SESSIONSTATE = $PSCmdlet.SessionState
 
     $poshCommand = Get-PoshCommand
     (& $poshCommand init pwsh --config="$config") | Invoke-Expression


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines

### Description

**Changes in init script `omp.ps1` for PowerShell:**

1. Do not leave temporary variables (`$Prompt` and `$secondaryPrompt`) in the current scope.

2. Use `$global:POSH_TRANSIENT` instead of `$env:POSH_TRANSIENT`. Its value is always automatically changed and there is no need to make it an environment variable.

3. Align all `OMP` prefixed global variable names using uppercase.

---

**Changes in `.vscode/launch.json`:**

Remove a redundant equal sign in `"--config==${workspaceRoot}/themes/cinnamon.omp.json"`.

---

BTW, I have another idea of moving the init stuff into a script block and making it a [**dynamic module**](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/new-module?view=powershell-7.2) imported in `omp.ps1`. This helps to utilize the encapsulation feature of the module, reduce unnecessary exports of global functions and global/environment variables to provide a tidy scope and make the script easily-maintained. I'm interested in completing further work and making it practical in the future.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
