### PR TITLE
docs: themes linking to master branch caused 404s

### DIFF
--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -42,7 +42,7 @@ A [block][block] has properties that indicate its position and the [segments][se
 A [segment][segment] renders a single context like showing the current folder, user information or git status
 when relevant. It can be styled any way you want, resulting in visualizing the prompt you are looking for.
 
-For your convenience, the existing [themes][themes] from [Oh My Posh][omp-themes] have been added to version 3, so you
+For your convenience, the existing [themes][themes] from [Oh My Posh][themes] have been added to version 3, so you
 can get started even without having to understand the theming. So, let's no longer waste time on theory, have a look at the
 installation guide to get started right away!
 
@@ -50,4 +50,3 @@ installation guide to get started right away!
 [block]: /docs/configuration/block
 [segment]: /docs/configuration/segment
 [themes]: https://github.com/JanDeDobbeleer/oh-my-posh/tree/main/themes
-[omp-themes]: https://github.com/JanDeDobbeleer/oh-my-posh/tree/master/Themes


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

Just a simple fix for an incorrect docs link

