### PR TITLE
Fix debug, set `POSH_THEME` env for CMD init and revise docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,9 @@
 ### Prerequisites
 
-- [ ] I have read and understood the `CONTRIBUTING` guide
+- [ ] I have read and understood the [contributing guide][CONTRIBUTING.md]
 - [ ] The commit message follows the [conventional commits][cc] guidelines
 - [ ] Tests for the changes have been added (for bug fixes/features)
-- [ ] Docs have been added / updated (for bug fixes/features)
+- [ ] Docs have been added/updated (for bug fixes/features)
 
 ### Description
 
@@ -18,4 +18,5 @@ Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your
 
 -->
 
+[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
 [cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
         "primary",
         "--config=${workspaceRoot}/themes/default.omp.json",
         "--shell=pwsh",
-        "--terminal-width=200",
+        "--terminal-width=200"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "args": [
         "config",
         "migrate",
-        "--config=${workspaceRoot}/themes/default.omp.json",
+        "--config=${workspaceRoot}/themes/default.omp.json"
       ]
     },
     {
@@ -131,8 +131,8 @@
       "mode": "debug",
       "program": "${workspaceRoot}/src",
       "args": [
-        "cache",
+        "cache"
       ]
-    },
+    }
   ]
 }

--- a/docs/blog/2022-03-20-whats-new-1.mdx
+++ b/docs/blog/2022-03-20-whats-new-1.mdx
@@ -17,12 +17,12 @@ What a week it’s been! Oh My Posh turned 6 years old and we dropped a ton of s
 ## Swag
 
 After seeing Scott Hanselman wear his oh my zsh shirt while we got to talk about
-Oh My posh on [Windows Wednesdays] [windows-wednesdays], I got the sudden urge to expand his wardrobe.
+Oh My Posh on [Windows Wednesdays] [windows-wednesdays], I got the sudden urge to expand his wardrobe.
 
 <iframe class="youtube" src="https://www.youtube.com/embed/uO_F5W2LbSk" frameborder="0" allowfullscreen></iframe>
 
 And so, we did. Got in touch with [Marc Duiker][marc] and we got to work. The result? A ton of new goodies.
-Consider this to be **the first artist series** for Oh My posh, a way to also highlight some talented
+Consider this to be **the first artist series** for Oh My Posh, a way to also highlight some talented
 people in the community. All profits go to the development of the project and artists also get a 20% royalty
 per item sold. If you know any interesting artists to work with for the next batch, be sure to let me know!
 
@@ -35,12 +35,12 @@ So, what are you waiting for? Get some!
 
 ### CLI interface
 
-Something I've been sleeping on for a long time, Oh My posh finally has a new CLI interface.
+Something I've been sleeping on for a long time, Oh My Posh finally has a new CLI interface.
 Starting out I had no experience in Go, nor any idea on how to create a proper CLI interface.
 Over the years the interface grew, but **_not in a very sustainable way_**, it was a chain of if statements
 which was a bit of a pain to support.
 
-You can now interact with Oh my Posh via an interface powered by [Cobra][cobra]. Not only does this
+You can now interact with Oh My Posh via an interface powered by [Cobra][cobra]. Not only does this
 bring maintainability and extensibility, it at once introduces a few added features.
 
 #### Init

--- a/docs/blog/2022-03-27-whats-new-2.mdx
+++ b/docs/blog/2022-03-27-whats-new-2.mdx
@@ -52,7 +52,7 @@ We already supported [fish shell][fish] for a while, but we stepped up the game.
 as my primary shell, so obviously it couldn't stay behind. I suggest you also have
 a go at it, it's a very enjoyable experience.
 
-But OK, what changed? We now support the following out of the box:
+But OK, what changed? We now support the following out-of-the-box:
 
 - [right prompt][right]
 - [transient prompt][transient]

--- a/docs/blog/2022-03-28-idiots-everywhere.md
+++ b/docs/blog/2022-03-28-idiots-everywhere.md
@@ -12,7 +12,7 @@ hide_table_of_contents: false
 ---
 
 It finally happened, **I introduced a bug** that only appears in 1 use case and it can’t be resolved as it’s the result of
-using an old and new version of Oh My posh at the same time. Who does that you might ask? Well, it can be because you’re
+using an old and new version of Oh My Posh at the same time. Who does that you might ask? Well, it can be because you’re
 using WSL on Windows, or VM’s on any system while sharing the same configuration cross installation.
 Not the main use-case, but also not exotic either.
 

--- a/docs/docs/configuration/tooltips.mdx
+++ b/docs/docs/configuration/tooltips.mdx
@@ -8,7 +8,7 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
 :::info
-Due to limitations (or not having found a way just yet), this feature only works in `fish`, `zsh`, `powershell` and `cmd` (as of [clink][clink] version v1.2.46) for
+Due to limitations (or not having found a way just yet), this feature only works in `fish`, `zsh`, `powershell` and `cmd` (as of [Clink][clink] v1.2.46+) for
 the time being.
 :::
 

--- a/docs/docs/installation/prompt.mdx
+++ b/docs/docs/installation/prompt.mdx
@@ -50,11 +50,11 @@ Once added, reload your profile for the changes to take effect.
 </TabItem>
 <TabItem value="cmd">
 
-There's no out of the box support for Windows CMD when it comes to custom prompts.
+There's no out-of-the-box support for Windows CMD when it comes to custom prompts.
 There is however a way to do it using [Clink][clink], which at the same time supercharges
 your cmd experience. Follow the installation instructions and make sure you select autostart.
 
-Integrating Oh my Posh with Clink is easy: create a new file called oh-my-posh.lua in your Clink
+Integrating Oh My Posh with Clink is easy: create a new file called oh-my-posh.lua in your Clink
 scripts directory (run `clink info` inside cmd to find that file's location).
 
 :::warning

--- a/docs/docs/migrating-module.md
+++ b/docs/docs/migrating-module.md
@@ -34,7 +34,7 @@ Make sure to move these before running the command.
 
 ### Install oh-my-posh
 
-See your platform's installation guide. The preferred ways are **winget** and **homebrew**.
+See your platform's installation guide. The preferred ways are **winget** and **Homebrew**.
 
 - [Windows][windows]
 - [macOS][macos]
@@ -64,7 +64,7 @@ oh-my-posh init pwsh --config ~/.custom.omp.json | Invoke-Expression
 
 And replace `~/.custom.omp.json` with the location of your theme.
 
-#### I have an out of the box theme
+#### I have an out-of-the-box theme
 
 ```powershell
 oh-my-posh init pwsh --config "$env:POSH_THEMES_PATH\jandedobbeleer.omp.json" | Invoke-Expression
@@ -73,8 +73,8 @@ oh-my-posh init pwsh --config "$env:POSH_THEMES_PATH\jandedobbeleer.omp.json" | 
 Replace `jandedobbeleer.omp.json` with the theme you use.
 
 :::caution
-Only winget can add the `$env:POSH_THEMES_PATH` variable. For homebrew, use
-`$(brew --prefix oh-my-posh)/themes/jandedobbeleer.omp.json`
+Only winget can add the environment variable `POSH_THEMES_PATH` automatically. For Homebrew, use
+`$(brew --prefix oh-my-posh)/themes/jandedobbeleer.omp.json`.
 :::
 
 [init]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/src/shell/scripts/omp.ps1

--- a/src/cli/debug.go
+++ b/src/cli/debug.go
@@ -21,6 +21,7 @@ var debugCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		startTime := time.Now()
 		env := &environment.ShellEnvironment{
+			Version: cliVersion,
 			CmdFlags: &environment.Flags{
 				Config: config,
 				Debug:  true,

--- a/src/shell/scripts/omp.lua
+++ b/src/shell/scripts/omp.lua
@@ -33,6 +33,8 @@ local function omp_config()
     return [["::CONFIG::"]]
 end
 
+os.setenv("POSH_THEME", omp_config())
+
 local function can_async()
     if (clink.version_encoded or 0) >= 10030001 then
         return settings.get("prompt.async")


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines

### Description

1. Add a contributing guide link in the PR template.

2. Minor revision in the documentation.

3. Initialize `ShellEnvironment.Version` in `oh-my-posh debug`.

	<details><summary>This should fix a bug:</summary>

	When neither a config is specified nor the env `POSH_THEME` is set, the download URL of the default remote config for `oh-my-posh debug` is `https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/v/themes/default.omp.json`, which always leads to an HTTP 404.

	```
	...
	2022/05/08 21:43:05 error: HTTPRequest
	HTTP status code 404
	2022/05/08 21:43:05 HTTPRequest duration: 2.5092674s, args: https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/v/themes/default.omp.json
	2022/05/08 21:43:05 downloadConfig duration: 2.5092674s, args: https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/v/themes/default.omp.json
	...
	```

	</details>

3. Set the environment variable `POSH_THEME` in the init script (`omp.lua`) for CMD as is set for other shells. This is for the consistency of cross-shell features.


[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
