### PR TITLE
fix(wakatime-docs): broken `properties` table + add subsection for URL with Env. Var.

### DIFF
--- a/website/docs/segments/wakatime.mdx
+++ b/website/docs/segments/wakatime.mdx
@@ -55,7 +55,7 @@ If the developer or the user of the theme wants to use the reference of their Wa
 
 :::note 
 
-`WAKATIME_API_KEY` **is not a strict name to use** as an Environment Variable for this segment in particular, any name is possible as long as it exists and matches from your Environment Variables and the reference from the theme itself.
+`WAKATIME_API_KEY` **is not a strict name to use** as an Environment Variable for this segment in particular, **any name is possible and acceptable** as long as it exists and matches from your Environment Variables and from the theme itself.
 
 Please refer to the [Environment Variable][templates-environment-variables] page for more information.
 

--- a/website/docs/segments/wakatime.mdx
+++ b/website/docs/segments/wakatime.mdx
@@ -42,7 +42,7 @@ The free tier for is sufficient. You'll find the API key in your profile setting
 
 ### Dynamic API Key
 
-If the developer or the user of the theme wants to use the reference of their Wakatime API key (_stored from their Environment Variables_) without statically declaring them, then the following modification can be done.
+If you don't want to include the API key into your configuration, the following modification can be done.
 
 ```json
 "properties": {

--- a/website/docs/segments/wakatime.mdx
+++ b/website/docs/segments/wakatime.mdx
@@ -34,11 +34,11 @@ The free tier for is sufficient. You'll find the API key in your profile setting
 
 ## Properties
 
-| Name            | Type      | Description                                                                                                                                                                             |
-| --------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `url`           | `string`  | Your Wakatime [summaries][wk-summaries] URL, including the API key. Example above. Defaults to ``.                                                                                      |
-| `http_timeout`  | `int`     | The time it takes to consider a http request as timed-out. Defaults to `20` ms. If no segment is shown, try increasing this timeout.                                                    |
-| `cache_timeout` | `int`     | The number of minutes to invalidate/renew the Wakatime segment output. Defaults to `10` m. Setting this to `0` disables the cache and requests to the Wakatime API for a new response.  |
+| Name            | Type      | Description                                                                                                                                                                                                       |
+| --------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `url`           | `string`  | The Wakatime [summaries][wk-summaries] URL, including the API key. Example above. Defaults to ``.                                                                                                                 |
+| `http_timeout`  | `int`     | The time (_in milliseconds_, `ms`) it takes to consider an http request as **timed-out**. Defaults to `20`. If no segment is shown, try increasing this timeout.                                                  |
+| `cache_timeout` | `int`     | The time (_in minutes_, `m`) it takes to invalidate/renew the Wakatime segment output. Defaults to `10`. Setting this to `0` disables the cache and requests to the API everytime the user presses the Enter key. |
 
 ### Dynamic API Key
 

--- a/website/docs/segments/wakatime.mdx
+++ b/website/docs/segments/wakatime.mdx
@@ -55,7 +55,7 @@ If you don't want to include the API key into your configuration, the following 
 
 :::note 
 
-`WAKATIME_API_KEY` **is not a strict name to use** as an Environment Variable for this segment in particular, **any name is possible and acceptable** as long as it exists and matches from your Environment Variables and from the theme itself.
+`WAKATIME_API_KEY` is an example, **any name is possible and acceptable** as long as the environment variable exists and contains the API key value.
 
 Please refer to the [Environment Variable][templates-environment-variables] page for more information.
 

--- a/website/docs/segments/wakatime.mdx
+++ b/website/docs/segments/wakatime.mdx
@@ -34,11 +34,32 @@ The free tier for is sufficient. You'll find the API key in your profile setting
 
 ## Properties
 
-| Name  | Type     | Description                                                                                         |
-| ----- | -------- | --------------------------------------------------------------------------------------------------- |
-| `url` | `string` | Your Wakatime [summaries][wk-summaries] URL, including the API key. Example above. You'll know this |
+| Name            | Type      | Description                                                                                                                                                                             |
+| --------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `url`           | `string`  | Your Wakatime [summaries][wk-summaries] URL, including the API key. Example above. Defaults to ``.                                                                                      |
+| `http_timeout`  | `int`     | The time it takes to consider a http request as timed-out. Defaults to `20` ms. If no segment is shown, try increasing this timeout.                                                    |
+| `cache_timeout` | `int`     | The number of minutes to invalidate/renew the Wakatime segment output. Defaults to `10` m. Setting this to `0` disables the cache and requests to the Wakatime API for a new response.  |
 
-works if you can curl it yourself and a result. - defaults to `` |`http_timeout`|`int`|The default timeout for http request is 20ms. If no segment is shown, try increasing this timeout.| |`cache_timeout`|`int`|The default timeout for request caching is 10m. A value of 0 disables the cache.|
+### Dynamic API Key
+
+If the developer or the user of the theme wants to use the reference of their Wakatime API key (_stored from their Environment Variables_) without statically declaring them, then the following modification can be done.
+
+```json
+"properties": {
+  // highlight-next-line
+  "url": "https://wakatime.com/api/v1/users/current/summaries?start=today&end=today&api_key={{ .Env.WAKATIME_API_KEY }}",
+  "cache_timeout": 10,
+  "http_timeout": 500
+}
+```
+
+:::note 
+
+`WAKATIME_API_KEY` **is not a strict name to use** as an Environment Variable for this segment in particular, any name is possible as long as it exists and matches from your Environment Variables and the reference from the theme itself.
+
+Please refer to the [Environment Variable][templates-environment-variables] page for more information.
+
+:::
 
 ## Template ([info][templates])
 
@@ -66,3 +87,4 @@ works if you can curl it yourself and a result. - defaults to `` |`http_timeout`
 [wt]: https://wakatime.com
 [wk-summaries]: https://wakatime.com/developers#summaries
 [templates]: /docs/configuration/templates
+[templates-environment-variables]: /docs/configuration/templates#environment-variables


### PR DESCRIPTION
### Prerequisites

- [X] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [X] The commit message follows the [conventional commits][cc] guidelines
- [X] Docs have been added/updated (for bug fixes/features)

### Description

This PR introduces a fix for the `wakatime` segment documentation wherein the properties are not structured properly. In line with this, a new subsection **Dynamic API Key** is also added which introduces the use of Environment Variable along with the URL, rather than statically declaring them.