### PR TITLE
docs: improve zsh example with correct initialization

### DIFF
--- a/website/docs/installation/prompt.mdx
+++ b/website/docs/installation/prompt.mdx
@@ -106,7 +106,7 @@ Note this will still load Oh My Posh for [iTerm2][iterm2] or any other modern da
 Once added, reload your profile for the changes to take effect.
 
 ```bash
-source ~/.zshrc
+exec zsh
 ```
 
 </TabItem>


### PR DESCRIPTION
For zsh, eval isn't the correct way to reload.
Changed to `exec zsh`, which could also be `exec zsh -l` for login shell.

This is helpful when reloading to avoid scope and other issues. See for example a brief write-up [reload-zsh-configuration](https://batsov.com/articles/2022/09/15/reload-zsh-configuration/)

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

<!--TemplateBody-->

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
