### PR TITLE
theme(huvix): remove extra {} from executiontime template

### DIFF
--- a/themes/huvix.omp.json
+++ b/themes/huvix.omp.json
@@ -48,7 +48,7 @@
             "threshold": 100
           },
           "style": "powerline",
-          "template": "{{{ .FormattedMs }}}",
+          "template": "{{ .FormattedMs }}",
           "type": "executiontime"
         }
       ],


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

Fix the error caused by extra curly brackets.

Before: `@USER ➜ ~  invalid template text |`
After: `@USER ➜ ~  1.38s |`
<!--TemplateBody-->

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
