### PR TITLE
fix(docs): typo in new blog, rgeardless => regardless

### DIFF
--- a/website/blog/2022-05-19-whats-new-3.mdx
+++ b/website/blog/2022-05-19-whats-new-3.mdx
@@ -142,7 +142,7 @@ can write to the current folder
 - Upstream gone logic for git was broken, and has been fixed
 - PSReadLine in PowerShell now receives the correct amount of prompt lines (`Set-PSReadlineOption -ExtraPromptLineCount`),
 this fixes weird behaviour when using a transient prompt when your config results in a multiline prompt
-- The [winget][winget] installer now adds `PATH` entries correctly, rgeardless of the installation mode
+- The [winget][winget] installer now adds `PATH` entries correctly, regardless of the installation mode
 
 That's it for this time, see you for the next one 🤞🏻
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

Fixed typo in blog post

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
