### PR TITLE
Update to sample code and theme

### DIFF
--- a/themes/pararussel.omp.json
+++ b/themes/pararussel.omp.json
@@ -43,7 +43,7 @@
         {
           "foreground": "#ffffff",
           "properties": {
-            "command": "git log --pretty=format:%cr -1 || date +%H:%m:%S",
+            "command": "git log --pretty=format:%cr -1 || date +%H:%M:%S",
             "shell": "bash"
           },
           "style": "plain",

--- a/website/docs/configuration/line-error.mdx
+++ b/website/docs/configuration/line-error.mdx
@@ -30,9 +30,9 @@ You need to extend or create a custom theme with your prompt overrides. For exam
 ```json
 {
     "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
-    "blocks": {
+    "blocks": [
         ...
-    },
+    ],
     "valid_line": {
         "background": "transparent",
         "foreground": "#ffffff",

--- a/website/docs/segments/command.mdx
+++ b/website/docs/segments/command.mdx
@@ -33,7 +33,7 @@ error). The `&&` functionality will join the output of the commands when success
       "foreground": "#ffffff",
       "properties": {
         "shell": "bash",
-        "command": "git log --pretty=format:%cr -1 || date +%H:%m:%S"
+        "command": "git log --pretty=format:%cr -1 || date +%H:%M:%S"
       }
     }
   ]


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

Hello,
There is a mixup with the command used to represent minutes in the sample configuration code in commands.mdx

`date +%m` displays the month[01-12]
`date +%M` displays the minutes[00-59]

So to display the proper time, it should be `%M` instead.
The same error in pararussel theme is also fixed in this 

Thank you.