### PR TITLE
Fix the exporting to image and the migration

### DIFF
--- a/src/engine/image.go
+++ b/src/engine/image.go
@@ -47,12 +47,14 @@ const (
 
 	fg                  = "FG"
 	bg                  = "BG"
+	bc                  = "BC" // for base 16 colors
 	str                 = "STR"
 	url                 = "URL"
 	invertedColor       = "inverted"
 	invertedColorSingle = "invertedsingle"
 	fullColor           = "full"
 	foreground          = "foreground"
+	background          = "background"
 	reset               = "reset"
 	bold                = "bold"
 	boldReset           = "boldr"
@@ -176,6 +178,7 @@ func (ir *ImageRenderer) Init(config string) {
 		invertedColorSingle: `^(?P<STR>\x1b\[(?P<BG>\d{2,3});49m\x1b\[7m)`,
 		fullColor:           `^(?P<STR>(\x1b\[48;2;(?P<BG>(\d+;?){3})m)(\x1b\[38;2;(?P<FG>(\d+;?){3})m))`,
 		foreground:          `^(?P<STR>(\x1b\[38;2;(?P<FG>(\d+;?){3})m))`,
+		background:          `^(?P<STR>(\x1b\[48;2;(?P<BG>(\d+;?){3})m))`,
 		reset:               `^(?P<STR>\x1b\[0m)`,
 		bold:                `^(?P<STR>\x1b\[1m)`,
 		boldReset:           `^(?P<STR>\x1b\[22m)`,
@@ -185,7 +188,7 @@ func (ir *ImageRenderer) Init(config string) {
 		underlineReset:      `^(?P<STR>\x1b\[24m)`,
 		strikethrough:       `^(?P<STR>\x1b\[9m)`,
 		strikethroughReset:  `^(?P<STR>\x1b\[29m)`,
-		color16:             `^(?P<STR>\x1b\[(?P<FG>\d{2,3})m)`,
+		color16:             `^(?P<STR>\x1b\[(?P<BC>\d{2,3})m)`,
 		left:                `^(?P<STR>\x1b\[(\d{1,3})D)`,
 		osc99:               `^(?P<STR>\x1b\]9;9;(.+)\x1b\\)`,
 		lineChange:          `^(?P<STR>\x1b\[(\d)[FB])`,
@@ -476,6 +479,9 @@ func (ir *ImageRenderer) shouldPrint() bool {
 		case foreground:
 			ir.foregroundColor = NewRGBColor(match[fg])
 			return false
+		case background:
+			ir.backgroundColor = NewRGBColor(match[bg])
+			return false
 		case reset:
 			ir.foregroundColor = ir.defaultForegroundColor
 			ir.backgroundColor = nil
@@ -489,7 +495,7 @@ func (ir *ImageRenderer) shouldPrint() bool {
 		case strikethrough, strikethroughReset, left, osc99, lineChange, consoleTitle:
 			return false
 		case color16:
-			ir.setBase16Color(match[fg])
+			ir.setBase16Color(match[bc])
 			return false
 		case link:
 			ir.AnsiString = match[url] + ir.AnsiString

--- a/src/engine/segment.go
+++ b/src/engine/segment.go
@@ -30,7 +30,7 @@ type Segment struct {
 	Properties          properties.Map  `json:"properties,omitempty"`
 
 	writer          SegmentWriter
-	Enabled         bool
+	Enabled         bool `json:"-"`
 	text            string
 	env             environment.Environment
 	backgroundCache string

--- a/src/test/jandedobbeleer-palette.omp.json
+++ b/src/test/jandedobbeleer-palette.omp.json
@@ -8,10 +8,8 @@
           "background": "p:session",
           "foreground": "p:white",
           "leading_diamond": "\ue0b6",
-          "properties": {
-            "template": " {{ .UserName }} "
-          },
           "style": "diamond",
+          "template": " {{ .UserName }} ",
           "trailing_diamond": "\ue0b0",
           "type": "session"
         },
@@ -22,10 +20,10 @@
           "properties": {
             "folder_separator_icon": " \ue0b1 ",
             "home_icon": "~",
-            "style": "folder",
-            "template": " \uf74a  {{ .Path }} "
+            "style": "folder"
           },
           "style": "powerline",
+          "template": " \uf74a  {{ .Path }} ",
           "type": "path"
         },
         {
@@ -43,10 +41,10 @@
             "branch_max_length": 25,
             "fetch_stash_count": true,
             "fetch_status": true,
-            "fetch_upstream_icon": true,
-            "template": " {{ .UpstreamIcon }}{{ .HEAD }}{{ .BranchStatus }}{{ if .Working.Changed }} \uf044 {{ .Working.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }} \uf046 {{ .Staging.String }}{{ end }}{{ if gt .StashCount 0 }} \uf692 {{ .StashCount }}{{ end }} "
+            "fetch_upstream_icon": true
           },
           "style": "powerline",
+          "template": " {{ .UpstreamIcon }}{{ .HEAD }}{{ .BranchStatus }}{{ if .Working.Changed }} \uf044 {{ .Working.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }} \uf046 {{ .Staging.String }}{{ end }}{{ if gt .StashCount 0 }} \uf692 {{ .StashCount }}{{ end }} ",
           "trailing_diamond": "\ue0b4",
           "type": "git"
         },
@@ -55,10 +53,10 @@
           "foreground": "p:white",
           "powerline_symbol": "\ue0b0",
           "properties": {
-            "fetch_version": true,
-            "template": " \uf898 {{ if .PackageManagerIcon }}{{ .PackageManagerIcon }} {{ end }}{{ .Full }} "
+            "fetch_version": true
           },
           "style": "powerline",
+          "template": " \uf898 {{ if .PackageManagerIcon }}{{ .PackageManagerIcon }} {{ end }}{{ .Full }} ",
           "type": "node"
         },
         {
@@ -66,10 +64,10 @@
           "foreground": "p:black",
           "powerline_symbol": "\ue0b0",
           "properties": {
-            "fetch_version": true,
-            "template": " \ue626 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
+            "fetch_version": true
           },
           "style": "powerline",
+          "template": " \ue626 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} ",
           "type": "go"
         },
         {
@@ -77,10 +75,10 @@
           "foreground": "p:black",
           "powerline_symbol": "\ue0b0",
           "properties": {
-            "fetch_version": true,
-            "template": " \ue624 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
+            "fetch_version": true
           },
           "style": "powerline",
+          "template": " \ue624 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} ",
           "type": "julia"
         },
         {
@@ -89,10 +87,10 @@
           "powerline_symbol": "\ue0b0",
           "properties": {
             "display_mode": "files",
-            "fetch_virtual_env": false,
-            "template": " \ue235 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
+            "fetch_virtual_env": false
           },
           "style": "powerline",
+          "template": " \ue235 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} ",
           "type": "python"
         },
         {
@@ -101,10 +99,10 @@
           "powerline_symbol": "\ue0b0",
           "properties": {
             "display_mode": "files",
-            "fetch_version": true,
-            "template": " \ue791 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
+            "fetch_version": true
           },
           "style": "powerline",
+          "template": " \ue791 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} ",
           "type": "ruby"
         },
         {
@@ -113,10 +111,10 @@
           "powerline_symbol": "\ue0b0",
           "properties": {
             "display_mode": "files",
-            "fetch_version": false,
-            "template": " \uf0e7{{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
+            "fetch_version": false
           },
           "style": "powerline",
+          "template": " \uf0e7{{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} ",
           "type": "azfunc"
         },
         {
@@ -127,30 +125,28 @@
           "foreground": "p:white",
           "powerline_symbol": "\ue0b0",
           "properties": {
-            "display_default": false,
-            "template": " \ue7ad {{ .Profile }}{{ if .Region }}@{{ .Region }}{{ end }} "
+            "display_default": false
           },
           "style": "powerline",
+          "template": " \ue7ad {{ .Profile }}{{ if .Region }}@{{ .Region }}{{ end }} ",
           "type": "aws"
         },
         {
           "background": "p:root",
           "foreground": "p:black",
           "powerline_symbol": "\ue0b0",
-          "properties": {
-            "template": " \uf0ad "
-          },
           "style": "powerline",
+          "template": " \uf0ad ",
           "type": "root"
         },
         {
           "background": "p:executiontime",
           "foreground": "p:white",
           "properties": {
-            "always_enabled": true,
-            "template": "<transparent>\ue0b0</> \ufbab{{ .FormattedMs }}\u2800"
+            "always_enabled": true
           },
           "style": "plain",
+          "template": "<transparent>\ue0b0</> \ufbab{{ .FormattedMs }}\u2800",
           "type": "executiontime"
         },
         {
@@ -160,10 +156,10 @@
           ],
           "foreground": "p:white",
           "properties": {
-            "always_enabled": true,
-            "template": "<parentBackground>\ue0b0</> \ue23a "
+            "always_enabled": true
           },
           "style": "diamond",
+          "template": "<parentBackground>\ue0b0</> \ue23a ",
           "trailing_diamond": "\ue0b4",
           "type": "exit"
         }
@@ -175,10 +171,8 @@
         {
           "background": "p:shell",
           "foreground": "p:white",
-          "properties": {
-            "template": "<#0077c2,transparent>\ue0b6</> \uf489 {{ .Name }} <transparent,#0077c2>\ue0b2</>"
-          },
           "style": "plain",
+          "template": "<#0077c2,transparent>\ue0b6</> \uf489 {{ .Name }} <transparent,#0077c2>\ue0b2</>",
           "type": "shell"
         },
         {
@@ -188,10 +182,10 @@
           "powerline_symbol": "\ue0b2",
           "properties": {
             "paused_icon": "\uf04c ",
-            "playing_icon": "\uf04b ",
-            "template": " \uf167 {{ .Icon }}{{ if ne .Status \"stopped\" }}{{ .Artist }} - {{ .Track }}{{ end }} "
+            "playing_icon": "\uf04b "
           },
           "style": "powerline",
+          "template": " \uf167 {{ .Icon }}{{ if ne .Status \"stopped\" }}{{ .Artist }} - {{ .Track }}{{ end }} ",
           "type": "ytm"
         },
         {
@@ -207,10 +201,10 @@
           "properties": {
             "charged_icon": "\ue22f ",
             "charging_icon": "\ue234 ",
-            "discharging_icon": "\ue231 ",
-            "template": " {{ if not .Error }}{{ .Icon }}{{ .Percentage }}{{ end }}{{ .Error }}\uf295 "
+            "discharging_icon": "\ue231 "
           },
           "style": "powerline",
+          "template": " {{ if not .Error }}{{ .Icon }}{{ .Percentage }}{{ end }}{{ .Error }}\uf295 ",
           "type": "battery"
         },
         {
@@ -218,10 +212,8 @@
           "foreground": "p:black",
           "invert_powerline": true,
           "leading_diamond": "\ue0b2",
-          "properties": {
-            "template": " {{ .CurrentDate | date .Format }} "
-          },
           "style": "diamond",
+          "template": " {{ .CurrentDate | date .Format }} ",
           "trailing_diamond": "\ue0b4",
           "type": "time"
         }
@@ -262,5 +254,5 @@
     "white": "#FFFFFF",
     "ytm": "#1BD760"
   },
-  "version": 1
+  "version": 2
 }

--- a/src/test/jandedobbeleer.omp.json
+++ b/src/test/jandedobbeleer.omp.json
@@ -8,10 +8,8 @@
           "background": "#c386f1",
           "foreground": "#ffffff",
           "leading_diamond": "\ue0b6",
-          "properties": {
-            "template": " {{ .UserName }} "
-          },
           "style": "diamond",
+          "template": " {{ .UserName }} ",
           "trailing_diamond": "\ue0b0",
           "type": "session"
         },
@@ -22,10 +20,10 @@
           "properties": {
             "folder_separator_icon": " \ue0b1 ",
             "home_icon": "~",
-            "style": "folder",
-            "template": " \uf74a  {{ .Path }} "
+            "style": "folder"
           },
           "style": "powerline",
+          "template": " \uf74a  {{ .Path }} ",
           "type": "path"
         },
         {
@@ -43,10 +41,10 @@
             "branch_max_length": 25,
             "fetch_stash_count": true,
             "fetch_status": true,
-            "fetch_upstream_icon": true,
-            "template": " {{ .UpstreamIcon }}{{ .HEAD }}{{ .BranchStatus }}{{ if .Working.Changed }} \uf044 {{ .Working.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }} \uf046 {{ .Staging.String }}{{ end }}{{ if gt .StashCount 0 }} \uf692 {{ .StashCount }}{{ end }} "
+            "fetch_upstream_icon": true
           },
           "style": "powerline",
+          "template": " {{ .UpstreamIcon }}{{ .HEAD }}{{ .BranchStatus }}{{ if .Working.Changed }} \uf044 {{ .Working.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }} \uf046 {{ .Staging.String }}{{ end }}{{ if gt .StashCount 0 }} \uf692 {{ .StashCount }}{{ end }} ",
           "trailing_diamond": "\ue0b4",
           "type": "git"
         },
@@ -55,10 +53,10 @@
           "foreground": "#ffffff",
           "powerline_symbol": "\ue0b0",
           "properties": {
-            "fetch_version": true,
-            "template": " \uf898 {{ if .PackageManagerIcon }}{{ .PackageManagerIcon }} {{ end }}{{ .Full }} "
+            "fetch_version": true
           },
           "style": "powerline",
+          "template": " \uf898 {{ if .PackageManagerIcon }}{{ .PackageManagerIcon }} {{ end }}{{ .Full }} ",
           "type": "node"
         },
         {
@@ -66,10 +64,10 @@
           "foreground": "#111111",
           "powerline_symbol": "\ue0b0",
           "properties": {
-            "fetch_version": true,
-            "template": " \ue626 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
+            "fetch_version": true
           },
           "style": "powerline",
+          "template": " \ue626 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} ",
           "type": "go"
         },
         {
@@ -77,10 +75,10 @@
           "foreground": "#111111",
           "powerline_symbol": "\ue0b0",
           "properties": {
-            "fetch_version": true,
-            "template": " \ue624 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
+            "fetch_version": true
           },
           "style": "powerline",
+          "template": " \ue624 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} ",
           "type": "julia"
         },
         {
@@ -89,10 +87,10 @@
           "powerline_symbol": "\ue0b0",
           "properties": {
             "display_mode": "files",
-            "fetch_virtual_env": false,
-            "template": " \ue235 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
+            "fetch_virtual_env": false
           },
           "style": "powerline",
+          "template": " \ue235 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} ",
           "type": "python"
         },
         {
@@ -101,10 +99,10 @@
           "powerline_symbol": "\ue0b0",
           "properties": {
             "display_mode": "files",
-            "fetch_version": true,
-            "template": " \ue791 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
+            "fetch_version": true
           },
           "style": "powerline",
+          "template": " \ue791 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} ",
           "type": "ruby"
         },
         {
@@ -113,10 +111,10 @@
           "powerline_symbol": "\ue0b0",
           "properties": {
             "display_mode": "files",
-            "fetch_version": false,
-            "template": " \uf0e7{{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
+            "fetch_version": false
           },
           "style": "powerline",
+          "template": " \uf0e7{{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} ",
           "type": "azfunc"
         },
         {
@@ -127,30 +125,28 @@
           "foreground": "#ffffff",
           "powerline_symbol": "\ue0b0",
           "properties": {
-            "display_default": false,
-            "template": " \ue7ad {{ .Profile }}{{ if .Region }}@{{ .Region }}{{ end }} "
+            "display_default": false
           },
           "style": "powerline",
+          "template": " \ue7ad {{ .Profile }}{{ if .Region }}@{{ .Region }}{{ end }} ",
           "type": "aws"
         },
         {
           "background": "#ffff66",
           "foreground": "#111111",
           "powerline_symbol": "\ue0b0",
-          "properties": {
-            "template": " \uf0ad "
-          },
           "style": "powerline",
+          "template": " \uf0ad ",
           "type": "root"
         },
         {
           "background": "#83769c",
           "foreground": "#ffffff",
           "properties": {
-            "always_enabled": true,
-            "template": "<transparent>\ue0b0</> \ufbab{{ .FormattedMs }}\u2800"
+            "always_enabled": true
           },
           "style": "plain",
+          "template": "<transparent>\ue0b0</> \ufbab{{ .FormattedMs }}\u2800",
           "type": "executiontime"
         },
         {
@@ -160,10 +156,10 @@
           ],
           "foreground": "#ffffff",
           "properties": {
-            "always_enabled": true,
-            "template": "<parentBackground>\ue0b0</> \ue23a "
+            "always_enabled": true
           },
           "style": "diamond",
+          "template": "<parentBackground>\ue0b0</> \ue23a ",
           "trailing_diamond": "\ue0b4",
           "type": "exit"
         }
@@ -175,10 +171,8 @@
         {
           "background": "#0077c2",
           "foreground": "#ffffff",
-          "properties": {
-            "template": "<#0077c2,transparent>\ue0b6</> \uf489 {{ .Name }} <transparent,#0077c2>\ue0b2</>"
-          },
           "style": "plain",
+          "template": "<#0077c2,transparent>\ue0b6</> \uf489 {{ .Name }} <transparent,#0077c2>\ue0b2</>",
           "type": "shell"
         },
         {
@@ -188,10 +182,10 @@
           "powerline_symbol": "\ue0b2",
           "properties": {
             "paused_icon": "\uf04c ",
-            "playing_icon": "\uf04b ",
-            "template": " \uf167 {{ .Icon }}{{ if ne .Status \"stopped\" }}{{ .Artist }} - {{ .Track }}{{ end }} "
+            "playing_icon": "\uf04b "
           },
           "style": "powerline",
+          "template": " \uf167 {{ .Icon }}{{ if ne .Status \"stopped\" }}{{ .Artist }} - {{ .Track }}{{ end }} ",
           "type": "ytm"
         },
         {
@@ -207,10 +201,10 @@
           "properties": {
             "charged_icon": "\ue22f ",
             "charging_icon": "\ue234 ",
-            "discharging_icon": "\ue231 ",
-            "template": " {{ if not .Error }}{{ .Icon }}{{ .Percentage }}{{ end }}{{ .Error }}\uf295 "
+            "discharging_icon": "\ue231 "
           },
           "style": "powerline",
+          "template": " {{ if not .Error }}{{ .Icon }}{{ .Percentage }}{{ end }}{{ .Error }}\uf295 ",
           "type": "battery"
         },
         {
@@ -218,10 +212,8 @@
           "foreground": "#111111",
           "invert_powerline": true,
           "leading_diamond": "\ue0b2",
-          "properties": {
-            "template": " {{ .CurrentDate | date .Format }} "
-          },
           "style": "diamond",
+          "template": " {{ .CurrentDate | date .Format }} ",
           "trailing_diamond": "\ue0b4",
           "type": "time"
         }
@@ -231,5 +223,5 @@
   ],
   "console_title_template": "{{ .Shell }} in {{ .Folder }}",
   "final_space": true,
-  "version": 1
+  "version": 2
 }

--- a/themes/1_shell.omp.json
+++ b/themes/1_shell.omp.json
@@ -7,94 +7,75 @@
       "segments": [
         {
           "foreground": "#ffbebc",
-          "leading_diamond": "<#ff70a6>  </>",
-          "powerline_symbol": "",
+          "leading_diamond": "<#ff70a6> \ue200 </>",
           "properties": {
-            "display_host": true,
-            "template": "{{ .UserName }} <#ffffff>on</>"
+            "display_host": true
           },
           "style": "diamond",
-          "trailing_diamond": "",
+          "template": "{{ .UserName }} <#ffffff>on</>",
           "type": "session"
         },
         {
           "foreground": "#bc93ff",
-          "leading_diamond": "",
           "properties": {
-            "template": " {{ .CurrentDate | date .Format }} ",
             "time_format": "Monday <#ffffff>at</> 3:04 PM"
           },
           "style": "diamond",
-          "trailing_diamond": "",
+          "template": " {{ .CurrentDate | date .Format }} ",
           "type": "time"
         },
         {
           "foreground": "#ee79d1",
-          "leading_diamond": "",
           "properties": {
             "branch_icon": "\ue725 ",
             "fetch_stash_count": true,
             "fetch_status": true,
             "fetch_upstream_icon": true,
-            "fetch_worktree_count": true,
-            "template": " {{ .UpstreamIcon }}{{ .HEAD }}{{ .BranchStatus }}{{ if .Working.Changed }} \uf044 {{ .Working.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }} \uf046 {{ .Staging.String }}{{ end }}{{ if gt .StashCount 0 }} \uf692 {{ .StashCount }}{{ end }} "
+            "fetch_worktree_count": true
           },
           "style": "diamond",
-          "trailing_diamond": "",
+          "template": " {{ .UpstreamIcon }}{{ .HEAD }}{{ .BranchStatus }}{{ if .Working.Changed }} \uf044 {{ .Working.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }} \uf046 {{ .Staging.String }}{{ end }}{{ if gt .StashCount 0 }} \uf692 {{ .StashCount }}{{ end }} ",
           "type": "git"
         }
       ],
-
       "type": "prompt"
     },
     {
       "alignment": "right",
-      "newline": false,
       "segments": [
         {
           "foreground": "#a9ffb4",
-          "properties": {
-            "template": ""
-          },
           "style": "plain",
           "type": "text"
         },
         {
           "foreground": "#a9ffb4",
-          "leading_diamond": "",
           "properties": {
             "style": "dallas",
-            "template": " {{ .FormattedMs }}s <#ffffff></>",
             "threshold": 0
           },
           "style": "diamond",
-          "trailing_diamond": "",
+          "template": " {{ .FormattedMs }}s <#ffffff>\ue601</>",
           "type": "executiontime"
         },
         {
           "properties": {
-            "root_icon": "\uf292 ",
-            "template": " \uf0e7 "
+            "root_icon": "\uf292 "
           },
           "style": "diamond",
+          "template": " \uf0e7 ",
           "type": "root"
         },
         {
           "foreground": "#94ffa2",
-          "leading_diamond": "",
-          "properties": {
-            "template": " <#ffffff>CPU:</> {{ round .PhysicalPercentUsed .Precision }}% "
-          },
           "style": "diamond",
+          "template": " <#ffffff>CPU:</> {{ round .PhysicalPercentUsed .Precision }}% ",
           "type": "sysinfo"
         },
         {
           "foreground": "#81ff91",
-          "properties": {
-            "template": "<#ffffff></> <#ffffff>RAM:</> {{ (div ((sub .PhysicalTotalMemory .PhysicalFreeMemory)|float64) 1000000000.0) }}/{{ (div .PhysicalTotalMemory 1000000000.0) }}GB "
-          },
           "style": "diamond",
-          "trailing_diamond": "",
+          "template": "<#ffffff>\uf6dc</> <#ffffff>RAM:</> {{ (div ((sub .PhysicalTotalMemory .PhysicalFreeMemory)|float64) 1000000000.0) }}/{{ (div .PhysicalTotalMemory 1000000000.0) }}GB ",
           "type": "sysinfo"
         }
       ],
@@ -106,34 +87,34 @@
       "segments": [
         {
           "foreground": "#ffafd2",
-          "leading_diamond": "<#00c7fc>  </><#ffafd2>{</>",
+          "leading_diamond": "<#00c7fc> \ue285 </><#ffafd2>{</>",
           "properties": {
-            "folder_icon": "",
-            "folder_separator_icon": "易",
+            "folder_icon": "\uf07b",
+            "folder_separator_icon": "\uf9e0",
             "home_icon": "home",
-            "style": "agnoster_full",
-            "template": " \ue5ff {{ .Path }} "
+            "style": "agnoster_full"
           },
           "style": "diamond",
+          "template": " \ue5ff {{ .Path }} ",
           "trailing_diamond": "<#ffafd2>}</>",
           "type": "path"
         },
         {
           "foreground": "#A9FFB4",
-          "foreground_templates": ["{{ if gt .Code 0 }}#ef5350{{ end }}"],
+          "foreground_templates": [
+            "{{ if gt .Code 0 }}#ef5350{{ end }}"
+          ],
           "properties": {
-            "always_enabled": true,
-            "template": "  "
+            "always_enabled": true
           },
           "style": "plain",
+          "template": " \ue286 ",
           "type": "exit"
         }
       ],
       "type": "prompt"
     }
   ],
-  "console_title": true,
-  "console_title_style": "template",
   "console_title_template": "{{ .Folder }}",
   "osc99": true,
   "transient_prompt": {
@@ -141,5 +122,5 @@
     "foreground": "#FEF5ED",
     "template": "\ue285 "
   },
-  "version": 1
+  "version": 2
 }

--- a/themes/dracula.omp.json
+++ b/themes/dracula.omp.json
@@ -8,10 +8,8 @@
           "background": "#6272a4",
           "foreground": "#ffffff",
           "leading_diamond": "\ue0b6",
-          "properties": {
-            "template": "{{ .UserName }} "
-          },
           "style": "diamond",
+          "template": "{{ .UserName }} ",
           "type": "session"
         },
         {
@@ -19,10 +17,10 @@
           "foreground": "#ffffff",
           "powerline_symbol": "\ue0b0",
           "properties": {
-            "style": "folder",
-            "template": " {{ .Path }} "
+            "style": "folder"
           },
           "style": "powerline",
+          "template": " {{ .Path }} ",
           "type": "path"
         },
         {
@@ -33,30 +31,28 @@
             "branch_icon": "",
             "fetch_stash_count": true,
             "fetch_status": false,
-            "fetch_upstream_icon": true,
-            "template": " \u279c ({{ .UpstreamIcon }}{{ .HEAD }}{{ if gt .StashCount 0 }} \uf692 {{ .StashCount }}{{ end }}) "
+            "fetch_upstream_icon": true
           },
           "style": "powerline",
+          "template": " \u279c ({{ .UpstreamIcon }}{{ .HEAD }}{{ if gt .StashCount 0 }} \uf692 {{ .StashCount }}{{ end }}) ",
           "type": "git"
         },
         {
           "background": "#8be9fd",
           "foreground": "#ffffff",
           "powerline_symbol": "\ue0b0",
-          "properties": {
-            "template": " \ue718 {{ if .PackageManagerIcon }}{{ .PackageManagerIcon }} {{ end }}{{ .Full }} "
-          },
           "style": "powerline",
+          "template": " \ue718 {{ if .PackageManagerIcon }}{{ .PackageManagerIcon }} {{ end }}{{ .Full }} ",
           "type": "node"
         },
         {
           "background": "#ff79c6",
           "foreground": "#ffffff",
           "properties": {
-            "template": " \u2665 {{ .CurrentDate | date .Format }} ",
             "time_format": "15:04"
           },
           "style": "diamond",
+          "template": " \u2665 {{ .CurrentDate | date .Format }} ",
           "trailing_diamond": "\ue0b0",
           "type": "time"
         }
@@ -65,5 +61,5 @@
     }
   ],
   "final_space": true,
-  "version": 1
+  "version": 2
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines

### Description

This PR will fix the following:

1. When the background color of a segment is a custom one but the foreground color not, `oh-my-posh config export image` cannot render it correctly, and the ANSI sequence of the background color will be output as it is.

	<details><summary>E.g.</summary>

	For the following config (problematic part only):

	```json
	{
	  "alignment": "right",
	  "segments": [
	    {
	      "background_templates": [
	        "{{if ne .Code 0}}red{{else}}green{{end}}"
	      ],
	      "foreground": "white",
	      "leading_diamond": "\ue0b2",
	      "properties": {
	        "always_enabled": true
	      },
	      "style": "diamond",
	      "template": " <b>{{if ne .Code 0}}{{.Code}}{{else}}\u2714{{end}}</b> ",
	      "type": "exit"
	    },
	    {
	      "background": "#556b2f",
	      "foreground": "white",
	      "powerline_symbol": "\ue0b0",
	      "properties": {
	        "always_enabled": true
	      },
	      "style": "powerline",
	      "template": " \uf56a {{.FormattedMs}} ",
	      "type": "executiontime"
	    },
	    {
	      "background": "#008080",
	      "foreground": "white",
	      "style": "diamond",
	      "template": " \uf64f {{.CurrentDate | date .Format}} ",
	      "trailing_diamond": "\ue0b0",
	      "type": "time"
	    }
	  ],
	  "type": "prompt"
	}
	```

	- Expected:

		![omp-config-export-image-expected](https://user-images.githubusercontent.com/83903009/167528560-e642d2ef-ffa4-4a47-9274-56730707d019.png)

	- Actual:

		![omp-config-export-image-actual](https://user-images.githubusercontent.com/83903009/167528596-72770603-2ccb-4286-93fc-6c15f908a600.png)

	</details>

2. An unexpected `"Enabled": false` appears in the config after a migration. This didn't happen until v7.79.2 (a7b0021) is released. BTW, migrate shipped themes from version 1 to 2.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
