### PR TITLE
Sample syntax fix

### DIFF
--- a/docs/docs/configuration/debug-prompt.md
+++ b/docs/docs/configuration/debug-prompt.md
@@ -21,9 +21,9 @@ You need to extend or create a custom theme with your debug prompt override. For
 ```json
 {
     "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
-    "blocks": {
+    "blocks": [
         ...
-    },
+    ],
     "debug_prompt": {
         "background": "transparent",
         "foreground": "#ffffff",

--- a/docs/docs/configuration/secondary-prompt.md
+++ b/docs/docs/configuration/secondary-prompt.md
@@ -20,9 +20,9 @@ You need to extend or create a custom theme with your secondary prompt override.
 ```json
 {
     "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
-    "blocks": {
+    "blocks": [
         ...
-    },
+    ],
     "secondary_prompt": {
         "background": "transparent",
         "foreground": "#ffffff",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

Fixes an issue where some pages in the documentation show "blocks" as being a JSON object whereas other pages show it as being an array of objects, which is correct.

<!--TemplateBody-->

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
