### PR TITLE
fix(shell): wrap path with single quotes

### DIFF
--- a/src/shell/scripts/omp.bash
+++ b/src/shell/scripts/omp.bash
@@ -1,4 +1,4 @@
-export POSH_THEME="::CONFIG::"
+export POSH_THEME='::CONFIG::'
 export POWERLINE_COMMAND="oh-my-posh"
 export CONDA_PROMPT_MODIFIER=false
 

--- a/src/shell/scripts/omp.fish
+++ b/src/shell/scripts/omp.fish
@@ -1,4 +1,4 @@
-set --export POSH_THEME "::CONFIG::"
+set --export POSH_THEME '::CONFIG::'
 set --global POWERLINE_COMMAND "oh-my-posh"
 set --global CONDA_PROMPT_MODIFIER false
 set --global omp_tooltip_command ""
@@ -7,7 +7,7 @@ set --global omp_transient 0
 function fish_prompt
     set --local omp_status_cache_temp $status
     if test "$omp_transient" = "1"
-      ::OMP:: print transient --config $POSH_THEME --shell fish --error $omp_status_cache --execution-time $omp_duration --stack-count $omp_stack_count --shell-version $FISH_VERSION
+      '::OMP::' print transient --config $POSH_THEME --shell fish --error $omp_status_cache --execution-time $omp_duration --stack-count $omp_stack_count --shell-version $FISH_VERSION
       return
     end
     set --global omp_status_cache $omp_status_cache_temp
@@ -25,7 +25,7 @@ function fish_prompt
       set --global --export omp_last_status_generation $status_generation
     end
 
-    ::OMP:: print primary --config $POSH_THEME --shell fish --error $omp_status_cache --execution-time $omp_duration --stack-count $omp_stack_count --shell-version $FISH_VERSION
+    '::OMP::' print primary --config $POSH_THEME --shell fish --error $omp_status_cache --execution-time $omp_duration --stack-count $omp_stack_count --shell-version $FISH_VERSION
 end
 
 function fish_right_prompt
@@ -35,14 +35,14 @@ function fish_right_prompt
       return
     end
     if test -n "$omp_tooltip_command"
-      set omp_tooltip_prompt (::OMP:: print tooltip --config $POSH_THEME --shell fish --shell-version $FISH_VERSION --command $omp_tooltip_command)
+      set omp_tooltip_prompt ('::OMP::' print tooltip --config $POSH_THEME --shell fish --shell-version $FISH_VERSION --command $omp_tooltip_command)
       if test -n "$omp_tooltip_prompt"
         echo -n $omp_tooltip_prompt
         set omp_tooltip_command ""
         return
       end
     end
-    ::OMP:: print right --config $POSH_THEME --shell fish --error $omp_status_cache --execution-time $omp_duration --stack-count $omp_stack_count --shell-version $FISH_VERSION
+    '::OMP::' print right --config $POSH_THEME --shell fish --error $omp_status_cache --execution-time $omp_duration --stack-count $omp_stack_count --shell-version $FISH_VERSION
 end
 
 function postexec_omp --on-event fish_postexec

--- a/src/shell/scripts/omp.nu
+++ b/src/shell/scripts/omp.nu
@@ -8,9 +8,9 @@ let-env PROMPT_COMMAND_RIGHT = {''}
 let-env NU_VERSION = (version | get version)
 
 # PROMPTS
-let-env PROMPT_MULTILINE_INDICATOR = (^::OMP:: print secondary $"--config=($env.POSH_THEME)" --shell=nu $"--shell-version=($env.NU_VERSION)")
+let-env PROMPT_MULTILINE_INDICATOR = (^'::OMP::' print secondary $"--config=($env.POSH_THEME)" --shell=nu $"--shell-version=($env.NU_VERSION)")
 
 let-env PROMPT_COMMAND = {
     let width = (term size -c | get columns | into string)
-    ^::OMP:: print primary $"--config=($env.POSH_THEME)" --shell=nu $"--shell-version=($env.NU_VERSION)" $"--execution-time=($env.CMD_DURATION_MS)" $"--error=($env.LAST_EXIT_CODE)" $"--terminal-width=($width)"
+    ^'::OMP::' print primary $"--config=($env.POSH_THEME)" --shell=nu $"--shell-version=($env.NU_VERSION)" $"--execution-time=($env.CMD_DURATION_MS)" $"--error=($env.LAST_EXIT_CODE)" $"--terminal-width=($width)"
 }

--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -37,12 +37,12 @@ if ($null -eq $env:POSH_GIT_ENABLED) {
 # used to detect empty hit
 $global:OMP_LASTHISTORYID = -1
 
-if (Test-Path "::CONFIG::") {
-    $env:POSH_THEME = (Resolve-Path -Path "::CONFIG::").ProviderPath
+if (Test-Path '::CONFIG::') {
+    $env:POSH_THEME = (Resolve-Path -Path '::CONFIG::').ProviderPath
 }
 
 # set secondary prompt`
-Set-PSReadLineOption -ContinuationPrompt (@(Start-Utf8Process "::OMP::" "print secondary --config=""$Env:POSH_THEME""") -join "`n")
+Set-PSReadLineOption -ContinuationPrompt (@(Start-Utf8Process '::OMP::' "print secondary --config=""$Env:POSH_THEME""") -join "`n")
 
 function global:Set-PoshContext {}
 
@@ -66,7 +66,7 @@ Set-Item -Force -Path Function:prompt -Value {
     $lastCommandSuccess = $?
     #store the last exit code for restore
     $realLASTEXITCODE = $global:LASTEXITCODE
-    $omp = "::OMP::"
+    $omp = '::OMP::'
     $cleanPWD, $cleanPSWD = Get-PoshContext
     if ($global:POSH_TRANSIENT -eq $true) {
         @(Start-Utf8Process $omp "print transient --error=$global:OMP_ERRORCODE --pwd=""$cleanPWD"" --pswd=""$cleanPSWD"" --execution-time=$global:OMP_EXECUTIONTIME --config=""$Env:POSH_THEME"" --shell-version=""$env:SHELL_VERSION""") -join "`n"
@@ -148,7 +148,7 @@ function global:Export-PoshTheme {
         $Format = 'json'
     )
 
-    $omp = "::OMP::"
+    $omp = '::OMP::'
     $configString = @(Start-Utf8Process $omp "config export --config=""$Env:POSH_THEME"" --format=$Format")
     # if no path, copy to clipboard by default
     if ($FilePath -ne "") {
@@ -166,7 +166,7 @@ function global:Enable-PoshTooltips {
     Set-PSReadlineKeyHandler -Key SpaceBar -ScriptBlock {
         [Microsoft.PowerShell.PSConsoleReadLine]::Insert(' ')
         $position = $host.UI.RawUI.CursorPosition
-        $omp = "::OMP::"
+        $omp = '::OMP::'
         $cleanPWD, $cleanPSWD = Get-PoshContext
         $command = $null
         $cursor = $null
@@ -194,7 +194,7 @@ function global:Enable-PoshTransientPrompt {
 }
 
 function global:Enable-PoshLineError {
-    $omp = "::OMP::"
+    $omp = '::OMP::'
     $validLine = @(Start-Utf8Process $omp "print valid --config=""$Env:POSH_THEME""") -join "`n"
     $errorLine = @(Start-Utf8Process $omp "print error --config=""$Env:POSH_THEME""") -join "`n"
     Set-PSReadLineOption -PromptText $validLine, $errorLine
@@ -259,7 +259,7 @@ function global:Get-PoshThemes() {
         $themes | Select-Object @{ Name = 'hyperlink'; Expression = { Get-Hyperlink -uri $_.fullname } } | Format-Table -HideTableHeaders
     }
     else {
-        $omp = "::OMP::"
+        $omp = '::OMP::'
         $themes | ForEach-Object -Process {
             Write-Host "Theme: $(Get-Hyperlink -uri $_.fullname -name $_.BaseName.Replace('.omp', ''))`n"
             @(Start-Utf8Process $omp "print primary --config=""$($_.FullName)"" --pwd=""$PWD"" --shell pwsh")

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -1,4 +1,4 @@
-export POSH_THEME="::CONFIG::"
+export POSH_THEME='::CONFIG::'
 export POWERLINE_COMMAND="oh-my-posh"
 export CONDA_PROMPT_MODIFIER=false
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines

### Description

This may fix errors occur in specific cases where there are spaces in the OMP executable path.

<details><summary>Example of an error in fish</summary>

Run:

```fish
"/home/myname/o m p/oh-my-posh" init fish | source
```

Output:

```
/home/myname/o: command not found
- (line 28): 
    /home/myname/o m p/oh-my-posh print primary --config $POSH_THEME --shell fish --error $omp_status_cache --execution-time $omp_duration --stack-count $omp_stack_count --shell-version $FISH_VERSION
    ^
in function 'fish_prompt'
in command substitution
/home/myname/o: command not found
- (line 45): 
    /home/myname/o m p/oh-my-posh print right --config $POSH_THEME --shell fish --error $omp_status_cache --execution-time $omp_duration --stack-count $omp_stack_count --shell-version $FISH_VERSION
    ^
in function 'fish_right_prompt'
in command substitution
```

</details>

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
