### PR TITLE
Disabling-feature support and PowerShell-specific fix for the transient prompt

### DIFF
--- a/src/shell/scripts/omp.fish
+++ b/src/shell/scripts/omp.fish
@@ -79,3 +79,7 @@ end
 function enable_poshtransientprompt
   bind \r _render_transient
 end
+
+function disable_poshtransientprompt
+  bind -e \r
+end

--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -130,6 +130,11 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
         }
     }
 
+    function Disable-PoshTransientPrompt {
+        Set-PSReadLineKeyHandler -Key Enter -Function AcceptLine
+        $script:TransientPrompt = $false
+    }
+
     function Enable-PoshLineError {
         $validLine = @(Start-Utf8Process $script:OMPExecutable @("print", "valid", "--config=$env:POSH_THEME", "--shell=::SHELL::")) -join "`n"
         $errorLine = @(Start-Utf8Process $script:OMPExecutable @("print", "error", "--config=$env:POSH_THEME", "--shell=::SHELL::")) -join "`n"
@@ -319,6 +324,7 @@ Example:
         "Set-PoshContext"
         "Enable-PoshTooltips"
         "Enable-PoshTransientPrompt"
+        "Disable-PoshTransientPrompt"
         "Enable-PoshLineError"
         "Export-PoshTheme"
         "Get-PoshThemes"

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -94,3 +94,7 @@ _posh-zle-line-init() {
 function enable_poshtransientprompt() {
   zle -N zle-line-init _posh-zle-line-init
 }
+
+function disable_poshtransientprompt() {
+  zle -N zle-line-init
+}

--- a/website/docs/configuration/transient.mdx
+++ b/website/docs/configuration/transient.mdx
@@ -76,11 +76,10 @@ properties below - defaults to `{{ .Shell }}> `
 }>
 <TabItem value="pwsh">
 
-
 Invoke Oh My Posh in your `$PROFILE` and add the following line below.
 
 ```powershell
-oh-my-posh init pwsh --config $env:POSH_THEMES_PATH/jandedobbeleer.omp.json | Invoke-Expression
+oh-my-posh init pwsh --config "$env:POSH_THEMES_PATH/jandedobbeleer.omp.json" | Invoke-Expression
 // highlight-start
 Enable-PoshTransientPrompt
 // highlight-end
@@ -95,7 +94,7 @@ Restart your shell or reload your `$PROFILE` using `. $PROFILE` for the changes 
 </TabItem>
 <TabItem value="cmd">
 
-Set the transient prompt in [clink][clink] to `always` in the `oh-my-posh.lua` script to enable the feature:
+You can run the command below to enable the feature permanently:
 
 ```shell
 clink set prompt.transient always
@@ -123,10 +122,61 @@ Invoke Oh My Posh in `~/.config/fish/config.fish` and add the following line bel
 enable_poshtransientprompt
 ```
 
-Restart your shell or reload fish using `exec fish` for the changes to take effect.
+Restart your shell or reload `~/.config/fish/config.fish` using `exec fish` for the changes to take effect.
 
 </TabItem>
 </Tabs>
+
+## Disable the feature
+
+<Tabs
+  defaultValue="pwsh"
+  groupId="shell"
+  values={[
+    { label: 'powershell', value: 'pwsh', },
+    { label: 'cmd', value: 'cmd', },
+    { label: 'zsh', value: 'zsh', },
+    { label: 'fish', value: 'fish', },
+  ]
+}>
+<TabItem value="pwsh">
+
+You can use this function to disable the feature when you are in a PowerShell session:
+
+```powershell
+Disable-PoshTransientPrompt
+```
+
+</TabItem>
+<TabItem value="cmd">
+
+You can run the command below to disable the feature permanently:
+
+```shell
+clink set prompt.transient off
+```
+
+Restart your shell for the changes to take effect.
+
+</TabItem>
+<TabItem value="zsh">
+
+You can use this function to disable the feature when you are in a zsh session:
+
+```bash
+disable_poshtransientprompt
+```
+
+</TabItem>
+<TabItem value="fish">
+
+You can use this function to disable the feature when you are in a fish session:
+
+```bash
+disable_poshtransientprompt
+```
+
+</TabItem>
 
 [colors]: /docs/configuration/colors
 [go-text-template]: https://golang.org/pkg/text/template/


### PR DESCRIPTION
**[Superseded]** Part of this PR has been superseded by #2567.

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description

1. Add functions for disabling the transient prompt feature in a PowerShell/zsh/fish session:

	- PowerShell: `Disable-PoshTransientPrompt`
	- zsh: `disable_poshtransientprompt`
	- fish: `disable_poshtransientprompt`

2. Fix a bug in PowerShell: if transient prompt is enabled and `PredictionViewStyle` for PSReadLine is set to `ListView`, once the command line is accepted with the suggestion list active, the text buffer below the current prompt line will persist, causing cluttered output of the command. Special thanks to @rashil2000 for providing this workaround in starship/starship#4143.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
