### PR TITLE
feat(shell): perform cleanup for a new initialization

### DIFF
--- a/src/shell/scripts/omp.fish
+++ b/src/shell/scripts/omp.fish
@@ -55,6 +55,14 @@ function postexec_omp --on-event fish_postexec
   set --global --export omp_lastcommand $argv
 end
 
+# perform cleanup so a new initialization in current session works
+if test "$(string match -e '_render_transient' $(bind \r --user 2>/dev/null))" != ''
+  bind -e \r
+end
+if test "$(string match -e '_render_tooltip' $(bind \x20 --user 2>/dev/null))" != ''
+  bind -e \x20
+end
+
 # tooltip
 
 function _render_tooltip

--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -102,7 +102,7 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
     }
 
     if ("::TOOLTIPS::" -eq "true") {
-        Set-PSReadLineKeyHandler -Key SpaceBar -ScriptBlock {
+        Set-PSReadLineKeyHandler -Key Spacebar -BriefDescription 'OhMyPoshSpaceKeyHandler' -ScriptBlock {
             [Microsoft.PowerShell.PSConsoleReadLine]::Insert(' ')
             $position = $host.UI.RawUI.CursorPosition
             $cleanPWD, $cleanPSWD = Get-PoshContext
@@ -118,7 +118,7 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
     }
 
     if ("::TRANSIENT::" -eq "true") {
-        Set-PSReadLineKeyHandler -Key Enter -ScriptBlock {
+        Set-PSReadLineKeyHandler -Key Enter -BriefDescription 'OhMyPoshEnterKeyHandler' -ScriptBlock {
             $previousOutputEncoding = [Console]::OutputEncoding
             try {
                 $parseErrors = $null
@@ -349,6 +349,16 @@ Example:
     function Enable-PoshTooltips {}
     function Enable-PoshTransientPrompt {}
     function Enable-PoshLineError {}
+
+    # perform cleanup on removal so a new initialization in current session works
+    $ExecutionContext.SessionState.Module.OnRemove += {
+        if ((Get-PSReadLineKeyHandler -Key Spacebar).Function -eq 'OhMyPoshSpaceKeyHandler') {
+            Remove-PSReadLineKeyHandler -Key Spacebar
+        }
+        if ((Get-PSReadLineKeyHandler -Key Enter).Function -eq 'OhMyPoshEnterKeyHandler') {
+            Set-PSReadLineKeyHandler -Key Enter -Function AcceptLine
+        }
+    }
 
     Export-ModuleMember -Function @(
         "Set-PoshContext"

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -42,7 +42,15 @@ if [ "$TERM" != "linux" ]; then
   _install-omp-hooks
 fi
 
-function self-insert() {
+# perform cleanup so a new initialization in current session works
+if [[ "$(zle -lL self-insert)" = *"_posh-self-insert"* ]]; then
+  zle -N self-insert
+fi
+if [[ "$(zle -lL zle-line-init)" = *"_posh-zle-line-init"* ]]; then
+  zle -N zle-line-init
+fi
+
+function _posh-self-insert() {
   # ignore an empty buffer
   if [[ -z  "$BUFFER"  ]]; then
     zle .self-insert
@@ -50,10 +58,10 @@ function self-insert() {
   fi
   # trigger a tip check only if the input is a space character
   if [[ "$KEYS" = " " ]]; then
-    tooltip=$(::OMP:: print tooltip --config="$POSH_THEME" --shell=zsh --error="$omp_last_error" --command="$BUFFER" --shell-version="$ZSH_VERSION")
+    local tooltip=$(::OMP:: print tooltip --config="$POSH_THEME" --shell=zsh --error="$omp_last_error" --command="$BUFFER" --shell-version="$ZSH_VERSION")
   fi
   # ignore an empty tooltip
-  if [[ ! -z "$tooltip" ]]; then
+  if [[ -n "$tooltip" ]]; then
     RPROMPT=$tooltip
     zle .reset-prompt
   fi
@@ -61,7 +69,7 @@ function self-insert() {
 }
 
 if [[ "::TOOLTIPS::" = "true" ]]; then
-  zle -N self-insert
+  zle -N self-insert _posh-self-insert
 fi
 
 function _posh-zle-line-init() {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

In initialization scripts for PowerShell, fish and zsh, perform cleanup so a new initialization in the current shell session works.

- In PowerShell and fish, reset keybindings of <kbd>Enter</kbd> and <kbd>Space</kbd>.
- In zsh, reset `self-insert` and `zle-line-init` widgets.

Now it's safe to change the theme with a new initialization (`oh-my-posh init ...`) in the current shell session, which somehow makes debugging easier since we don't have to restart the shell. This partially resolved a problem in PowerShell which is mentioned [here](https://github.com/JanDeDobbeleer/oh-my-posh/pull/2643#issuecomment-1210203464). However, the trick of just changing the `POSH_THEME` environment variable will never work perfectly.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
