### PR TITLE
Adapt git segment property documentation

### DIFF
--- a/website/docs/segments/git.mdx
+++ b/website/docs/segments/git.mdx
@@ -23,7 +23,7 @@ twice, so in case you're having a slow repository, it's better to migrate to the
 :::
 
 :::caution
-Starting from version 3.152.0, `display_status` is disabled by default.
+Starting from version 3.152.0, `fetch_status` is disabled by default.
 It improves performance but reduces the quantity of information. Don't forget to enable it in your theme if needed.
 An alternative is to use the [Posh-Git segment][poshgit].
 :::


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

The documentation states that `display_status` is disabled by default. Therefore, my first intuition was to copy the variable name and set it to `true` in the property section. However, that didn't work.
I checked `git.go` directly and couldn't find any reference for `display_status`. By setting `fetch_status` everything works as expected.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
