### PR TITLE
fix:minor change in gcp segment doc

### DIFF
--- a/website/docs/segments/gcp.mdx
+++ b/website/docs/segments/gcp.mdx
@@ -17,7 +17,7 @@ Display the currently active GCP project, region and account
   "powerline_symbol": "\uE0B0",
   "foreground": "#ffffff",
   "background": "#47888d",
-  "template": " \uE7B2 {{.Project} :: {{.Account}} "
+  "template": " \uE7B2 {{.Project}} :: {{.Account}} "
 }
 ```
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description
Added a curly brace in GCP segment documentation because without the now added curly brace the GCP segment rendered `invalid template text` on prompt as seen here.
![image](https://user-images.githubusercontent.com/57610394/194270661-481b9264-9e9a-45c7-aad1-00c8c291c5c0.png)

<!--TemplateBody-->

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
