### PR TITLE
Support Nushell v0.70.0+

### DIFF
--- a/src/shell/scripts/omp.nu
+++ b/src/shell/scripts/omp.nu
@@ -17,7 +17,7 @@ export-env {
         # See https://github.com/nushell/nushell/discussions/6402#discussioncomment-3466687.
         let cmd_duration = if $env.CMD_DURATION_MS == "0823" { 0 } else { $env.CMD_DURATION_MS }
 
-        let width = (term size -c | get columns | into string)
+        let width = ((term size).columns | into string)
         ^::OMP:: print primary $"--config=($env.POSH_THEME)" --shell=nu $"--shell-version=($env.NU_VERSION)" $"--execution-time=($cmd_duration)" $"--error=($env.LAST_EXIT_CODE)" $"--terminal-width=($width)"
     }
 }

--- a/website/docs/installation/customize.mdx
+++ b/website/docs/installation/customize.mdx
@@ -160,7 +160,7 @@ Once altered, reload your config for the changes to take effect.
 <TabItem value="nu">
 
 :::caution
-Oh My Posh requires Nushell v0.68.1 or higher.
+Oh My Posh requires Nushell v0.70.0 or higher.
 :::
 
 Run the following command:

--- a/website/docs/installation/prompt.mdx
+++ b/website/docs/installation/prompt.mdx
@@ -153,7 +153,7 @@ exec fish
 <TabItem value="nu">
 
 :::caution
-Oh My Posh requires Nushell v0.68.1 or higher.
+Oh My Posh requires Nushell v0.70.0 or higher.
 :::
 
 Run the following command:


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description

According to Nushell's [release note](https://www.nushell.sh/blog/2022-10-18-nushell-0_70.html), the `-c` flag for `term size` has been removed, which is a breaking change, IMO. 😅 (Related: nushell/nushell#6651.) So we will get an error:

```
The `term size` command doesn't have flag `-c`.
```

in the initialization. To resolve this, we have to use `(term size).columns` instead.

This PR will also update the minimum supported Nushell version to 0.70.0.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
