### PR TITLE
feat(ipify): added offline response

### DIFF
--- a/src/segments/ipify.go
+++ b/src/segments/ipify.go
@@ -1,6 +1,7 @@
 package segments
 
 import (
+	"net"
 	"oh-my-posh/environment"
 	"oh-my-posh/properties"
 )
@@ -13,6 +14,8 @@ type IPify struct {
 
 const (
 	IpifyURL properties.Property = "url"
+
+	OFFLINE = "OFFLINE"
 )
 
 func (i *IPify) Template() string {
@@ -46,6 +49,9 @@ func (i *IPify) getResult() (string, error) {
 	httpTimeout := i.props.GetInt(properties.HTTPTimeout, properties.DefaultHTTPTimeout)
 
 	body, err := i.env.HTTPRequest(url, nil, httpTimeout)
+	if dnsErr, OK := err.(*net.DNSError); OK && dnsErr.IsNotFound {
+		return OFFLINE, nil
+	}
 	if err != nil {
 		return "", err
 	}

--- a/src/segments/ipify_test.go
+++ b/src/segments/ipify_test.go
@@ -2,6 +2,7 @@ package segments
 
 import (
 	"errors"
+	"net"
 	"oh-my-posh/mock"
 	"oh-my-posh/properties"
 	"testing"
@@ -36,10 +37,17 @@ func TestIpifySegment(t *testing.T) {
 			Template:        "Ext. IP: {{.IP}}",
 		},
 		{
-			Case:            "Error in retrieving data",
+			Case:            "Network Error",
 			Response:        "nonsense",
-			Error:           errors.New("Something went wrong"),
+			ExpectedString:  "",
+			Error:           errors.New("network is unreachable"),
 			ExpectedEnabled: false,
+		},
+		{
+			Case:            "Offline",
+			ExpectedString:  OFFLINE,
+			Error:           &net.DNSError{IsNotFound: true},
+			ExpectedEnabled: true,
 		},
 	}
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)


### Description
Added offline response for IPify when the HTTPRequest returns an error (httpTimeout)
### Why do that?
Because the  IPify segment can mainly be used for check online connection, personally it seems more useful if I can see when I'm offline than just returning 'null'/nothing to the shell.
![image](https://user-images.githubusercontent.com/40523695/182764456-06558890-02a0-4869-b64d-a795f4bc3b1d.png)

### About the tests:
I couldn't make a useful test that check if it's online or offline, what I did is check if `err == Get "https://api.ipify.org": dial tcp: lookup api.ipify.org: no such host`, then it will `return "OFFLINE"`, however in the case of any other error occurs, it wil `return "", err`

If approved I'll update the docs and include the description of this feature.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary