### PR TITLE
docs:Added completion info

### DIFF
--- a/website/docs/installation/prompt.mdx
+++ b/website/docs/installation/prompt.mdx
@@ -66,6 +66,14 @@ Once added, reload your profile for the changes to take effect.
 . $PROFILE
 ```
 
+:::tip
+To add command autocompletion to oh-my-posh, reopen your PowerShell profile and add the next line.
+
+```powershell
+oh-my-posh completion powershell | Invoke-Expression
+```
+:::
+
 </TabItem>
 <TabItem value="cmd">
 
@@ -95,7 +103,7 @@ Add the following to `~/.zshrc`:
 eval "$(oh-my-posh init zsh)"
 ```
 
-:::tip
+:::info
 As the standard terminal has issues displaying the ANSI characters correctly, you might want to skip loading just for that terminal and instead of the line above, place this in your `~/.zshrc`:
 
 ```bash
@@ -112,6 +120,14 @@ Once added, reload your profile for the changes to take effect.
 ```bash
 source ~/.zshrc
 ```
+
+:::tip
+To add command autocompletion to oh-my-posh, add the next line to `~/.zshrc`.
+
+```bash
+eval "$(oh-my-posh completion zsh)"
+```
+:::
 
 </TabItem>
 <TabItem value="bash">
@@ -134,6 +150,14 @@ Or, when using `~/.profile`.
 . ~/.profile
 ```
 
+:::tip
+To add command autocompletion to oh-my-posh, add the next line to your profile file.
+
+```bash
+eval "$(oh-my-posh completion bash)"
+```
+:::
+
 </TabItem>
 <TabItem value="fish">
 
@@ -152,6 +176,14 @@ Once added, reload your config for the changes to take effect.
 ```bash
 exec fish
 ```
+
+:::tip
+To add command autocompletion to oh-my-posh, initialize in `~/.config/fish/config.fish`:
+
+```bash
+oh-my-posh completion fish | source
+```
+:::
 
 </TabItem>
 <TabItem value="nu">


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

I have not seen in the docs any part that talks about the 'completion' command. So I decided to add it myself.

I was just able to test for pwsh and bash, but there is this [discussion](https://github.com/JanDeDobbeleer/oh-my-posh/discussions/1960) for fish, and the command worked for bash so I expect to work the same in zsh.

The problem comes with pwsh that always marks an error when running, so can you point me out where the completion scripts are in the repo because I was not able to find them.
