### PR TITLE
fix(git): parse SSH URL's more reliably

### DIFF
--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -396,8 +396,8 @@ func (g *Git) getUpstreamIcon() string {
 		}
 		url = strings.TrimPrefix(url, "ssh://")
 		url = strings.TrimPrefix(url, "git://")
-		if strings.HasPrefix(url, "git@") {
-			url = strings.TrimPrefix(url, "git@")
+		if i := strings.Index(url, "@"); i >= 0 {
+			url = url[i+1:]
 			url = strings.Replace(url, ":", "/", 1)
 		}
 		url = strings.TrimSuffix(url, ".git")

--- a/src/segments/git_test.go
+++ b/src/segments/git_test.go
@@ -597,6 +597,7 @@ func TestGitUpstream(t *testing.T) {
 	}{
 		{Case: "No upstream", Expected: "", Upstream: ""},
 		{Case: "SSH url", Expected: "G", Upstream: "ssh://git@git.my.domain:3001/ADIX7/dotconfig.git"},
+		{Case: "Gitea", Expected: "EX", Upstream: "_gitea@src.example.com:user/repo.git"},
 		{Case: "GitHub", Expected: "GH", Upstream: "github.com/test"},
 		{Case: "Gitlab", Expected: "GL", Upstream: "gitlab.com/test"},
 		{Case: "Bitbucket", Expected: "BB", Upstream: "bitbucket.org/test"},
@@ -619,6 +620,7 @@ func TestGitUpstream(t *testing.T) {
 			GitIcon:         "G",
 			UpstreamIcons: map[string]string{
 				"mycustom.server": "CU",
+				"src.example.com": "EX",
 			},
 		}
 		g := &Git{


### PR DESCRIPTION
fix(git): parse SSH URL's more reliably

resolves #3472

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/JanDeDobbeleer/oh-my-posh/pull/3478).
* __->__ #3478
