### PR TITLE
restore ansi cursor pos

### DIFF
--- a/src/shell/scripts/omp.bash
+++ b/src/shell/scripts/omp.bash
@@ -9,6 +9,26 @@ PS0='${omp_start_time:0:$((omp_start_time="$(_omp_start_timer)",0))}'
 # set secondary prompt
 PS2="$(::OMP:: print secondary --config="$POSH_THEME" --shell=bash --shell-version="$BASH_VERSION")"
 
+function _set_posh_cursor_position() {
+      # not supported in Midnight Commander
+    # see https://github.com/JanDeDobbeleer/oh-my-posh/issues/3415
+    if [[ -v MC_SID ]]; then
+        return
+    fi
+
+    local oldstty=$(stty -g)
+    stty raw -echo min 0
+
+    local COL
+    local ROW
+    IFS=';' read -sdR -p $'\E[6n' ROW COL
+
+    stty $oldstty
+
+    export POSH_CURSOR_LINE=${ROW#*[}
+    export POSH_CURSOR_COLUMN=${COL}
+}
+
 function _omp_start_timer() {
     ::OMP:: get millis
 }
@@ -28,6 +48,7 @@ function _omp_hook() {
         omp_start_time=""
     fi
     set_poshcontext
+    _set_posh_cursor_position
     PS1="$(::OMP:: print primary --config="$POSH_THEME" --shell=bash --shell-version="$BASH_VERSION" --error="$ret" --execution-time="$omp_elapsed" --stack-count="$omp_stack_count" | tr -d '\0')"
     return $ret
 }

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -7,6 +7,28 @@ export POSH_PROMPT_COUNT=0
 # set secondary prompt
 PS2="$(::OMP:: print secondary --config="$POSH_THEME" --shell=zsh)"
 
+function _set_posh_cursor_position() {
+  # not supported in Midnight Commander
+  # see https://github.com/JanDeDobbeleer/oh-my-posh/issues/3415
+  if [[ -v MC_SID ]]; then
+      return
+  fi
+
+  local oldstty=$(stty -g)
+  stty raw -echo min 0
+
+  local pos
+  echo -en "\033[6n" > /dev/tty
+  read -r -d R pos
+  pos=${pos:2} # strip off the esc-[
+  local parts=(${(s:;:)pos})
+
+  stty $oldstty
+
+  export POSH_CURSOR_LINE=${parts[1]}
+  export POSH_CURSOR_COLUMN=${parts[2]}
+}
+
 # template function for context loading
 function set_poshcontext() {
   return
@@ -27,6 +49,7 @@ function prompt_ohmyposh_precmd() {
   count=$((POSH_PROMPT_COUNT+1))
   export POSH_PROMPT_COUNT=$count
   set_poshcontext
+  _set_posh_cursor_position
   eval "$(::OMP:: print primary --config="$POSH_THEME" --error="$omp_last_error" --execution-time="$omp_elapsed" --stack-count="$omp_stack_count" --eval --shell=zsh --shell-version="$ZSH_VERSION")"
   unset omp_start_time
 }

--- a/website/docs/configuration/block.mdx
+++ b/website/docs/configuration/block.mdx
@@ -86,8 +86,9 @@ Tells the engine what to do with the block. There are two options:
 
 ### Newline
 
-Start the block on a new line - defaults to `false`. For `pwsh` and `cmd` this will not print a newline that's defined
-on the first block when the prompt is on the first line (when using clear), or when the shell session starts (1st prompt).
+Start the block on a new line - defaults to `false`. For `bash`, `zsh`, `pwsh` and `cmd` this will not print a newline
+that's defined on the first block when the prompt is on the first line (when using clear), or when the shell session
+starts (1st prompt).
 
 ### Alignment
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -127,7 +127,7 @@ module.exports = {
       copyright: `Copyright © ${new Date().getFullYear()} <a href='https://github.com/sponsors/JanDeDobbeleer' target='_blank'>Jan De Dobbeleer</a> and <a href='/docs/contributors'>contributors</a>.`,
     },
     appInsights: {
-      instrumentationKey: '72804848-dc30-4856-8245-4fa1450b041f',
+      instrumentationKey: '51741aa7-e087-4e80-b7b0-0863d467462a',
     },
     algolia: {
       appId: 'XIR4RB3TM1',


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description

- feat(shell): restore line logic for zsh and bash
- docs: update instrumentation key

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
