### PR TITLE
Explicitly set stack count to 0 if stack is empty.

### DIFF
--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -4,7 +4,11 @@ if ($null -ne (Get-Module -Name "oh-my-posh-core")) {
 }
 
 function Get-PoshStackCount {
-    return (Get-Location -Stack).Count
+    $locations = Get-Location -Stack
+    if ($locations) {
+        return $locations.Count
+    }
+    return 0
 }
 
 New-Module -Name "oh-my-posh-core" -ScriptBlock {


### PR DESCRIPTION
After upgrading to oh-my-posh 7.88.1, I noticed this error:

```text
Error: invalid argument "" for "-s, --stack-count" flag: strconv.ParseInt: parsing "": invalid syntax
```

![Screenshot 2022-05-22 115947](https://user-images.githubusercontent.com/11180071/169711542-a540fd7c-1b8e-4f74-a5d1-c773fb4e47c9.png)

I exported and inspected the output of 

```powershell
(@(&"C:/Users/Ajay/AppData/Local/Programs/oh-my-posh/bin/oh-my-posh.exe" init pwsh --config="D:\Themes\oh-my-posh\cool.omp.json" --print) -join "`n")
```
and it looks OK.

If I save the output to a `.ps1` file and run it, I don't get an error and I get the prompt according to my theme as expected.



### Prerequisites

- [X] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [X] The commit message follows the [conventional commits][cc] guidelines
- [] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

<!--TemplateBody-->

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
