### PR TITLE
docs(iterm): corrected documentation and theme

### DIFF
--- a/themes/devious-diamonds.omp.yaml
+++ b/themes/devious-diamonds.omp.yaml
@@ -5,6 +5,7 @@ blocks:
     newline: true
     segments:
       - type: iterm
+        interactive: true
         style: plain
         foreground: cyan
         template: "{{ .PromptMark }}"

--- a/website/docs/segments/iterm.mdx
+++ b/website/docs/segments/iterm.mdx
@@ -19,6 +19,7 @@ You will need to set env var `ITERM2_SQUELCH_MARK = 1` prior to initiating Oh My
 ```json
 {
   "type": "iterm",
+  "interactive": true,
   "style": "plain",
   "foreground": "#80ffea",
   "template": "{{ .PromptMark }}"


### PR DESCRIPTION
### Prerequisites
- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description
iTerm segment requires that the `interactive` property be set to `true` for proper operation.
The segment generates code that runs in the shell and cannot be escaped.
