### PR TITLE
Converts the Golang RTL icon to a LTR icon

### DIFF
--- a/website/docs/segments/golang.mdx
+++ b/website/docs/segments/golang.mdx
@@ -17,7 +17,7 @@ Display the currently active golang version.
   "powerline_symbol": "\uE0B0",
   "foreground": "#ffffff",
   "background": "#7FD5EA",
-  "template": " \uFCD1 {{ .Full }} "
+  "template": " \u202D\uFCD1 {{ .Full }} "
 }
 ```
 


### PR DESCRIPTION
The used Golang icon has an RTL property so it always ends up at right side of the string. Combined with other segments which are LTR the icon will appear at unexpected places. By prefixing the code with `\u202D` the icon is converted to LTR and appears where expected.