### PR TITLE
fix(docs): fonts under installation

### DIFF
--- a/website/docs/configuration/overview.mdx
+++ b/website/docs/configuration/overview.mdx
@@ -5,7 +5,7 @@ sidebar_label: General
 ---
 
 import Tabs from "@theme/Tabs";
-import TabItem from "@theme/TabItem"
+import TabItem from "@theme/TabItem";
 
 Oh My Posh renders your prompt based on the definition of _blocks_ (like Lego) which contain one or more _segments_.
 A really simple configuration could look like this. The default format is `json`, but we also support `toml` and `yaml`.
@@ -59,16 +59,16 @@ starting point to create your own configuration.
 # yaml-language-server: $schema=https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json
 final_space: true
 blocks:
-- type: prompt
-  alignment: left
-  segments:
-  - type: path
-    style: powerline
-    powerline_symbol: ""
-    foreground: "#ffffff"
-    background: "#61AFEF"
-    properties:
-      style: folder
+  - type: prompt
+    alignment: left
+    segments:
+      - type: path
+        style: powerline
+        powerline_symbol: ""
+        foreground: "#ffffff"
+        background: "#61AFEF"
+        properties:
+          style: folder
 ```
 
 </TabItem>
@@ -126,7 +126,7 @@ For example, the following is a valid `--config` flag:
 - final_space: `boolean` - when true adds a space at the end of the prompt
 - osc99: `boolean` - when true adds support for OSC9;9; (notify terminal of current working directory)
 - terminal_background: `string` [color][colors] - terminal background color, set to your terminal's background color when
-you notice black elements in Windows Terminal or the Visual Studio Code integrated terminal
+  you notice black elements in Windows Terminal or the Visual Studio Code integrated terminal
 - accent_color: `string` [color][colors] - accent color, used as a fallback when the `accent` [color][accent] is not supported
 
 ### JSON Schema Validation
@@ -175,7 +175,7 @@ While for yaml:
 Converters won't catch this change, so you will need to adjust manually.
 
 [releases]: https://github.com/JanDeDobbeleer/oh-my-posh/releases/latest
-[font]: /docs/configuration/fonts
+[font]: /docs/installation/fonts
 [schema]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/themes/schema.json
 [themes]: https://github.com/JanDeDobbeleer/oh-my-posh/tree/main/themes
 [colors]: /docs/configuration/colors


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [N/A] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description
When I re-created my YAML/TOML documenation, I didn't account for the move from /docs/configuration/fonts to /docs/installation/fonts. This corrects that.

<!--TemplateBody-->

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
