### PR TITLE
[re-fix] fix(pwsh): run command corretly in Constrained Language mode

### DIFF
--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -35,7 +35,7 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
         )
 
         if ($ExecutionContext.SessionState.LanguageMode -eq "ConstrainedLanguage") {
-            $standardOut = Invoke-Expression "& '$FileName' `$Arguments 2>&1"
+            $standardOut = Invoke-Expression "& `$FileName `$Arguments 2>&1"
             $standardOut -join "`n"
             return
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

A re-fix for #2563. See [my comment](https://github.com/JanDeDobbeleer/oh-my-posh/pull/2563/files#r928191966).

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
