### PR TITLE
chore: allow commit body lines of 200 characters

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -15,6 +15,10 @@ rules:
     - perf
     - test
     - revert
+  body-max-line-length:
+    - 2
+    - always
+    - 200
 help: |
   **Possible types**:
   `chore`:    Change build process, tooling or dependencies.


### PR DESCRIPTION
dependabot is limited in its capabilities

### Prerequisites

- [ ] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [ ] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

<!--TemplateBody-->

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
