### PR TITLE
docs: change `fontFace` to `font.face` in Windows Terminal instructions

### DIFF
--- a/docs/docs/configuration/fonts.md
+++ b/docs/docs/configuration/fonts.md
@@ -19,7 +19,7 @@ Download your chosen Nerd Font, and install the font system-wide. See this [thre
 
 Once you have installed a Nerd Font, you will need to configure the Windows Terminal to use it. This can be easily done
 by modifying the Windows Terminal settings (default shortcut: `CTRL + SHIFT + ,`). In your `settings.json` file, add the
-`fontFace` attribute under the `defaults` attribute in `profiles`:
+`font.face` attribute under the `defaults` attribute in `profiles`:
 
 ```json
 {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description

Corrects the `fontFace` attribute to `font.face` in the instructions for updating Windows Terminal settings to use Nerd Fonts.