### PR TITLE
Refactor init scripts and remove outdated CLI help text

### DIFF
--- a/src/cli/config_export.go
+++ b/src/cli/config_export.go
@@ -31,12 +31,7 @@ Exports the ~/myconfig.omp.json config file and prints the result to stdout.
 
 > oh-my-posh config export --config ~/myconfig.omp.json --format toml
 
-Exports the ~/myconfig.omp.json config file to toml and prints the result to stdout.
-
-> oh-my-posh config export --config ~/myconfig.omp.json --format toml --write
-
-Exports the ~/myconfig.omp.json config file to toml and writes the result to your config file.
-A backup of the current config can be found at ~/myconfig.omp.json.bak.`,
+Exports the ~/myconfig.omp.json config file to toml and prints the result to stdout.`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		env := &platform.Shell{

--- a/src/shell/scripts/omp.bash
+++ b/src/shell/scripts/omp.bash
@@ -15,6 +15,7 @@ function _set_posh_cursor_position() {
     if [[ -v MC_SID ]];then
         return
     fi
+    local pos
     echo -ne "\033[6n"            # ask the terminal for the position
     read -s -d\[ garbage          # discard the first part of the response
     read -s -d R pos              # store the position in bash variable 'pos'

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -13,6 +13,7 @@ function _set_posh_cursor_position() {
   if [[ -v MC_SID ]];then
       return
   fi
+  local pos
   echo -ne "\033[6n"            # ask the terminal for the position
   read -s -d\[ garbage          # discard the first part of the response
   read -s -d R pos              # store the position in bash variable 'pos'
@@ -34,7 +35,7 @@ function prompt_ohmyposh_precmd() {
   omp_stack_count=${#dirstack[@]}
   omp_elapsed=-1
   if [ $omp_start_time ]; then
-    omp_now=$(::OMP:: get millis --shell=zsh)
+    local omp_now=$(::OMP:: get millis --shell=zsh)
     omp_elapsed=$(($omp_now-$omp_start_time))
   fi
   count=$((POSH_PROMPT_COUNT+1))
@@ -43,7 +44,6 @@ function prompt_ohmyposh_precmd() {
   _set_posh_cursor_position
   eval "$(::OMP:: print primary --config="$POSH_THEME" --error="$omp_last_error" --execution-time="$omp_elapsed" --stack-count="$omp_stack_count" --eval --shell=zsh --shell-version="$ZSH_VERSION")"
   unset omp_start_time
-  unset omp_now
 }
 
 function _install-omp-hooks() {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

1. Use local variables inside functions defined in init scripts for Bash and Zsh.
2. The `-w`/`--write` flag for `oh-my-posh config export` was removed for a long time (since commit [`906ce85`](https://github.com/JanDeDobbeleer/oh-my-posh/commit/906ce85d5bb9b9e4d56d6756b9ab280bc48fab84#diff-24777e3dc6567c356988d8e833b3489c69c659149cb71b8672c0a4e82634cb35L55)), and the help text should be updated as well.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
