### PR TITLE
fix(shell): sync PWD creation

### DIFF
--- a/src/platform/shell.go
+++ b/src/platform/shell.go
@@ -394,8 +394,9 @@ func (env *Shell) Getenv(key string) string {
 }
 
 func (env *Shell) Pwd() string {
+	env.Lock()
 	defer env.Trace(time.Now())
-	defer env.Debug(env.cwd)
+	defer env.Unlock()
 	if env.cwd != "" {
 		return env.cwd
 	}
@@ -409,6 +410,7 @@ func (env *Shell) Pwd() string {
 	}
 	if env.CmdFlags != nil && env.CmdFlags.PWD != "" {
 		env.cwd = correctPath(env.CmdFlags.PWD)
+		env.Debug(env.cwd)
 		return env.cwd
 	}
 	dir, err := os.Getwd()
@@ -417,6 +419,7 @@ func (env *Shell) Pwd() string {
 		return ""
 	}
 	env.cwd = correctPath(dir)
+	env.Debug(env.cwd)
 	return env.cwd
 }
 
@@ -772,9 +775,7 @@ func (env *Shell) Logs() string {
 }
 
 func (env *Shell) TemplateCache() *TemplateCache {
-	env.Lock()
 	defer env.Trace(time.Now())
-	defer env.Unlock()
 	if env.tmplCache != nil {
 		return env.tmplCache
 	}

--- a/src/shell/scripts/omp.py
+++ b/src/shell/scripts/omp.py
@@ -3,7 +3,7 @@ import uuid
 $POWERLINE_COMMAND = "oh-my-posh"
 $POSH_THEME = "::CONFIG::"
 $POSH_PID = uuid.uuid4().hex
-$POSH_SHELL_VERSION = ""
+$POSH_SHELL_VERSION = $XONSH_VERSION
 
 def get_command_context():
     last_cmd = __xonsh__.history[-1] if __xonsh__.history else None
@@ -13,11 +13,11 @@ def get_command_context():
 
 def posh_primary():
     status, duration = get_command_context()
-    return $(::OMP:: print primary --config=@($POSH_THEME) --shell=xonsh --error=@(status) --execution-time=@(duration) | cat)
+    return $(::OMP:: print primary --config=@($POSH_THEME) --shell=xonsh --error=@(status) --execution-time=@(duration) --shell-version=@($POSH_SHELL_VERSION) | cat)
 
 def posh_right():
     status, duration = get_command_context()
-    return $(::OMP:: print right --config=@($POSH_THEME) --shell=xonsh --error=@(status) --execution-time=@(duration) | cat)
+    return $(::OMP:: print right --config=@($POSH_THEME) --shell=xonsh --error=@(status) --execution-time=@(duration) --shell-version=@($POSH_SHELL_VERSION) | cat)
 
 
 $PROMPT = posh_primary


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 04eba85</samp>

This pull request improves the thread-safety and logging of the `Shell` struct in `src/platform/shell.go` and adds xonsh shell version support to the `omp.py` script in `src/shell/scripts/omp.py`.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 04eba85</samp>

*  Add locking to `Pwd` function to prevent data races ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3654/files?diff=unified&w=0#diff-7b082f4396f0c936b17e8deb6c4ea8ec54cb48509691b08354c28ef55aa18557L397-R399))
*  Add debug logs to `Pwd` function to print current working directory ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3654/files?diff=unified&w=0#diff-7b082f4396f0c936b17e8deb6c4ea8ec54cb48509691b08354c28ef55aa18557R413), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3654/files?diff=unified&w=0#diff-7b082f4396f0c936b17e8deb6c4ea8ec54cb48509691b08354c28ef55aa18557R422))
*  Remove locking from `TemplateCache` function as it is no longer needed ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3654/files?diff=unified&w=0#diff-7b082f4396f0c936b17e8deb6c4ea8ec54cb48509691b08354c28ef55aa18557L775-R778))
*  Set `$POSH_SHELL_VERSION` variable to `$XONSH_VERSION` in `omp.py` script ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3654/files?diff=unified&w=0#diff-ad1f01e855628eefd5e9e7151512e206455bf6ae430ad43eb6a27a9d7ba9aa4eL6-R6))
*  Pass shell version to `::OMP::` command in `posh_primary` and `posh_right` functions in `omp.py` script ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3654/files?diff=unified&w=0#diff-ad1f01e855628eefd5e9e7151512e206455bf6ae430ad43eb6a27a9d7ba9aa4eL16-R20))