### PR TITLE
feat(scoop): Add POSH_THEMES_PATH environment variable

### DIFF
--- a/packages/scoop/oh-my-posh.json
+++ b/packages/scoop/oh-my-posh.json
@@ -13,6 +13,9 @@
       }
   },
   "env_add_path": "bin",
+  "env_set": {
+    "POSH_THEMES_PATH": "$dir\\themes"
+  },
   "checkver": {
       "github": "https://github.com/JanDeDobbeleer/oh-my-posh"
   },

--- a/website/docs/migrating-module.md
+++ b/website/docs/migrating-module.md
@@ -73,7 +73,7 @@ oh-my-posh init pwsh --config "$env:POSH_THEMES_PATH\jandedobbeleer.omp.json" | 
 Replace `jandedobbeleer.omp.json` with the theme you use.
 
 :::caution
-Only winget can add the environment variable `POSH_THEMES_PATH` automatically. For Homebrew, use
+Only winget and scoop add the environment variable `POSH_THEMES_PATH` automatically. For Homebrew, use
 `$(brew --prefix oh-my-posh)/themes/jandedobbeleer.omp.json`.
 :::
 


### PR DESCRIPTION
### Prerequisites

- [X] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [X] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [X] Docs have been added/updated (for bug fixes/features)

### Description

Adds support for setting the `POSH_THEMES_PATH` environment variable when installing with `scoop`.