### PR TITLE
PowerShell-specific refactoring and tweak

### DIFF
--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -125,12 +125,16 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
                     [Microsoft.PowerShell.PSConsoleReadLine]::InvokePrompt()
                 }
             } finally {
+                # If PSReadline is set to display suggestion list, this workaround is needed to clear the buffer below
+                # before accepting the current commandline. The max amount of items in the list is 10, so 12 lines
+                # are cleared (10 + 1 more for the prompt + 1 more for current commandline).
                 if ((Get-PSReadLineOption).PredictionViewStyle -eq 'ListView') {
-                    # If PSReadline is set to display suggestion list, this workaround is needed to clear the buffer below
-                    # before accepting the current commandline. The max amount of items in the list is 10, so 12 lines
-                    # are cleared (10 + 1 more for the prompt + 1 more for current commandline).
-                    [Microsoft.PowerShell.PSConsoleReadLine]::Insert("`n" * [System.Math]::Min($Host.UI.RawUI.WindowSize.Height - $Host.UI.RawUI.CursorPosition.Y - 1, 12))
-                    [Microsoft.PowerShell.PSConsoleReadLine]::Undo()
+                    $terminalHeight = $Host.UI.RawUI.WindowSize.Height
+                    # only do this on an valid value
+                    if ([int]$terminalHeight -gt 0) {
+                        [Microsoft.PowerShell.PSConsoleReadLine]::Insert("`n" * [System.Math]::Min($terminalHeight - $Host.UI.RawUI.CursorPosition.Y - 1, 12))
+                        [Microsoft.PowerShell.PSConsoleReadLine]::Undo()
+                    }
                 }
                 [Microsoft.PowerShell.PSConsoleReadLine]::AcceptLine()
                 [Console]::OutputEncoding = $previousOutputEncoding

--- a/website/docs/configuration/debug-prompt.mdx
+++ b/website/docs/configuration/debug-prompt.mdx
@@ -49,6 +49,7 @@ properties below - defaults to `[DBG]: `
 - `.Shell`: `string` - the current shell name
 - `.UserName`: `string` - the current user name
 - `.HostName`: `string` - the host name
+- `.Code`: `int` - the last exit code
 - `.Env.VarName`: `string` - Any environment variable where `VarName` is the environment variable name
 
 [go-text-template]: https://golang.org/pkg/text/template/


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description

1. Refactor the logic of `prompt` function in the init script `omp.ps1` for PowerShell, and with this we now support the global template property `.Code` for the debug prompt in PowerShell, the same to any global properties in the future. This refactoring also handles the count of lines for three types of prompts properly, which fixes bugs of line overwriting, no line wrap, etc. for the debug prompt in a transient-prompt-enabled context, if the count of lines is different between the debug and the primary prompts.

2. A tweak in the workaround for the transient prompt in PowerShell.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
