### PR TITLE
Fix typos in TestCanUpgrade

### DIFF
--- a/src/upgrade/notice_test.go
+++ b/src/upgrade/notice_test.go
@@ -22,9 +22,9 @@ func TestCanUpgrade(t *testing.T) {
 		GOOS           string
 	}{
 		{Case: "Up to date", CurrentVersion: "3.0.0", LatestVersion: "v3.0.0"},
-		{Case: "Oudated Windows", Expected: true, CurrentVersion: "3.0.0", LatestVersion: "v3.0.1", GOOS: platform.WINDOWS},
-		{Case: "Oudated Linux", Expected: true, CurrentVersion: "3.0.0", LatestVersion: "v3.0.1", GOOS: platform.LINUX},
-		{Case: "Oudated Darwin", Expected: true, CurrentVersion: "3.0.0", LatestVersion: "v3.0.1", GOOS: platform.DARWIN},
+		{Case: "Outdated Windows", Expected: true, CurrentVersion: "3.0.0", LatestVersion: "v3.0.1", GOOS: platform.WINDOWS},
+		{Case: "Outdated Linux", Expected: true, CurrentVersion: "3.0.0", LatestVersion: "v3.0.1", GOOS: platform.LINUX},
+		{Case: "Outdated Darwin", Expected: true, CurrentVersion: "3.0.0", LatestVersion: "v3.0.1", GOOS: platform.DARWIN},
 		{Case: "Cached", Cache: true},
 		{Case: "Error", Error: fmt.Errorf("error")},
 	}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] ~~Tests for the changes have been added (for bug fixes/features)~~ **not applicable**
- [ ] ~~Docs have been added/updated (for bug fixes/features)~~ **not applicable**

### Description
This just fixes some typos of the [recent commit](393f30a082e96f7341b1e4213e80867bedeacab2) regarding the upgrade notices.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
