### PR TITLE
feat(dotnettarget): add dotnettarget segment

### DIFF
--- a/src/engine/segment.go
+++ b/src/engine/segment.go
@@ -106,6 +106,8 @@ const (
 	DENO SegmentType = "deno"
 	// DOTNET writes which dotnet version is currently active
 	DOTNET SegmentType = "dotnet"
+	// DOTNETTARGET writes which version of .NET the current project is targeting
+	DOTNETTARGET SegmentType = "dotnettarget"
 	// EXECUTIONTIME writes the execution time of the last run command
 	EXECUTIONTIME SegmentType = "executiontime"
 	// EXIT writes the last exit code
@@ -283,6 +285,7 @@ func (segment *Segment) mapSegmentWithWriter(env environment.Environment) error 
 		DART:          &segments.Dart{},
 		DENO:          &segments.Deno{},
 		DOTNET:        &segments.Dotnet{},
+		DOTNETTARGET:  &segments.DotnetTarget{},
 		EXECUTIONTIME: &segments.Executiontime{},
 		EXIT:          &segments.Exit{},
 		FLUTTER:       &segments.Flutter{},

--- a/src/segments/dotnet_target.go
+++ b/src/segments/dotnet_target.go
@@ -2,12 +2,10 @@ package segments
 
 import (
 	"errors"
-	"fmt"
 	"oh-my-posh/environment"
 	"oh-my-posh/properties"
 	"oh-my-posh/regex"
 	"strings"
-	"time"
 )
 
 type DotnetTarget struct {
@@ -53,7 +51,6 @@ func (d *DotnetTarget) Enabled() bool {
 }
 
 func (d *DotnetTarget) getProjectFiles() []string {
-	defer d.env.Trace(time.Now(), "getProjectFiles")
 	var files []string
 	for _, extension := range d.extensions {
 		cwd := d.env.Pwd()
@@ -65,8 +62,6 @@ func (d *DotnetTarget) getProjectFiles() []string {
 			}
 		}
 	}
-	total := fmt.Sprintf("%d file(s) found", len(files))
-	d.env.Log(environment.Debug, "getProjectFiles", total)
 	return files
 }
 

--- a/src/segments/dotnet_target.go
+++ b/src/segments/dotnet_target.go
@@ -1,0 +1,105 @@
+package segments
+
+import (
+	"errors"
+	"fmt"
+	"oh-my-posh/environment"
+	"oh-my-posh/properties"
+	"oh-my-posh/regex"
+	"strings"
+	"time"
+)
+
+type DotnetTarget struct {
+	props      properties.Properties
+	env        environment.Environment
+	extensions []string
+
+	Text  string
+	Error string
+}
+
+const (
+	tfmRegex = "(?P<tag><.*TargetFramework.*>(?P<tfm>.*)</.*TargetFramework.*>)"
+)
+
+func (d *DotnetTarget) Template() string {
+	return " {{ if .Error }}{{ .Error }}{{ else }}{{ .Text }}{{ end }} "
+}
+
+func (d *DotnetTarget) Init(props properties.Properties, env environment.Environment) {
+	d.props = props
+	d.env = env
+	d.extensions = []string{".csproj", ".vbproj", ".fsproj"}
+}
+
+func (d *DotnetTarget) Enabled() bool {
+	files := d.getProjectFiles()
+	if len(files) < 1 {
+		return false
+	}
+	tfms := make([]string, len(files))
+	displayError := d.props.GetBool(properties.DisplayError, false)
+	for i, file := range files {
+		tfm, err := d.extractTFM(file)
+		if err != nil {
+			d.Error = err.Error()
+			return displayError
+		}
+		tfms[i] = tfm
+	}
+	d.Text = d.unifyTFMs(tfms)
+	return true
+}
+
+func (d *DotnetTarget) getProjectFiles() []string {
+	defer d.env.Trace(time.Now(), "getProjectFiles")
+	var files []string
+	for _, extension := range d.extensions {
+		cwd := d.env.Pwd()
+		entries := d.env.LsDir(cwd)
+		for _, entry := range entries {
+			name := entry.Name()
+			if strings.HasSuffix(name, extension) && !entry.IsDir() {
+				files = append(files, name)
+			}
+		}
+	}
+	total := fmt.Sprintf("%d file(s) found", len(files))
+	d.env.Log(environment.Debug, "getProjectFiles", total)
+	return files
+}
+
+func (d *DotnetTarget) extractTFM(file string) (string, error) {
+	content := d.env.FileContent(file)
+	values := regex.FindNamedRegexMatch(tfmRegex, content)
+	if len(values) == 0 {
+		return "", errors.New("cannot extract TFM from " + file)
+	}
+	return values["tfm"], nil
+}
+
+// If (somehow!!!) there will be several TFMs,
+// this command will combine them and remove duplicates.
+func (d *DotnetTarget) unifyTFMs(tfms []string) string {
+	// The monikers inside <TargetFrameworks> tag are separated by a semicolon,
+	// so we join them in a single string first
+	tfmsStr := strings.Join(tfms, ";")
+	// and then split to select the unique instances
+	tfmsArr := strings.Split(tfmsStr, ";")
+	uniqueArr := unique(tfmsArr)
+	return strings.Join(uniqueArr, ";")
+}
+
+func unique(arr []string) []string {
+	occurred := map[string]bool{}
+	result := []string{}
+	for e := range arr {
+		if !occurred[arr[e]] {
+			occurred[arr[e]] = true
+			result = append(result, arr[e])
+		}
+	}
+
+	return result
+}

--- a/src/segments/dotnet_target_test.go
+++ b/src/segments/dotnet_target_test.go
@@ -1,0 +1,73 @@
+package segments
+
+import (
+	"io/fs"
+	"oh-my-posh/mock"
+	"oh-my-posh/properties"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type DotnetProjectFile struct{}
+
+func (d DotnetProjectFile) Name() string { return "Foo.csproj" }
+func (d DotnetProjectFile) IsDir() bool  { return false }
+func (d DotnetProjectFile) Type() fs.FileMode {
+	var mode fs.FileMode
+	return mode
+}
+func (d DotnetProjectFile) Info() (fs.FileInfo, error) {
+	var info fs.FileInfo
+	return info, nil
+}
+
+func TestDotnetTargetSegment(t *testing.T) {
+	cwd := "/usr/home/project"
+	file := DotnetProjectFile{}
+
+	cases := []struct {
+		Case            string
+		ExpectedString  string
+		ExpectedEnabled bool
+		FileContent     string
+		DisplayError    bool
+	}{
+		{
+			Case:            "No project files found",
+			ExpectedEnabled: false,
+		},
+		{
+			Case:            "Empty project file",
+			ExpectedString:  "cannot extract TFM from " + file.Name(),
+			ExpectedEnabled: true,
+			FileContent:     "",
+			DisplayError:    true,
+		},
+		{
+			Case:            "Regular project file",
+			ExpectedString:  "netcoreapp3.1",
+			ExpectedEnabled: true,
+			FileContent:     "...<TargetFramework>netcoreapp3.1</TargetFramework>...",
+		},
+	}
+
+	for _, tc := range cases {
+		env := new(mock.MockedEnvironment)
+		env.On("Pwd").Return(cwd)
+		if tc.ExpectedEnabled {
+			env.On("LsDir", cwd).Return([]fs.DirEntry{file})
+		} else {
+			env.On("LsDir", cwd).Return([]fs.DirEntry{})
+		}
+		env.On("FileContent", file.Name()).Return(tc.FileContent)
+		props := properties.Map{
+			properties.DisplayError: tc.DisplayError,
+		}
+		dotnettarget := &DotnetTarget{}
+		dotnettarget.Init(props, env)
+		enabled := dotnettarget.Enabled()
+		assert.Equal(t, tc.ExpectedEnabled, enabled, tc.Case)
+		assert.Equal(t, tc.ExpectedString, renderTemplate(env, dotnettarget.Template(), dotnettarget), tc.Case)
+	}
+}

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -232,6 +232,7 @@
             "cftarget",
             "cmake",
             "dotnet",
+            "dotnettarget",
             "dart",
             "exit",
             "executiontime",
@@ -2804,6 +2805,31 @@
           "then": {
             "title": "GCP Segment",
             "description": "https://ohmyposh.dev/docs/segments/gcp"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "dotnettarget"
+              }
+            }
+          },
+          "then": {
+            "title": "Dotnet Target segment",
+            "description": "https://ohmyposh.dev/docs/segments/dotnettarget",
+            "properties": {
+              "properties": {
+                "properties": {
+                  "display_error": {
+                    "type": "boolean",
+                    "title": "Display Error",
+                    "description": "Show the error when failing to retrieve the target framework moniker",
+                    "default": false
+                  }
+                }
+              }
+            }
           }
         }
       ]

--- a/website/docs/segments/dotnettarget.mdx
+++ b/website/docs/segments/dotnettarget.mdx
@@ -1,0 +1,56 @@
+---
+id: dotnettarget
+title: Dotnet Target
+sidebar_label: Dotnet Target
+---
+
+## What
+
+Display target framework moniker ([TFM][tfm]) of the current project.
+
+:::note
+
+*If the working directory contains multiple projects (which is considered very bad tone!), the segment will combine their monikers and remove duplicate versions, like in this example:*
+
+`net6.0;net5.0` + `net5.0;net48` = `net6.0;net5.0;net48`
+
+:::
+
+## Sample Configuration
+
+```json
+{
+  "type": "dotnettarget",
+  "style": "powerline",
+  "powerline_symbol": "\ue0b0",
+  "foreground": "#e8eef1",
+  "background": "#3d4b91",
+  "template": " \uE77F {{ .Text }} "
+}
+```
+
+## Properties
+
+| Name                   | Type      | Description                                                                                                                                                                                                                          |
+| ---------------------- | --------- | -------------------------------------------------------------------------------------------|
+| `display_error`        | `boolean` | show the error when failing to retrieve the target framework moniker - defaults to `false` |
+
+## Template ([info][templates])
+
+:::note default template
+
+```template
+{{ if .Error }}{{ .Error }}{{ else }}{{ .Text }}{{ end }}
+```
+
+:::
+
+### Properties
+
+| Name             | Type     | Description                                             |
+| ---------------- | -------- | ------------------------------------------------------- |
+| `.Text`          | `string` | the target framework moniker (TFM)                      |
+| `.Error`         | `string` | the error in case retrieving the TFM information failed |
+
+[templates]: /docs/configuration/templates
+[tfm]: https://learn.microsoft.com/en-us/dotnet/standard/frameworks

--- a/website/docs/segments/dotnettarget.mdx
+++ b/website/docs/segments/dotnettarget.mdx
@@ -6,7 +6,7 @@ sidebar_label: Dotnet Target
 
 ## What
 
-Display target framework moniker ([TFM][tfm]) of the current project.
+Display the target framework moniker ([TFM][tfm]) of the current project.
 
 :::note
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -67,6 +67,7 @@ module.exports = {
         "segments/dart",
         "segments/deno",
         "segments/dotnet",
+        "segments/dotnettarget",
         "segments/executiontime",
         "segments/exit",
         "segments/flutter",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description

This PR adds a new segment to display the target .NET framework version moniker (TFM) of the current project.

Resolves #1568

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
