### PR TITLE
Docs revision on "Change your prompt" & "Customize"

### DIFF
--- a/website/docs/installation/customize.mdx
+++ b/website/docs/installation/customize.mdx
@@ -24,13 +24,13 @@ to change the `--config` option of the `oh-my-posh init <shell>` line in your `p
 }>
 <TabItem value="windows">
 
-When using the Windows installer (winget or Store install), you can make use of the `$POSH_THEMES` environment variable
-that points to all [themes][themes] on your file system.
+When using the Windows installer (via winget or Store), you can make use of the `POSH_THEMES_PATH` environment variable
+that points to a directory including all [themes][themes] on your file system.
 
 For example, to use the [jandedobbeleer][jandedobbeleer] theme, alter the init line like this (`powershell`):
 
 ```powershell
-oh-my-posh init pwsh --config "$env:POSH_THEMES/jandedobbeleer.omp.json" | Invoke-Expression
+oh-my-posh init pwsh --config "$env:POSH_THEMES_PATH/jandedobbeleer.omp.json" | Invoke-Expression
 ```
 
 </TabItem>

--- a/website/docs/installation/customize.mdx
+++ b/website/docs/installation/customize.mdx
@@ -139,21 +139,32 @@ Once altered, reload your config for the changes to take effect.
 Oh My Posh requires Nushell >= 0.60.0
 :::
 
-Edit `$nu.configuration/path` and add the following lines at the bottom.
+Run the following command:
 
 ```bash
 oh-my-posh init nu --config ~/.jandedobbeleer.omp.json
+```
+
+it saves the initialization script to `~/.oh-my-posh.nu` by default.
+Then edit the Nushell config file (`$nu.config-path`) and add the following line at the bottom:
+
+```bash
 source ~/.oh-my-posh.nu
 ```
 
-If you want to save the initialization script elsewhere, replace the lines above with these:
+If you want to save the initialization script elsewhere, you should run a command like:
 
 ```bash
 oh-my-posh init nu --config ~/.jandedobbeleer.omp.json --print | save /mylocation/myscript.nu
+```
+
+and add the `source` line like:
+
+```bash
 source /mylocation/myscript.nu
 ```
 
-Once altered, restart nu shell for the changes to take effect.
+Once altered, restart Nushell for the changes to take effect.
 
 </TabItem>
 </Tabs>

--- a/website/docs/installation/prompt.mdx
+++ b/website/docs/installation/prompt.mdx
@@ -160,21 +160,32 @@ exec fish
 Oh My Posh requires Nushell >= 0.60.0
 :::
 
-Edit `$nu.config-path` and add the following lines at the bottom.
+Run the following command:
 
 ```bash
 oh-my-posh init nu
+```
+
+it saves the initialization script to `~/.oh-my-posh.nu` by default.
+Then edit the Nushell config file (`$nu.config-path`) and add the following line at the bottom:
+
+```bash
 source ~/.oh-my-posh.nu
 ```
 
-If you want to save the initialization script elsewhere, replace the lines above with these:
+If you want to save the initialization script elsewhere, you should run a command like:
 
 ```bash
 oh-my-posh init nu --print | save /mylocation/myscript.nu
+```
+
+and add the `source` line like:
+
+```bash
 source /mylocation/myscript.nu
 ```
 
-Restart Nushell for the changes to take effect.
+Once added, restart Nushell for the changes to take effect.
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

1. Correct descriptions about initialization in Nushell on the "Change your prompt" & "Customize" page.

	According to [Nushell docs](https://www.nushell.sh/book/thinking_in_nu.html#think-of-nushell-as-a-compiled-language):

	> Nushell runs the whole block as if it were a single file, rather than running one line at a time.

	we should run `oh-my-posh init nu ...` to create and save the initialization script before we can add the `source` line to the Nushell config file.

2. Correct the environment variable name `POSH_THEMES` to `POSH_THEMES_PATH` on the "Customize" page.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
