### PR TITLE
Update to sample code in commands.mdx

### DIFF
--- a/website/docs/segments/command.mdx
+++ b/website/docs/segments/command.mdx
@@ -33,7 +33,7 @@ error). The `&&` functionality will join the output of the commands when success
       "foreground": "#ffffff",
       "properties": {
         "shell": "bash",
-        "command": "git log --pretty=format:%cr -1 || date +%H:%m:%S"
+        "command": "git log --pretty=format:%cr -1 || date +%H:%M:%S"
       }
     }
   ]


### PR DESCRIPTION
Hello, 
There is a small mixup with the command used to represent minutes in the sample configuration code.

`date +%m` displays the month[01-12]

`date +%M` displays the minutes[00-59]

So to display the system time, it should be `%M` instead.

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [ ] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

<!--TemplateBody-->

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
