### PR TITLE
fix bash rprompt

### DIFF
--- a/src/cli/config_export_image.go
+++ b/src/cli/config_export_image.go
@@ -58,7 +58,7 @@ Exports the config to an image file using customized output options.`,
 		defer env.Close()
 		cfg := engine.LoadConfig(env)
 		ansi := &color.Ansi{}
-		ansi.InitPlain(shell.PLAIN)
+		ansi.InitPlain()
 		writerColors := cfg.MakeColors(env)
 		writer := &color.AnsiWriter{
 			Ansi:               ansi,

--- a/src/cli/debug.go
+++ b/src/cli/debug.go
@@ -31,7 +31,7 @@ var debugCmd = &cobra.Command{
 		defer env.Close()
 		cfg := engine.LoadConfig(env)
 		ansi := &color.Ansi{}
-		ansi.InitPlain(shell.PLAIN)
+		ansi.InitPlain()
 		writerColors := cfg.MakeColors(env)
 		writer := &color.AnsiWriter{
 			Ansi:               ansi,

--- a/src/cli/print.go
+++ b/src/cli/print.go
@@ -68,7 +68,7 @@ var printCmd = &cobra.Command{
 		ansi.Init(env.Shell())
 		var writer color.Writer
 		if plain {
-			ansi.InitPlain(env.Shell())
+			ansi.InitPlain()
 			writer = &color.PlainWriter{
 				Ansi: ansi,
 			}

--- a/src/color/ansi.go
+++ b/src/color/ansi.go
@@ -128,7 +128,7 @@ func (a *Ansi) Init(shellName string) {
 	}
 }
 
-func (a *Ansi) InitPlain(shellName string) {
+func (a *Ansi) InitPlain() {
 	a.Init(shell.PLAIN)
 }
 

--- a/src/color/ansi_test.go
+++ b/src/color/ansi_test.go
@@ -80,7 +80,7 @@ func TestFormatText(t *testing.T) {
 	}
 	for _, tc := range cases {
 		a := Ansi{}
-		a.InitPlain(shell.PLAIN)
+		a.InitPlain()
 		formattedText := a.formatText(tc.Text)
 		assert.Equal(t, tc.Expected, formattedText, tc.Case)
 	}

--- a/src/color/text.go
+++ b/src/color/text.go
@@ -10,7 +10,8 @@ func (ansi *Ansi) MeasureText(text string) int {
 	// skip strings with ANSI
 	if !strings.Contains(text, "\x1b") {
 		text = ansi.TrimEscapeSequences(text)
-		return utf8.RuneCountInString(text)
+		length := utf8.RuneCountInString(text)
+		return length
 	}
 	if strings.Contains(text, "\x1b]8;;") {
 		matches := regex.FindAllNamedRegexMatch(ansi.hyperlinkRegex, text)
@@ -20,7 +21,8 @@ func (ansi *Ansi) MeasureText(text string) int {
 	}
 	text = ansi.TrimAnsi(text)
 	text = ansi.TrimEscapeSequences(text)
-	return utf8.RuneCountInString(text)
+	length := utf8.RuneCountInString(text)
+	return length
 }
 
 func (ansi *Ansi) TrimAnsi(text string) string {

--- a/src/console/title_test.go
+++ b/src/console/title_test.go
@@ -61,7 +61,7 @@ func TestGetTitle(t *testing.T) {
 			Folder:   "vagrant",
 		})
 		ansi := &color.Ansi{}
-		ansi.InitPlain(tc.ShellName)
+		ansi.InitPlain()
 		ct := &Title{
 			Env:      env,
 			Ansi:     ansi,
@@ -116,7 +116,7 @@ func TestGetConsoleTitleIfGethostnameReturnsError(t *testing.T) {
 			HostName: "",
 		})
 		ansi := &color.Ansi{}
-		ansi.InitPlain(tc.ShellName)
+		ansi.InitPlain()
 		ct := &Title{
 			Env:      env,
 			Ansi:     ansi,

--- a/src/engine/block.go
+++ b/src/engine/block.go
@@ -53,7 +53,7 @@ func (b *Block) Init(env environment.Environment, writer color.Writer, ansi *col
 
 func (b *Block) InitPlain(env environment.Environment, config *Config) {
 	b.ansi = &color.Ansi{}
-	b.ansi.InitPlain(env.Shell())
+	b.ansi.InitPlain()
 	b.writer = &color.AnsiWriter{
 		Ansi:               b.ansi,
 		TerminalBackground: shell.ConsoleBackgroundColor(env, config.TerminalBackground),

--- a/src/engine/engine.go
+++ b/src/engine/engine.go
@@ -41,6 +41,9 @@ func (e *Engine) string() string {
 }
 
 func (e *Engine) canWriteRPrompt() bool {
+	if e.rprompt == "" || e.Plain {
+		return false
+	}
 	consoleWidth, err := e.Env.TerminalWidth()
 	if err != nil || consoleWidth == 0 {
 		return true
@@ -86,7 +89,7 @@ func (e *Engine) shouldFill(block *Block, length int) (string, bool) {
 		return "", false
 	}
 	terminalWidth, err := e.Env.TerminalWidth()
-	if err != nil && terminalWidth == 0 {
+	if err != nil || terminalWidth == 0 {
 		return "", false
 	}
 	padLength := terminalWidth - e.currentLineLength - length
@@ -106,7 +109,7 @@ func (e *Engine) shouldFill(block *Block, length int) (string, bool) {
 func (e *Engine) renderBlock(block *Block) {
 	// when in bash, for rprompt blocks we need to write plain
 	// and wrap in escaped mode or the prompt will not render correctly
-	if block.Type == RPrompt && e.Env.Shell() == shell.BASH {
+	if e.Env.Shell() == shell.BASH && (block.Type == RPrompt || block.Alignment == Right) {
 		block.InitPlain(e.Env, e.Config)
 	} else {
 		block.Init(e.Env, e.Writer, e.Ansi)
@@ -127,28 +130,42 @@ func (e *Engine) renderBlock(block *Block) {
 		if block.VerticalOffset != 0 {
 			e.writeANSI(e.Ansi.ChangeLine(block.VerticalOffset))
 		}
-		switch block.Alignment {
-		case Right:
-			text, length := block.RenderSegments()
-			if padText, OK := e.shouldFill(block, length); OK {
-				e.write(padText)
-			}
-			e.writeANSI(e.Ansi.CarriageForward())
-			e.writeANSI(e.Ansi.GetCursorForRightWrite(length, block.HorizontalOffset))
-			e.currentLineLength = 0
-			e.write(text)
-		case Left:
+
+		if block.Alignment == Left {
 			text, length := block.RenderSegments()
 			e.currentLineLength += length
 			e.write(text)
+			break
 		}
-	case RPrompt:
+
+		if block.Alignment != Right {
+			break
+		}
+
 		text, length := block.RenderSegments()
-		e.rpromptLength = length
-		if e.Env.Shell() == shell.BASH {
-			text = e.Ansi.FormatText(text)
+		padText, hasPadText := e.shouldFill(block, length)
+		if hasPadText {
+			// in this case we can print plain
+			e.write(padText)
+			e.write(text)
+			break
 		}
-		e.rprompt = text
+		// this can contain ANSI escape sequences
+		ansi := e.Ansi
+		if e.Env.Shell() == shell.BASH {
+			ansi = &color.Ansi{}
+			ansi.InitPlain()
+		}
+		prompt := ansi.CarriageForward()
+		prompt += ansi.GetCursorForRightWrite(length, block.HorizontalOffset)
+		prompt += text
+		e.currentLineLength = 0
+		if e.Env.Shell() == shell.BASH {
+			prompt = e.Ansi.FormatText(prompt)
+		}
+		e.write(prompt)
+	case RPrompt:
+		e.rprompt, e.rpromptLength = block.RenderSegments()
 	}
 	// Due to a bug in Powershell, the end of the line needs to be cleared.
 	// If this doesn't happen, the portion after the prompt gets colored in the background
@@ -213,8 +230,8 @@ func (e *Engine) print() string {
 		prompt := fmt.Sprintf("PS1=\"%s\"", strings.ReplaceAll(e.string(), `"`, `\"`))
 		prompt += fmt.Sprintf("\nRPROMPT=\"%s\"", e.rprompt)
 		return prompt
-	case shell.PWSH, shell.PWSH5, shell.BASH, shell.PLAIN, shell.NU:
-		if e.rprompt == "" || !e.canWriteRPrompt() || e.Plain {
+	case shell.PWSH, shell.PWSH5, shell.PLAIN, shell.NU:
+		if !e.canWriteRPrompt() {
 			break
 		}
 		e.write(e.Ansi.SaveCursorPosition())
@@ -222,6 +239,21 @@ func (e *Engine) print() string {
 		e.write(e.Ansi.GetCursorForRightWrite(e.rpromptLength, 0))
 		e.write(e.rprompt)
 		e.write(e.Ansi.RestoreCursorPosition())
+	case shell.BASH:
+		if !e.canWriteRPrompt() {
+			break
+		}
+		// in bash, the entire rprompt needs to be escaped for the prompt to be interpreted correctly
+		// see https://github.com/JanDeDobbeleer/oh-my-posh/pull/2398
+		ansi := &color.Ansi{}
+		ansi.InitPlain()
+		prompt := ansi.SaveCursorPosition()
+		prompt += ansi.CarriageForward()
+		prompt += ansi.GetCursorForRightWrite(e.rpromptLength, 0)
+		prompt += e.rprompt
+		prompt += ansi.RestoreCursorPosition()
+		prompt = e.Ansi.FormatText(prompt)
+		e.write(prompt)
 	}
 	return e.string()
 }

--- a/src/engine/engine_test.go
+++ b/src/engine/engine_test.go
@@ -58,7 +58,7 @@ func engineRender() {
 	defer testClearDefaultConfig()
 
 	ansi := &color.Ansi{}
-	ansi.InitPlain(env.Shell())
+	ansi.InitPlain()
 	writerColors := cfg.MakeColors(env)
 	writer := &color.AnsiWriter{
 		Ansi:               ansi,

--- a/src/engine/engine_test.go
+++ b/src/engine/engine_test.go
@@ -34,10 +34,11 @@ func TestCanWriteRPrompt(t *testing.T) {
 		env := new(mock.MockedEnvironment)
 		env.On("TerminalWidth").Return(tc.TerminalWidth, tc.TerminalWidthError)
 		engine := &Engine{
-			Env: env,
+			Env:               env,
+			rpromptLength:     tc.RPromptLength,
+			currentLineLength: tc.PromptLength,
+			rprompt:           "hello",
 		}
-		engine.rpromptLength = tc.RPromptLength
-		engine.currentLineLength = tc.PromptLength
 		got := engine.canWriteRPrompt()
 		assert.Equal(t, tc.Expected, got, tc.Case)
 	}

--- a/src/engine/image_test.go
+++ b/src/engine/image_test.go
@@ -3,7 +3,6 @@ package engine
 import (
 	"io/ioutil"
 	"oh-my-posh/color"
-	"oh-my-posh/shell"
 	"os"
 	"path/filepath"
 	"testing"
@@ -33,7 +32,7 @@ func runImageTest(config, content string) (string, error) {
 	}
 	defer os.Remove(file.Name())
 	ansi := &color.Ansi{}
-	ansi.InitPlain(shell.PLAIN)
+	ansi.InitPlain()
 	image := &ImageRenderer{
 		AnsiString: content,
 		Ansi:       ansi,


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description

- refactor: remove shell name from plain init
- fix(bash): escape rprompt entirely


<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
