### PR TITLE
fix(environment): detect WSL shared path correctly

### DIFF
--- a/src/environment/shell_unix.go
+++ b/src/environment/shell_unix.go
@@ -98,7 +98,11 @@ func (env *ShellEnvironment) WindowsRegistryKeyValue(path string) (*WindowsRegis
 }
 
 func (env *ShellEnvironment) InWSLSharedDrive() bool {
-	return env.IsWsl() && strings.HasPrefix(env.Pwd(), "/mnt/c")
+	if !env.IsWsl() {
+		return false
+	}
+	windowsPath := env.ConvertToWindowsPath(env.Pwd())
+	return !strings.HasPrefix(windowsPath, `\\wsl.localhost`)
 }
 
 func (env *ShellEnvironment) ConvertToWindowsPath(path string) string {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

This is a follow-up fix for 199993b, which detects any WSL shared paths under `/mnt` correctly and supports symlinks.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
