### PR TITLE
Add support for the Redhat icon

### DIFF
--- a/src/segments/os.go
+++ b/src/segments/os.go
@@ -51,6 +51,8 @@ const (
 	Nixos properties.Property = "nixos"
 	// Opensuse the string/icon to use for Opensuse
 	Opensuse properties.Property = "opensuse"
+	// Redhat the string/icon to use for Redhat
+	Redhat properties.Property = "redhat"
 	// Sabayon the string/icon to use for Sabayon
 	Sabayon properties.Property = "sabayon"
 	// Slackware the string/icon to use for Slackware
@@ -120,6 +122,8 @@ func (oi *Os) getDistroIcon(distro string) string {
 		return oi.props.GetString(Nixos, "\uF313")
 	case "opensuse":
 		return oi.props.GetString(Opensuse, "\uF314")
+	case "redhat":
+		return oi.props.GetString(Redhat, "\uF316")
 	case "sabayon":
 		return oi.props.GetString(Sabayon, "\uF317")
 	case "slackware":

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -1566,6 +1566,12 @@
                     "description": "The icon to use for Opensuse",
                     "default": "\uF314"
                   },
+                  "redhat": {
+                    "type": "string",
+                    "title": "Redhat Icon",
+                    "description": "The icon to use for Redhat",
+                    "default": "\uF316"
+                  },
                   "sabayon": {
                     "type": "string",
                     "title": "Sabayon Icon",

--- a/website/docs/segments/os.mdx
+++ b/website/docs/segments/os.mdx
@@ -47,6 +47,7 @@ Display OS specific info - defaults to Icon.
 | `mint`                | `string`  | the icon to use for Mint - defaults to Mint icon - defaults to `\uF30e`             |
 | `nixos`               | `string`  | the icon to use for Nixos - defaults to Nixos icon - defaults to `\uF313`           |
 | `opensuse`            | `string`  | the icon to use for Opensuse - defaults to Opensuse icon - defaults to `\uF314`     |
+| `redhat`              | `string`  | the icon to use for Redhat - defaults to Redhat icon - defaults to `\uF316`         |
 | `sabayon`             | `string`  | the icon to use for Sabayon - defaults to Sabayon icon - defaults to `\uF317`       |
 | `slackware`           | `string`  | the icon to use for Slackware - defaults to Slackware icon - defaults to `\uF319`   |
 | `ubuntu`              | `string`  | the icon to use for Ubuntu - defaults to Ubuntu icon - defaults to `\uF31b`         |


### PR DESCRIPTION
Because 'redhat' wasn't recognized as the OS name, the icon always defaulted to the generic tux icon. This commit adds support for displaying the 'shadow man' icon where the OS name is 'redhat'.