### PR TITLE
Improve the documentation and the CLI

### DIFF
--- a/docs/docs/installation/windows.mdx
+++ b/docs/docs/installation/windows.mdx
@@ -64,7 +64,7 @@ This installs a couple of things:
 - `oh-my-posh.exe` - Windows executable
 - `themes` - The latest Oh My Posh [themes][themes]
 
-For the `$PATH` to reload, a restart of your terminal is advised.
+For the `PATH` to be reloaded, a restart of your terminal is advised.
 
 :::warning Antivirus software
 Due to frequent updates of Oh My Posh, Antivirus software occasionally flags it (false positive).
@@ -130,22 +130,22 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; Invoke-Expression ((New-Object
 }>
 <TabItem value="winget">
 
-You can find the themes winget installs inside the `$env:POSH_THEMES_PATH` folder.
-To use `jandedobbeleer.omp.json` for example, you can refer to it using `$env:POSH_THEMES_PATH\jandedobbeleer.omp.json`
+You can find the themes winget installs inside the folder indicated by the environment variable `POSH_THEMES_PATH`.
+To use `jandedobbeleer.omp.json` in PowerShell for example, you can refer to it using `$env:POSH_THEMES_PATH\jandedobbeleer.omp.json`
 when setting the prompt using the `--config` flag.
 
 </TabItem>
 <TabItem value="scoop">
 
 You can find the themes scoop installs inside the `"$(scoop prefix oh-my-posh)\themes\"` folder.
-To use `jandedobbeleer.omp.json` for example, you can refer to it using `"$(scoop prefix oh-my-posh)\themes\jandedobbeleer.omp.json"`
+To use `jandedobbeleer.omp.json` in PowerShell for example, you can refer to it using `"$(scoop prefix oh-my-posh)\themes\jandedobbeleer.omp.json"`
 when setting the prompt using the `--config` flag.
 
 </TabItem>
 <TabItem value="manual">
 
-You can find the themes inside the `$env:POSH_THEMES_PATH` folder.
-To use `jandedobbeleer.omp.json` for example, you can refer to it using `$env:POSH_THEMES_PATH\jandedobbeleer.omp.json`
+You can find the themes inside the folder indicated by the environment variable `POSH_THEMES_PATH`.
+To use `jandedobbeleer.omp.json` in PowerShell for example, you can refer to it using `$env:POSH_THEMES_PATH\jandedobbeleer.omp.json`
 when setting the prompt using the `--config` flag.
 
 </TabItem>

--- a/docs/docs/share-theme.md
+++ b/docs/docs/share-theme.md
@@ -13,13 +13,13 @@ Depending on your config, you might have to tweak the output a little bit.
 :::
 
 The oh-my-posh executable has the `config export image` command to export your current theme configuration
-to the current directory.
+to an image file (.png).
 
 ```powershell
 oh-my-posh config export image --cursor-padding 50
 ```
 
-There are a couple of additional switches you can use to tweak the image rendering:
+There are a couple of additional flags you can use to tweak the image rendering:
 
 - `--cursor-padding`: spaces to add after the cursor indication (`_`)
 - `--rprompt-offset`: spaces to add **before** a block that's right aligned

--- a/src/cli/args.go
+++ b/src/cli/args.go
@@ -1,0 +1,13 @@
+package cli
+
+import "github.com/spf13/cobra"
+
+func NoArgsOrOneValidArg(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return nil
+	}
+	if err := cobra.ExactArgs(1)(cmd, args); err != nil {
+		return err
+	}
+	return cobra.OnlyValidArgs(cmd, args)
+}

--- a/src/cli/cache.go
+++ b/src/cli/cache.go
@@ -16,6 +16,7 @@ var getCache = &cobra.Command{
 	Use:   "cache [path|clear|edit]",
 	Short: "Interact with the oh-my-posh cache",
 	Long: `Interact with the oh-my-posh cache.
+
 You can do the following:
 
 - path: list cache path
@@ -26,7 +27,7 @@ You can do the following:
 		"clear",
 		"edit",
 	},
-	Args: cobra.OnlyValidArgs,
+	Args: NoArgsOrOneValidArg,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			_ = cmd.Help()

--- a/src/cli/config.go
+++ b/src/cli/config.go
@@ -11,9 +11,17 @@ import (
 // configCmd represents the config command
 var configCmd = &cobra.Command{
 	Use:   "config [export|migrate|edit]",
-	Short: "Interact with the configuration",
-	Long: `Interact with the configuration
-It allows to export, migrate or edit the configuration.`,
+	Short: "Interact with the config",
+	Long: `Interact with the config.
+
+You can export, migrate or edit the config.`,
+	ValidArgs: []string{
+		"export",
+		"migrate",
+		"edit",
+		"get",
+	},
+	Args: NoArgsOrOneValidArg,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			_ = cmd.Help()

--- a/src/cli/config_export.go
+++ b/src/cli/config_export.go
@@ -66,8 +66,8 @@ func cleanOutputPath(path string, env environment.Environment) string {
 		path = filepath.Join(env.Home(), path)
 	}
 	if !filepath.IsAbs(path) {
-		if absConfigFile, err := filepath.Abs(path); err == nil {
-			path = absConfigFile
+		if absPath, err := filepath.Abs(path); err == nil {
+			path = absPath
 		}
 	}
 	return filepath.Clean(path)

--- a/src/cli/config_export.go
+++ b/src/cli/config_export.go
@@ -17,11 +17,12 @@ var (
 // exportCmd represents the export command
 var exportCmd = &cobra.Command{
 	Use:   "export",
-	Short: "Export your configuration",
-	Long: `Export your configuration
-You can choose to print the output to stdout, or export your configuration in the format of your choice.
+	Short: "Export your config",
+	Long: `Export your config.
 
-Example usage
+You can choose to print the output to stdout, or export your config in the format of your choice.
+
+Example usage:
 
 > oh-my-posh config export --config ~/myconfig.omp.json
 
@@ -33,8 +34,9 @@ Exports the ~/myconfig.omp.json config file to toml and prints the result to std
 
 > oh-my-posh config export --config ~/myconfig.omp.json --format toml --write
 
-Exports the  ~/myconfig.omp.json config file to toml and writes the result to your config file.
+Exports the ~/myconfig.omp.json config file to toml and writes the result to your config file.
 A backup of the current config can be found at ~/myconfig.omp.json.bak.`,
+	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		env := &environment.ShellEnvironment{
 			Version: cliVersion,
@@ -72,7 +74,7 @@ func cleanOutputPath(path string, env environment.Environment) string {
 }
 
 func init() { // nolint:gochecknoinits
-	exportCmd.Flags().StringVarP(&format, "format", "f", "json", "configuration format to migrate to")
+	exportCmd.Flags().StringVarP(&format, "format", "f", "json", "config format to migrate to")
 	exportCmd.Flags().StringVarP(&output, "output", "o", "", "config file to export to")
 	configCmd.AddCommand(exportCmd)
 }

--- a/src/cli/config_export_image.go
+++ b/src/cli/config_export_image.go
@@ -22,20 +22,25 @@ var (
 var imageCmd = &cobra.Command{
 	Use:   "image",
 	Short: "Export your config to an image",
-	Long: `Export your config to an image
-
-> oh-my-posh config export image --config ~/myconfig.omp.json
-
-Exports the configuration to an image file called ~/myconfig.png.
-
-> oh-my-posh config export image --config ~/myconfig.omp.json --author "John Doe"
+	Long: `Export your config to an image.
 
 You can tweak the output by using additional flags:
 
 - author: displays the author below the prompt
 - cursor-padding: the padding of the prompt cursor
 - rprompt-offset: the offset of the right prompt
-- background-color: the background color of the image`,
+- background-color: the background color of the image
+
+Example usage:
+
+> oh-my-posh config export image --config ~/myconfig.omp.json
+
+Exports the config to an image file called myconfig.png in the current working directory.
+
+> oh-my-posh config export image --config ~/myconfig.omp.json --author "John Doe"
+
+Exports the config to an image file using customized output options.`,
+	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		env := &environment.ShellEnvironment{
 			Version: cliVersion,

--- a/src/cli/config_export_image.go
+++ b/src/cli/config_export_image.go
@@ -16,6 +16,7 @@ var (
 	cursorPadding int
 	rPromptOffset int
 	bgColor       string
+	outputImage   string
 )
 
 // imageCmd represents the image command
@@ -36,6 +37,10 @@ Example usage:
 > oh-my-posh config export image --config ~/myconfig.omp.json
 
 Exports the config to an image file called myconfig.png in the current working directory.
+
+> oh-my-posh config export image --config ~/myconfig.omp.json --output ~/mytheme.png
+
+Exports the config to an image file ~/mytheme.png.
 
 > oh-my-posh config export image --config ~/myconfig.omp.json --author "John Doe"
 
@@ -81,6 +86,9 @@ Exports the config to an image file using customized output options.`,
 			BgColor:       bgColor,
 			Ansi:          ansi,
 		}
+		if outputImage != "" {
+			imageCreator.Path = cleanOutputPath(outputImage, env)
+		}
 		imageCreator.Init(env.Flags().Config)
 		err := imageCreator.SavePNG()
 		if err != nil {
@@ -94,5 +102,6 @@ func init() { // nolint:gochecknoinits
 	imageCmd.Flags().StringVar(&bgColor, "background-color", "", "image background color")
 	imageCmd.Flags().IntVar(&cursorPadding, "cursor-padding", 0, "prompt cursor padding")
 	imageCmd.Flags().IntVar(&rPromptOffset, "rprompt-offset", 0, "right prompt offset")
+	imageCmd.Flags().StringVarP(&outputImage, "output", "o", "", "image file (.png) to export to")
 	exportCmd.AddCommand(imageCmd)
 }

--- a/src/cli/config_migrate.go
+++ b/src/cli/config_migrate.go
@@ -16,9 +16,10 @@ var (
 // migrateCmd represents the migrate command
 var migrateCmd = &cobra.Command{
 	Use:   "migrate",
-	Short: "Migrate your configuration",
-	Long: `Migrate your configuration
-You can choose to print the output to stdout, or migrate your configuration in the format of your choice.
+	Short: "Migrate your config",
+	Long: `Migrate your config.
+
+You can choose to print the output to stdout, or migrate your config in the format of your choice.
 
 Example usage
 
@@ -32,8 +33,9 @@ Migrates the ~/myconfig.omp.json config file to toml and prints the result to st
 
 > oh-my-posh config migrate --config ~/myconfig.omp.json --format toml --write
 
-Migrates the  ~/myconfig.omp.json config file to toml and writes the result to your config file.
+Migrates the ~/myconfig.omp.json config file to toml and writes the result to your config file.
 A backup of the current config can be found at ~/myconfig.omp.json.bak.`,
+	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		env := &environment.ShellEnvironment{
 			Version: cliVersion,
@@ -55,7 +57,7 @@ A backup of the current config can be found at ~/myconfig.omp.json.bak.`,
 }
 
 func init() { //nolint:gochecknoinits
-	migrateCmd.Flags().BoolVarP(&write, "write", "w", false, "write the migrated configuration back to the config file")
-	migrateCmd.Flags().StringVarP(&format, "format", "f", "json", "the configuration format to migrate to")
+	migrateCmd.Flags().BoolVarP(&write, "write", "w", false, "write the migrated config back to the config file")
+	migrateCmd.Flags().StringVarP(&format, "format", "f", "json", "the config format to migrate to")
 	configCmd.AddCommand(migrateCmd)
 }

--- a/src/cli/debug.go
+++ b/src/cli/debug.go
@@ -15,7 +15,7 @@ import (
 var debugCmd = &cobra.Command{
 	Use:   "debug",
 	Short: "Print the prompt in debug mode",
-	Long:  "Print the prompt in debug mode",
+	Long:  "Print the prompt in debug mode.",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		env := &environment.ShellEnvironment{

--- a/src/cli/get.go
+++ b/src/cli/get.go
@@ -13,6 +13,7 @@ var getCmd = &cobra.Command{
 	Use:   "get [shell|millis]",
 	Short: "Get a value from oh-my-posh",
 	Long: `Get a value from oh-my-posh.
+
 This command is used to get the value of the following variables:
 
 - shell
@@ -21,7 +22,7 @@ This command is used to get the value of the following variables:
 		"millis",
 		"shell",
 	},
-	Args: cobra.OnlyValidArgs,
+	Args: NoArgsOrOneValidArg,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			_ = cmd.Help()

--- a/src/cli/init.go
+++ b/src/cli/init.go
@@ -14,9 +14,10 @@ var (
 
 	initCmd = &cobra.Command{
 		Use:   "init [bash|zsh|fish|powershell|pwsh|cmd|nu] --config ~/.mytheme.omp.json",
-		Short: "Initialize your shell and configuration",
-		Long: `Allows to initialize your shell and configuration.
-See the documentation to initialize your shell: https://ohmyposh.dev/docs/prompt.`,
+		Short: "Initialize your shell and config",
+		Long: `Initialize your shell and config.
+
+See the documentation to initialize your shell: https://ohmyposh.dev/docs/installation/prompt.`,
 		ValidArgs: []string{
 			"bash",
 			"zsh",
@@ -26,7 +27,7 @@ See the documentation to initialize your shell: https://ohmyposh.dev/docs/prompt
 			"cmd",
 			"nu",
 		},
-		Args: cobra.OnlyValidArgs,
+		Args: NoArgsOrOneValidArg,
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) == 0 {
 				_ = cmd.Help()

--- a/src/cli/print.go
+++ b/src/cli/print.go
@@ -40,7 +40,7 @@ var printCmd = &cobra.Command{
 		"valid",
 		"error",
 	},
-	Args: cobra.OnlyValidArgs,
+	Args: NoArgsOrOneValidArg,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			_ = cmd.Help()

--- a/src/cli/prompt.go
+++ b/src/cli/prompt.go
@@ -8,8 +8,8 @@ import (
 var promptCmd = &cobra.Command{
 	Use:   "prompt",
 	Short: "Set up the prompt for your shell (deprecated)",
-	Long: `Set up the prompt for your shell (deprecated)
-Allows to initialize one of the supported shells, or to set the prompt manually for a custom shell.`,
+	Long:  `Set up the prompt for your shell. (deprecated)`,
+	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		_ = cmd.Help()
 	},

--- a/src/cli/root.go
+++ b/src/cli/root.go
@@ -38,7 +38,6 @@ on getting started, have a look at the docs at https://ohmyposh.dev`,
 func Execute(version string) {
 	cliVersion = version
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }

--- a/src/cli/version.go
+++ b/src/cli/version.go
@@ -10,7 +10,8 @@ import (
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version",
-	Long:  "Print oh-my-posh version and build information.",
+	Long:  "Print the version number of oh-my-posh.",
+	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println(cliVersion)
 	},

--- a/src/engine/image.go
+++ b/src/engine/image.go
@@ -105,7 +105,7 @@ type ImageRenderer struct {
 	BgColor       string
 	Ansi          *color.Ansi
 
-	path string
+	Path string
 
 	factor float64
 
@@ -136,8 +136,10 @@ type ImageRenderer struct {
 }
 
 func (ir *ImageRenderer) Init(config string) {
-	match := regex.FindNamedRegexMatch(`.*(\/|\\)(?P<STR>.+).omp.(json|yaml|toml)`, config)
-	ir.path = fmt.Sprintf("%s.png", match[str])
+	if ir.Path == "" {
+		match := regex.FindNamedRegexMatch(`.*(\/|\\)(?P<STR>.+)\.(json|yaml|yml|toml)`, config)
+		ir.Path = fmt.Sprintf("%s.png", strings.TrimSuffix(match[str], ".omp"))
+	}
 
 	f := 2.0
 
@@ -446,7 +448,7 @@ func (ir *ImageRenderer) SavePNG() error {
 		x += w
 	}
 
-	return dc.SavePNG(ir.path)
+	return dc.SavePNG(ir.Path)
 }
 
 func (ir *ImageRenderer) shouldPrint() bool {

--- a/src/engine/image_test.go
+++ b/src/engine/image_test.go
@@ -5,16 +5,31 @@ import (
 	"oh-my-posh/color"
 	"oh-my-posh/shell"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func runImageTest(content string) error {
+var cases = []struct {
+	Case   string
+	Config string
+}{
+	{Case: ".omp.json suffix", Config: "~/jandedobbeleer.omp.json"},
+	{Case: ".omp.yaml suffix", Config: "~/jandedobbeleer.omp.yaml"},
+	{Case: ".omp.yml suffix", Config: "~/jandedobbeleer.omp.yml"},
+	{Case: ".omp.toml suffix", Config: "~/jandedobbeleer.omp.toml"},
+	{Case: ".json suffix", Config: "~/jandedobbeleer.json"},
+	{Case: ".yaml suffix", Config: "~/jandedobbeleer.yaml"},
+	{Case: ".yml suffix", Config: "~/jandedobbeleer.yml"},
+	{Case: ".toml suffix", Config: "~/jandedobbeleer.toml"},
+}
+
+func runImageTest(config, content string) (string, error) {
 	poshImagePath := "jandedobbeleer.png"
 	file, err := ioutil.TempFile("", poshImagePath)
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer os.Remove(file.Name())
 	ansi := &color.Ansi{}
@@ -23,18 +38,27 @@ func runImageTest(content string) error {
 		AnsiString: content,
 		Ansi:       ansi,
 	}
-	image.Init("~/jandedobbeleer.omp.json")
+	image.Init(config)
 	err = image.SavePNG()
-	return err
+	if err == nil {
+		os.Remove(image.Path)
+	}
+	return filepath.Base(image.Path), err
 }
 
 func TestStringImageFileWithText(t *testing.T) {
-	err := runImageTest("foobar")
-	assert.NoError(t, err)
+	for _, tc := range cases {
+		filename, err := runImageTest(tc.Config, "foobar")
+		assert.Equal(t, "jandedobbeleer.png", filename, tc.Case)
+		assert.NoError(t, err)
+	}
 }
 
 func TestStringImageFileWithANSI(t *testing.T) {
 	prompt := `[38;2;40;105;131m[0m[48;2;40;105;131m[38;2;224;222;244m jan [0m[38;2;40;105;131m[0m[38;2;224;222;244m [0m`
-	err := runImageTest(prompt)
-	assert.NoError(t, err)
+	for _, tc := range cases {
+		filename, err := runImageTest(tc.Config, prompt)
+		assert.Equal(t, "jandedobbeleer.png", filename, tc.Case)
+		assert.NoError(t, err)
+	}
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the `CONTRIBUTING` guide
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description

1. Make the installation guide on Windows more accurate. (The `$env:` prefix is available for PowerShell only.)

2. Adjust the help text and the argument validation for CLI calls.

3. Print error message only once for a CLI call failure.

	<details>

	E.g., run `oh-my-posh get invalid-arg`, it shows:

	```
	Error: invalid argument "invalid-arg" for "oh-my-posh get"
	Usage:
	  oh-my-posh get [shell|millis] [flags]

	Flags:
	  -h, --help   help for get

	Global Flags:
	  -c, --config string   config (required)

	invalid argument "invalid-arg" for "oh-my-posh get"
	```

	The error message `invalid argument ...` is printed twice, at the beginning and the end, which is redundant. When `SilenceErrors` is `false` for a command, the error returned by `cobra.OnlyValidArgs` will be printed first in `(*cobra.Command).ExecuteC`, which is inherent in Cobra:

	```go
	if !cmd.SilenceErrors && !c.SilenceErrors {
		c.PrintErrln("Error:", err.Error())
	}
	```

	and then `(*cobra.Command).ExecuteC` returns this error so it is finally passed to `cli.Execute`, causing the message to be printed once more:

	https://github.com/JanDeDobbeleer/oh-my-posh/blob/5e9a7f57435bde284a2bff1154d2f0e29c0907da/src/cli/root.go#L40-L43

	We should remove the latter. This doesn't affect an error that is printed inside `(*cobra.Command).ExecuteC` and not returned by it.

	</details>

4. Add `-o, --output` flag for `oh-my-posh config export image`. This allows users to specify the output image file path.

	BTW, a bug fix: when using a YAML config file with a .yml suffix, the filename of the output image file will be merely `.png`.

✅ **All above have been validated.**

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
