### PR TITLE
docs(nu): remove the outdated tip

### DIFF
--- a/website/docs/installation/customize.mdx
+++ b/website/docs/installation/customize.mdx
@@ -190,18 +190,6 @@ source /mylocation/myscript.nu
 
 Once altered, restart Nushell for the changes to take effect.
 
-:::tip
-For the time being, there is a [problem][homebrew-problem] with the initialization using Oh My Posh installed via Homebrew.
-To resolve this, you can use the `--strict` flag which tells Oh My Posh to use the executable name and not the
-full path in the initialization. For example:
-
-```bash
-oh-my-posh init nu --config ~/jandedobbeleer.omp.json --print --strict | save /mylocation/myscript.nu
-```
-
-This way for a new Oh My Posh version that does not update the initialization script, you don't have to recreate a new one.
-:::
-
 </TabItem>
 </Tabs>
 

--- a/website/docs/installation/prompt.mdx
+++ b/website/docs/installation/prompt.mdx
@@ -183,18 +183,6 @@ source /mylocation/myscript.nu
 
 Once added, restart Nushell for the changes to take effect.
 
-:::tip
-For the time being, there is a [problem][homebrew-problem] with the initialization using Oh My Posh installed via Homebrew.
-To resolve this, you can use the `--strict` flag which tells Oh My Posh to use the executable name and not the
-full path in the initialization. For example:
-
-```bash
-oh-my-posh init nu --print --strict | save /mylocation/myscript.nu
-```
-
-This way for a new Oh My Posh version that does not update the initialization script, you don't have to recreate a new one.
-:::
-
 </TabItem>
 </Tabs>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

We can remove the following tip from the [docs](https://ohmyposh.dev/docs/installation/customize):

> For the time being, there is a [problem](https://github.com/JanDeDobbeleer/oh-my-posh/discussions/2644) with the initialization using Oh My Posh installed via Homebrew. To resolve this...

since the described problem is outdated now because we have a two-step dynamic initialization for Nushell. E.g.,

in `$nu.env-path`:

```sh
oh-my-posh init nu --config "~/mytheme.omp.json" --print | save "/mylocation/myscript.nu" --force
```

and in `$nu.config-path`:

```sh
source "/mylocation/myscript.nu"
```

This way without a `--strict` flag, OMP installed via Homebrew still works fine.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
