### PR TITLE
Correct docs and update the theme schema

### DIFF
--- a/themes/schema.json
+++ b/themes/schema.json
@@ -2655,18 +2655,23 @@
     },
     "valid_line": {
       "$ref": "#/definitions/extra_prompt",
-      "title": "Valid Prompt Setting",
-      "description": "https://ohmyposh.dev/docs/configuration/prompt-override"
+      "title": "Valid Line Setting (for PowerShell only)",
+      "description": "https://ohmyposh.dev/docs/configuration/line-error"
     },
     "error_line": {
       "$ref": "#/definitions/extra_prompt",
-      "title": "Error Prompt Setting",
-      "description": "https://ohmyposh.dev/docs/configuration/prompt-override"
+      "title": "Error Line Setting (for PowerShell only)",
+      "description": "https://ohmyposh.dev/docs/configuration/line-error"
     },
     "secondary_prompt": {
       "$ref": "#/definitions/extra_prompt",
       "title": "Secondary Prompt Setting",
       "description": "https://ohmyposh.dev/docs/configuration/secondary-prompt"
+    },
+    "debug_prompt": {
+      "$ref": "#/definitions/extra_prompt",
+      "title": "Debug Prompt Setting (for PowerShell only)",
+      "description": "https://ohmyposh.dev/docs/configuration/debug-prompt"
     },
     "palette": {
       "type": "object",

--- a/website/docs/configuration/line-error.mdx
+++ b/website/docs/configuration/line-error.mdx
@@ -79,6 +79,7 @@ If you import **PSReadLine** separately, make sure to import it before the `Enab
 
 Restart your shell or reload your `$PROFILE` using `. $PROFILE` for the changes to take effect.
 
+[colors]: /docs/configuration/colors
 [go-text-template]: https://golang.org/pkg/text/template/
 [sprig]: https://masterminds.github.io/sprig/
 [console-title]: /docs/configuration/title#console-title-template


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description

1. Correct a broken link of `colors` in https://ohmyposh.dev/docs/configuration/line-error.
2. Add `debug_prompt` property to the theme schema and update links of `valid_line`/`error_line`.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
