### PR TITLE
fix(shell): split environment variable name and value correctly

### DIFF
--- a/src/platform/shell.go
+++ b/src/platform/shell.go
@@ -724,13 +724,11 @@ func (env *Shell) TemplateCache() *TemplateCache {
 	const separator = "="
 	values := os.Environ()
 	for value := range values {
-		splitted := strings.Split(values[value], separator)
-		if len(splitted) != 2 {
+		key, val, valid := strings.Cut(values[value], separator)
+		if !valid {
 			continue
 		}
-		key := splitted[0]
-		val := splitted[1:]
-		tmplCache.Env[key] = strings.Join(val, separator)
+		tmplCache.Env[key] = val
 	}
 	pwd := env.Pwd()
 	tmplCache.PWD = ReplaceHomeDirPrefixWithTilde(env, pwd)


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

Fix #3379.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
