### PR TITLE
feat: dotnet section visible when *.slnf files present

### DIFF
--- a/docs/docs/segments/dotnet.md
+++ b/docs/docs/segments/dotnet.md
@@ -30,7 +30,7 @@ Display the currently active .NET SDK version.
 - missing_command_text: `string` - text to display when the command is missing - defaults to empty
 - display_mode: `string` - determines when the segment is displayed
   - `always`: the segment is always displayed
-  - `files`: the segment is only displayed when `*.cs`, `*.vb`, `*.fs`, `*.fsx`, `*.sln`, `*.csproj`, `*.vbproj`,
+  - `files`: the segment is only displayed when `*.cs`, `*.vb`, `*.fs`, `*.fsx`, `*.sln`, `*.slnf`, `*.csproj`, `*.vbproj`,
   or `*.fsproj` files are present (default)
 - version_url_template: `string` - A go text/template [template][templates] that creates the changelog URL
 

--- a/src/segments/dotnet.go
+++ b/src/segments/dotnet.go
@@ -20,7 +20,7 @@ func (d *Dotnet) Init(props properties.Properties, env environment.Environment) 
 	d.language = language{
 		env:        env,
 		props:      props,
-		extensions: []string{"*.cs", "*.csx", "*.vb", "*.sln", "*.csproj", "*.vbproj", "*.fs", "*.fsx", "*.fsproj", "global.json"},
+		extensions: []string{"*.cs", "*.csx", "*.vb", "*.sln", "*.slnf", "*.csproj", "*.vbproj", "*.fs", "*.fsx", "*.fsproj", "global.json"},
 		commands: []*cmd{
 			{
 				executable: "dotnet",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description
Makes the dotnet section visible by default when in a directory containing solution filter files (*.slnf). Updated relevant docs page too.

Fixes #2185