### PR TITLE
fix(fish): repaint tooltip on sigint

### DIFF
--- a/src/shell/scripts/omp.fish
+++ b/src/shell/scripts/omp.fish
@@ -62,6 +62,11 @@ function postexec_omp --on-event fish_postexec
   set --global --export omp_lastcommand $argv
 end
 
+# fix tooltip not resetting on SIGINT (ctrl+c)
+function sigint_omp --on-signal INT
+    commandline --function repaint
+end
+
 # perform cleanup so a new initialization in current session works
 if test "$(string match -e '_render_transient' $(bind \r --user 2>/dev/null))" != ''
   bind -e \r


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
~~Docs have been added/updated (for bug fixes/features)~~ N/A

### Description
This fixes part of #3093 where a tooltip would not reset after ctrl+c.

I wasn't able to test within the devcontainer since it was using an old version of fish (3.1.2) and I wasn't able to get it upgraded. I tested locally by manually creating that event and it cleared as expected.