### PR TITLE
fix(elixir): match on `*.exs` files too

### DIFF
--- a/src/segments/elixir.go
+++ b/src/segments/elixir.go
@@ -17,7 +17,7 @@ func (e *Elixir) Init(props properties.Properties, env platform.Environment) {
 	e.language = language{
 		env:        env,
 		props:      props,
-		extensions: []string{"*.ex"},
+		extensions: []string{"*.ex", "*.exs"},
 		commands: []*cmd{
 			{
 				executable: "elixir",

--- a/website/docs/segments/elixir.mdx
+++ b/website/docs/segments/elixir.mdx
@@ -23,13 +23,13 @@ Display the currently active elixir version.
 
 ## Properties
 
-| Name                   | Type      | Description                                                                                                                                            |
-| ---------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `home_enabled`         | `boolean` | display the segment in the HOME folder or not - defaults to `false`                                                                                    |
-| `fetch_version`        | `boolean` | fetch the flutter version - defaults to `true`                                                                                                         |
-| `missing_command_text` | `string`  | text to display when the command is missing - defaults to empty                                                                                        |
-| `display_mode`         | `string`  | <ul><li>`always`: the segment is always displayed</li><li>`files`: the segment is only displayed when `*.ex` files are present (**default**)</li></ul> |
-| `version_url_template` | `string`  | a go [text/template][go-text-template] [template][templates] that creates the URL of the version info / release notes                                  |
+| Name                   | Type      | Description                                                                                                                                                       |
+| ---------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `home_enabled`         | `boolean` | display the segment in the HOME folder or not - defaults to `false`                                                                                               |
+| `fetch_version`        | `boolean` | fetch the flutter version - defaults to `true`                                                                                                                    |
+| `missing_command_text` | `string`  | text to display when the command is missing - defaults to empty                                                                                                   |
+| `display_mode`         | `string`  | <ul><li>`always`: the segment is always displayed</li><li>`files`: the segment is only displayed when `*.ex` or `*.exs` files are present (**default**)</li></ul> |
+| `version_url_template` | `string`  | a go [text/template][go-text-template] [template][templates] that creates the URL of the version info / release notes                                             |
 
 ## Template ([info][templates])
 


### PR DESCRIPTION
The `.exs` file extension is used for Elixir scripts. This also includes project files and tests in Mix projects.

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description

<!--TemplateBody-->

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
