### PR TITLE
fix(python): set `home_enabled` to `false` by default

### DIFF
--- a/src/segments/python.go
+++ b/src/segments/python.go
@@ -52,7 +52,6 @@ func (p *Python) Init(props properties.Properties, env platform.Environment) {
 		},
 		versionURLTemplate: "https://docs.python.org/release/{{ .Major }}.{{ .Minor }}.{{ .Patch }}/whatsnew/changelog.html#python-{{ .Major }}-{{ .Minor }}-{{ .Patch }}",
 		displayMode:        props.GetString(DisplayMode, DisplayModeEnvironment),
-		homeEnabled:        props.GetBool(HomeEnabled, true),
 	}
 }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

Set the `home_enabled` property of a `python` segment to `false` by default so as to be consistent with [docs](https://ohmyposh.dev/docs/segments/python#properties):

> display the segment in the HOME folder or not - defaults to `false`

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
