### PR TITLE
Use actual characters for OSes

### DIFF
--- a/themes/atomic.omp.json
+++ b/themes/atomic.omp.json
@@ -205,9 +205,9 @@
           "foreground": "#222222",
           "leading_diamond": "\ue0b6",
           "properties": {
-            "linux": "\ue27f",
-            "macos": "\ue27f",
-            "windows": "\ue27f"
+            "linux": "\ue712",
+            "macos": "\ue711",
+            "windows": "\ue70f"
           },
           "style": "diamond",
           "template": " {{ if .WSL }}WSL at {{ end }}{{.Icon}}<#262626> \ue0b2</>",


### PR DESCRIPTION
### Description

Use better unicode characters for operating systems.  Current values are the Atom icon for all operating systems.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
