### PR TITLE
docs: fixed typo in node.mdx

### DIFF
--- a/website/docs/segments/node.mdx
+++ b/website/docs/segments/node.mdx
@@ -54,7 +54,7 @@ the URL of the version info / release notes
 - `.Patch`: `string` - patch number
 - `.URL`: `string` - URL of the version info / release notes
 - `.Error`: `string` - error encountered when fetching the version string
-- `.PackageManagerIcon`: `string` - the Yarn on NPM icon when setting `fetch_package_manager` to `true`
+- `.PackageManagerIcon`: `string` - the Yarn or NPM icon when setting `fetch_package_manager` to `true`
 - `.Mismatch`: `boolean` - if the version in `.nvmrc` matches with `.Full`
 
 [go-text-template]: https://golang.org/pkg/text/template/


### PR DESCRIPTION
Documentation for the Node segment had a tiny typo

### Prerequisites

- [ x ] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [ x ] The commit message follows the [conventional commits][cc] guidelines
- [ x ] Tests for the changes have been added (for bug fixes/features)
- [ x ] Docs have been added/updated (for bug fixes/features)

### Description

There was a typo in the documentation for the Node segment

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
