### PR TITLE
Correction to CLI help text and minor revision to docs

### DIFF
--- a/src/cli/font.go
+++ b/src/cli/font.go
@@ -15,7 +15,7 @@ var fontCmd = &cobra.Command{
 
 This command is used to install fonts and configure the font in your terminal.
 
-  - install: oh-my-posh install font https://github.com/ryanoasis/nerd-fonts/releases/download/v2.1.0/3270.zip`,
+  - install: oh-my-posh font install https://github.com/ryanoasis/nerd-fonts/releases/download/v2.1.0/3270.zip`,
 	ValidArgs: []string{
 		"install",
 		"configure",

--- a/src/font/cli.go
+++ b/src/font/cli.go
@@ -212,7 +212,7 @@ func (m *main) View() string {
 	case installFont:
 		return textStyle.Render(fmt.Sprintf("%s Installing %s", m.spinner.View(), m.fontname))
 	case quit:
-		return textStyle.Render("No need to install a new font? That’s cool.")
+		return textStyle.Render("No need to install a new font? That's cool.")
 	case done:
 		return textStyle.Render(fmt.Sprintf("Successfully installed %s 🚀", m.fontname))
 	}

--- a/website/docs/installation/windows.mdx
+++ b/website/docs/installation/windows.mdx
@@ -16,7 +16,7 @@ To display all icons, we recommend the use of a [Nerd Font][fonts].
 :::
 
 :::caution
-When using oh-my-posh inside the WSL, make sure to follow the [linux][linux] installation guide.
+When using oh-my-posh inside the WSL, make sure to follow the [Linux][linux] installation guide.
 :::
 
 <a href="pathname://ms-windows-store://pdp/?productid=XP8K0HKJFRXGCK" target="_blank">
@@ -138,23 +138,23 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; Invoke-Expression ((New-Object
 }>
 <TabItem value="winget">
 
-You can find the themes winget installs inside the folder indicated by the environment variable `POSH_THEMES_PATH`.
-To use `jandedobbeleer.omp.json` in PowerShell for example, you can refer to it using `$env:POSH_THEMES_PATH\jandedobbeleer.omp.json`
-when setting the prompt using the `--config` flag.
+You can find the themes in the folder indicated by the environment variable `POSH_THEMES_PATH`.
+For example, you can use `oh-my-posh init pwsh --config "$env:POSH_THEMES_PATH\jandedobbeleer.omp.json"`
+for the prompt initialization in PowerShell.
 
 </TabItem>
 <TabItem value="scoop">
 
-You can find the themes scoop installs inside the `"$(scoop prefix oh-my-posh)\themes\"` folder.
-To use `jandedobbeleer.omp.json` in PowerShell for example, you can refer to it using `"$(scoop prefix oh-my-posh)\themes\jandedobbeleer.omp.json"`
-when setting the prompt using the `--config` flag.
+You can find the themes in the `$(scoop prefix oh-my-posh)\themes` folder.
+For example, you can use `oh-my-posh init pwsh --config "$(scoop prefix oh-my-posh)\themes\jandedobbeleer.omp.json"`
+for the prompt initialization in PowerShell.
 
 </TabItem>
 <TabItem value="manual">
 
-You can find the themes inside the folder indicated by the environment variable `POSH_THEMES_PATH`.
-To use `jandedobbeleer.omp.json` in PowerShell for example, you can refer to it using `$env:POSH_THEMES_PATH\jandedobbeleer.omp.json`
-when setting the prompt using the `--config` flag.
+You can find the themes in the folder indicated by the environment variable `POSH_THEMES_PATH`.
+For example, you can use `oh-my-posh init pwsh --config "$env:POSH_THEMES_PATH\jandedobbeleer.omp.json"`
+for the prompt initialization in PowerShell.
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

1. Correct the help text for `font` subcommand: `oh-my-posh install font` -> `oh-my-posh font install`.

2. Revise the guide on using default themes on Windows.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
