### PR TITLE
docs:Make PS command work despite store/winget conflict

### DIFF
--- a/website/docs/installation/windows.mdx
+++ b/website/docs/installation/windows.mdx
@@ -43,7 +43,7 @@ When using oh-my-posh inside the WSL, make sure to follow the [Linux][linux] ins
 Open a PowerShell prompt and run the following command:
 
 ```powershell
-winget install oh-my-posh
+winget install JanDeDobbeleer.OhMyPosh
 ```
 
 </TabItem>


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] ~~Tests for the changes have been added (for bug fixes/features)~~
- [ ] ~~Docs have been added/updated (for bug fixes/features)~~

### Description

Fix currently non-working installation instruction. As noted over in the [Q&A](https://github.com/JanDeDobbeleer/oh-my-posh/discussions/2402), the current install instructions don't work because two versions are available, one in msstore and via winget. The change I propose is the solution offered by the maintainer in the Q&A post I referenced.