### PR TITLE
fix(scoop): innosetup package installation

### DIFF
--- a/packages/scoop/oh-my-posh.json
+++ b/packages/scoop/oh-my-posh.json
@@ -16,12 +16,6 @@
       "hash": "<HASH-386>"
     }
   },
-  "installer": {
-    "args": [
-      "/CURRENTUSER",
-      "/VERYSILENT"
-    ]
-  },
   "innosetup": true,
   "checkver": {
     "github": "https://github.com/JanDeDobbeleer/oh-my-posh"


### PR DESCRIPTION
scoop will extract innosetup package directly when enabling `"innosetup": true,`, conflicting with the `installer` config

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

<!--TemplateBody-->

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
