### PR TITLE
feat(pwsh): make it compatible with NVS auto-switching

### DIFF
--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -331,8 +331,14 @@ Example:
     }
 
     function prompt {
-        # store the orignal last command execution status and last exit code
-        $script:OriginalLastExecutionStatus = $?
+        # store the orignal last command execution status
+        if ($global:NVS_ORIGINAL_LASTEXECUTIONSTATUS -is [bool]) {
+            # make it compatible with NVS auto-switching, if enabled
+            $script:OriginalLastExecutionStatus = $global:NVS_ORIGINAL_LASTEXECUTIONSTATUS
+        } else {
+            $script:OriginalLastExecutionStatus = $?
+        }
+        # store the orignal last exit code
         $script:OriginalLastExitCode = $global:LASTEXITCODE
 
         Set-PoshPromptType


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

Since my [fix](https://github.com/jasongin/nvs/pull/254) for NVS auto-switching has been merged recently, we can now store the correct value of the last command execution status (`$?`) when NVS auto-switching is enabled in PowerShell.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
