### PR TITLE
Add red cross after git repo

### DIFF
--- a/themes/ys.omp.json
+++ b/themes/ys.omp.json
@@ -48,8 +48,11 @@
         },
         {
           "style": "plain",
-          "template": "<darkGray>on</> <white>git:</><cyan>{{ .HEAD }}</> ",
-          "type": "git"
+          "template": "<darkGray>on</> <white>git:</><cyan>{{ .HEAD }}</>{{ if .Working.Changed }}<red> x</>{{ end }} ",
+          "type": "git",
+          "properties": {
+            "fetch_status": true
+          }
         },
         {
           "foreground": "darkGray",

--- a/themes/ys.omp.json
+++ b/themes/ys.omp.json
@@ -48,7 +48,7 @@
         },
         {
           "style": "plain",
-          "template": "<darkGray>on</> <white>git:</>{{ .HEAD }} ",
+          "template": "<darkGray>on</> <white>git:</><cyan>{{ .HEAD }}</> ",
           "type": "git"
         },
         {


### PR DESCRIPTION

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

Comparing oh-my-posh's `ys` theme:

![image](https://user-images.githubusercontent.com/1343979/198526608-f30ea8df-5338-4caf-a119-6a20d8a9b848.png)

with [oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh/wiki/Themes#ys)'s:

![image](https://user-images.githubusercontent.com/1343979/198526663-142b0be6-b5dd-49dc-80cb-9c35451ca251.png)

I noticed that two things were missing:

1. Cyancolor on the branch name is missing
2. No indication that the current git repo is "dirty"

So, this humble PR amends those two items:

![ys](https://user-images.githubusercontent.com/1343979/198527393-27a00b85-77b3-43ed-a13b-2280cf06dc1a.png)


I've seen some [issues](https://github.com/JanDeDobbeleer/oh-my-posh/issues/753) with using `fetch_status` so I can understand if that's a bit controversial. Let me know if so.

Regarding if I should update the docs checkbox above - I'm not sure if I should add the image generated by 
```
oh-my-posh config export image --cursor-padding 50
```
? (the one included above)

It has my user name in it instead of the `runner` on the current web site and I don't want to take credit just for fixing some colors, if this PR is approved. Can it be easily changed for the sake of capturing the image? Excuse my noob question 🤷 

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
