### PR TITLE
Enable adding prompt SegmentWriters at runtime

### DIFF
--- a/src/engine/new.go
+++ b/src/engine/new.go
@@ -52,3 +52,32 @@ func New(flags *platform.Flags) *Engine {
 
 	return eng
 }
+
+// AddSegment allows to add a user-implemented prompt segment writer to the engine.
+// This segment is added according to the following logic:
+// If the currently loaded configuration contains a segment (in one or more blocks)
+// matching this segment type, it will use the provided segment writer for this type.
+// If no segment type is found, either in all blocks or in the specified one, a new
+// segment is created with this type and writer, and appended to the specified block.
+//
+// NOTE to @JanDeDobbeleer: The logic specified above assumes that when the configuration
+// is parsed, it does not consider whether or not a given segment indeed has an exiting
+// SegmentWriter: it just creates the &Segment{} and adds it to the block's list.
+// It is only, to my understanding, when the said segment has to render itself that it
+// will look into the map of existing segment writers.
+// So, if I'm right:
+// - Either the config specifies a segment, without this method being called before
+//   rendering, and the segment will silently fail.
+// - Or the config specifies the segment, this method is then called, and the segment
+//   will correctly render itself.
+//
+// NOTE2: Do we even need this function to be a method of the Engine ?
+func (eng *Engine) AddSegment(stype SegmentType, segment SegmentWriter) {
+	if segment == nil {
+		return
+	}
+
+	// Else, simply add the writer to the list of user-defined ones.
+	// It can now be used by any previously or to-be loaded configuration.
+	userSegments[stype] = segment
+}

--- a/src/engine/new.go
+++ b/src/engine/new.go
@@ -54,24 +54,6 @@ func New(flags *platform.Flags) *Engine {
 }
 
 // AddSegment allows to add a user-implemented prompt segment writer to the engine.
-// This segment is added according to the following logic:
-// If the currently loaded configuration contains a segment (in one or more blocks)
-// matching this segment type, it will use the provided segment writer for this type.
-// If no segment type is found, either in all blocks or in the specified one, a new
-// segment is created with this type and writer, and appended to the specified block.
-//
-// NOTE to @JanDeDobbeleer: The logic specified above assumes that when the configuration
-// is parsed, it does not consider whether or not a given segment indeed has an exiting
-// SegmentWriter: it just creates the &Segment{} and adds it to the block's list.
-// It is only, to my understanding, when the said segment has to render itself that it
-// will look into the map of existing segment writers.
-// So, if I'm right:
-// - Either the config specifies a segment, without this method being called before
-//   rendering, and the segment will silently fail.
-// - Or the config specifies the segment, this method is then called, and the segment
-//   will correctly render itself.
-//
-// NOTE2: Do we even need this function to be a method of the Engine ?
 func (eng *Engine) AddSegment(stype SegmentType, segment SegmentWriter) {
 	if segment == nil {
 		return

--- a/src/engine/new.go
+++ b/src/engine/new.go
@@ -52,14 +52,3 @@ func New(flags *platform.Flags) *Engine {
 
 	return eng
 }
-
-// AddSegment allows to add a user-implemented prompt segment writer to the engine.
-func (eng *Engine) AddSegment(stype SegmentType, segment SegmentWriter) {
-	if segment == nil {
-		return
-	}
-
-	// Else, simply add the writer to the list of user-defined ones.
-	// It can now be used by any previously or to-be loaded configuration.
-	userSegments[stype] = segment
-}

--- a/src/engine/segment.go
+++ b/src/engine/segment.go
@@ -211,6 +211,76 @@ const (
 	YTM SegmentType = "ytm"
 )
 
+// PromptSegments contains all available prompt segment writers.
+// Consumers of the library can also add their own segment writer.
+var PromptSegments = map[SegmentType]SegmentWriter{
+	ANGULAR:       &segments.Angular{},
+	AWS:           &segments.Aws{},
+	AZ:            &segments.Az{},
+	AZFUNC:        &segments.AzFunc{},
+	BATTERY:       &segments.Battery{},
+	BREWFATHER:    &segments.Brewfather{},
+	CDS:           &segments.Cds{},
+	CF:            &segments.Cf{},
+	CFTARGET:      &segments.CfTarget{},
+	CMD:           &segments.Cmd{},
+	CONNECTION:    &segments.Connection{},
+	CRYSTAL:       &segments.Crystal{},
+	CMAKE:         &segments.Cmake{},
+	DART:          &segments.Dart{},
+	DENO:          &segments.Deno{},
+	DOTNET:        &segments.Dotnet{},
+	EXECUTIONTIME: &segments.Executiontime{},
+	EXIT:          &segments.Exit{},
+	FLUTTER:       &segments.Flutter{},
+	FOSSIL:        &segments.Fossil{},
+	GCP:           &segments.Gcp{},
+	GIT:           &segments.Git{},
+	GITVERSION:    &segments.GitVersion{},
+	GOLANG:        &segments.Golang{},
+	HASKELL:       &segments.Haskell{},
+	IPIFY:         &segments.IPify{},
+	ITERM:         &segments.ITerm{},
+	JAVA:          &segments.Java{},
+	JULIA:         &segments.Julia{},
+	KOTLIN:        &segments.Kotlin{},
+	KUBECTL:       &segments.Kubectl{},
+	LUA:           &segments.Lua{},
+	NBGV:          &segments.Nbgv{},
+	NIGHTSCOUT:    &segments.Nightscout{},
+	NODE:          &segments.Node{},
+	NPM:           &segments.Npm{},
+	NX:            &segments.Nx{},
+	OS:            &segments.Os{},
+	OWM:           &segments.Owm{},
+	PATH:          &segments.Path{},
+	PERL:          &segments.Perl{},
+	PHP:           &segments.Php{},
+	PLASTIC:       &segments.Plastic{},
+	PROJECT:       &segments.Project{},
+	PYTHON:        &segments.Python{},
+	R:             &segments.R{},
+	ROOT:          &segments.Root{},
+	RUBY:          &segments.Ruby{},
+	RUST:          &segments.Rust{},
+	SESSION:       &segments.Session{},
+	SHELL:         &segments.Shell{},
+	SPOTIFY:       &segments.Spotify{},
+	STRAVA:        &segments.Strava{},
+	SVN:           &segments.Svn{},
+	SWIFT:         &segments.Swift{},
+	SYSTEMINFO:    &segments.SystemInfo{},
+	TERRAFORM:     &segments.Terraform{},
+	TEXT:          &segments.Text{},
+	TIME:          &segments.Time{},
+	UI5TOOLING:    &segments.UI5Tooling{},
+	WAKATIME:      &segments.Wakatime{},
+	WINREG:        &segments.WindowsRegistry{},
+	WITHINGS:      &segments.Withings{},
+	XMAKE:         &segments.XMake{},
+	YTM:           &segments.Ytm{},
+}
+
 func (segment *Segment) shouldIncludeFolder() bool {
 	if segment.env == nil {
 		return true
@@ -275,90 +345,14 @@ func (segment *Segment) background() string {
 
 func (segment *Segment) mapSegmentWithWriter(env platform.Environment) error {
 	segment.env = env
-	// functions := map[SegmentType]SegmentWriter{
-	// 	ANGULAR:       &segments.Angular{},
-	// 	AWS:           &segments.Aws{},
-	// 	AZ:            &segments.Az{},
-	// 	AZFUNC:        &segments.AzFunc{},
-	// 	BATTERY:       &segments.Battery{},
-	// 	BREWFATHER:    &segments.Brewfather{},
-	// 	CDS:           &segments.Cds{},
-	// 	CF:            &segments.Cf{},
-	// 	CFTARGET:      &segments.CfTarget{},
-	// 	CMD:           &segments.Cmd{},
-	// 	CONNECTION:    &segments.Connection{},
-	// 	CRYSTAL:       &segments.Crystal{},
-	// 	CMAKE:         &segments.Cmake{},
-	// 	DART:          &segments.Dart{},
-	// 	DENO:          &segments.Deno{},
-	// 	DOTNET:        &segments.Dotnet{},
-	// 	EXECUTIONTIME: &segments.Executiontime{},
-	// 	EXIT:          &segments.Exit{},
-	// 	FLUTTER:       &segments.Flutter{},
-	// 	FOSSIL:        &segments.Fossil{},
-	// 	GCP:           &segments.Gcp{},
-	// 	GIT:           &segments.Git{},
-	// 	GITVERSION:    &segments.GitVersion{},
-	// 	GOLANG:        &segments.Golang{},
-	// 	HASKELL:       &segments.Haskell{},
-	// 	IPIFY:         &segments.IPify{},
-	// 	ITERM:         &segments.ITerm{},
-	// 	JAVA:          &segments.Java{},
-	// 	JULIA:         &segments.Julia{},
-	// 	KOTLIN:        &segments.Kotlin{},
-	// 	KUBECTL:       &segments.Kubectl{},
-	// 	LUA:           &segments.Lua{},
-	// 	NBGV:          &segments.Nbgv{},
-	// 	NIGHTSCOUT:    &segments.Nightscout{},
-	// 	NODE:          &segments.Node{},
-	// 	NPM:           &segments.Npm{},
-	// 	NX:            &segments.Nx{},
-	// 	OS:            &segments.Os{},
-	// 	OWM:           &segments.Owm{},
-	// 	PATH:          &segments.Path{},
-	// 	PERL:          &segments.Perl{},
-	// 	PHP:           &segments.Php{},
-	// 	PLASTIC:       &segments.Plastic{},
-	// 	PROJECT:       &segments.Project{},
-	// 	PYTHON:        &segments.Python{},
-	// 	R:             &segments.R{},
-	// 	ROOT:          &segments.Root{},
-	// 	RUBY:          &segments.Ruby{},
-	// 	RUST:          &segments.Rust{},
-	// 	SESSION:       &segments.Session{},
-	// 	SHELL:         &segments.Shell{},
-	// 	SPOTIFY:       &segments.Spotify{},
-	// 	STRAVA:        &segments.Strava{},
-	// 	SVN:           &segments.Svn{},
-	// 	SWIFT:         &segments.Swift{},
-	// 	SYSTEMINFO:    &segments.SystemInfo{},
-	// 	TERRAFORM:     &segments.Terraform{},
-	// 	TEXT:          &segments.Text{},
-	// 	TIME:          &segments.Time{},
-	// 	UI5TOOLING:    &segments.UI5Tooling{},
-	// 	WAKATIME:      &segments.Wakatime{},
-	// 	WINREG:        &segments.WindowsRegistry{},
-	// 	WITHINGS:      &segments.Withings{},
-	// 	XMAKE:         &segments.XMake{},
-	// 	YTM:           &segments.Ytm{},
-	// }
-
-	functions := segment.getSegmentWriters()
 
 	if segment.Properties == nil {
 		segment.Properties = make(properties.Map)
 	}
-	if writer, ok := functions[segment.Type]; ok {
+
+	if writer, ok := PromptSegments[segment.Type]; ok {
 		writer.Init(segment.Properties, env)
 		segment.writer = writer
-		return nil
-	}
-
-	// This segment might have been added in this compiled program
-	// with engine.AddSegment(), in which case its segment writer is
-	// not nil. If that is the case, we return without an error, since
-	// this segment is ready to work.
-	if segment.writer != nil {
 		return nil
 	}
 
@@ -442,87 +436,4 @@ func (segment *Segment) SetText() {
 	case shell.ZSH:
 		segment.text = strings.NewReplacer("`", "\\`", `%`, `%%`).Replace(segment.text)
 	}
-}
-
-// userSegments is a list of segment writers that have been added at runtime.
-var userSegments = make(map[SegmentType]SegmentWriter)
-
-func (segment *Segment) getSegmentWriters() map[SegmentType]SegmentWriter {
-	// Builtins.
-	functions := map[SegmentType]SegmentWriter{
-		ANGULAR:       &segments.Angular{},
-		AWS:           &segments.Aws{},
-		AZ:            &segments.Az{},
-		AZFUNC:        &segments.AzFunc{},
-		BATTERY:       &segments.Battery{},
-		BREWFATHER:    &segments.Brewfather{},
-		CDS:           &segments.Cds{},
-		CF:            &segments.Cf{},
-		CFTARGET:      &segments.CfTarget{},
-		CMD:           &segments.Cmd{},
-		CONNECTION:    &segments.Connection{},
-		CRYSTAL:       &segments.Crystal{},
-		CMAKE:         &segments.Cmake{},
-		DART:          &segments.Dart{},
-		DENO:          &segments.Deno{},
-		DOTNET:        &segments.Dotnet{},
-		EXECUTIONTIME: &segments.Executiontime{},
-		EXIT:          &segments.Exit{},
-		FLUTTER:       &segments.Flutter{},
-		FOSSIL:        &segments.Fossil{},
-		GCP:           &segments.Gcp{},
-		GIT:           &segments.Git{},
-		GITVERSION:    &segments.GitVersion{},
-		GOLANG:        &segments.Golang{},
-		HASKELL:       &segments.Haskell{},
-		IPIFY:         &segments.IPify{},
-		ITERM:         &segments.ITerm{},
-		JAVA:          &segments.Java{},
-		JULIA:         &segments.Julia{},
-		KOTLIN:        &segments.Kotlin{},
-		KUBECTL:       &segments.Kubectl{},
-		LUA:           &segments.Lua{},
-		NBGV:          &segments.Nbgv{},
-		NIGHTSCOUT:    &segments.Nightscout{},
-		NODE:          &segments.Node{},
-		NPM:           &segments.Npm{},
-		NX:            &segments.Nx{},
-		OS:            &segments.Os{},
-		OWM:           &segments.Owm{},
-		PATH:          &segments.Path{},
-		PERL:          &segments.Perl{},
-		PHP:           &segments.Php{},
-		PLASTIC:       &segments.Plastic{},
-		PROJECT:       &segments.Project{},
-		PYTHON:        &segments.Python{},
-		R:             &segments.R{},
-		ROOT:          &segments.Root{},
-		RUBY:          &segments.Ruby{},
-		RUST:          &segments.Rust{},
-		SESSION:       &segments.Session{},
-		SHELL:         &segments.Shell{},
-		SPOTIFY:       &segments.Spotify{},
-		STRAVA:        &segments.Strava{},
-		SVN:           &segments.Svn{},
-		SWIFT:         &segments.Swift{},
-		SYSTEMINFO:    &segments.SystemInfo{},
-		TERRAFORM:     &segments.Terraform{},
-		TEXT:          &segments.Text{},
-		TIME:          &segments.Time{},
-		UI5TOOLING:    &segments.UI5Tooling{},
-		WAKATIME:      &segments.Wakatime{},
-		WINREG:        &segments.WindowsRegistry{},
-		WITHINGS:      &segments.Withings{},
-		XMAKE:         &segments.XMake{},
-		YTM:           &segments.Ytm{},
-	}
-
-	// Adding user-defined ones.
-	for stype, writer := range userSegments {
-		if writer != nil {
-			functions[stype] = writer
-		}
-	}
-
-	return functions
 }

--- a/src/engine/segment.go
+++ b/src/engine/segment.go
@@ -211,9 +211,9 @@ const (
 	YTM SegmentType = "ytm"
 )
 
-// PromptSegments contains all available prompt segment writers.
+// Segments contains all available prompt segment writers.
 // Consumers of the library can also add their own segment writer.
-var PromptSegments = map[SegmentType]SegmentWriter{
+var Segments = map[SegmentType]SegmentWriter{
 	ANGULAR:       &segments.Angular{},
 	AWS:           &segments.Aws{},
 	AZ:            &segments.Az{},
@@ -350,7 +350,7 @@ func (segment *Segment) mapSegmentWithWriter(env platform.Environment) error {
 		segment.Properties = make(properties.Map)
 	}
 
-	if writer, ok := PromptSegments[segment.Type]; ok {
+	if writer, ok := Segments[segment.Type]; ok {
 		writer.Init(segment.Properties, env)
 		segment.writer = writer
 		return nil

--- a/src/engine/segment.go
+++ b/src/engine/segment.go
@@ -275,73 +275,76 @@ func (segment *Segment) background() string {
 
 func (segment *Segment) mapSegmentWithWriter(env platform.Environment) error {
 	segment.env = env
-	functions := map[SegmentType]SegmentWriter{
-		ANGULAR:       &segments.Angular{},
-		AWS:           &segments.Aws{},
-		AZ:            &segments.Az{},
-		AZFUNC:        &segments.AzFunc{},
-		BATTERY:       &segments.Battery{},
-		BREWFATHER:    &segments.Brewfather{},
-		CDS:           &segments.Cds{},
-		CF:            &segments.Cf{},
-		CFTARGET:      &segments.CfTarget{},
-		CMD:           &segments.Cmd{},
-		CONNECTION:    &segments.Connection{},
-		CRYSTAL:       &segments.Crystal{},
-		CMAKE:         &segments.Cmake{},
-		DART:          &segments.Dart{},
-		DENO:          &segments.Deno{},
-		DOTNET:        &segments.Dotnet{},
-		EXECUTIONTIME: &segments.Executiontime{},
-		EXIT:          &segments.Exit{},
-		FLUTTER:       &segments.Flutter{},
-		FOSSIL:        &segments.Fossil{},
-		GCP:           &segments.Gcp{},
-		GIT:           &segments.Git{},
-		GITVERSION:    &segments.GitVersion{},
-		GOLANG:        &segments.Golang{},
-		HASKELL:       &segments.Haskell{},
-		IPIFY:         &segments.IPify{},
-		ITERM:         &segments.ITerm{},
-		JAVA:          &segments.Java{},
-		JULIA:         &segments.Julia{},
-		KOTLIN:        &segments.Kotlin{},
-		KUBECTL:       &segments.Kubectl{},
-		LUA:           &segments.Lua{},
-		NBGV:          &segments.Nbgv{},
-		NIGHTSCOUT:    &segments.Nightscout{},
-		NODE:          &segments.Node{},
-		NPM:           &segments.Npm{},
-		NX:            &segments.Nx{},
-		OS:            &segments.Os{},
-		OWM:           &segments.Owm{},
-		PATH:          &segments.Path{},
-		PERL:          &segments.Perl{},
-		PHP:           &segments.Php{},
-		PLASTIC:       &segments.Plastic{},
-		PROJECT:       &segments.Project{},
-		PYTHON:        &segments.Python{},
-		R:             &segments.R{},
-		ROOT:          &segments.Root{},
-		RUBY:          &segments.Ruby{},
-		RUST:          &segments.Rust{},
-		SESSION:       &segments.Session{},
-		SHELL:         &segments.Shell{},
-		SPOTIFY:       &segments.Spotify{},
-		STRAVA:        &segments.Strava{},
-		SVN:           &segments.Svn{},
-		SWIFT:         &segments.Swift{},
-		SYSTEMINFO:    &segments.SystemInfo{},
-		TERRAFORM:     &segments.Terraform{},
-		TEXT:          &segments.Text{},
-		TIME:          &segments.Time{},
-		UI5TOOLING:    &segments.UI5Tooling{},
-		WAKATIME:      &segments.Wakatime{},
-		WINREG:        &segments.WindowsRegistry{},
-		WITHINGS:      &segments.Withings{},
-		XMAKE:         &segments.XMake{},
-		YTM:           &segments.Ytm{},
-	}
+	// functions := map[SegmentType]SegmentWriter{
+	// 	ANGULAR:       &segments.Angular{},
+	// 	AWS:           &segments.Aws{},
+	// 	AZ:            &segments.Az{},
+	// 	AZFUNC:        &segments.AzFunc{},
+	// 	BATTERY:       &segments.Battery{},
+	// 	BREWFATHER:    &segments.Brewfather{},
+	// 	CDS:           &segments.Cds{},
+	// 	CF:            &segments.Cf{},
+	// 	CFTARGET:      &segments.CfTarget{},
+	// 	CMD:           &segments.Cmd{},
+	// 	CONNECTION:    &segments.Connection{},
+	// 	CRYSTAL:       &segments.Crystal{},
+	// 	CMAKE:         &segments.Cmake{},
+	// 	DART:          &segments.Dart{},
+	// 	DENO:          &segments.Deno{},
+	// 	DOTNET:        &segments.Dotnet{},
+	// 	EXECUTIONTIME: &segments.Executiontime{},
+	// 	EXIT:          &segments.Exit{},
+	// 	FLUTTER:       &segments.Flutter{},
+	// 	FOSSIL:        &segments.Fossil{},
+	// 	GCP:           &segments.Gcp{},
+	// 	GIT:           &segments.Git{},
+	// 	GITVERSION:    &segments.GitVersion{},
+	// 	GOLANG:        &segments.Golang{},
+	// 	HASKELL:       &segments.Haskell{},
+	// 	IPIFY:         &segments.IPify{},
+	// 	ITERM:         &segments.ITerm{},
+	// 	JAVA:          &segments.Java{},
+	// 	JULIA:         &segments.Julia{},
+	// 	KOTLIN:        &segments.Kotlin{},
+	// 	KUBECTL:       &segments.Kubectl{},
+	// 	LUA:           &segments.Lua{},
+	// 	NBGV:          &segments.Nbgv{},
+	// 	NIGHTSCOUT:    &segments.Nightscout{},
+	// 	NODE:          &segments.Node{},
+	// 	NPM:           &segments.Npm{},
+	// 	NX:            &segments.Nx{},
+	// 	OS:            &segments.Os{},
+	// 	OWM:           &segments.Owm{},
+	// 	PATH:          &segments.Path{},
+	// 	PERL:          &segments.Perl{},
+	// 	PHP:           &segments.Php{},
+	// 	PLASTIC:       &segments.Plastic{},
+	// 	PROJECT:       &segments.Project{},
+	// 	PYTHON:        &segments.Python{},
+	// 	R:             &segments.R{},
+	// 	ROOT:          &segments.Root{},
+	// 	RUBY:          &segments.Ruby{},
+	// 	RUST:          &segments.Rust{},
+	// 	SESSION:       &segments.Session{},
+	// 	SHELL:         &segments.Shell{},
+	// 	SPOTIFY:       &segments.Spotify{},
+	// 	STRAVA:        &segments.Strava{},
+	// 	SVN:           &segments.Svn{},
+	// 	SWIFT:         &segments.Swift{},
+	// 	SYSTEMINFO:    &segments.SystemInfo{},
+	// 	TERRAFORM:     &segments.Terraform{},
+	// 	TEXT:          &segments.Text{},
+	// 	TIME:          &segments.Time{},
+	// 	UI5TOOLING:    &segments.UI5Tooling{},
+	// 	WAKATIME:      &segments.Wakatime{},
+	// 	WINREG:        &segments.WindowsRegistry{},
+	// 	WITHINGS:      &segments.Withings{},
+	// 	XMAKE:         &segments.XMake{},
+	// 	YTM:           &segments.Ytm{},
+	// }
+
+	functions := segment.getSegmentWriters()
+
 	if segment.Properties == nil {
 		segment.Properties = make(properties.Map)
 	}
@@ -350,6 +353,15 @@ func (segment *Segment) mapSegmentWithWriter(env platform.Environment) error {
 		segment.writer = writer
 		return nil
 	}
+
+	// This segment might have been added in this compiled program
+	// with engine.AddSegment(), in which case its segment writer is
+	// not nil. If that is the case, we return without an error, since
+	// this segment is ready to work.
+	if segment.writer != nil {
+		return nil
+	}
+
 	return errors.New("unable to map writer")
 }
 
@@ -430,4 +442,87 @@ func (segment *Segment) SetText() {
 	case shell.ZSH:
 		segment.text = strings.NewReplacer("`", "\\`", `%`, `%%`).Replace(segment.text)
 	}
+}
+
+// userSegments is a list of segment writers that have been added at runtime.
+var userSegments = make(map[SegmentType]SegmentWriter)
+
+func (segment *Segment) getSegmentWriters() map[SegmentType]SegmentWriter {
+	// Builtins.
+	functions := map[SegmentType]SegmentWriter{
+		ANGULAR:       &segments.Angular{},
+		AWS:           &segments.Aws{},
+		AZ:            &segments.Az{},
+		AZFUNC:        &segments.AzFunc{},
+		BATTERY:       &segments.Battery{},
+		BREWFATHER:    &segments.Brewfather{},
+		CDS:           &segments.Cds{},
+		CF:            &segments.Cf{},
+		CFTARGET:      &segments.CfTarget{},
+		CMD:           &segments.Cmd{},
+		CONNECTION:    &segments.Connection{},
+		CRYSTAL:       &segments.Crystal{},
+		CMAKE:         &segments.Cmake{},
+		DART:          &segments.Dart{},
+		DENO:          &segments.Deno{},
+		DOTNET:        &segments.Dotnet{},
+		EXECUTIONTIME: &segments.Executiontime{},
+		EXIT:          &segments.Exit{},
+		FLUTTER:       &segments.Flutter{},
+		FOSSIL:        &segments.Fossil{},
+		GCP:           &segments.Gcp{},
+		GIT:           &segments.Git{},
+		GITVERSION:    &segments.GitVersion{},
+		GOLANG:        &segments.Golang{},
+		HASKELL:       &segments.Haskell{},
+		IPIFY:         &segments.IPify{},
+		ITERM:         &segments.ITerm{},
+		JAVA:          &segments.Java{},
+		JULIA:         &segments.Julia{},
+		KOTLIN:        &segments.Kotlin{},
+		KUBECTL:       &segments.Kubectl{},
+		LUA:           &segments.Lua{},
+		NBGV:          &segments.Nbgv{},
+		NIGHTSCOUT:    &segments.Nightscout{},
+		NODE:          &segments.Node{},
+		NPM:           &segments.Npm{},
+		NX:            &segments.Nx{},
+		OS:            &segments.Os{},
+		OWM:           &segments.Owm{},
+		PATH:          &segments.Path{},
+		PERL:          &segments.Perl{},
+		PHP:           &segments.Php{},
+		PLASTIC:       &segments.Plastic{},
+		PROJECT:       &segments.Project{},
+		PYTHON:        &segments.Python{},
+		R:             &segments.R{},
+		ROOT:          &segments.Root{},
+		RUBY:          &segments.Ruby{},
+		RUST:          &segments.Rust{},
+		SESSION:       &segments.Session{},
+		SHELL:         &segments.Shell{},
+		SPOTIFY:       &segments.Spotify{},
+		STRAVA:        &segments.Strava{},
+		SVN:           &segments.Svn{},
+		SWIFT:         &segments.Swift{},
+		SYSTEMINFO:    &segments.SystemInfo{},
+		TERRAFORM:     &segments.Terraform{},
+		TEXT:          &segments.Text{},
+		TIME:          &segments.Time{},
+		UI5TOOLING:    &segments.UI5Tooling{},
+		WAKATIME:      &segments.Wakatime{},
+		WINREG:        &segments.WindowsRegistry{},
+		WITHINGS:      &segments.Withings{},
+		XMAKE:         &segments.XMake{},
+		YTM:           &segments.Ytm{},
+	}
+
+	// Adding user-defined ones.
+	for stype, writer := range userSegments {
+		if writer != nil {
+			functions[stype] = writer
+		}
+	}
+
+	return functions
 }


### PR DESCRIPTION
Hello Jan !
First off: #3223 works like-a-charm. Really, really great.

So I'm coming back with another, even simpler demand ! Complementing the previous one.
This commit adds a an exported function to add SegmentWriters to the engine at runtime.

To be honest, before trying to implement this I thought I was in for troubles...
But the changes to make where simple beyond imagination.

This commit would allow anyone to write prompt segments from any type provided they
implement the `SegmentWriter` interface. Once again, within the context of a readline
program, this is just fire.

Thanks for any consideration once again !
Available at any time for questions/fixes/anything.
