### PR TITLE
docs: add `"type": "newline"` to block.mdx

### DIFF
--- a/website/docs/configuration/block.mdx
+++ b/website/docs/configuration/block.mdx
@@ -80,10 +80,29 @@ Tells the engine what to do with the block. There are two options:
 - `prompt` renders one or more segments
 - `rprompt` renders one or more segments aligned to the right of the cursor. Only one `rprompt` block is permitted.
 Supported on zsh, bash, PowerShell, cmd and fish.
+- `newline` renders your cursor in a new line, useful if your custom prompt is full of segments and you aim at readabilty. 
+
+:::info
+Example given shows a segment with just this property as the last segment in the `blocks` list:
+
+```json
+        {
+            "type": "newline"
+        }
+```
+:::
+
+:::tip
+Do not confuse this `"type": "newline"` argument with the property `"newline": true`. The former is to append a new line (after a segment or prompt), the later is to prepend a new line (before a segment or prompt)
+:::
 
 ### Newline
 
 Start the block on a new line - defaults to `false`.
+
+:::info
+See TIP in [Type](#type 'feeling lazy, uh?') section above.
+:::
 
 ### Alignment
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description

I'm pretty noob, so I hope the adjustment I made are fine

I was looking for a way to add a new line `\n`to get the cursor on a separate line and found no mention about this third kind of argument of `type` property.

Found the solution after a long while in a [comment of yours](https://github.com/JanDeDobbeleer/oh-my-posh/issues/607#issuecomment-812333646)

<!--TemplateBody-->

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
