### PR TITLE
feat(segment): added cmake segment

### DIFF
--- a/src/engine/segment.go
+++ b/src/engine/segment.go
@@ -90,6 +90,8 @@ const (
 	CF SegmentType = "cf"
 	// Cloud Foundry logged in target
 	CFTARGET SegmentType = "cftarget"
+	// CMAKE writes the active cmake version
+	CMAKE SegmentType = "cmake"
 	// CMD writes the output of a shell command
 	CMD SegmentType = "command"
 	// CRYSTAL writes the active crystal version
@@ -268,6 +270,7 @@ func (segment *Segment) mapSegmentWithWriter(env environment.Environment) error 
 		CFTARGET:      &segments.CfTarget{},
 		CMD:           &segments.Cmd{},
 		CRYSTAL:       &segments.Crystal{},
+		CMAKE:         &segments.Cmake{},
 		DART:          &segments.Dart{},
 		DOTNET:        &segments.Dotnet{},
 		EXECUTIONTIME: &segments.Executiontime{},

--- a/src/segments/cmake.go
+++ b/src/segments/cmake.go
@@ -1,0 +1,34 @@
+package segments
+
+import (
+	"oh-my-posh/environment"
+	"oh-my-posh/properties"
+)
+
+type Cmake struct {
+	language
+}
+
+func (c *Cmake) Template() string {
+	return languageTemplate
+}
+
+func (c *Cmake) Init(props properties.Properties, env environment.Environment) {
+	c.language = language{
+		env:        env,
+		props:      props,
+		extensions: []string{"*.cmake", "CMakeLists.txt"},
+		commands: []*cmd{
+			{
+				executable: "cmake",
+				args:       []string{"--version"},
+				regex:      `cmake version (?P<version>((?P<major>[0-9]+).(?P<minor>[0-9]+).(?P<patch>[0-9]+)))`,
+			},
+		},
+		versionURLTemplate: "https://cmake.org/cmake/help/v{{ .Major }}.{{ .Minor }}",
+	}
+}
+
+func (c *Cmake) Enabled() bool {
+	return c.language.Enabled()
+}

--- a/src/segments/cmake_test.go
+++ b/src/segments/cmake_test.go
@@ -1,0 +1,34 @@
+package segments
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCmake(t *testing.T) {
+	cases := []struct {
+		Case           string
+		ExpectedString string
+		Version        string
+	}{
+		{Case: "Cmake 3.23.2", ExpectedString: "3.23.2", Version: "cmake version 3.23.2"},
+		{Case: "Cmake 2.3.13", ExpectedString: "2.3.12", Version: "cmake version 2.3.12"},
+		{Case: "", ExpectedString: "", Version: ""},
+	}
+	for _, tc := range cases {
+		params := &mockedLanguageParams{
+			cmd:           "cmake",
+			versionParam:  "--version",
+			versionOutput: tc.Version,
+			extension:     "*.cmake",
+		}
+		env, props := getMockedLanguageEnv(params)
+		c := &Cmake{}
+		c.Init(props, env)
+		failMsg := fmt.Sprintf("Failed in case: %s", tc.Case)
+		assert.True(t, c.Enabled(), failMsg)
+		assert.Equal(t, tc.ExpectedString, renderTemplate(env, c.Template(), c), failMsg)
+	}
+}

--- a/themes/kushal.omp.json
+++ b/themes/kushal.omp.json
@@ -27,7 +27,7 @@
             "windows": "\ue70f"
           },
           "style": "diamond",
-          "template": " {{ if .WSL }}\ue712 on {{ end }}{{ .Icon }}  ",
+          "template": " {{ if .WSL }}\ue712 on {{ end }}{{ .Icon }} ",
           "type": "os"
         },
         {
@@ -47,6 +47,14 @@
           "type": "root"
         },
         {
+          "type": "cmake",
+          "style": "powerline",
+          "powerline_symbol": "\uE0B0",
+          "foreground": "#E8EAEE",
+          "background": "#1E9748",
+          "template": " \ue61e \ue61d cmake {{ .Full }} "
+        },
+        {
           "background": "#1BD4CD",
           "background_templates": [
             "{{ if or (.Working.Changed) (.Staging.Changed) }}#16B1AC{{ end }}",
@@ -64,7 +72,7 @@
             "fetch_worktree_count": true
           },
           "style": "powerline",
-          "template": " {{ .UpstreamIcon }}{{ .HEAD }}{{ .BranchStatus }}{{ if .Working.Changed }} \uf044 {{ .Working.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }}<#DAE15F> \uf046 {{ .Staging.String }}</>{{ end }}{{ if gt .StashCount 0 }} \uf692 {{ .StashCount }}{{ end }} ",
+          "template": " {{ .UpstreamIcon }}{{ .HEAD }}{{ .BranchStatus }}{{ if .Working.Changed }} \uf044 {{ .Working.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }}<#CAEBE1> \uf046 {{ .Staging.String }}</>{{ end }}{{ if gt .StashCount 0 }} \uf692 {{ .StashCount }}{{ end }} ",
           "type": "git"
         }
       ],
@@ -114,7 +122,7 @@
         {
           "foreground": "#F2D3B6",
           "properties": {
-            "time_format": "<#D6DEEB>\uf64f 15:04:05</> <#79DFE1>|</> \uf5ef 1 Jan, Monday"
+            "time_format": "<#D6DEEB>\uf64f 15:04:05</> <#79DFE1>|</> \uf5ef 2 Jan, Monday"
           },
           "style": "plain",
           "template": "{{ .CurrentDate | date .Format }} <#79DFE1>|</>",

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -205,6 +205,7 @@
             "cds",
             "cf",
             "cftarget",
+            "cmake",
             "dotnet",
             "dart",
             "exit",
@@ -530,6 +531,40 @@
                     "title": "Command",
                     "description": "the command(s) to run",
                     "default": "echo no command specified"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "cmake"
+              }
+            }
+          },
+          "then": {
+            "title": "Cmake Segment",
+            "description": "https://ohmyposh.dev/docs/segments/cmake",
+            "properties": {
+              "properties": {
+                "properties": {
+                  "home_enabled": {
+                    "$ref": "#/definitions/home_enabled"
+                  },
+                  "fetch_version": {
+                    "$ref": "#/definitions/fetch_version"
+                  },
+                  "display_mode": {
+                    "$ref": "#/definitions/display_mode"
+                  },
+                  "missing_command_text": {
+                    "$ref": "#/definitions/missing_command_text"
+                  },
+                  "version_url_template": {
+                    "$ref": "#/definitions/version_url_template"
                   }
                 }
               }

--- a/website/docs/segments/cmake.mdx
+++ b/website/docs/segments/cmake.mdx
@@ -1,0 +1,56 @@
+---
+id: cmake
+title: Cmake
+sidebar_label: Cmake
+---
+
+## What
+
+Display the currently active [Cmake][cmake-github] version.
+
+## Sample Configuration
+
+```json
+{
+  "type": "cmake",
+  "style": "powerline",
+  "powerline_symbol": "\uE0B0",
+  "foreground": "#E8EAEE",
+  "background": "#1E9748",
+  "template": " \ue61e \ue61d cmake {{ .Full }} "
+}
+```
+
+## Properties
+
+- home_enabled: `boolean` - display the segment in the HOME folder or not - defaults to `false`
+- fetch_version: `boolean` - display the cmake version - defaults to `true`
+- missing_command_text: `string` - text to display when the command is missing - defaults to empty
+- display_mode: `string` - determines when the segment is displayed
+  - `always`: the segment is always displayed
+  - `files`: the segment is only displayed when `*.cmake` or `CMakeLists.txt` files are present (default)
+- version_url_template: `string` - a go [text/template][go-text-template] [template][templates] that creates
+  the URL of the version info / release notes
+
+## Template ([info][templates])
+
+:::note default template
+
+```template
+{{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }}
+```
+
+:::
+
+### Properties
+
+- `.Full`: `string` - the full version
+- `.Major`: `string` - major number
+- `.Minor`: `string` - minor number
+- `.Patch`: `string` - patch number
+- `.URL`: `string` - URL of the version info / release notes
+- `.Error`: `string` - error encountered when fetching the version string
+
+[cmake-github]: https://github.com/Kitware/CMake
+[go-text-template]: https://golang.org/pkg/text/template/
+[templates]: /docs/configuration/templates

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -62,6 +62,7 @@ module.exports = {
         "segments/crystal",
         "segments/cf",
         "segments/cftarget",
+        "segments/cmake",
         "segments/dart",
         "segments/dotnet",
         "segments/executiontime",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description
This PR adds a new segment and updates a theme.
Added a segment for [CMake][cmake-github]. Cmake is a popular build system generator mostly used in C and C++ projects.
Updated kushal theme to include the new cmake segment.

### Images
![kushal](https://user-images.githubusercontent.com/83660514/179194040-48e01c60-e729-41c9-a53f-a3f4df399d39.png)
<!--TemplateBody-->
<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.
-->
[cmake-github]: https://github.com/Kitware/CMake
[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary