### PR TITLE
fix(scm): convert to Windows path with `/` instead of `\`

### DIFF
--- a/src/environment/shell_unix.go
+++ b/src/environment/shell_unix.go
@@ -106,7 +106,7 @@ func (env *ShellEnvironment) InWSLSharedDrive() bool {
 }
 
 func (env *ShellEnvironment) ConvertToWindowsPath(path string) string {
-	windowsPath, err := env.RunCommand("wslpath", "-w", path)
+	windowsPath, err := env.RunCommand("wslpath", "-m", path)
 	if err == nil {
 		return windowsPath
 	}

--- a/src/environment/shell_windows.go
+++ b/src/environment/shell_windows.go
@@ -228,7 +228,7 @@ func (env *ShellEnvironment) InWSLSharedDrive() bool {
 }
 
 func (env *ShellEnvironment) ConvertToWindowsPath(path string) string {
-	return path
+	return strings.ReplaceAll(path, `\`, "/")
 }
 
 func (env *ShellEnvironment) ConvertToLinuxPath(path string) string {

--- a/src/segments/scm.go
+++ b/src/segments/scm.go
@@ -94,10 +94,10 @@ func (s *scm) FileContents(folder, file string) string {
 }
 
 func (s *scm) convertToWindowsPath(path string) string {
-	if !s.IsWslSharedPath {
-		return path
+	if s.env.GOOS() == environment.WINDOWS || s.IsWslSharedPath {
+		return s.env.ConvertToWindowsPath(path)
 	}
-	return s.env.ConvertToWindowsPath(path)
+	return path
 }
 
 func (s *scm) convertToLinuxPath(path string) string {

--- a/src/segments/svn.go
+++ b/src/segments/svn.go
@@ -81,7 +81,7 @@ func (s *Svn) shouldDisplay() bool {
 		s.workingDir = Svndir.Path
 		s.rootDir = Svndir.Path
 		// convert the worktree file path to a windows one when in wsl 2 shared folder
-		s.realDir = strings.TrimSuffix(s.convertToWindowsPath(Svndir.Path), ".svn")
+		s.realDir = strings.TrimSuffix(s.convertToWindowsPath(Svndir.Path), "/.svn")
 		return true
 	}
 	// handle worktree


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

This will fix a bug where a `git` command fails on Windows or in a WSL shared path. Related commit: 4213be5.

Part of `oh-my-posh debug` output on my end:

```
2022/08/29 19:49:14 error: RunCommand
cmd.Run() failed
2022/08/29 19:49:14 debug: RunCommand
fatal: this operation must be run in a work tree

2022/08/29 19:49:14 RunCommand duration: 85.743103ms, args: git.exe -C C:\Users\LY\projs\oh-my-posh\.git --no-optional-locks -c core.quotepath=false -c color.status=false status -unormal --branch --porcelain=2
```

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
