### PR TITLE
Bug fix for the transient prompt in PowerShell and revision on docs

### DIFF
--- a/website/docs/configuration/transient.mdx
+++ b/website/docs/configuration/transient.mdx
@@ -80,7 +80,7 @@ properties below - defaults to `{{ .Shell }}> `
 Invoke Oh My Posh in your `$PROFILE` and add the following line below.
 
 ```powershell
-oh-my-posh init pwsh --config $env:POSH_THEMES_PATH/jandedobbeleer.omp.json | Invoke-Expression
+oh-my-posh init pwsh --config "$env:POSH_THEMES_PATH/jandedobbeleer.omp.json" | Invoke-Expression
 // highlight-start
 Enable-PoshTransientPrompt
 // highlight-end
@@ -95,7 +95,7 @@ Restart your shell or reload your `$PROFILE` using `. $PROFILE` for the changes 
 </TabItem>
 <TabItem value="cmd">
 
-Set the transient prompt in [clink][clink] to `always` in the `oh-my-posh.lua` script to enable the feature:
+You can run the command below to enable the feature permanently:
 
 ```shell
 clink set prompt.transient always


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

1. Fix a bug in PowerShell: if transient prompt is enabled and `PredictionViewStyle` for PSReadLine is set to `ListView`, once the command line is accepted with the suggestion list active, the text buffer below the current prompt line will persist, causing cluttered output of the command.

2. Documentaion revision: `clink set prompt.transient always` should be run in a shell, not appended to the `oh-my-posh.lua` script.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
