### PR TITLE
fix(bash): do not escape on Windows

### DIFF
--- a/src/engine/segment.go
+++ b/src/engine/segment.go
@@ -356,7 +356,8 @@ func (segment *Segment) SetText() {
 	// see https://github.com/JanDeDobbeleer/oh-my-posh/discussions/2255
 	// this can't happen where we do regular text replacement in ansi.go
 	// as that would also replace valid \[\] sequences and break the prompt
-	if segment.env.Shell() == shell.BASH {
+	// except for git bash on Windows
+	if segment.env.Shell() == shell.BASH && segment.env.Platform() != environment.WindowsPlatform {
 		segment.text = strings.ReplaceAll(segment.text, `\`, `\\`)
 	}
 	segment.Enabled = len(strings.ReplaceAll(segment.text, " ", "")) > 0


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description

resolves #2263


<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
