### PR TITLE
docs: add time zone example using Sprig

### DIFF
--- a/website/docs/segments/time.md
+++ b/website/docs/segments/time.md
@@ -76,5 +76,14 @@ Show the current timestamp.
 - StampMicro = "Jan _2 15:04:05.000000"
 - StampNano  = "Jan _2 15:04:05.000000000"
 
+## Examples
+
+To display the time in multiple time zones, using [Sprig's Date Functions][sprig-date]:
+
+```text
+{{ .CurrentDate | date .Format }} {{ dateInZone "15:04Z" .CurrentDate "UTC" }}
+```
+
 [templates]: /docs/configuration/templates
 [format]: https://yourbasic.org/golang/format-parse-string-time-date-example/
+[sprig-date]: https://masterminds.github.io/sprig/date.html


### PR DESCRIPTION
### Prerequisites

- [x ] I have read and understood the `CONTRIBUTING` guide
- [x ] The commit message follows the [conventional commits][cc] guidelines
- [n/a ] Tests for the changes have been added (for bug fixes/features)
- [ x] Docs have been added / updated (for bug fixes/features)

### Description

Coming from pilot, sysadmin, and distributed team experiences I thought it would be useful to include an example in the documentation to display time in more than one time zone (esp. UTC since sometimes servers are configured in different time zones than dev machines).

Generally, Sprig provides excellent additions to templates for oh-my-posh and other places may benefits from similar function cross-references as well.