### PR TITLE
theme(tiwahu): mapped `shell` and new `nu` prompt

### DIFF
--- a/themes/tiwahu.omp.json
+++ b/themes/tiwahu.omp.json
@@ -128,9 +128,10 @@
           "properties": {
             "mapped_shell_names": {
               "pwsh": "\u276f",
+              "shell": "\u276f",
               "cmd": ">",
               "lua": ">",
-              "nu": ">",
+              "nu": ":)",
               "fish": "~>",
               "zsh": "%",
               "bash": "$"


### PR DESCRIPTION
### Prerequisites

- [X] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [X] The commit message follows the [conventional commits][cc] guidelines
- [ ] ~~Tests for the changes have been added (for bug fixes/features)~~
- [ ] ~~Docs have been added/updated (for bug fixes/features)~~

### Description

- Mapping for `shell` shell (used in theme example image gen, I guess)
- New `nu` shell prompt (so I can tell the difference)

<!--TemplateBody-->

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
