### PR TITLE
fix(shell): escape special characters correctly

### DIFF
--- a/src/color/ansi.go
+++ b/src/color/ansi.go
@@ -266,9 +266,12 @@ func (a *Ansi) ClearAfter() string {
 }
 
 func (a *Ansi) Title(title string) string {
-	// we have to do this to prevent bash from misidentifying escape sequences
-	if a.shell == shell.BASH {
-		title = strings.ReplaceAll(title, `\`, `\\`)
+	// we have to do this to prevent bash/zsh from misidentifying escape sequences
+	switch a.shell {
+	case shell.BASH:
+		title = strings.NewReplacer("`", "\\`", `\`, `\\`).Replace(title)
+	case shell.ZSH:
+		title = strings.NewReplacer("`", "\\`", `%`, `%%`).Replace(title)
 	}
 	return fmt.Sprintf(a.title, title)
 }

--- a/src/engine/segment.go
+++ b/src/engine/segment.go
@@ -395,12 +395,11 @@ func (segment *Segment) SetText() {
 	if segment.Interactive {
 		return
 	}
+	// we have to do this to prevent bash/zsh from misidentifying escape sequences
 	switch segment.env.Shell() {
-	case shell.BASH, shell.FISH:
-		segment.text = strings.ReplaceAll(segment.text, `\`, `\\`)
+	case shell.BASH:
+		segment.text = strings.NewReplacer("`", "\\`", `\`, `\\`).Replace(segment.text)
 	case shell.ZSH:
-		segment.text = strings.ReplaceAll(segment.text, `%`, `%%`)
-	case shell.PWSH, shell.PWSH5:
-		segment.text = strings.ReplaceAll(segment.text, "`", "``")
+		segment.text = strings.NewReplacer("`", "\\`", `%`, `%%`).Replace(segment.text)
 	}
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

Use the same escaping logic in the console title and segments. Fix #2715.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
