### PR TITLE
Correct docs and fix empty-tooltip bug

### DIFF
--- a/.versionrc.json
+++ b/.versionrc.json
@@ -14,7 +14,7 @@
     },
     {
       "type": "revert",
-      "section": "Refactor"
+      "section": "Reverts"
     },
     {
       "type": "theme",

--- a/docs/docs/segments/angular.md
+++ b/docs/docs/segments/angular.md
@@ -44,9 +44,8 @@ Display the currently active [Angular CLI][angular-cli-docs] version.
 - `.Major`: `string` - major number
 - `.Minor`: `string` - minor number
 - `.Patch`: `string` - patch number
-- `.Prerelease`: `string` - prerelease info text
-- `.BuildMetadata`: `string` - build metadata
-- `.Error`: `string` - when fetching the version string errors
+- `.URL`: `string` - URL of the version info / release notes
+- `.Error`: `string` - error encountered when fetching the version string
 
 [templates]: /docs/configuration/templates
 [angular-cli-docs]: https://angular.io/cli

--- a/docs/docs/segments/azfunc.md
+++ b/docs/docs/segments/azfunc.md
@@ -50,9 +50,7 @@ Display the currently active [Azure Functions CLI][az-func-core-tools] version.
 - `.Major`: `string` - major number
 - `.Minor`: `string` - minor number
 - `.Patch`: `string` - patch number
-- `.Prerelease`: `string` - prerelease info text
-- `.BuildMetadata`: `string` - build metadata
-- `.Error`: `string` - when fetching the version string errors
+- `.Error`: `string` - error encountered when fetching the version string
 
 [templates]: /docs/configuration/templates
 [az-func-core-tools]: https://github.com/Azure/azure-functions-core-tools

--- a/docs/docs/segments/cds.md
+++ b/docs/docs/segments/cds.md
@@ -48,9 +48,7 @@ Display the active [CDS CLI][sap-cap-cds] version.
 - `.Major`: `string` - major number
 - `.Minor`: `string` - minor number
 - `.Patch`: `string` - patch number
-- `.Prerelease`: `string` - prerelease info text
-- `.BuildMetadata`: `string` - build metadata
-- `.Error`: `string` - when fetching the version string errors
+- `.Error`: `string` - error encountered when fetching the version string
 - `.HasDependency`: `bool` - a flag if `@sap/cds` was found in `package.json`
 
 [templates]: /docs/configuration/templates

--- a/docs/docs/segments/cf.md
+++ b/docs/docs/segments/cf.md
@@ -47,9 +47,8 @@ Display the active [Cloud Foundry CLI][cloud-foundry] version.
 - `.Major`: `string` - major number
 - `.Minor`: `string` - minor number
 - `.Patch`: `string` - patch number
-- `.Prerelease`: `string` - prerelease info text
-- `.BuildMetadata`: `string` - build metadata
-- `.Error`: `string` - when fetching the version string errors
+- `.URL`: `string` - URL of the version info / release notes
+- `.Error`: `string` - error encountered when fetching the version string
 
 [templates]: /docs/configuration/templates
 [cloud-foundry]: https://github.com/cloudfoundry/cli

--- a/docs/docs/segments/crystal.md
+++ b/docs/docs/segments/crystal.md
@@ -47,8 +47,7 @@ Display the currently active crystal version.
 - `.Major`: `string` - major number
 - `.Minor`: `string` - minor number
 - `.Patch`: `string` - patch number
-- `.Prerelease`: `string` - prerelease info text
-- `.BuildMetadata`: `string` - build metadata
-- `.Error`: `string` - when fetching the version string errors
+- `.URL`: `string` - URL of the version info / release notes
+- `.Error`: `string` - error encountered when fetching the version string
 
 [templates]: /docs/configuration/templates

--- a/docs/docs/segments/dart.md
+++ b/docs/docs/segments/dart.md
@@ -48,8 +48,7 @@ folder are present (default)
 - `.Major`: `string` - major number
 - `.Minor`: `string` - minor number
 - `.Patch`: `string` - patch number
-- `.Prerelease`: `string` - prerelease info text
-- `.BuildMetadata`: `string` - build metadata
-- `.Error`: `string` - when fetching the version string errors
+- `.URL`: `string` - URL of the version info / release notes
+- `.Error`: `string` - error encountered when fetching the version string
 
 [templates]: /docs/configuration/templates

--- a/docs/docs/segments/dotnet.md
+++ b/docs/docs/segments/dotnet.md
@@ -52,7 +52,8 @@ Display the currently active [.NET SDK][net-sdk-docs] version.
 - `.Patch`: `string` - patch number
 - `.Prerelease`: `string` - prerelease info text
 - `.BuildMetadata`: `string` - build metadata
-- `.Error`: `string` - when fetching the version string errors
+- `.URL`: `string` - URL of the version info / release notes
+- `.Error`: `string` - error encountered when fetching the version string
 
 [templates]: /docs/configuration/templates
 [net-sdk-docs]: https://docs.microsoft.com/en-us/dotnet/core/tools

--- a/docs/docs/segments/golang.md
+++ b/docs/docs/segments/golang.md
@@ -48,8 +48,7 @@ Display the currently active golang version.
 - `.Major`: `string` - major number
 - `.Minor`: `string` - minor number
 - `.Patch`: `string` - patch number
-- `.Prerelease`: `string` - prerelease info text
-- `.BuildMetadata`: `string` - build metadata
-- `.Error`: `string` - when fetching the version string errors
+- `.URL`: `string` - URL of the version info / release notes
+- `.Error`: `string` - error encountered when fetching the version string
 
 [templates]: /docs/configuration/templates

--- a/docs/docs/segments/haskell.md
+++ b/docs/docs/segments/haskell.md
@@ -53,9 +53,8 @@ Using stack ghc will decrease performance.
 - `.Major`: `string` - major number
 - `.Minor`: `string` - minor number
 - `.Patch`: `string` - patch number
-- `.Prerelease`: `string` - prerelease info text
-- `.BuildMetadata`: `string` - build metadata
-- `.Error`: `string` - when fetching the version string errors
+- `.URL`: `string` - URL of the version info / release notes
+- `.Error`: `string` - error encountered when fetching the version string
 - `.StackGhc`: `boolean` - `true` if stack ghc was used, otherwise `false`
 
 [templates]: /docs/configuration/templates

--- a/docs/docs/segments/java.md
+++ b/docs/docs/segments/java.md
@@ -60,8 +60,6 @@ Display the currently active java version.
 - `.Major`: `string` - major number
 - `.Minor`: `string` - minor number
 - `.Patch`: `string` - patch number
-- `.Prerelease`: `string` - prerelease info text
-- `.BuildMetadata`: `string` - build metadata
-- `.Error`: `string` - when fetching the version string errors
+- `.Error`: `string` - error encountered when fetching the version string
 
 [templates]: /docs/configuration/templates

--- a/docs/docs/segments/julia.md
+++ b/docs/docs/segments/julia.md
@@ -47,8 +47,7 @@ Display the currently active julia version.
 - `.Major`: `string` - major number
 - `.Minor`: `string` - minor number
 - `.Patch`: `string` - patch number
-- `.Prerelease`: `string` - prerelease info text
-- `.BuildMetadata`: `string` - build metadata
-- `.Error`: `string` - when fetching the version string errors
+- `.URL`: `string` - URL of the version info / release notes
+- `.Error`: `string` - error encountered when fetching the version string
 
 [templates]: /docs/configuration/templates

--- a/docs/docs/segments/kotlin.md
+++ b/docs/docs/segments/kotlin.md
@@ -47,9 +47,8 @@ Display the currently active [Kotlin][kotlin] version.
 - `.Major`: `string` - major number
 - `.Minor`: `string` - minor number
 - `.Patch`: `string` - patch number
-- `.Prerelease`: `string` - prerelease info text
-- `.BuildMetadata`: `string` - build metadata
-- `.Error`: `string` - when fetching the version string errors
+- `.URL`: `string` - URL of the version info / release notes
+- `.Error`: `string` - error encountered when fetching the version string
 
 [templates]: /docs/configuration/templates
 [kotlin]: https://kotlinlang.org/

--- a/docs/docs/segments/node.md
+++ b/docs/docs/segments/node.md
@@ -49,9 +49,8 @@ Display the currently active [Node.js][node-js] version.
 - `.Major`: `string` - major number
 - `.Minor`: `string` - minor number
 - `.Patch`: `string` - patch number
-- `.Prerelease`: `string` - prerelease info text
-- `.BuildMetadata`: `string` - build metadata
-- `.Error`: `string` - when fetching the version string errors
+- `.URL`: `string` - URL of the version info / release notes
+- `.Error`: `string` - error encountered when fetching the version string
 - `.PackageManagerIcon`: `string` - the Yarn on NPM icon when setting `fetch_package_manager` to `true`
 - `.Mismatch`: `boolean` - if the version in `.nvmrc` matches with `.Full`
 

--- a/docs/docs/segments/npm.md
+++ b/docs/docs/segments/npm.md
@@ -37,7 +37,8 @@ Display the currently active [npm][npm-docs] version.
 - `.Major`: `string` - major number
 - `.Minor`: `string` - minor number
 - `.Patch`: `string` - patch number
-- `.Error`: `string` - when fetching the version string errors
+- `.URL`: `string` - URL of the version info / release notes
+- `.Error`: `string` - error encountered when fetching the version string
 
 [templates]: /docs/configuration/templates
 [npm-docs]: https://docs.npmjs.com/about-npm

--- a/docs/docs/segments/php.md
+++ b/docs/docs/segments/php.md
@@ -48,8 +48,7 @@ files are present (default)
 - `.Major`: `string` - major number
 - `.Minor`: `string` - minor number
 - `.Patch`: `string` - patch number
-- `.Prerelease`: `string` - prerelease info text
-- `.BuildMetadata`: `string` - build metadata
-- `.Error`: `string` - when fetching the version string errors
+- `.URL`: `string` - URL of the version info / release notes
+- `.Error`: `string` - error encountered when fetching the version string
 
 [templates]: /docs/configuration/templates

--- a/docs/docs/segments/python.md
+++ b/docs/docs/segments/python.md
@@ -55,8 +55,7 @@ or not - defaults to `true`
 - `.Major`: `string` - major number
 - `.Minor`: `string` - minor number
 - `.Patch`: `string` - patch number
-- `.Prerelease`: `string` - prerelease info text
-- `.BuildMetadata`: `string` - build metadata
-- `.Error`: `string` - when fetching the version string errors
+- `.URL`: `string` - URL of the version info / release notes
+- `.Error`: `string` - error encountered when fetching the version string
 
 [templates]: /docs/configuration/templates

--- a/docs/docs/segments/r.md
+++ b/docs/docs/segments/r.md
@@ -48,9 +48,8 @@ Display the currently active [R][r-homepage] version.
 - `.Major`: `string` - major number
 - `.Minor`: `string` - minor number
 - `.Patch`: `string` - patch number
-- `.Prerelease`: `string` - prerelease info text
-- `.BuildMetadata`: `string` - build metadata
-- `.Error`: `string` - when fetching the version string errors
+- `.URL`: `string` - URL of the version info / release notes
+- `.Error`: `string` - error encountered when fetching the version string
 
 [templates]: /docs/configuration/templates
 [r-homepage]: https://www.r-project.org/

--- a/docs/docs/segments/ruby.md
+++ b/docs/docs/segments/ruby.md
@@ -47,8 +47,6 @@ Display the currently active ruby version.
 - `.Major`: `string` - major number
 - `.Minor`: `string` - minor number
 - `.Patch`: `string` - patch number
-- `.Prerelease`: `string` - prerelease info text
-- `.BuildMetadata`: `string` - build metadata
-- `.Error`: `string` - when fetching the version string errors
+- `.Error`: `string` - error encountered when fetching the version string
 
 [templates]: /docs/configuration/templates

--- a/docs/docs/segments/rust.md
+++ b/docs/docs/segments/rust.md
@@ -47,8 +47,6 @@ Display the currently active rust version.
 - `.Major`: `string` - major number
 - `.Minor`: `string` - minor number
 - `.Patch`: `string` - patch number
-- `.Prerelease`: `string` - prerelease info text
-- `.BuildMetadata`: `string` - build metadata
-- `.Error`: `string` - when fetching the version string errors
+- `.Error`: `string` - error encountered when fetching the version string
 
 [templates]: /docs/configuration/templates

--- a/docs/docs/segments/swift.md
+++ b/docs/docs/segments/swift.md
@@ -47,9 +47,8 @@ Display the currently active [Swift][swift] version.
 - `.Major`: `string` - major number
 - `.Minor`: `string` - minor number
 - `.Patch`: `string` - patch number
-- `.Prerelease`: `string` - prerelease info text
-- `.BuildMetadata`: `string` - build metadata
-- `.Error`: `string` - when fetching the version string errors
+- `.URL`: `string` - URL of the version info / release notes
+- `.Error`: `string` - error encountered when fetching the version string
 
 [templates]: /docs/configuration/templates
 [swift]: https://www.swift.org/

--- a/docs/docs/segments/ui5tooling.md
+++ b/docs/docs/segments/ui5tooling.md
@@ -50,9 +50,8 @@ see [the documentation][ui5-version-help]).
 - `.Major`: `string` - major number
 - `.Minor`: `string` - minor number
 - `.Patch`: `string` - patch number
-- `.Prerelease`: `string` - prerelease info text
-- `.BuildMetadata`: `string` - build metadata
-- `.Error`: `string` - when fetching the version string errors
+- `.URL`: `string` - URL of the version info / release notes
+- `.Error`: `string` - error encountered when fetching the version string
 
 [templates]: /docs/configuration/templates
 [ui5-homepage]: https://sap.github.io/ui5-tooling

--- a/src/engine/engine.go
+++ b/src/engine/engine.go
@@ -253,10 +253,16 @@ func (e *Engine) PrintTooltip(tip string) string {
 	switch e.Env.Shell() {
 	case shell.ZSH, shell.CMD, shell.FISH:
 		block.Init(e.Env, e.Writer, e.Ansi)
+		if !block.Enabled() {
+			return ""
+		}
 		text, _ := block.RenderSegments()
 		return text
 	case shell.PWSH, shell.PWSH5:
 		block.InitPlain(e.Env, e.Config)
+		if !block.Enabled() {
+			return ""
+		}
 		text, length := block.RenderSegments()
 		e.write(e.Ansi.ClearAfter())
 		e.write(e.Ansi.CarriageForward())
@@ -264,7 +270,7 @@ func (e *Engine) PrintTooltip(tip string) string {
 		e.write(text)
 		return e.string()
 	}
-	return " "
+	return ""
 }
 
 type ExtraPromptType int


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description

1. Correct docs:

	- `.Prerelease` and `.BuildMetadata` only work in `dotnet` segments for the time being.
	- Add descriptions of `.URL` for language segments.
	- Revise descriptions of `.Error` for language segments.

2. Fix a bug: when a tooltip is supposed to be rendered as empty, OMP panics because of a nil `activeSegment`. We should check `(*Block).Enabled` before calling `(*Block).RenderSegments`.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
