### PR TITLE
theme(atomicBit): show calendar icon

### DIFF
--- a/themes/atomicBit.omp.json
+++ b/themes/atomicBit.omp.json
@@ -149,7 +149,7 @@
             "time_format": "_2,15:04"
           },
           "style": "plain",
-          "template": "<#ffffff>[</>{{ .CurrentDate | date .Format }}<#ffffff>]</>",
+          "template": "<#ffffff>[</>\uf5ef{{ .CurrentDate | date .Format }}<#ffffff>]</>",
           "type": "time"
         }
       ],


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description
Updated line 152 to show the calendar icon at the right of the date and time.

<!--TemplateBody-->

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
