### PR TITLE
fix(windows): revert use of virtual file system for Windows apps

### DIFF
--- a/src/platform/shell_windows.go
+++ b/src/platform/shell_windows.go
@@ -120,12 +120,19 @@ func (env *Shell) CachePath() string {
 
 func (env *Shell) LookWinAppPath(file string) (string, error) {
 	winAppPath := filepath.Join(env.Getenv("LOCALAPPDATA"), `\Microsoft\WindowsApps\`)
-	command := file + ".exe"
+	if !strings.HasSuffix(file, ".exe") {
+		file += ".exe"
+	}
 	isWinStoreApp := func() bool {
-		return env.HasFilesInDir(winAppPath, command)
+		pattern := winAppPath + env.PathSeparator() + file
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			return false
+		}
+		return len(matches) != 0
 	}
 	if isWinStoreApp() {
-		commandFile := filepath.Join(winAppPath, command)
+		commandFile := filepath.Join(winAppPath, file)
 		return readWinAppLink(commandFile)
 	}
 	return "", errors.New("no Windows Store App")


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description

the virtual file system is unable to detect the presence of an
AppExecLink, so we need to revert back to using the real file system

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
