### PR TITLE
Fix chips theme with a leading diamond

### DIFF
--- a/themes/chips.omp.json
+++ b/themes/chips.omp.json
@@ -212,6 +212,7 @@
             "{{ if empty .Full }}p:c-project-generic-error{{ else }}p:c-project-python{{ end }}"
           ],
           "foreground": "p:c-badge-text",
+          "leading_diamond": "\uE0B6",
           "properties": {
             "display_mode": "context"
           },


### PR DESCRIPTION
The leading_diamond is missing therefore the python item missed its left part.

Simply added it back.

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description
The leading diamond for Python component was missing, as this shows:

![Screenshot 2022-11-29 at 23 42 57](https://user-images.githubusercontent.com/5921660/204737186-b543a720-a7e4-41eb-995d-a251c88b131c.png)

After adding it back in the theme JSON file:

![Screenshot 2022-11-29 at 23 42 50](https://user-images.githubusercontent.com/5921660/204737210-4fb6abb7-db08-45c4-a183-26e916964a18.png)

<!--TemplateBody-->

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
