### PR TITLE
fix(wakatime)!: fix struct `wtData` binding from API response, from `Cummulative` to `Cumulative`

### DIFF
--- a/src/segments/wakatime.go
+++ b/src/segments/wakatime.go
@@ -2,6 +2,7 @@ package segments
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/platform"
 	"github.com/jandedobbeleer/oh-my-posh/src/properties"
@@ -21,13 +22,13 @@ type wtTotals struct {
 }
 
 type wtData struct {
-	CummulativeTotal wtTotals `json:"cummulative_total"`
-	Start            string   `json:"start"`
-	End              string   `json:"end"`
+	CumulativeTotal wtTotals `json:"cumulative_total"`
+	Start           string   `json:"start"`
+	End             string   `json:"end"`
 }
 
 func (w *Wakatime) Template() string {
-	return " {{ secondsRound .CummulativeTotal.Seconds }} "
+	return " {{ secondsRound .CumulativeTotal.Seconds }} "
 }
 
 func (w *Wakatime) Enabled() bool {
@@ -61,6 +62,13 @@ func (w *Wakatime) setAPIData() error {
 	err = json.Unmarshal(body, &w.wtData)
 	if err != nil {
 		return err
+	}
+
+	// In case of Wakatime API changes, validate if one of the fields of `w.wtData`, is empty.
+	if (w.wtData.CumulativeTotal == wtTotals{}) ||
+		(w.wtData.Start == "") ||
+		(w.wtData.End == "") {
+		return fmt.Errorf("One of the fields of Wakatime segment is empty. | %+v - Error", w.wtData)
 	}
 
 	if cacheTimeout > 0 {

--- a/src/segments/wakatime.go
+++ b/src/segments/wakatime.go
@@ -68,7 +68,7 @@ func (w *Wakatime) setAPIData() error {
 	if (w.wtData.CumulativeTotal == wtTotals{}) ||
 		(w.wtData.Start == "") ||
 		(w.wtData.End == "") {
-		return fmt.Errorf("One of the fields of Wakatime segment is empty. | %+v - Error", w.wtData)
+		return fmt.Errorf("Some context of Wakatime segment is missing. Please check Wakatime API for changes that resulted to this error. | Payload: %+v - Error", w.wtData)
 	}
 
 	if cacheTimeout > 0 {

--- a/src/segments/wakatime.go
+++ b/src/segments/wakatime.go
@@ -64,13 +64,6 @@ func (w *Wakatime) setAPIData() error {
 		return err
 	}
 
-	// In case of Wakatime API changes, validate if one of the fields of `w.wtData`, is empty.
-	if (w.wtData.CumulativeTotal == wtTotals{}) ||
-		(w.wtData.Start == "") ||
-		(w.wtData.End == "") {
-		return fmt.Errorf("Some context of Wakatime segment is missing. Please check Wakatime API for changes that resulted to this error. | Payload: %+v - Error", w.wtData)
-	}
-
 	if cacheTimeout > 0 {
 		w.env.Cache().Set(url, string(body), cacheTimeout)
 	}

--- a/src/segments/wakatime.go
+++ b/src/segments/wakatime.go
@@ -2,7 +2,6 @@ package segments
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/platform"
 	"github.com/jandedobbeleer/oh-my-posh/src/properties"

--- a/src/segments/wakatime_test.go
+++ b/src/segments/wakatime_test.go
@@ -73,8 +73,7 @@ func TestWTTrackedTime(t *testing.T) {
 
 	for _, tc := range cases {
 		env := &mock.MockedEnvironment{}
-
-		response := fmt.Sprintf(`{"cummulative_total": {"seconds": %.2f, "text": "x"}}`, float64(tc.Seconds))
+		response := fmt.Sprintf(`{"cumulative_total": {"seconds": %.2f, "text": "x"}, "start": "2023-01-01T00:00:00Z", "end": "2023-01-01T00:01:00Z"}`, float64(tc.Seconds))
 
 		env.On("HTTPRequest", FAKEAPIURL).Return([]byte(response), tc.Error)
 

--- a/src/segments/wakatime_test.go
+++ b/src/segments/wakatime_test.go
@@ -73,7 +73,7 @@ func TestWTTrackedTime(t *testing.T) {
 
 	for _, tc := range cases {
 		env := &mock.MockedEnvironment{}
-		response := fmt.Sprintf(`{"cumulative_total": {"seconds": %.2f, "text": "x"}, "start": "2023-01-01T00:00:00Z", "end": "2023-01-01T00:01:00Z"}`, float64(tc.Seconds))
+		response := fmt.Sprintf(`{"cumulative_total": {"seconds": %.2f, "text": "x"}}`, float64(tc.Seconds))
 
 		env.On("HTTPRequest", FAKEAPIURL).Return([]byte(response), tc.Error)
 

--- a/website/docs/segments/wakatime.mdx
+++ b/website/docs/segments/wakatime.mdx
@@ -53,7 +53,7 @@ If you don't want to include the API key into your configuration, the following 
 }
 ```
 
-:::note 
+:::note
 
 `WAKATIME_API_KEY` is an example, **any name is possible and acceptable** as long as the environment variable exists and contains the API key value.
 
@@ -66,7 +66,7 @@ Please refer to the [Environment Variable][templates-environment-variables] page
 :::note default template
 
 ```template
-{{ secondsRound .CummulativeTotal.Seconds }}
+{{ secondsRound .CumulativeTotal.Seconds }}
 ```
 
 :::
@@ -75,7 +75,7 @@ Please refer to the [Environment Variable][templates-environment-variables] page
 
 | Name                | Type       | Description                              |
 | ------------------- | ---------- | ---------------------------------------- |
-| `.CummulativeTotal` | `wtTotals` | object holding total tracked time values |
+| `.CumulativeTotal` | `wtTotals` | object holding total tracked time values |
 
 ### wtTotals Properties
 


### PR DESCRIPTION
### Prerequisites

- [X] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [X] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [X] Docs have been added/updated (for bug fixes/features)

### Description

**This is a breaking change.**

It's been a while since I noticed that the Wakatime segment for my theme has disappeared. Upon inspection, Wakatime has changed one of the returned JSON's parent key names from `cummulative_total` to `cumulative_total`.

The following is just the excerpt of the payload as of now:

```json
{
  "cumulative_total": {
    "decimal": "0.02",
    "digital": "0:01",
    "seconds": 109.270097,
    "text": "1 min"
  },
  "daily_average": {},
  "data": [ ],
  "end": "2023-03-11T15:59:59Z",
  "start": "2023-03-10T16:00:00Z"
}
```

The unexpected change was _assumed in the first place_ since I have [snapshots of my theme](https://github.com/CodexLink/chips.omp.json#git-states-segment) that shows the Wakatime segment. After finding the problem, it is somehow true that the API changed. But upon (light) research, I can't seem to find any evidence that their API has changed, but either way ...

This PR fixes that by **correcting the spelling** from **cummulative** to **cumulative** for both **component** and **documentation** hence, _becoming a breaking change_. Other than that, the PR also contains the following:

- Added an additional checking that emits an error stating that the response returned from the Wakatime API should be checked due to struct `wtData` containing _an empty context_/_is an empty struct_.
- Added an additional context from the fake payload (on _wakatime_test.go_) to avoid tripping the test cases.

> Note that the additional checker (for the `wtData`) from the _wakatime.go_ was not added to the part of test cases since it's going to be a bit of a hassle vs. adding the checker itself from the main code segment instead.

> Plus, the test cases (_exclusive to wakatime_) are just emulating the context that the API returned. Declaring another test case will have other test cases to adjust because the `response` must be compatible with every test case declared. _But in the end, it's possible to include it in the test case, but there will be adjustments_.

### Disclaimer

This is **my first time using Golang**, suggestions and requests for changes are extremely welcome.