### PR TITLE
docs: updating --config on bash section

### DIFF
--- a/website/docs/installation/customize.mdx
+++ b/website/docs/installation/customize.mdx
@@ -127,7 +127,7 @@ Once altered, restart cmd for the changes to take effect.
 Adjust or add the following line to `~/.zshrc`:
 
 ```bash
-eval "$(oh-my-posh init zsh --config ~/jandedobbeleer.omp.json)"
+eval "$(oh-my-posh init zsh --config ~/.poshthemes/jandedobbeleer.omp.json)"
 ```
 
 Once altered, reload your profile for the changes to take effect.
@@ -146,7 +146,7 @@ Use the full path to the config file, not the relative path or `~` as a shorthan
 Adjust or add the following line in `~/.bashrc` (could be `~/.profile` or `~/.bash_profile` depending on your environment):
 
 ```bash
-eval "$(oh-my-posh init bash --config ~/jandedobbeleer.omp.json)"
+eval "$(oh-my-posh init bash --config ~/.poshthemes/jandedobbeleer.omp.json)"
 ```
 
 Once altered, reload your profile for the changes to take effect.


### PR DESCRIPTION
In the manual installation process, when downloading .zip file with all themes, the themes were extracted to ~/.poshthemes/, following the installing steps, when customizing the code the installation docs are as follow

```bash
    eval "$(oh-my-posh init bash --config ~/jandedobbeleer.omp.json)"
```
Pointing to ~/, or HOME directory, where the "'.bashrc" file are located, so it will not work, unless the user extract only the theme that he want to ~/ or extract all themes to ~/

But the installation instructions suggest to extract all themes to "~/.poshthemes" so I just updated the command to:

```bash
    eval "$(oh-my-posh init bash --config ~/.poshthemes/jandedobbeleer.omp.json)"
```

In all places that bash or zsh appears

### Prerequisites

- [ ] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [ ] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

<!--TemplateBody-->

<!---

Tips:

If you're not comfortable with working with Git, we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
