### PR TITLE
Don't load mapstructure Decode options more than once

### DIFF
--- a/src/engine/config.go
+++ b/src/engine/config.go
@@ -113,11 +113,14 @@ func loadConfig(env platform.Environment) *Config {
 	config.AddDriver(yaml.Driver)
 	config.AddDriver(json.Driver)
 	config.AddDriver(toml.Driver)
-	config.WithOptions(func(opt *config.Options) {
-		opt.DecoderConfig = &mapstructure.DecoderConfig{
-			TagName: "json",
-		}
-	})
+
+	if config.Default().IsEmpty() {
+		config.WithOptions(func(opt *config.Options) {
+			opt.DecoderConfig = &mapstructure.DecoderConfig{
+				TagName: "json",
+			}
+		})
+	}
 
 	err := config.LoadFiles(configFile)
 	if err != nil {


### PR DESCRIPTION
This PR ensures that the options for decoding the configuration struct are not set more than once, so that multiple prompt engines can be loaded in the same runtime. Useful for closed-loop applications that make use of different "menus", each with its own prompt context/configuration.