### PR TITLE
fix(cmd): escape special characters in a tip

### DIFF
--- a/src/shell/scripts/omp.lua
+++ b/src/shell/scripts/omp.lua
@@ -113,10 +113,13 @@ local function set_posh_tooltip(command)
     if command == nil then
         return
     end
-    -- escape double quote characters properly, if any
-    command = string.gsub(command, '\\+"', '%1%1"')
-    command = string.gsub(command, '\\+$', '%1%1')
+
+    -- escape special characters properly, if any
+    command = string.gsub(command, '(\\+)"', '%1%1"')
+    command = string.gsub(command, '(\\+)$', '%1%1')
     command = string.gsub(command, '"', '\\"')
+    command = string.gsub(command, '([&<>%(%)@%^|])', '^%1')
+
     local prompt_exe = string.format('%s print tooltip --shell=cmd %s --config=%s --command="%s"', omp_exe(), error_level_option(), omp_config(), command)
     local tooltip = run_posh_command(prompt_exe)
     if tooltip ~= "" then


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

Fix a bug where an error (`'...' is not recognized as an internal or external command`) may occur in CMD when the command contains special characters.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
