### PR TITLE
Fix bugs about paths

### DIFF
--- a/src/environment/shell_unix.go
+++ b/src/environment/shell_unix.go
@@ -102,7 +102,7 @@ func (env *ShellEnvironment) InWSLSharedDrive() bool {
 		return false
 	}
 	windowsPath := env.ConvertToWindowsPath(env.Pwd())
-	return !strings.HasPrefix(windowsPath, `//wsl.localhost`) && !strings.HasPrefix(windowsPath, `//wsl$`)
+	return !strings.HasPrefix(windowsPath, `//wsl.localhost/`) && !strings.HasPrefix(windowsPath, `//wsl$/`)
 }
 
 func (env *ShellEnvironment) ConvertToWindowsPath(path string) string {

--- a/src/segments/path.go
+++ b/src/segments/path.go
@@ -357,8 +357,8 @@ func (pt *Path) replaceMappedLocations(pwd string) string {
 
 	mappedLocations := map[string]string{}
 	if pt.props.GetBool(MappedLocationsEnabled, true) {
-		mappedLocations["HKCU:"] = pt.props.GetString(WindowsRegistryIcon, "\uF013")
-		mappedLocations["HKLM:"] = pt.props.GetString(WindowsRegistryIcon, "\uF013")
+		mappedLocations["hkcu:"] = pt.props.GetString(WindowsRegistryIcon, "\uF013")
+		mappedLocations["hklm:"] = pt.props.GetString(WindowsRegistryIcon, "\uF013")
 		mappedLocations[pt.normalize(pt.env.Home())] = pt.props.GetString(HomeIcon, "~")
 	}
 

--- a/src/segments/python_test.go
+++ b/src/segments/python_test.go
@@ -79,6 +79,7 @@ func TestPythonTemplate(t *testing.T) {
 
 	for _, tc := range cases {
 		env := new(mock.MockedEnvironment)
+		env.On("GOOS").Return("")
 		env.On("HasCommand", "python").Return(true)
 		env.On("CommandPath", mock2.Anything).Return(tc.PythonPath)
 		env.On("RunCommand", "python", []string{"--version"}).Return("Python 3.8.4", nil)
@@ -118,6 +119,7 @@ func TestPythonPythonInContext(t *testing.T) {
 
 	for _, tc := range cases {
 		env := new(mock.MockedEnvironment)
+		env.On("GOOS").Return("")
 		env.On("PathSeparator").Return("")
 		env.On("Getenv", "VIRTUAL_ENV").Return(tc.VirtualEnvName)
 		env.On("Getenv", "CONDA_ENV_PATH").Return("")

--- a/src/segments/svn.go
+++ b/src/segments/svn.go
@@ -62,8 +62,7 @@ func (s *Svn) Enabled() bool {
 }
 
 func (s *Svn) shouldDisplay() bool {
-	// when in wsl/wsl2 and in a windows shared folder
-	// we must use Svn.exe and convert paths accordingly
+	// when in a WSL shared folder, we must use git.exe and convert paths accordingly
 	// for worktrees, stashes, and path to work
 	s.IsWslSharedPath = s.env.InWSLSharedDrive()
 	if !s.env.HasCommand(s.getCommand(SVNCOMMAND)) {
@@ -80,7 +79,7 @@ func (s *Svn) shouldDisplay() bool {
 	if Svndir.IsDir {
 		s.workingDir = Svndir.Path
 		s.rootDir = Svndir.Path
-		// convert the worktree file path to a windows one when in wsl 2 shared folder
+		// convert the worktree file path to a windows one when in a WSL shared folder
 		s.realDir = strings.TrimSuffix(s.convertToWindowsPath(Svndir.Path), "/.svn")
 		return true
 	}
@@ -89,10 +88,9 @@ func (s *Svn) shouldDisplay() bool {
 	dirPointer := strings.Trim(s.env.FileContent(Svndir.Path), " \r\n")
 	matches := regex.FindNamedRegexMatch(`^Svndir: (?P<dir>.*)$`, dirPointer)
 	if matches != nil && matches["dir"] != "" {
-		// if we open a worktree file in a shared wsl2 folder, we have to convert it back
+		// if we open a worktree file in a WSL shared folder, we have to convert it back
 		// to the mounted path
 		s.workingDir = s.convertToLinuxPath(matches["dir"])
-		return false
 	}
 	return false
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

Fix two bugs:

1. `.Dir` and `.RepoName` are not correctly populated in a `git` segment. Related comment: https://github.com/JanDeDobbeleer/oh-my-posh/discussions/2717#discussioncomment-3522468.

2. On Windows, the registry path prefix `HKCU:` and `HKLM:` don't map to a default registry icon (`\uF013`) even if the property is not customized.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
