### PR TITLE
fix(chips): fix time execution segment and battery state color logic rendering (`v1.2.2`)

### DIFF
--- a/themes/chips.omp.json
+++ b/themes/chips.omp.json
@@ -58,7 +58,7 @@
             "{{ if lt .Ms 60000 }}p:c-exec-fast{{ end }}",
             "{{ if lt .Ms 3600000 }}p:c-exec-normal{{ end }}",
             "{{ if lt .Ms 10800000 }}p:c-exec-slow{{ end }}",
-            "{{ if gt .Ms 10800001 }}p:c-exec-slower{{ end }}"
+            "{{ if ge .Ms 10800000 }}p:c-exec-slower{{ end }}"
           ],
           "foreground": "p:c-badge-text",
           "leading_diamond": "\uE0B6",
@@ -77,7 +77,7 @@
             "{{ if lt (.CummulativeTotal.Seconds | int64) 10800 }}p:c-wakatime-warm-up{{ end }}",
             "{{ if lt (.CummulativeTotal.Seconds | int64) 25200 }}p:c-wakatime-working{{ end }}",
             "{{ if lt (.CummulativeTotal.Seconds | int64) 28000 }}p:c-wakatime-quota{{ end }}",
-            "{{ if gt (.CummulativeTotal.Seconds | int64) 28801 }}p:c-wakatime-overtime{{ end }}"
+            "{{ if ge (.CummulativeTotal.Seconds | int64) 28800 }}p:c-wakatime-overtime{{ end }}"
           ],
           "foreground": "p:c-badge-text",
           "leading_diamond": "\uE0B6",
@@ -112,13 +112,13 @@
         {
           "background_templates": [
             "{{ if .Error }}p:c-battery-state-error{{ end }}",
-            "{{ if lt .Percentage 15 }}p:c-battery-15-less{{ end }}",
-            "{{ if and (gt .Percentage 16) (lt .Percentage 30) }}p:c-battery-30-less{{ end }}",
-            "{{ if and (gt .Percentage 31) (lt .Percentage 45) }}p:c-battery-45-less{{ end }}",
-            "{{ if and (gt .Percentage 46) (lt .Percentage 55) }}p:c-battery-55-less{{ end }}",
-            "{{ if and (gt .Percentage 56) (lt .Percentage 70) }}p:c-battery-70-less{{ end }}",
-            "{{ if and (gt .Percentage 71) (lt .Percentage 90) }}p:c-battery-90-less{{ end }}",
-            "{{ if and (gt .Percentage 91) (le .Percentage 100) }}p:c-battery-100-less{{ end }}"
+            "{{ if le .Percentage 15 }}p:c-battery-15-less{{ end }}",
+            "{{ if and (ge .Percentage 16) (le .Percentage 30) }}p:c-battery-30-less{{ end }}",
+            "{{ if and (ge .Percentage 31) (le .Percentage 45) }}p:c-battery-45-less{{ end }}",
+            "{{ if and (ge .Percentage 46) (le .Percentage 55) }}p:c-battery-55-less{{ end }}",
+            "{{ if and (ge .Percentage 56) (le .Percentage 70) }}p:c-battery-70-less{{ end }}",
+            "{{ if and (ge .Percentage 71) (le .Percentage 90) }}p:c-battery-90-less{{ end }}",
+            "{{ if and (ge .Percentage 91) (le .Percentage 100) }}p:c-battery-100-less{{ end }}"
           ],
           "foreground": "p:c-badge-text",
           "leading_diamond": "\uE0B6",

--- a/website/export_themes.js
+++ b/website/export_themes.js
@@ -29,7 +29,7 @@ themeConfigOverrrides.set('amro.omp.json', newThemeConfig(40, 100, 'AmRo', '#1C2
 themeConfigOverrrides.set('avit.omp.json', newThemeConfig(40, 80));
 themeConfigOverrrides.set('blueish.omp.json', newThemeConfig(40, 100));
 themeConfigOverrrides.set('cert.omp.json', newThemeConfig(40, 50));
-themeConfigOverrrides.set('chips.omp.json', newThemeConfig(25, 30, 'CodexLink | v1.2.0 | More samples at https://github.com/CodexLink/chips.omp.json'));
+themeConfigOverrrides.set('chips.omp.json', newThemeConfig(25, 30, 'CodexLink | v1.2.2 (02/09/2023) | https://github.com/CodexLink/chips.omp.json'));
 themeConfigOverrrides.set('cinnamon.omp.json', newThemeConfig(40, 80));
 themeConfigOverrrides.set('craver.omp.json', newThemeConfig(40, 80, 'Nick Craver', '#282c34'));
 themeConfigOverrrides.set('darkblood.omp.json', newThemeConfig(40, 40));


### PR DESCRIPTION
### Prerequisites

- [X] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [X] The commit message follows the [conventional commits][cc] guidelines

### Description
This release contains various fixes for the time execution segment color rendering, as well as fixes for inconsistent spacing.

## What's Changed
* Release/1.2.0: More PL badge support by @CodexLink in https://github.com/CodexLink/chips.omp.json/pull/1

- [fix(battery-segment): ensure edge-case percentage is included for render](https://github.com/CodexLink/chips.omp.json/tree/51fd6139905d19a25a57246bf7b4c31453ec5b7c)

- [fix(python-segment): add missing leading-diamond](https://github.com/CodexLink/chips.omp.json/tree/8bde033c572b668075f8931203e46856fcc8b808)
- - > Overshadowed commit from `oh-my-posh` upstream: https://github.com/JanDeDobbeleer/oh-my-posh/commit/c7616c1f7dd4994bf620ae67b683aecbf67570f6

- [fix(time): fix scope time coverage](https://github.com/CodexLink/chips.omp.json/tree/43314c40aeac0d94fe255edf5c1d31c2f4f50c07)

File Theme Hash: `77AC0C750C9864A6648A05064AFC036808C9B273C7F26801424A533A9489C13C`

**Full Changelog**: https://github.com/CodexLink/chips.omp.json/compare/v1.2.0...v1.2.2