### PR TITLE
fix(pwsh): disable tooltips for `ConstrainedLanguage` mode

### DIFF
--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -101,7 +101,7 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
         }
     }
 
-    if ("::TOOLTIPS::" -eq "true") {
+    if (("::TOOLTIPS::" -eq "true") -and ($ExecutionContext.SessionState.LanguageMode -ne "ConstrainedLanguage")) {
         Set-PSReadLineKeyHandler -Key Spacebar -BriefDescription 'OhMyPoshSpaceKeyHandler' -ScriptBlock {
             [Microsoft.PowerShell.PSConsoleReadLine]::Insert(' ')
             $position = $host.UI.RawUI.CursorPosition
@@ -112,7 +112,7 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
             Write-Host $standardOut -NoNewline
             $host.UI.RawUI.CursorPosition = $position
             # we need this workaround to prevent the text after cursor from disappearing when the tooltip is rendered
-            [Microsoft.PowerShell.PSConsoleReadLine]::Insert(" ")
+            [Microsoft.PowerShell.PSConsoleReadLine]::Insert(' ')
             [Microsoft.PowerShell.PSConsoleReadLine]::Undo()
         }
     }

--- a/website/docs/configuration/tooltips.mdx
+++ b/website/docs/configuration/tooltips.mdx
@@ -8,8 +8,8 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
 :::info
-Due to limitations (or not having found a way just yet), this feature only works in `fish`, `zsh`, `powershell` and `cmd` (as of [Clink][clink] v1.2.46+) for
-the time being.
+Due to limitations (or not having found a way just yet), this feature only works in `fish`, `zsh`, `powershell`
+(`ConstrainedLanguage` mode unsupported) and `cmd` (as of [Clink][clink] v1.2.46+) for the time being.
 :::
 
 ![Tooltip Demo](/img/posh-tooltip.gif)

--- a/website/docs/configuration/transient.mdx
+++ b/website/docs/configuration/transient.mdx
@@ -8,7 +8,7 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
 :::info
-This feature only works in `fish`, `zsh`, `powershell` and `cmd` for the time being.
+This feature only works in `fish`, `zsh`, `powershell` (`ConstrainedLanguage` mode unsupported) and `cmd` for the time being.
 :::
 
 Transient prompt, when enabled, replaces the prompt with a simpler one to allow more screen real estate.

--- a/website/docs/faq.mdx
+++ b/website/docs/faq.mdx
@@ -195,7 +195,7 @@ SAVEHIST=10000
 setopt appendhistory
 ```
 
-### Fish: $( ... ) is not supported
+### Fish: $(...) is not supported
 
 You should update fish to v3.4.0 or higher. Fish supports `$(...)` and `"$(...)"` since v3.4.0, as described in its [changelog][fish-changelog].
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

The reason is the same as that for disabling the transient prompt in `ConstrainedLanguage` mode.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
