### PR TITLE
Align tooltip behaviors

### DIFF
--- a/docs/docs/configuration/tooltips.mdx
+++ b/docs/docs/configuration/tooltips.mdx
@@ -49,9 +49,9 @@ You need to extend or create a custom theme with your tooltips. For example:
 }
 ```
 
-This configuration will render a right-aligned git segment when you type `git` or `g` followed by a space. Keep in mind that
-this is a blocking call, meaning that if the segment renders slow, you can't type until it's visible. Optimizations in this space
-are being explored.
+This configuration will render a right-aligned git segment when you type `git` or `g` followed by a space.
+A tip should not include any leading or trailing space but an interpolated one can be used, e.g., `g s`.
+Keep in mind that this is a blocking call, meaning that if the segment renders slow, you can't type until it's visible. Optimizations in this space are being explored.
 
 ## Enable the feature
 

--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -88,7 +88,6 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
             $command = $null
             $cursor = $null
             [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$command, [ref]$cursor)
-            $command = ($command -split " ")[0]
             $standardOut = @(Start-Utf8Process $script:OMPExecutable @("print", "tooltip", "--pwd=$cleanPWD", "--pswd=$cleanPSWD", "--config=$env:POSH_THEME", "--command=$command", "--shell-version=$script:PSVersion"))
             Write-Host $standardOut -NoNewline
             $host.UI.RawUI.CursorPosition = $position

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -42,7 +42,7 @@ if [ "$TERM" != "linux" ]; then
   _install-omp-hooks
 fi
 
-function self-insert() {
+function _render_tooltip() {
   # ignore an empty buffer
   if [[ -z  "$BUFFER"  ]]; then
     zle .self-insert
@@ -58,7 +58,8 @@ function self-insert() {
 }
 
 function enable_poshtooltips() {
-  zle -N self-insert
+  zle -N _render_tooltip
+  bindkey " " _render_tooltip
 }
 
 _posh-zle-line-init() {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Docs have been added/updated (for bug fixes/features)

### Description

Hi, Jan. Currently, tooltips behave differently in different shells. We should give a consideration on the cross-shell consistency.

<details><summary>ℹ️ Info</summary>

AFAIK:

- **In zsh:**
	- Tooltips are implemented by user-defined widgets in ZLE.
	- **WHATEVER** single character input can trigger tooltip rendering.
	- A tip-check uses the **ENTIRE** command line buffer.

- **In PowerShell:**
	- Tooltips are implemented by `Set-PSReadLineKeyHandler`.
	- Only a **SPACE** character input can trigger tooltip rendering.
	- A tip-check uses only the **FIRST WORD** of command line buffer.

I have not tested fish or cmd yet and I know little about fish or Lua scripts, but via source code, I got these keys:

- **In fish:**
	- Only a **SPACE** character input can trigger tooltip rendering.
	- A tip-check uses the **ENTIRE** command line buffer.

- **In cmd:**
	- Only a **SPACE** character input can trigger tooltip rendering.
	- A tip-check uses only the **FIRST WORD** of command line buffer.

</details>

I have some ideas about it.

<details><summary>💡 Idea 1</summary>

I noticed the description in the [documentation](https://ohmyposh.dev/docs/configuration/tooltips#configuration):

> This configuration will render a right-aligned git segment when you type `git` or `g` followed by a **space**.

However, in zsh whatever single character input will trigger a tip-check on the buffer. This is unreasonable in certain cases. E.g., someone uses `g` as the tip of a `git` tooltip and `go` for a `go` one, when the user wants to get a `go` tooltip rendered in a Git repo, a `g` must be typed first, and then `o`, while at this point the `git` tooltip gets rendered, which is obviously superfluous for the user, especially in a large-size repo this may lead to an unnecessary slowdown. So it's better to make it the same as that in other shells.

I have got it done in this draft. ✅

</details>

<details><summary>💡 Idea 2</summary>

If a tip-check uses the entire command line buffer, it supports a tip including interpolated spaces, e.g., `g s` for a `git` tooltip. I think this can be applied to all these 4 shells to improve flexibility and ensure consistency.

I have got it done in PowerShell. Lacking knowledge about Lua scripts, I'm not able to adjust that in cmd for the time being but it may be done later on. Or, would be so grateful if you adopt this and get the rest work done. 🙏

</details>

OMP is an awesome project. Thanks for your hard work!

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
