### PR TITLE
fix(platform): detect WSL via `/proc/version`

### DIFF
--- a/src/platform/shell_unix.go
+++ b/src/platform/shell_unix.go
@@ -5,6 +5,7 @@ package platform
 import (
 	"errors"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -29,11 +30,19 @@ func (env *Shell) QueryWindowTitles(_, _ string) (string, error) {
 
 func (env *Shell) IsWsl() bool {
 	defer env.Trace(time.Now())
-	// one way to check
-	// version := env.FileContent("/proc/version")
-	// return strings.Contains(version, "microsoft")
-	// using env variable
-	return env.Getenv("WSL_DISTRO_NAME") != ""
+	const key = "is_wsl"
+	if val, found := env.Cache().Get(key); found {
+		env.Debug(val)
+		return val == "true"
+	}
+	var val bool
+	defer func() {
+		env.Cache().Set(key, strconv.FormatBool(val), -1)
+	}()
+	version := env.FileContent("/proc/version")
+	val = strings.Contains(version, "microsoft")
+	env.Debug(strconv.FormatBool(val))
+	return val
 }
 
 func (env *Shell) IsWsl2() bool {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

Currently, `(*platform.Shell).IsWsl` returns `false` in an SSH session from Windows host to WSL because the environment variable `WSL_DISTRO_NAME` is not populated in this way.

Expected:

![expected](https://user-images.githubusercontent.com/83903009/228902226-443f4507-2ac1-48e6-bc05-de30f8154558.png)

Actual:

![actual](https://user-images.githubusercontent.com/83903009/228902216-f5c14d20-554b-4ffa-955f-5e8f8c1e32f7.png)

This PR will fix the above issue as it should detect WSL more reliably.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
