### PR TITLE
feat(cftarget): add display_mode

### DIFF
--- a/src/segments/cf_target.go
+++ b/src/segments/cf_target.go
@@ -1,7 +1,8 @@
 package segments
 
 import (
-	"regexp"
+	"errors"
+	"strings"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/platform"
 	"github.com/jandedobbeleer/oh-my-posh/src/properties"
@@ -31,54 +32,63 @@ func (c *CfTarget) Init(props properties.Properties, env platform.Environment) {
 }
 
 func (c *CfTarget) Enabled() bool {
-	return c.setCFTargetStatus()
-}
-
-func (c *CfTarget) getCFTargetCommandOutput() string {
 	if !c.env.HasCommand("cf") {
-		return ""
-	}
-
-	output, err := c.env.RunCommand("cf", "target")
-
-	if err != nil {
-		return ""
-	}
-
-	return output
-}
-
-func (c *CfTarget) setCFTargetStatus() bool {
-	output := c.getCFTargetCommandOutput()
-
-	if output == "" {
 		return false
 	}
 
-	regex := regexp.MustCompile(`API endpoint:\s*(?P<api_url>http[s].*)|user:\s*(?P<user>.*)|org:\s*(?P<org>.*)|space:\s*(?P<space>(.*))`)
-	match := regex.FindAllStringSubmatch(output, -1)
-	result := make(map[string]string)
+	displayMode := c.props.GetString(DisplayMode, DisplayModeAlways)
+	if displayMode != DisplayModeFiles {
+		return c.setCFTargetStatus()
+	}
 
-	for i, name := range regex.SubexpNames() {
-		if i == 0 || len(name) == 0 {
+	manifest, err := c.env.HasParentFilePath("manifest.yml")
+	if err != nil || manifest.IsDir {
+		return false
+	}
+
+	return c.setCFTargetStatus()
+}
+
+func (c *CfTarget) setCFTargetStatus() bool {
+	output, err := c.getCFTargetCommandOutput()
+
+	if err != nil {
+		return false
+	}
+
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		splitted := strings.SplitN(line, ":", 2)
+		if len(splitted) < 2 {
 			continue
 		}
-
-		for j, val := range match[i-1] {
-			if j == 0 {
-				continue
-			}
-
-			if val != "" {
-				result[name] = val
-			}
+		key := splitted[0]
+		value := strings.TrimSpace(splitted[1])
+		switch key {
+		case "API endpoint":
+			c.URL = value
+		case "user":
+			c.User = value
+		case "org":
+			c.Org = value
+		case "space":
+			c.Space = value
 		}
 	}
 
-	c.URL = result["api_url"]
-	c.Org = result["org"]
-	c.Space = result["space"]
-	c.User = result["user"]
-
 	return true
+}
+
+func (c *CfTarget) getCFTargetCommandOutput() (string, error) {
+	output, err := c.env.RunCommand("cf", "target")
+
+	if err != nil {
+		return "", err
+	}
+
+	if len(output) == 0 {
+		return "", errors.New("cf command output is empty")
+	}
+
+	return output, nil
 }

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -2863,7 +2863,16 @@
           },
           "then": {
             "title": "Clound Foundry Target segment",
-            "description": "https://ohmyposh.dev/docs/segments/cftarget"
+            "description": "https://ohmyposh.dev/docs/segments/cftarget",
+            "properties": {
+              "properties": {
+                "properties": {
+                  "display_mode": {
+                    "$ref": "#/definitions/display_mode"
+                  }
+                }
+              }
+            }
           }
         },
         {

--- a/website/docs/segments/cftarget.mdx
+++ b/website/docs/segments/cftarget.mdx
@@ -21,6 +21,12 @@ Display the details of the logged [Cloud Foundry endpoint][cf-target] (`cf targe
 }
 ```
 
+## Properties
+
+| Name           | Type     | Description                                                                                                                                                     |
+| -------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `display_mode` | `string` | <ul><li>`always`: the segment is always displayed (**default**)</li><li>`files`: the segment is only displayed when a `manifest.yml` file is present </li></ul> |
+
 ## Template ([info][templates])
 
 :::note default template


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1335b1f</samp>

Added a `display_mode` property to the `CfTarget` segment to control its visibility based on the existence of a `manifest.yml` file. Updated the segment logic, tests, schema, and documentation accordingly.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1335b1f</samp>

*  Add and document `display_mode` property to `CfTarget` segment ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3649/files?diff=unified&w=0#diff-ec3dac06620cce64305d2c8de93c5942f80faacbd794e5d356e85d8641170ca4L4-R5), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3649/files?diff=unified&w=0#diff-ec3dac06620cce64305d2c8de93c5942f80faacbd794e5d356e85d8641170ca4L34-R93), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3649/files?diff=unified&w=0#diff-892c540c9bfebcb3bb8a0be1714201cd17eb6f0d40367c09f80d56e883b7335eL2866-R2875), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3649/files?diff=unified&w=0#diff-a222c519961aadf82dd9103d302f58c1fe039c5a4d44c962ed9054cedf35b9c1R24-R29))
  - Check `display_mode` and `manifest.yml` file presence in `Enabled` function ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3649/files?diff=unified&w=0#diff-ec3dac06620cce64305d2c8de93c5942f80faacbd794e5d356e85d8641170ca4L34-R93))
  - Return error if `cf` command output is empty or fails in `getCFTargetCommandOutput` function ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3649/files?diff=unified&w=0#diff-ec3dac06620cce64305d2c8de93c5942f80faacbd794e5d356e85d8641170ca4L34-R93))
  - Use `strings.Split` instead of `regexp` to parse `cf` command output in `setCFTargetStatus` function ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3649/files?diff=unified&w=0#diff-ec3dac06620cce64305d2c8de93c5942f80faacbd794e5d356e85d8641170ca4L34-R93))
  - Add `display_mode` to schema of `CfTarget` segment in `themes/schema.json` ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3649/files?diff=unified&w=0#diff-892c540c9bfebcb3bb8a0be1714201cd17eb6f0d40367c09f80d56e883b7335eL2866-R2875))
  - Document `display_mode` property in `website/docs/segments/cftarget.mdx` ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3649/files?diff=unified&w=0#diff-a222c519961aadf82dd9103d302f58c1fe039c5a4d44c962ed9054cedf35b9c1R24-R29))
* Update test cases and setup for `CfTarget` segment ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3649/files?diff=unified&w=0#diff-4f6e602c1ef9cc4b72058e94f0300bfdd91cf58556a39aba5ba148f2abb68a79R4), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3649/files?diff=unified&w=0#diff-4f6e602c1ef9cc4b72058e94f0300bfdd91cf58556a39aba5ba148f2abb68a79R10), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3649/files?diff=unified&w=0#diff-4f6e602c1ef9cc4b72058e94f0300bfdd91cf58556a39aba5ba148f2abb68a79L16-R63), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3649/files?diff=unified&w=0#diff-4f6e602c1ef9cc4b72058e94f0300bfdd91cf58556a39aba5ba148f2abb68a79L53-R81), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3649/files?diff=unified&w=0#diff-4f6e602c1ef9cc4b72058e94f0300bfdd91cf58556a39aba5ba148f2abb68a79L64-R90))
  - Add `errors` and `platform` packages to imports in `src/segments/cf_target_test.go` ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3649/files?diff=unified&w=0#diff-4f6e602c1ef9cc4b72058e94f0300bfdd91cf58556a39aba5ba148f2abb68a79R4), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3649/files?diff=unified&w=0#diff-4f6e602c1ef9cc4b72058e94f0300bfdd91cf58556a39aba5ba148f2abb68a79R10))
  - Modify test cases to include `DisplayMode`, `FileInfo`, and `CommandError` fields and remove `ExpectedEnabled` field ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3649/files?diff=unified&w=0#diff-4f6e602c1ef9cc4b72058e94f0300bfdd91cf58556a39aba5ba148f2abb68a79L16-R63))
  - Mock `HasParentFilePath` function and set `DisplayMode` property in test setup ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3649/files?diff=unified&w=0#diff-4f6e602c1ef9cc4b72058e94f0300bfdd91cf58556a39aba5ba148f2abb68a79L53-R81))
  - Use length of `ExpectedString` field to check `Enabled` function and remove `CommandError` field from fail message in test assertions ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3649/files?diff=unified&w=0#diff-4f6e602c1ef9cc4b72058e94f0300bfdd91cf58556a39aba5ba148f2abb68a79L64-R90))
