### PR TITLE
theme: updated lambdageneration to view date

### DIFF
--- a/themes/lambdageneration.omp.json
+++ b/themes/lambdageneration.omp.json
@@ -100,10 +100,10 @@
           "background": "#292929",
           "foreground": "#fb7e14",
           "properties": {
-            "time_format": "15:04:05"
+            "time_format": "15:04:05, _2"
           },
           "style": "diamond",
-          "template": "{{ .CurrentDate | date .Format }} \uf017 ",
+          "template": "{{ .CurrentDate | date .Format }} \uf5ef ",
           "trailing_diamond": "\ue0b4",
           "type": "time"
         }


### PR DESCRIPTION
Previously, the date was not visible in lambdageneration theme even when the CurrentDate element is in there in JSON. Added a little code in lines 103 and 106 to view the date.

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description
Date is not visible in **lambdageneration** theme, even when the _.CurrentDate_ element is there in [JSON](https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/themes/lambdageneration.omp.json)


<!--TemplateBody-->

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
