### PR TITLE
Theme fix: Improve readability of emodipt-extend  

### DIFF
--- a/themes/emodipt-extend.omp.json
+++ b/themes/emodipt-extend.omp.json
@@ -3,6 +3,7 @@
     "blocks": [
       {
         "alignment": "left",
+        "newline": true,
         "segments": [
           {
             "foreground": "#E5C07B",


### PR DESCRIPTION
Add a blank line after the last output to prevent it from looking mashed together and improve readability