### PR TITLE
fix(pwsh): set initial value for `$script:ExecutionTime`

### DIFF
--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -15,6 +15,7 @@ function global:Get-PoshStackCount {
 
 New-Module -Name "oh-my-posh-core" -ScriptBlock {
     $script:ErrorCode = 0
+    $script:ExecutionTime = 0
     $script:OMPExecutable = ::OMP::
     $script:ShellName = "::SHELL::"
     $script:PSVersion = $PSVersionTable.PSVersion.ToString()
@@ -286,17 +287,14 @@ Example:
     }
 
     function Update-PoshErrorCode {
-        $script:ExecutionTime = -1
         $lastHistory = Get-History -ErrorAction Ignore -Count 1
         # error code should be updated only when a non-empty command is run
         if (($null -eq $lastHistory) -or ($script:LastHistoryId -eq $lastHistory.Id)) {
+            $script:ExecutionTime = 0
             return
         }
         $script:LastHistoryId = $lastHistory.Id
         $script:ExecutionTime = ($lastHistory.EndExecutionTime - $lastHistory.StartExecutionTime).TotalMilliseconds
-        if (-not ($script:ExecutionTime -is [int])) {
-            $script:ExecutionTime = 0
-        }
         if ($script:OriginalLastExecutionStatus) {
             $script:ErrorCode = 0
             return


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

@muchisx @ander-Sgr @vunhatchuong123 I cannot validate this fix because I've never been able to reproduce the bug mentioned in #2633 and #2640 on my end. 😓 Can you do a test when this goes live?

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
