### PR TITLE
secondary prompts context

### DIFF
--- a/src/engine/engine.go
+++ b/src/engine/engine.go
@@ -354,6 +354,8 @@ const (
 )
 
 func (e *Engine) PrintExtraPrompt(promptType ExtraPromptType) string {
+	// populate env with latest context
+	e.Env.LoadTemplateCache()
 	var prompt *Segment
 	switch promptType {
 	case Debug:

--- a/src/engine/segment_test.go
+++ b/src/engine/segment_test.go
@@ -71,7 +71,7 @@ func TestShouldIncludeFolder(t *testing.T) {
 	}
 	for _, tc := range cases {
 		env := new(mock.MockedEnvironment)
-		env.On("GOOS").Return(environment.LinuxPlatform)
+		env.On("GOOS").Return(environment.LINUX)
 		env.On("Home").Return("")
 		env.On("Pwd").Return(cwd)
 		env.On("DirMatchesOneOf", cwd, []string{"Projects/oh-my-posh"}).Return(tc.Included)

--- a/src/environment/shell.go
+++ b/src/environment/shell.go
@@ -29,10 +29,10 @@ import (
 )
 
 const (
-	Unknown         = "unknown"
-	WindowsPlatform = "windows"
-	DarwinPlatform  = "darwin"
-	LinuxPlatform   = "linux"
+	UNKNOWN = "unknown"
+	WINDOWS = "windows"
+	DARWIN  = "darwin"
+	LINUX   = "linux"
 )
 
 var (
@@ -256,7 +256,7 @@ func (env *ShellEnvironment) resolveConfigPath() {
 	}
 	// Cygwin path always needs the full path as we're on Windows but not really.
 	// Doing filepath actions will convert it to a Windows path and break the init script.
-	if env.Platform() == WindowsPlatform && env.Shell() == "bash" {
+	if env.Platform() == WINDOWS && env.Shell() == "bash" {
 		return
 	}
 	configFile := env.CmdFlags.Config
@@ -572,7 +572,7 @@ func (env *ShellEnvironment) Shell() string {
 	name, err := p.Name()
 	if err != nil {
 		env.Log(Error, "Shell", err.Error())
-		return Unknown
+		return UNKNOWN
 	}
 	if name == "cmd.exe" {
 		p, _ = p.Parent()
@@ -580,7 +580,7 @@ func (env *ShellEnvironment) Shell() string {
 	}
 	if err != nil {
 		env.Log(Error, "Shell", err.Error())
-		return Unknown
+		return UNKNOWN
 	}
 	// Cache the shell value to speed things up.
 	env.CmdFlags.Shell = strings.Trim(strings.TrimSuffix(name, ".exe"), " ")
@@ -723,7 +723,7 @@ func (env *ShellEnvironment) TemplateCache() *TemplateCache {
 	}
 	goos := env.GOOS()
 	tmplCache.OS = goos
-	if goos == LinuxPlatform {
+	if goos == LINUX {
 		tmplCache.OS = env.Platform()
 	}
 	env.tmplCache = tmplCache
@@ -757,7 +757,7 @@ func dirMatchesOneOf(dir, home, goos string, regexes []string) bool {
 			normalizedElement = strings.Replace(normalizedElement, "~", normalizedHomeDir, 1)
 		}
 		pattern := fmt.Sprintf("^%s$", normalizedElement)
-		if goos == WindowsPlatform || goos == DarwinPlatform {
+		if goos == WINDOWS || goos == DARWIN {
 			pattern = "(?i)" + pattern
 		}
 		matched := regex.MatchString(pattern, normalizedCwd)

--- a/src/environment/shell_test.go
+++ b/src/environment/shell_test.go
@@ -53,21 +53,21 @@ func TestDirMatchesOneOf(t *testing.T) {
 		Pattern  string
 		Expected bool
 	}{
-		{GOOS: LinuxPlatform, HomeDir: "/home/bill", Dir: "/home/bill", Pattern: "/home/bill", Expected: true},
-		{GOOS: LinuxPlatform, HomeDir: "/home/bill", Dir: "/home/bill/foo", Pattern: "~/foo", Expected: true},
-		{GOOS: LinuxPlatform, HomeDir: "/home/bill", Dir: "/home/bill/foo", Pattern: "~/Foo", Expected: false},
-		{GOOS: LinuxPlatform, HomeDir: "/home/bill", Dir: "/home/bill/foo", Pattern: "~\\\\foo", Expected: true},
-		{GOOS: LinuxPlatform, HomeDir: "/home/bill", Dir: "/home/bill/foo/bar", Pattern: "~/fo.*", Expected: true},
-		{GOOS: LinuxPlatform, HomeDir: "/home/bill", Dir: "/home/bill/foo", Pattern: "~/fo\\w", Expected: true},
+		{GOOS: LINUX, HomeDir: "/home/bill", Dir: "/home/bill", Pattern: "/home/bill", Expected: true},
+		{GOOS: LINUX, HomeDir: "/home/bill", Dir: "/home/bill/foo", Pattern: "~/foo", Expected: true},
+		{GOOS: LINUX, HomeDir: "/home/bill", Dir: "/home/bill/foo", Pattern: "~/Foo", Expected: false},
+		{GOOS: LINUX, HomeDir: "/home/bill", Dir: "/home/bill/foo", Pattern: "~\\\\foo", Expected: true},
+		{GOOS: LINUX, HomeDir: "/home/bill", Dir: "/home/bill/foo/bar", Pattern: "~/fo.*", Expected: true},
+		{GOOS: LINUX, HomeDir: "/home/bill", Dir: "/home/bill/foo", Pattern: "~/fo\\w", Expected: true},
 
-		{GOOS: WindowsPlatform, HomeDir: "C:\\Users\\Bill", Dir: "C:\\Users\\Bill", Pattern: "C:\\\\Users\\\\Bill", Expected: true},
-		{GOOS: WindowsPlatform, HomeDir: "C:\\Users\\Bill", Dir: "C:\\Users\\Bill", Pattern: "C:/Users/Bill", Expected: true},
-		{GOOS: WindowsPlatform, HomeDir: "C:\\Users\\Bill", Dir: "C:\\Users\\Bill", Pattern: "c:/users/bill", Expected: true},
-		{GOOS: WindowsPlatform, HomeDir: "C:\\Users\\Bill", Dir: "C:\\Users\\Bill", Pattern: "~", Expected: true},
-		{GOOS: WindowsPlatform, HomeDir: "C:\\Users\\Bill", Dir: "C:\\Users\\Bill\\Foo", Pattern: "~/Foo", Expected: true},
-		{GOOS: WindowsPlatform, HomeDir: "C:\\Users\\Bill", Dir: "C:\\Users\\Bill\\Foo", Pattern: "~/foo", Expected: true},
-		{GOOS: WindowsPlatform, HomeDir: "C:\\Users\\Bill", Dir: "C:\\Users\\Bill\\Foo\\Bar", Pattern: "~/fo.*", Expected: true},
-		{GOOS: WindowsPlatform, HomeDir: "C:\\Users\\Bill", Dir: "C:\\Users\\Bill\\Foo", Pattern: "~/fo\\w", Expected: true},
+		{GOOS: WINDOWS, HomeDir: "C:\\Users\\Bill", Dir: "C:\\Users\\Bill", Pattern: "C:\\\\Users\\\\Bill", Expected: true},
+		{GOOS: WINDOWS, HomeDir: "C:\\Users\\Bill", Dir: "C:\\Users\\Bill", Pattern: "C:/Users/Bill", Expected: true},
+		{GOOS: WINDOWS, HomeDir: "C:\\Users\\Bill", Dir: "C:\\Users\\Bill", Pattern: "c:/users/bill", Expected: true},
+		{GOOS: WINDOWS, HomeDir: "C:\\Users\\Bill", Dir: "C:\\Users\\Bill", Pattern: "~", Expected: true},
+		{GOOS: WINDOWS, HomeDir: "C:\\Users\\Bill", Dir: "C:\\Users\\Bill\\Foo", Pattern: "~/Foo", Expected: true},
+		{GOOS: WINDOWS, HomeDir: "C:\\Users\\Bill", Dir: "C:\\Users\\Bill\\Foo", Pattern: "~/foo", Expected: true},
+		{GOOS: WINDOWS, HomeDir: "C:\\Users\\Bill", Dir: "C:\\Users\\Bill\\Foo\\Bar", Pattern: "~/fo.*", Expected: true},
+		{GOOS: WINDOWS, HomeDir: "C:\\Users\\Bill", Dir: "C:\\Users\\Bill\\Foo", Pattern: "~/fo\\w", Expected: true},
 	}
 
 	for _, tc := range cases {
@@ -84,7 +84,7 @@ func TestDirMatchesOneOfRegexInverted(t *testing.T) {
 			assert.Equal(t, "regexp: Compile(`^(?!Projects[\\/]).*$`): error parsing regexp: invalid or unsupported Perl syntax: `(?!`", err)
 		}
 	}()
-	_ = dirMatchesOneOf("Projects/oh-my-posh", "", LinuxPlatform, []string{"(?!Projects[\\/]).*"})
+	_ = dirMatchesOneOf("Projects/oh-my-posh", "", LINUX, []string{"(?!Projects[\\/]).*"})
 }
 
 func TestDirMatchesOneOfRegexInvertedNonEscaped(t *testing.T) {
@@ -95,5 +95,5 @@ func TestDirMatchesOneOfRegexInvertedNonEscaped(t *testing.T) {
 			assert.Equal(t, "regexp: Compile(`^(?!Projects/).*$`): error parsing regexp: invalid or unsupported Perl syntax: `(?!`", err)
 		}
 	}()
-	_ = dirMatchesOneOf("Projects/oh-my-posh", "", LinuxPlatform, []string{"(?!Projects/).*"})
+	_ = dirMatchesOneOf("Projects/oh-my-posh", "", LINUX, []string{"(?!Projects/).*"})
 }

--- a/src/environment/shell_windows.go
+++ b/src/environment/shell_windows.go
@@ -108,7 +108,7 @@ func (env *ShellEnvironment) TerminalWidth() (int, error) {
 }
 
 func (env *ShellEnvironment) Platform() string {
-	return WindowsPlatform
+	return WINDOWS
 }
 
 func (env *ShellEnvironment) CachePath() string {
@@ -353,7 +353,7 @@ func (env *ShellEnvironment) parseNetworkInterface(network *WLAN_INTERFACE_INFO,
 	case 8:
 		info.PhysType = AC
 	default:
-		info.PhysType = Unknown
+		info.PhysType = UNKNOWN
 	}
 
 	// see https://docs.microsoft.com/en-us/windows/win32/nativewifi/dot11-bss-type
@@ -408,7 +408,7 @@ func (env *ShellEnvironment) parseNetworkInterface(network *WLAN_INTERFACE_INFO,
 	case 7:
 		info.Authentication = WPA2PSK
 	default:
-		info.Authentication = Unknown
+		info.Authentication = UNKNOWN
 	}
 
 	// see https://docs.microsoft.com/en-us/windows/win32/nativewifi/dot11-cipher-algorithm
@@ -428,7 +428,7 @@ func (env *ShellEnvironment) parseNetworkInterface(network *WLAN_INTERFACE_INFO,
 	case 0x101:
 		info.Cipher = WEP
 	default:
-		info.Cipher = Unknown
+		info.Cipher = UNKNOWN
 	}
 
 	return &info, nil

--- a/src/font/download.go
+++ b/src/font/download.go
@@ -4,11 +4,13 @@ package font
 // component library.
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 )
 
 func Download(fontPath string) ([]byte, error) {
@@ -35,9 +37,14 @@ func isZipFile(data []byte) bool {
 }
 
 func getRemoteFile(location string) (data []byte, err error) {
-	var client = http.Client{}
-
-	resp, err := client.Get(location)
+	client := &http.Client{}
+	ctx, cancelF := context.WithTimeout(context.Background(), time.Second*time.Duration(60))
+	defer cancelF()
+	req, err := http.NewRequestWithContext(ctx, "GET", location, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return
 	}

--- a/src/font/nerd.go
+++ b/src/font/nerd.go
@@ -1,10 +1,12 @@
 package font
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
 	"strings"
+	"time"
 )
 
 type release struct {
@@ -21,7 +23,9 @@ func (a Asset) FilterValue() string { return a.Name }
 
 func Nerds() ([]*Asset, error) {
 	client := &http.Client{}
-	req, err := http.NewRequest("GET", "https://api.github.com/repos/ryanoasis/nerd-fonts/releases/latest", nil)
+	ctx, cancelF := context.WithTimeout(context.Background(), time.Second*time.Duration(20))
+	defer cancelF()
+	req, err := http.NewRequestWithContext(ctx, "GET", "https://api.github.com/repos/ryanoasis/nerd-fonts/releases/latest", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/src/mock/environment.go
+++ b/src/mock/environment.go
@@ -218,6 +218,10 @@ func (env *MockedEnvironment) TemplateCache() *environment.TemplateCache {
 	return args.Get(0).(*environment.TemplateCache)
 }
 
+func (env *MockedEnvironment) LoadTemplateCache() {
+	_ = env.Called()
+}
+
 func (env *MockedEnvironment) MockGitCommand(dir, returnValue string, args ...string) {
 	args = append([]string{"-C", dir, "--no-optional-locks", "-c", "core.quotepath=false", "-c", "color.status=false"}, args...)
 	env.On("RunCommand", "git", args).Return(returnValue, nil)

--- a/src/segments/az_test.go
+++ b/src/segments/az_test.go
@@ -120,7 +120,7 @@ func TestAzSegment(t *testing.T) {
 			content, _ := os.ReadFile("../test/AzureRmContext.json")
 			azureRmContext = string(content)
 		}
-		env.On("GOOS").Return(environment.LinuxPlatform)
+		env.On("GOOS").Return(environment.LINUX)
 		env.On("FileContent", filepath.Join(home, ".azure", "azureProfile.json")).Return(azureProfile)
 		env.On("FileContent", filepath.Join(home, ".azure", "AzureRmContext.json")).Return(azureRmContext)
 		env.On("Getenv", "AZURE_CONFIG_DIR").Return("")

--- a/src/segments/git_test.go
+++ b/src/segments/git_test.go
@@ -609,7 +609,7 @@ func TestGetGitCommand(t *testing.T) {
 		CWD             string
 		IsWslSharedPath bool
 	}{
-		{Case: "On Windows", Expected: "git.exe", GOOS: environment.WindowsPlatform},
+		{Case: "On Windows", Expected: "git.exe", GOOS: environment.WINDOWS},
 		{Case: "Non Windows", Expected: "git"},
 		{Case: "Iside WSL2, non shared", IsWSL: true, Expected: "git"},
 		{Case: "Iside WSL2, shared", Expected: "git.exe", IsWSL: true, IsWslSharedPath: true, CWD: "/mnt/bill"},

--- a/src/segments/os.go
+++ b/src/segments/os.go
@@ -68,11 +68,11 @@ func (oi *Os) Template() string {
 func (oi *Os) Enabled() bool {
 	goos := oi.env.GOOS()
 	switch goos {
-	case environment.WindowsPlatform:
+	case environment.WINDOWS:
 		oi.Icon = oi.props.GetString(Windows, "\uE62A")
-	case environment.DarwinPlatform:
+	case environment.DARWIN:
 		oi.Icon = oi.props.GetString(MacOS, "\uF179")
-	case environment.LinuxPlatform:
+	case environment.LINUX:
 		platform := oi.env.Platform()
 		displayDistroName := oi.props.GetBool(DisplayDistroName, false)
 		if displayDistroName {

--- a/src/segments/path.go
+++ b/src/segments/path.go
@@ -109,7 +109,18 @@ func (pt *Path) Enabled() bool {
 }
 
 func (pt *Path) Parent() string {
-	return filepath.Dir(pt.pwd)
+	if pt.pwd == pt.env.Home() {
+		return ""
+	}
+	parent := filepath.Dir(pt.pwd)
+	if pt.pwd == parent {
+		return ""
+	}
+	separator := pt.env.PathSeparator()
+	if parent == pt.rootLocation() || parent == separator {
+		separator = ""
+	}
+	return pt.replaceMappedLocations(parent) + separator
 }
 
 func (pt *Path) formatWindowsDrive(pwd string) string {

--- a/src/segments/path.go
+++ b/src/segments/path.go
@@ -113,7 +113,7 @@ func (pt *Path) Parent() string {
 }
 
 func (pt *Path) formatWindowsDrive(pwd string) string {
-	if pt.env.GOOS() != environment.WindowsPlatform || !strings.HasSuffix(pwd, ":") {
+	if pt.env.GOOS() != environment.WINDOWS || !strings.HasSuffix(pwd, ":") {
 		return pwd
 	}
 	return pwd + "\\"
@@ -333,7 +333,7 @@ func (pt *Path) normalize(inputPath string) string {
 	}
 	normalized = strings.ReplaceAll(normalized, "\\", "/")
 	goos := pt.env.GOOS()
-	if goos == environment.WindowsPlatform || goos == environment.DarwinPlatform {
+	if goos == environment.WINDOWS || goos == environment.DARWIN {
 		normalized = strings.ToLower(normalized)
 	}
 	return normalized

--- a/src/segments/path_test.go
+++ b/src/segments/path_test.go
@@ -344,8 +344,8 @@ func TestGetFullPath(t *testing.T) {
 		{Style: Folder, FolderSeparatorIcon: "|", Pwd: "/usr/home/abc", Expected: "abc"},
 		{Style: Folder, FolderSeparatorIcon: "|", Pwd: "/a/b/c/d", Expected: "d"},
 
-		{Style: Folder, FolderSeparatorIcon: "\\", Pwd: "C:\\", Expected: "C:\\", PathSeparator: "\\", GOOS: environment.WindowsPlatform},
-		{Style: Full, FolderSeparatorIcon: "\\", Pwd: "C:\\Users\\Jan", Expected: "C:\\Users\\Jan", PathSeparator: "\\", GOOS: environment.WindowsPlatform},
+		{Style: Folder, FolderSeparatorIcon: "\\", Pwd: "C:\\", Expected: "C:\\", PathSeparator: "\\", GOOS: environment.WINDOWS},
+		{Style: Full, FolderSeparatorIcon: "\\", Pwd: "C:\\Users\\Jan", Expected: "C:\\Users\\Jan", PathSeparator: "\\", GOOS: environment.WINDOWS},
 
 		// StackCountEnabled=true and StackCount=2
 		{Style: Full, FolderSeparatorIcon: "|", Pwd: "/", StackCount: 2, Expected: "2 /"},
@@ -476,14 +476,14 @@ func TestNormalizePath(t *testing.T) {
 		GOOS     string
 		Expected string
 	}{
-		{Input: "C:\\Users\\Bob\\Foo", GOOS: environment.LinuxPlatform, Expected: "C:/Users/Bob/Foo"},
-		{Input: "C:\\Users\\Bob\\Foo", GOOS: environment.WindowsPlatform, Expected: "c:/users/bob/foo"},
-		{Input: "~\\Bob\\Foo", GOOS: environment.LinuxPlatform, Expected: "/usr/home/Bob/Foo"},
-		{Input: "~\\Bob\\Foo", GOOS: environment.WindowsPlatform, Expected: "/usr/home/bob/foo"},
-		{Input: "/foo/~/bar", GOOS: environment.LinuxPlatform, Expected: "/foo/~/bar"},
-		{Input: "/foo/~/bar", GOOS: environment.WindowsPlatform, Expected: "/foo/~/bar"},
-		{Input: "~/baz", GOOS: environment.LinuxPlatform, Expected: "/usr/home/baz"},
-		{Input: "~/baz", GOOS: environment.WindowsPlatform, Expected: "/usr/home/baz"},
+		{Input: "C:\\Users\\Bob\\Foo", GOOS: environment.LINUX, Expected: "C:/Users/Bob/Foo"},
+		{Input: "C:\\Users\\Bob\\Foo", GOOS: environment.WINDOWS, Expected: "c:/users/bob/foo"},
+		{Input: "~\\Bob\\Foo", GOOS: environment.LINUX, Expected: "/usr/home/Bob/Foo"},
+		{Input: "~\\Bob\\Foo", GOOS: environment.WINDOWS, Expected: "/usr/home/bob/foo"},
+		{Input: "/foo/~/bar", GOOS: environment.LINUX, Expected: "/foo/~/bar"},
+		{Input: "/foo/~/bar", GOOS: environment.WINDOWS, Expected: "/foo/~/bar"},
+		{Input: "~/baz", GOOS: environment.LINUX, Expected: "/usr/home/baz"},
+		{Input: "~/baz", GOOS: environment.WINDOWS, Expected: "/usr/home/baz"},
 	}
 
 	for _, tc := range cases {

--- a/src/segments/scm.go
+++ b/src/segments/scm.go
@@ -110,7 +110,7 @@ func (s *scm) getCommand(command string) string {
 		return s.command
 	}
 	s.command = command
-	if s.env.GOOS() == environment.WindowsPlatform || s.IsWslSharedPath {
+	if s.env.GOOS() == environment.WINDOWS || s.IsWslSharedPath {
 		s.command += ".exe"
 	}
 	return s.command

--- a/src/segments/wifi.go
+++ b/src/segments/wifi.go
@@ -24,7 +24,7 @@ func (w *Wifi) Template() string {
 
 func (w *Wifi) Enabled() bool {
 	// This segment only supports Windows/WSL for now
-	if w.env.Platform() != environment.WindowsPlatform && !w.env.IsWsl() {
+	if w.env.Platform() != environment.WINDOWS && !w.env.IsWsl() {
 		return false
 	}
 	wifiInfo, err := w.env.WifiNetwork()

--- a/src/segments/wifi_test.go
+++ b/src/segments/wifi_test.go
@@ -45,7 +45,7 @@ func TestWiFiSegment(t *testing.T) {
 
 	for _, tc := range cases {
 		env := new(mock.MockedEnvironment)
-		env.On("Platform").Return(environment.WindowsPlatform)
+		env.On("Platform").Return(environment.WINDOWS)
 		env.On("IsWsl").Return(false)
 		env.On("WifiNetwork").Return(tc.Network, tc.WifiError)
 

--- a/src/segments/winreg.go
+++ b/src/segments/winreg.go
@@ -29,7 +29,7 @@ func (wr *WindowsRegistry) Init(props properties.Properties, env environment.Env
 }
 
 func (wr *WindowsRegistry) Enabled() bool {
-	if wr.env.GOOS() != environment.WindowsPlatform {
+	if wr.env.GOOS() != environment.WINDOWS {
 		return false
 	}
 

--- a/src/segments/winreg_test.go
+++ b/src/segments/winreg_test.go
@@ -60,7 +60,7 @@ func TestWinReg(t *testing.T) {
 
 	for _, tc := range cases {
 		env := new(mock.MockedEnvironment)
-		env.On("GOOS").Return(environment.WindowsPlatform)
+		env.On("GOOS").Return(environment.WINDOWS)
 		env.On("WindowsRegistryKeyValue", tc.Path).Return(tc.getWRKVOutput, tc.Err)
 		r := &WindowsRegistry{
 			env: env,

--- a/website/docs/segments/path.mdx
+++ b/website/docs/segments/path.mdx
@@ -147,7 +147,7 @@ folders at the same level, so if `C:\projectA\dev` and `C:\projectB\dev` exist, 
 ### Properties
 
 - `.Path`: `string` - the current directory (based on the `style` property)
-- `.Parent`: `string` - the current directory's parent folder
+- `.Parent`: `string` - the current directory's parent folder (designed for use with style `folder`)
 - `.Location`: `string` - the current directory (raw value)
 - `.StackCount`: `int` - the stack count
 - `.Writable`: `boolean` - is the current directory writable by the user or not


### PR DESCRIPTION
- feat: store template cache and reuse for extra prompts
- chore: rename platform variables
- fix(path): map Parent correctly

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description

resolves #2605
relates to #2587

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
