### PR TITLE
fix(schema): change default icon for Azure DevOps

### DIFF
--- a/themes/schema.json
+++ b/themes/schema.json
@@ -919,7 +919,7 @@
                     "type": "string",
                     "title": "Azure DevOps Icon",
                     "description": "Icon/text to display when the upstream is Azure DevOps",
-                    "default": "\uFD03"
+                    "default": "\uEBE8"
                   },
                   "git_icon": {
                     "type": "string",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

The existing default icon (FD03) is not the proper icon for Azure DevOps. This small change is to correct it to use the proper icon (EBE8) since it already exists in Nerd Fonts.
