### PR TITLE
fix(git): further fixes for submodule worktrees

### DIFF
--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -196,11 +196,15 @@ func (g *Git) hasWorktree(gitdir *environment.FileInfo) bool {
 	// we need the parent folder to detect where the real .git folder is
 	ind = strings.LastIndex(g.workingFolder, "/.git/modules")
 	if ind > -1 {
-		g.rootFolder = filepath.Join(gitdir.ParentFolder, g.workingFolder)
+		if !filepath.IsAbs(g.workingFolder) {
+			g.rootFolder = filepath.Join(gitdir.ParentFolder, g.workingFolder)
+		} else {
+			g.rootFolder = g.workingFolder
+		}
 		// this might be both a worktree and a submodule, where the path would look like
-		// this: ../.git/modules/module/path/worktrees/location. We cannot distinguish
+		// this: path/.git/modules/module/path/worktrees/location. We cannot distinguish
 		// between worktree and a module path containing the word 'worktree,' however.
-		ind = strings.LastIndex(g.rootFolder, g.env.PathSeparator()+"worktrees"+g.env.PathSeparator())
+		ind = strings.LastIndex(g.rootFolder, "/worktrees/")
 		if ind > -1 && g.env.HasFilesInDir(g.rootFolder, "gitdir") {
 			gitDir := filepath.Join(g.rootFolder, "gitdir")
 			realGitFolder := filepath.Clean(g.env.FileContent(gitDir))

--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -196,18 +196,14 @@ func (g *Git) hasWorktree(gitdir *environment.FileInfo) bool {
 	// we need the parent folder to detect where the real .git folder is
 	ind = strings.LastIndex(g.workingFolder, "/.git/modules")
 	if ind > -1 {
-		if !filepath.IsAbs(g.workingFolder) {
-			g.rootFolder = filepath.Join(gitdir.ParentFolder, g.workingFolder)
-		} else {
-			g.rootFolder = g.workingFolder
-		}
+		g.rootFolder = resolveGitPath(gitdir.ParentFolder, g.workingFolder)
 		// this might be both a worktree and a submodule, where the path would look like
 		// this: path/.git/modules/module/path/worktrees/location. We cannot distinguish
 		// between worktree and a module path containing the word 'worktree,' however.
 		ind = strings.LastIndex(g.rootFolder, "/worktrees/")
 		if ind > -1 && g.env.HasFilesInDir(g.rootFolder, "gitdir") {
 			gitDir := filepath.Join(g.rootFolder, "gitdir")
-			realGitFolder := filepath.Clean(g.env.FileContent(gitDir))
+			realGitFolder := g.env.FileContent(gitDir)
 			g.realFolder = strings.TrimSuffix(realGitFolder, ".git\n")
 			g.rootFolder = g.rootFolder[:ind]
 			g.workingFolder = g.rootFolder

--- a/src/segments/git_test.go
+++ b/src/segments/git_test.go
@@ -64,7 +64,6 @@ func TestEnabledInWorktree(t *testing.T) {
 		WorkingFolder         string
 		WorkingFolderAddon    string
 		WorkingFolderContent  string
-		GitDirContent         string
 		ExpectedRealFolder    string
 		ExpectedWorkingFolder string
 		ExpectedRootFolder    string
@@ -93,17 +92,17 @@ func TestEnabledInWorktree(t *testing.T) {
 			Case:                  "submodule with root working folder",
 			ExpectedEnabled:       true,
 			WorkingFolder:         "/repo/.git/modules/submodule",
-			ExpectedWorkingFolder: "/dev/repo/.git/modules/submodule",
-			ExpectedRealFolder:    "/dev/repo/.git/modules/submodule",
-			ExpectedRootFolder:    "/dev/repo/.git/modules/submodule",
+			ExpectedWorkingFolder: "/repo/.git/modules/submodule",
+			ExpectedRealFolder:    "/repo/.git/modules/submodule",
+			ExpectedRootFolder:    "/repo/.git/modules/submodule",
 			WindowsPaths:          true,
 		},
 		{
 			Case:                  "submodule with worktrees",
 			ExpectedEnabled:       true,
-			WorkingFolder:         "./.git/modules/module/path/worktrees/location",
-			WorkingFolderAddon:    "/dev/",
-			GitDirContent:         "/dev/worktree.git\n",
+			WorkingFolder:         "/dev/.git/modules/module/path/worktrees/location",
+			WorkingFolderAddon:    "gitdir",
+			WorkingFolderContent:  "/dev/worktree.git\n",
 			ExpectedWorkingFolder: "/dev/.git/modules/module/path",
 			ExpectedRealFolder:    "/dev/worktree",
 			ExpectedRootFolder:    "/dev/.git/modules/module/path",
@@ -126,9 +125,8 @@ func TestEnabledInWorktree(t *testing.T) {
 		env := new(mock.MockedEnvironment)
 		env.On("FileContent", "/dev/.git").Return(fmt.Sprintf("gitdir: %s", tc.WorkingFolder))
 		env.On("FileContent", filepath.Join(tc.WorkingFolder, tc.WorkingFolderAddon)).Return(tc.WorkingFolderContent)
+		env.On("HasFilesInDir", tc.WorkingFolder, tc.WorkingFolderAddon).Return(true)
 		env.On("HasFilesInDir", tc.WorkingFolder, "HEAD").Return(true)
-		env.On("HasFilesInDir", filepath.Join(tc.WorkingFolderAddon, tc.WorkingFolder), "gitdir").Return(true)
-		env.On("FileContent", filepath.Join(tc.WorkingFolderAddon, tc.WorkingFolder, "gitdir")).Return(tc.GitDirContent)
 		env.On("PathSeparator").Return(string(os.PathSeparator))
 		g := &Git{
 			scm: scm{

--- a/src/segments/git_unix.go
+++ b/src/segments/git_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package segments
+
+import "path/filepath"
+
+// resolveGitPath resolves path relative to base.
+func resolveGitPath(base, path string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Join(base, path)
+}

--- a/src/segments/git_unix_test.go
+++ b/src/segments/git_unix_test.go
@@ -1,0 +1,36 @@
+//go:build !windows
+
+package segments
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const TestRootPath = "/"
+
+func TestResolveGitPath(t *testing.T) {
+	cases := []struct {
+		Case     string
+		Base     string
+		Path     string
+		Expected string
+	}{
+		{
+			Case:     "relative path",
+			Base:     "dir/",
+			Path:     "sub",
+			Expected: "dir/sub",
+		},
+		{
+			Case:     "absolute path",
+			Base:     "/base",
+			Path:     "/absolute/path",
+			Expected: "/absolute/path",
+		},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.Expected, resolveGitPath(tc.Base, tc.Path), tc.Case)
+	}
+}

--- a/src/segments/git_windows.go
+++ b/src/segments/git_windows.go
@@ -1,0 +1,22 @@
+package segments
+
+import "path/filepath"
+
+// resolveGitPath resolves path relative to base.
+func resolveGitPath(base, path string) string {
+	if len(path) == 0 {
+		return base
+	}
+	if filepath.IsAbs(path) {
+		return path
+	}
+	// Note that git on Windows uses slashes exclusively. And it's okay
+	// because Windows actually accepts both directory separators. More
+	// importantly, however, parts of the git segment depend on those
+	// slashes.
+	if path[0] == '/' {
+		// path is a disk-relative path.
+		return filepath.VolumeName(base) + path
+	}
+	return filepath.ToSlash(filepath.Join(base, path))
+}

--- a/src/segments/git_windows_test.go
+++ b/src/segments/git_windows_test.go
@@ -1,0 +1,42 @@
+//go:build windows
+
+package segments
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const TestRootPath = "C:/"
+
+func TestResolveGitPath(t *testing.T) {
+	cases := []struct {
+		Case     string
+		Base     string
+		Path     string
+		Expected string
+	}{
+		{
+			Case:     "relative path",
+			Base:     "dir\\",
+			Path:     "sub",
+			Expected: "dir/sub",
+		},
+		{
+			Case:     "absolute path",
+			Base:     "C:\\base",
+			Path:     "C:/absolute/path",
+			Expected: "C:/absolute/path",
+		},
+		{
+			Case:     "disk-relative path",
+			Base:     "C:\\base",
+			Path:     "/absolute/path",
+			Expected: "C:/absolute/path",
+		},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.Expected, resolveGitPath(tc.Base, tc.Path), tc.Case)
+	}
+}


### PR DESCRIPTION
filepath.Join() just concatenates paths. We have to check manually for
an absolute path and discard the first component to end up with the
correct path.

Also, fix the tests to demonstrate actual behaviour of git, not what
filepath.Join() was doing.

Additionally, note that on Windows git paths in gitdir use unix
separators, so search for `/worktrees/` instead of using system
separator, just like when processing all the other cases.

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description

I have updated the code to actually handle absolute paths correctly. The tests seemed quite confused in particular, and needed some adjustments.

Interestingly, when testing on Windows, I discovered that prior attempt to use path separator when searching for `worktrees` in the path from Git was misguided as even my official Windows distribution of Git used `/` instead of the usual separator on Windows. This is probably why all the other searches ran on working forlder path also use `/`.

Tests pass on my Linux box. I also tested it in the wild both on Linux and Windows.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
