### PR TITLE
feat: add property for available memory

### DIFF
--- a/docs/docs/segments/sysinfo.md
+++ b/docs/docs/segments/sysinfo.md
@@ -41,7 +41,8 @@ Display SysInfo.
 ### Properties
 
 - `.PhysicalTotalMemory`: `int` - is the total of used physical memory
-- `.PhysicalFreeMemory`: `int` - is the total of free physical memory
+- `.PhysicalAvailableMemory`: `int` - is the total available physical memory (i.e. the amount immediately available to processes)
+- `.PhysicalFreeMemory`: `int` - is the total of free physical memory (i.e. considers memory used by the system for any reason [e.g. caching] as occupied)
 - `.PhysicalPercentUsed`: `float64` - is the percentage of physical memory in usage
 - `.SwapTotalMemory`: `int` - is the total of used swap memory
 - `.SwapFreeMemory`: `int` -  is the total of free swap memory

--- a/src/segments/sysinfo.go
+++ b/src/segments/sysinfo.go
@@ -16,12 +16,13 @@ type SystemInfo struct {
 
 	Precision int
 	// mem
-	PhysicalTotalMemory uint64
-	PhysicalFreeMemory  uint64
-	PhysicalPercentUsed float64
-	SwapTotalMemory     uint64
-	SwapFreeMemory      uint64
-	SwapPercentUsed     float64
+	PhysicalTotalMemory     uint64
+	PhysicalAvailableMemory uint64
+	PhysicalFreeMemory      uint64
+	PhysicalPercentUsed     float64
+	SwapTotalMemory         uint64
+	SwapFreeMemory          uint64
+	SwapPercentUsed         float64
 	// cpu
 	Times float64
 	CPU   []cpu.InfoStat
@@ -57,6 +58,7 @@ func (s *SystemInfo) Init(props properties.Properties, env environment.Environme
 	memStat, err := mem.VirtualMemory()
 	if err == nil {
 		s.PhysicalTotalMemory = memStat.Total
+		s.PhysicalAvailableMemory = memStat.Available
 		s.PhysicalFreeMemory = memStat.Free
 		s.PhysicalPercentUsed = memStat.UsedPercent
 	}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] (**N/A**) Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes/features)

### Description
I have added the [`.PhysicalAvailableMemory`][psutil] property to the `SystemInfo` segment. I personally find this number more helpful than the `.PhysicalFreeMemory` figure since that can also include memory used (but available) up by the system for other reasons.

I have amended the documentation to (hopefully) clarify the difference between this new property and the existing property.

re: Tests, currently the sysinfo tests test formatting, and as this new property is directly [available][gopsutil] without computation or modification of other code, I feel no modifications to existing unit tests are required.

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[psutil]: https://psutil.readthedocs.io/en/latest/#psutil.virtual_memory
[gopsutil]: https://github.com/shirou/gopsutil/blob/24a1ae54b4b1790202ca2780a56e23d1aa7d7210/mem/mem.go#L22
