### PR TITLE
fix: temp fix for generic http request

### DIFF
--- a/src/http/oauth.go
+++ b/src/http/oauth.go
@@ -106,5 +106,12 @@ func OauthResult[a any](o *OAuthRequest, url string, body io.Reader, requestModi
 		return nil
 	}
 
-	return do[a](&o.Request, url, body, addToken, requestModifiers...)
+	// TEMP requestModifiers cannot be passed as parameter and modified in the local function at the same time(different variables)
+
+	var err = addToken()
+	if err != nil {
+		var data a
+		return data, err
+	}
+	return do[a](&o.Request, url, body, nil, requestModifiers...)
 }

--- a/src/http/oauth_test.go
+++ b/src/http/oauth_test.go
@@ -101,6 +101,9 @@ func TestOauthResult(t *testing.T) {
 			CacheTimeout:      60,
 			CacheJSONResponse: jsonResponse,
 			ExpectedData:      successData,
+			// temp
+			RefreshToken:  "REFRESH_TOKEN",
+			TokenResponse: tokenResponse,
 		},
 		{
 			Case:              "Cache data, invalid data",
@@ -171,6 +174,7 @@ func TestOauthResult(t *testing.T) {
 		oauth.Init(env, props)
 
 		got, err := OauthResult[*data](oauth, url, nil)
+		fmt.Println(tc.Case)
 		assert.Equal(t, tc.ExpectedData, got, tc.Case)
 		if len(tc.ExpectedErrorMessage) == 0 {
 			assert.Nil(t, err, tc.Case)


### PR DESCRIPTION
fix commit cccb50298964eec06cb89b9c051dc12b646843e8
A full fix will follow

### Prerequisites

- [X] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [X] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

The refactoring of the oauth authentication introduced a regression. Currently, the bearer token is not added anymore.

<!--TemplateBody-->

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
