### PR TITLE
theme(poshmon): show date

### DIFF
--- a/themes/poshmon.omp.json
+++ b/themes/poshmon.omp.json
@@ -92,7 +92,7 @@
           ],
           "leading_diamond": "\ue0b6",
           "properties": {
-            "time_format": "15:04:05"
+            "time_format": "_2, 15:04:05"
           },
           "style": "diamond",
           "template": " \uf5ef {{ .CurrentDate | date .Format }} ",


### PR DESCRIPTION
Added changes to show date in prompt.

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description
Even when the currentdate element was there in the JSON, and the calendar icon was in the prompt. It was not showing the date. Added changes to check that. 
<!--TemplateBody-->

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
