### PR TITLE
fix(pwsh): prevent text from disappearing when a tooltip is rendered

### DIFF
--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -110,6 +110,9 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
             $standardOut = @(Start-Utf8Process $script:OMPExecutable @("print", "tooltip", "--error=$script:ErrorCode", "--pwd=$cleanPWD", "--shell=$script:ShellName", "--pswd=$cleanPSWD", "--config=$env:POSH_THEME", "--command=$command", "--shell-version=$script:PSVersion"))
             Write-Host $standardOut -NoNewline
             $host.UI.RawUI.CursorPosition = $position
+            # we need this workaround to prevent the text after cursor from disappearing when the tooltip is rendered
+            [Microsoft.PowerShell.PSConsoleReadLine]::Insert(" ")
+            [Microsoft.PowerShell.PSConsoleReadLine]::Undo()
         }
     }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

This workaround has resolved a problem in PowerShell. The following are steps to reproduce it:

1. Add a tooltip in the theme config (e.g., I use `git` as the tip in this case).
2. Enable tooltips by `Enable-PoshTooltips` in PowerShell.
3. **Enter a few spaces at the beginning of a command line,** then the tip `git`, and move the cursor back to front of the first character `g`.
4. Insert a space by pressing <kbd>Space</kbd>, which makes the tooltip **actually rendered**. Now the text `git` after the cursor disappears.
5. Now if we continue to insert a **non-space** character, the disappeared content can be reproduced.

A similar bug happens if the suggestion list is enabled (`Set-PSReadLineOption -PredictionViewStyle ListView`) and has been showed before we press <kbd>Space</kbd>.

A simple demo:

https://user-images.githubusercontent.com/83903009/181591180-0069c502-de8a-45a4-a9e3-382010404d3f.mp4

In this demo, the suggestion list should persist when the tooltip is rendered, however it didn't.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
