### PR TITLE
theme: add catppuccin

### DIFF
--- a/themes/catppuccin.omp.json
+++ b/themes/catppuccin.omp.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
+  "blocks": [
+    {
+      "alignment": "left",
+      "segments": [
+        {
+          "background": "#8AADF4",
+          "foreground": "#ffffff",
+          "powerline_symbol": "\ue0b4",
+          "leading_diamond": "\ue0b6",
+          "properties": {
+            "style": "full",
+            "alpine": "\uf300",
+            "arch": "\uf303",
+            "centos": "\uf304",
+            "debian": "\uf306",
+            "elementary": "\uf309",
+            "fedora": "\uf30a",
+            "gentoo": "\uf30d",
+            "linux": "\ue712",
+            "macos": "\ue711",
+            "manjaro": "\uf312",
+            "mint": "\uf30f",
+            "opensuse": "\uf314",
+            "raspbian": "\uf315",
+            "ubuntu": "\uebc9",
+            "windows": "\ue70f"
+          },
+          "style": "diamond",
+          "template": "{{.Icon}}",
+          "type": "os"
+        },
+        {
+          "background": "#8AADF4",
+          "foreground": "#494D64",
+          "powerline_symbol": "\ue0b4",
+          "style": "diamond",
+          "template": " {{ .UserName }} ",
+          "type": "session"
+        },
+        {
+          "background": "#F5BDE6",
+          "foreground": "#494D64",
+          "properties": {
+            "folder_icon": "<#494D64>..\ue5fe..</>",
+            "home_icon": "\uf015",
+            "style": "agnoster_short"
+          },
+          "powerline_symbol": "\ue0b4",
+          "style": "powerline",
+          "template": " {{ .Path }} ",
+          "type": "path"
+        },
+        {
+          "background": "#B7BDF8",
+          "foreground": "#494D64",
+          "style": "powerline",
+          "properties": {
+            "branch_icon": "\ue725 ",
+            "cherry_pick_icon": "\ue29b ",
+            "commit_icon": "\uf417 ",
+            "fetch_status": false,
+            "fetch_upstream_icon": false,
+            "merge_icon": "\ue727 ",
+            "no_commits_icon": "\uf594 ",
+            "rebase_icon": "\ue728 ",
+            "revert_icon": "\uf0e2 ",
+            "tag_icon": "\uf412 "
+          },
+          "powerline_symbol": "\ue0b4",
+          "template": " {{ .HEAD }} ",
+          "type": "git"
+        }
+      ],
+      "type": "prompt"
+    }
+  ],
+  "final_space": true,
+  "version": 2
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the contributing guide
- [x] The commit message follows the conventional commits guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description
 
Catppuccin is a community-driven pastel theme that aims to be the middle ground between low and high contrast themes. It consists of 4 soothing warm palettes with 26 eye-candy colors each, perfect for coding, designing, and much more!

More detailed information can be found at the links:
 https://github.com/IrwinJuice/catppuccin.omp
https://github.com/catppuccin
