### PR TITLE
fix: typo millies => millis

### DIFF
--- a/src/cli/get.go
+++ b/src/cli/get.go
@@ -10,7 +10,7 @@ import (
 
 // getCmd represents the get command
 var getCmd = &cobra.Command{
-	Use:   "get [shell|millies]",
+	Use:   "get [shell|millis]",
 	Short: "Get a value from oh-my-posh",
 	Long: `Get a value from oh-my-posh.
 This command is used to get the value of the following variables:


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes/features)

### Description

Fix small typo in output of: `oh-my-posh get`
Current output mentions "millies" as valid usage, which it isn't.
```
Get a value from oh-my-posh.
This command is used to get the value of the following variables:

- shell
- millis

Usage:
  oh-my-posh get [shell|millies] [flags]
```