### PR TITLE
fix(unity): output corrupt with CRLF line ending

### DIFF
--- a/src/segments/unity.go
+++ b/src/segments/unity.go
@@ -64,6 +64,7 @@ func (u *Unity) GetUnityVersion() (version string, err error) {
 
 	versionStartIndex := versionPrefixIndex + len(versionPrefix)
 	unityVersion := firstLine[versionStartIndex:]
+	unityVersion = strings.TrimSuffix(unityVersion, "\r")
 
 	return strings.TrimSuffix(unityVersion, "f1"), nil
 }

--- a/src/segments/unity.go
+++ b/src/segments/unity.go
@@ -64,7 +64,7 @@ func (u *Unity) GetUnityVersion() (version string, err error) {
 
 	versionStartIndex := versionPrefixIndex + len(versionPrefix)
 	unityVersion := firstLine[versionStartIndex:]
-	unityVersion = strings.TrimSuffix(unityVersion, "\r")
+	unityVersion = strings.TrimSpace(unityVersion)
 
 	return strings.TrimSuffix(unityVersion, "f1"), nil
 }

--- a/src/segments/unity_test.go
+++ b/src/segments/unity_test.go
@@ -147,6 +147,18 @@ func TestUnitySegment(t *testing.T) {
 			VersionFileExists:   true,
 			VersionFileText:     "2021.3.16f1",
 		},
+		{
+			Case:                "CRLF line ending",
+			ExpectedOutput:      "\ue721 2021.3.16 C# 9",
+			ExpectedToBeEnabled: true,
+			VersionFileExists:   true,
+			VersionFileText:     "m_EditorVersion: 2021.3.16f1\r\nm_EditorVersionWithRevision: 2021.3.16f1 (4016570cf34f)\r\n",
+			CacheGet: CacheGet{
+				key:   "2021.3",
+				val:   "C# 9",
+				found: true,
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description

Segments before the Unity segment get cut off if `ProjectSettings/ProjctVersion.txt` has CLRF line endings. Sorry for not catching this the first time around. I started trying it out on all the Unity projects on my machine, and stumbled across 2 projects that have this issue.

![oh-my-posh-debugging](https://user-images.githubusercontent.com/6819362/221575260-dfc78d7c-c5c1-4ade-aaee-256a635b6ceb.png)