### PR TITLE
feat(tooltip): make `.Code` property available

### DIFF
--- a/src/shell/scripts/omp.fish
+++ b/src/shell/scripts/omp.fish
@@ -39,7 +39,7 @@ function fish_right_prompt
       return
     end
     if test -n "$omp_tooltip_command"
-      set omp_tooltip_prompt ('::OMP::' print tooltip --config $POSH_THEME --shell fish --shell-version $FISH_VERSION --command $omp_tooltip_command)
+      set omp_tooltip_prompt ('::OMP::' print tooltip --config $POSH_THEME --shell fish --error $omp_status_cache --shell-version $FISH_VERSION --command $omp_tooltip_command)
       if test -n "$omp_tooltip_prompt"
         echo -n $omp_tooltip_prompt
         set omp_tooltip_command ""

--- a/src/shell/scripts/omp.lua
+++ b/src/shell/scripts/omp.lua
@@ -113,7 +113,7 @@ local function set_posh_tooltip(command)
     command = string.gsub(command, '\\+"', '%1%1"')
     command = string.gsub(command, '\\+$', '%1%1')
     command = string.gsub(command, '"', '\\"')
-    local prompt_exe = string.format('%s print tooltip --shell=cmd --config=%s --command="%s"', omp_exe(), omp_config(), command)
+    local prompt_exe = string.format('%s print tooltip --shell=cmd %s --config=%s --command="%s"', omp_exe(), error_level_option(), omp_config(), command)
     local tooltip = run_posh_command(prompt_exe)
     if tooltip ~= "" then
         tooltip_active = true

--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -107,7 +107,7 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
             $cleanPWD, $cleanPSWD = Get-PoshContext
             $command = $null
             [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$command, [ref]$null)
-            $standardOut = @(Start-Utf8Process $script:OMPExecutable @("print", "tooltip", "--pwd=$cleanPWD", "--shell=$script:ShellName", "--pswd=$cleanPSWD", "--config=$env:POSH_THEME", "--command=$command", "--shell-version=$script:PSVersion"))
+            $standardOut = @(Start-Utf8Process $script:OMPExecutable @("print", "tooltip", "--error=$script:ErrorCode", "--pwd=$cleanPWD", "--shell=$script:ShellName", "--pswd=$cleanPSWD", "--config=$env:POSH_THEME", "--command=$command", "--shell-version=$script:PSVersion"))
             Write-Host $standardOut -NoNewline
             $host.UI.RawUI.CursorPosition = $position
         }

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -50,7 +50,7 @@ function self-insert() {
   fi
   # trigger a tip check only if the input is a space character
   if [[ "$KEYS" = " " ]]; then
-    tooltip=$(::OMP:: print tooltip --config="$POSH_THEME" --shell=zsh --command="$BUFFER" --shell-version="$ZSH_VERSION")
+    tooltip=$(::OMP:: print tooltip --config="$POSH_THEME" --shell=zsh --error="$omp_last_error" --command="$BUFFER" --shell-version="$ZSH_VERSION")
   fi
   # ignore an empty tooltip
   if [[ ! -z "$tooltip" ]]; then


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

Make `.Code` property (the last exit code) available for the template of a tooltip segment.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
