### PR TITLE
ansi colors

### DIFF
--- a/src/color/colors.go
+++ b/src/color/colors.go
@@ -3,6 +3,7 @@ package color
 import (
 	"fmt"
 	"oh-my-posh/environment"
+	"strconv"
 
 	"github.com/gookit/color"
 )
@@ -78,10 +79,14 @@ func (d *DefaultColors) AnsiColorFromString(colorString string, isBackground boo
 		return colorFromName
 	}
 	style := color.HEX(colorString, isBackground)
-	if style.IsEmpty() {
-		return emptyAnsiColor
+	if !style.IsEmpty() {
+		return AnsiColor(style.String())
 	}
-	return AnsiColor(style.String())
+	if colorInt, err := strconv.ParseInt(colorString, 10, 8); err == nil {
+		c := color.C256(uint8(colorInt), isBackground)
+		return AnsiColor(c.String())
+	}
+	return emptyAnsiColor
 }
 
 // getAnsiColorFromName returns the color code for a given color name if the name is

--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -280,7 +280,7 @@ Example:
                     $global:Error[0] | Where-Object { $_ -ne $null } | Select-Object -ExpandProperty InvocationInfo
                 } catch { $null }
                 # check if the last command caused the last error
-                if ($null -ne $invocationInfo -and $script:LastHistoryId -eq $invocationInfo.HistoryId) {
+                if ($null -ne $invocationInfo -and $lastHistory.CommandLine -eq $invocationInfo.Line) {
                     $script:ErrorCode = 1
                 } elseif ($realLASTEXITCODE -is [int] -and $realLASTEXITCODE -ne 0) {
                     # native app exit code

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -17,7 +17,7 @@
     },
     "color_string": {
       "type": "string",
-      "pattern": "^(#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})|black|red|green|yellow|blue|magenta|cyan|white|default|darkGray|lightRed|lightGreen|lightYellow|lightBlue|lightMagenta|lightCyan|lightWhite|transparent|parentBackground|parentForeground|background|foreground|accent)$",
+      "pattern": "^(#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})|^([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$|black|red|green|yellow|blue|magenta|cyan|white|default|darkGray|lightRed|lightGreen|lightYellow|lightBlue|lightMagenta|lightCyan|lightWhite|transparent|parentBackground|parentForeground|background|foreground|accent)$",
       "title": "Color string",
       "description": "https://ohmyposh.dev/docs/configuration/colors",
       "format": "color"

--- a/website/docs/configuration/colors.mdx
+++ b/website/docs/configuration/colors.mdx
@@ -17,6 +17,8 @@ Oh My Posh supports multiple different color references, being:
   as well as 8 extended ANSI colors:
 
   `darkGray` `lightRed` `lightGreen` `lightYellow` `lightBlue` `lightMagenta` `lightCyan` `lightWhite`
+- 256 color palette using their number representation.
+  For example `0` is black, `1` is red, `2` is green, etc.
 - The `transparent` keyword which can be used to create either a transparent foreground override
   or transparent background color using the segment's foreground property.
 - The `foreground` keyword which can be used to reference the current segment's foreground color.


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description

- feat: support 256 colors
- revert(pwsh): check history id instead of command line


<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
