### PR TITLE
docs:Added source flag to winget installation

### DIFF
--- a/website/docs/installation/windows.mdx
+++ b/website/docs/installation/windows.mdx
@@ -43,7 +43,7 @@ When using oh-my-posh inside the WSL, make sure to follow the [Linux][linux] ins
 Open a PowerShell prompt and run the following command:
 
 ```powershell
-winget install JanDeDobbeleer.OhMyPosh
+winget install JanDeDobbeleer.OhMyPosh -s winget
 ```
 
 </TabItem>
@@ -101,7 +101,7 @@ Exclusions should be added with the full path to the executable, you can get it 
 Open a PowerShell prompt and run the following command:
 
 ```powershell
-winget upgrade oh-my-posh
+winget upgrade JanDeDobbeleer.OhMyPosh -s winget
 ```
 
 </TabItem>


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

I decided to add the source flag (-s winget) to the installation, because maybe you don't want to be prompted with a sort of error message that asks you to sign an agreement with Microsoft to let them know your device location. I propose to remove this annoying prompt by adding the source flag to winget.

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
