### PR TITLE
docs: add Requirements to installation

### DIFF
--- a/website/docs/installation/homebrew.mdx
+++ b/website/docs/installation/homebrew.mdx
@@ -1,4 +1,6 @@
-A [Homebrew][brew] formula is available for easy installation. When installing Homebrew for Linux, be sure to follow *[Next steps][nextsteps]* instructions to add Homebrew to your PATH and to your bash shell profile script.
+A [Homebrew][brew] formula is available for easy installation. When installing Homebrew for Linux,
+be sure to follow *[Next steps][nextsteps]* instructions to add Homebrew to your PATH and to your
+bash shell profile script, and *[Requirements][requirements]* to build Oh My Posh.
 
 ```bash
 brew install jandedobbeleer/oh-my-posh/oh-my-posh
@@ -28,6 +30,7 @@ brew update && brew upgrade && exec zsh
 :::
 
 [brew]: https://brew.sh
+[requirements]: https://docs.brew.sh/Homebrew-on-Linux#requirements
 [nextsteps]: https://docs.brew.sh/Homebrew-on-Linux#install
 [themes]: https://ohmyposh.dev/docs/themes
 [strange]: https://github.com/JanDeDobbeleer/oh-my-posh/issues/1287


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

I decided to reinstall homebrew in my system, this time I came across with this in their GitHub page.
>If running Linux or WSL, [there are some pre-requisite packages to install](https://docs.brew.sh/Homebrew-on-Linux#requirements).

Before I follow this, my installation always fail so intead of using `brew install jandedobbeleer/oh-my-posh/oh-my-posh`, I had to use `brew install oh-my-posh` which doesn't require building from source.

After following the [Requirements](https://docs.brew.sh/Homebrew-on-Linux#requirements) now the installation does not fail when trying to build. I consider important to be in the docs.