### PR TITLE
docs(nu): correct customization info

### DIFF
--- a/website/docs/installation/customize.mdx
+++ b/website/docs/installation/customize.mdx
@@ -92,23 +92,22 @@ Once altered, reload your config for the changes to take effect.
 </TabItem>
 <TabItem value="nu">
 
-**Nu < 0.32.0**
+:::warning
+Oh My Posh requires Nushell >= 0.60.0
+:::
+
+Edit `$nu.configuration/path` and add the following lines at the bottom.
 
 ```bash
-config set prompt  "= `{{$(oh-my-posh print primary --config ~/.jandedobbeleer.omp.json | str collect)}}`"
+oh-my-posh init nu --config ~/.jandedobbeleer.omp.json
+source ~/.oh-my-posh.nu
 ```
 
-**Nu >= 0.32.0**
+If you want to save the initialization script elsewhere, replace the lines above with these:
 
 ```bash
-config set prompt  "(oh-my-posh print primary --config ~/.jandedobbeleer.omp.json | str collect)"
-```
-
-**Nu >= 0.60.0**
-
-```bash
-let-env PROMPT_COMMAND = { oh-my-posh print primary --config ~/.jandedobbeleer.omp.json }
-let-env PROMPT_COMMAND_RIGHT = { oh-my-posh print right --config ~/.jandedobbeleer.omp.json }
+oh-my-posh init nu --config ~/.jandedobbeleer.omp.json --print | save /mylocation/myscript.nu
+source /mylocation/myscript.nu
 ```
 
 Once altered, restart nu shell for the changes to take effect.


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description

resolves #2293


<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
