### PR TITLE
fix: fix path to Posh-Git segment

### DIFF
--- a/website/docs/segments/git.mdx
+++ b/website/docs/segments/git.mdx
@@ -134,6 +134,6 @@ You can set the following properties to `true` to enable fetching additional inf
 - `.Changed`: `boolean` - if the status contains changes or not
 - `.String`: `string` - a string representation of the changes above
 
-[poshgit]: /docs/poshgit
+[poshgit]: /docs/segments/poshgit
 [templates]: /docs/configuration/templates
 [hyperlinks]: /docs/configuration/templates#helper-functions


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description

The was an error in link to the Posh-Git segment page.

<!--TemplateBody-->

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
