### PR TITLE
docs: fix warning grammar in gitversion.mdx

### DIFF
--- a/website/docs/segments/gitversion.mdx
+++ b/website/docs/segments/gitversion.mdx
@@ -10,7 +10,7 @@ Display the [GitVersion][gitversion] version.
 We _strongly_ recommend using [GitVersion Portable][gitversion-portable] for this.
 
 :::caution
-The GitVersion CLI can be a bit slow causing the prompt to feel slow. This why we cache
+The GitVersion CLI can be a bit slow, causing the prompt to feel slow. This is why we cache
 the value for 30 minutes by default.
 :::
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

Fixes a small grammar issue in the warning of gitversion.mdx