### PR TITLE
fix(pwsh): run command corretly in Constrained Language mode

### DIFF
--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -35,8 +35,7 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
         )
 
         if ($ExecutionContext.SessionState.LanguageMode -eq "ConstrainedLanguage") {
-            $_arguments = $Arguments -join ' '
-            $standardOut = Invoke-Expression "& $FileName $_arguments 2>&1"
+            $standardOut = Invoke-Expression "& '$FileName' `$Arguments 2>&1"
             $standardOut -join "`n"
             return
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

This PR has resolved an issue where the command can be run incorrectly in PowerShell Constrained Language mode if arguments contain space characters.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
