### PR TITLE
docs: Fix text/template link

### DIFF
--- a/website/docs/configuration/templates.mdx
+++ b/website/docs/configuration/templates.mdx
@@ -245,7 +245,7 @@ This can be used in templates and icons/text inside your config.
 [terminal-list-hyperlinks]: https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
 [path-segment]: /docs/path
 [git-segment]: /docs/git
-[go-text-template]: https://golang.org/pkg/text/template/eg
+[go-text-template]: https://pkg.go.dev/text/template
 [sprig]: https://masterminds.github.io/sprig/
 [glob]: https://pkg.go.dev/path/filepath#Glob
 [git]: /docs/segments/git


### PR DESCRIPTION
Fix text/template link

### Prerequisites

- [X] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [ ] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [X] Docs have been added/updated (for bug fixes/features)

### Description
Fix documentation link.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
