### PR TITLE
docs: Update FAQ about PowerShell UTF-8

### DIFF
--- a/website/docs/faq.mdx
+++ b/website/docs/faq.mdx
@@ -179,6 +179,14 @@ Check the spelling of the name, or if a path was included, verify that the path 
 
 The issue is that PowerShell on Windows doesn't yet default to UTF-8. Resolve the issue by setting the shell to UTF-8 in the scope of initializing Oh My Posh.
 
+:::info Why it matters?
+If the location contains non-ASCII characters, non-UTF-8 PowerShell may provide a wrong path to Oh My Posh, which can break the initialization.
+
+The scenario for non-ASCII location:
+- Your computer has a non-ASCII user name.
+- Your [config file](./installation/customize.mdx) is under your `$HOME`.
+:::
+
 To do so, edit your `$PROFILE`, find the line that initializes Oh My Posh (as highlighted below), and change it to the following:
 
 ```powershell

--- a/website/docs/faq.mdx
+++ b/website/docs/faq.mdx
@@ -177,8 +177,23 @@ For example:
 Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
 ```
 
-The issue is that PowerShell on Windows doesn't yet default to UTF8. Resolve the issue by adding the following line
-to the top of your `$PROFILE`:
+The issue is that PowerShell on Windows doesn't yet default to UTF-8. Resolve the issue by setting the shell to UTF-8 in the scope of initializing Oh My Posh.
+
+To do so, edit your `$PROFILE`, find the line that initializes Oh My Posh (as highlighted below), and change it to the following:
+
+```powershell
+$previousOutputEncoding = [Console]::OutputEncoding
+[Console]::OutputEncoding = [Text.Encoding]::UTF8
+try {
+    // highlight-start
+    oh-my-posh init pwsh --config ~/custom.omp.json | Invoke-Expression
+    // highlight-end
+} finally {
+    [Console]::OutputEncoding = $previousOutputEncoding
+}
+```
+
+Alternatively, let the whole shell become UTF-8. (Be aware: Unwanted side effects can happen.) Add the following line to the top of your `$PROFILE`:
 
 ```powershell
 $OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = New-Object System.Text.UTF8Encoding

--- a/website/docs/installation/customize.mdx
+++ b/website/docs/installation/customize.mdx
@@ -28,13 +28,6 @@ oh-my-posh init pwsh --config 'C:/Users/Posh/jandedobbeleer.omp.json' | Invoke-E
 oh-my-posh init pwsh --config 'https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/jandedobbeleer.omp.json' | Invoke-Expression
 ```
 
-:::tip Non-ASCII file path
-If the location contains non-ASCII characters (e.g. your computer has a CJK user name) and
-your shell is not UTF-8, PowerShell may provide a wrong path to Oh My Posh, which can break the initialization.
-
-In that case, set the shell to UTF-8 in the scope of initializing Oh My Posh. Please refer to [FAQ](../faq.mdx#powershell-the-term-oh-my-poshexe-is-not-recognized-as-a-name-of-a-cmdlet) for details.
-:::
-
 ### Get inspiration
 
 The Windows and homebrew installers also bundle the **predefined configurations** ([themes][themes]). You can use the

--- a/website/docs/installation/customize.mdx
+++ b/website/docs/installation/customize.mdx
@@ -28,6 +28,13 @@ oh-my-posh init pwsh --config 'C:/Users/Posh/jandedobbeleer.omp.json' | Invoke-E
 oh-my-posh init pwsh --config 'https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/jandedobbeleer.omp.json' | Invoke-Expression
 ```
 
+:::tip Non-ASCII file path
+If the location contains non-ASCII characters (e.g. your computer has a CJK user name) and
+your shell is not UTF-8, PowerShell may provide a wrong path to Oh My Posh, which can break the initialization.
+
+In that case, set the shell to UTF-8 in the scope of initializing Oh My Posh. Please refer to [FAQ](../faq.mdx#powershell-the-term-oh-my-poshexe-is-not-recognized-as-a-name-of-a-cmdlet) for details.
+:::
+
 ### Get inspiration
 
 The Windows and homebrew installers also bundle the **predefined configurations** ([themes][themes]). You can use the


### PR DESCRIPTION
The trick was only covered in blogs and issues before. And there's no need to set shell-wide UTF-8 now.

- [the blog](https://ohmyposh.dev/blog/whats-new-3#powershell-utf-8)
- JanDeDobbeleer/oh-my-posh#3097
- JanDeDobbeleer/oh-my-posh#2793
- JanDeDobbeleer/oh-my-posh#2597
- …

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] (N/A) Tests for the changes have been added (for bug fixes/features)
- [x] (N/A) Docs have been added/updated (for bug fixes/features)

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
