### PR TITLE
fix(config): do not resolve URL when download fails

### DIFF
--- a/docs/docs/installation/windows.mdx
+++ b/docs/docs/installation/windows.mdx
@@ -144,7 +144,7 @@ when setting the prompt using the `--config` flag.
 </TabItem>
 <TabItem value="manual">
 
-You can find the themes winget installs inside the `$env:POSH_THEMES_PATH` folder.
+You can find the themes inside the `$env:POSH_THEMES_PATH` folder.
 To use `jandedobbeleer.omp.json` for example, you can refer to it using `$env:POSH_THEMES_PATH\jandedobbeleer.omp.json`
 when setting the prompt using the `--config` flag.
 

--- a/src/engine/config.go
+++ b/src/engine/config.go
@@ -281,7 +281,7 @@ func defaultConfig() *Config {
 						BackgroundTemplates: []string{
 							"{{ if gt .Code 0 }}#f1184c{{ end }}",
 						},
-						Template: " \uE23A",
+						Template: " \uE23A ",
 						Properties: properties.Map{
 							properties.AlwaysEnabled: true,
 						},

--- a/src/environment/shell.go
+++ b/src/environment/shell.go
@@ -234,13 +234,15 @@ func (env *ShellEnvironment) resolveConfigPath() {
 		env.CmdFlags.Config = fmt.Sprintf("https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/v%s/themes/default.omp.json", env.Version)
 	}
 	if strings.HasPrefix(env.CmdFlags.Config, "https://") {
-		if err := env.downloadConfig(env.CmdFlags.Config); err == nil {
+		if err := env.downloadConfig(env.CmdFlags.Config); err != nil {
+			// make it use default config when download fails
+			env.CmdFlags.Config = ""
 			return
 		}
 	}
 	// Cygwin path always needs the full path as we're on Windows but not really.
 	// Doing filepath actions will convert it to a Windows path and break the init script.
-	if env.Platform() == WindowsPlatform && env.Shell() == "constants.BASH" {
+	if env.Platform() == WindowsPlatform && env.Shell() == "bash" {
 		return
 	}
 	configFile := env.CmdFlags.Config
@@ -569,7 +571,7 @@ func (env *ShellEnvironment) Shell() string {
 		return Unknown
 	}
 	// Cache the shell value to speed things up.
-	env.CmdFlags.Shell = strings.Trim(strings.Replace(name, ".exe", "", 1), " ")
+	env.CmdFlags.Shell = strings.Trim(strings.TrimSuffix(name, ".exe"), " ")
 	return env.CmdFlags.Shell
 }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines

### Description

Related: #2167.

1. Make an early return when the download of a remote config fails. This prevents from resolving the URL to an invalid path.

2. Fix a bash check statement on Windows.

3. Add a space character at the end of the template field in the default config's `exit` segment.

4. Remove the `winget installs` words in the documentation of the `manual` installation tab on Windows.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
