### PR TITLE
adding a new clean them named clean-view.opm.json, clean-view

### DIFF
--- a/themes/clean-view.omp.json
+++ b/themes/clean-view.omp.json
@@ -1,0 +1,100 @@
+{
+    "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
+    "blocks": [
+        {
+            "alignment": "left",
+            "segments": [
+                {
+                    "background": "#a313a8",
+                    "foreground": "#FFEB3B",
+                    "style": "plain",
+                    "template": "\u26a1 ",
+                    "type": "root"
+                },
+                {
+                    "background": "transparent",
+                    "foreground": "#ffffff",
+                    "style": "plain",
+                    "template": "{{ if .WSL }}WSL at {{ end }}{{.Icon}} ",
+                    "type": "os"
+                },
+                {
+                    "background": "#01579B",
+                    "foreground": "#ffffff",
+                    "leading_diamond": "<transparent,#01579B>\ue0b0</>",
+                    "properties": {
+                        "folder_icon": "\uf6d7",
+                        "folder_separator_icon": "<transparent> \ue0bd </>",
+                        "home_icon": "\uf7db",
+                        "style": "agnoster_short"
+                    },
+                    "style": "diamond",
+                    "template": " {{ .Path }} ",
+                    "trailing_diamond": "\ue0b0",
+                    "type": "path"
+                },
+                {
+                    "background": "#00C853",
+                    "background_templates": [
+                        "{{ if or (.Working.Changed) (.Staging.Changed) }}#FFEB3B{{ end }}",
+                        "{{ if and (gt .Ahead 0) (gt .Behind 0) }}#FFCC80{{ end }}",
+                        "{{ if gt .Ahead 0 }}#B388FF{{ end }}",
+                        "{{ if gt .Behind 0 }}#B388FF{{ end }}"
+                    ],
+                    "foreground": "#000000",
+                    "powerline_symbol": "\ue0b0",
+                    "properties": {
+                        "fetch_stash_count": true,
+                        "fetch_status": true
+                    },
+                    "style": "powerline",
+                    "template": " {{ .HEAD }}{{ if .Staging.Changed }}<#FF6F00> \uf046 {{ .Staging.String }}</>{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Working.Changed }} \uf044 {{ .Working.String }}{{ end }}{{ if gt .StashCount 0 }} \uf692 {{ .StashCount }}{{ end }} ",
+                    "type": "git"
+                },
+                {
+                    "background": "#49404f",
+                    "foreground": "#ffffff",
+                    "leading_diamond": "<transparent,#49404f>\ue0b0</>",
+                    "properties": {
+                        "style": "dallas",
+                        "threshold": 0
+                    },
+                    "style": "diamond",
+                    "template": " {{ .FormattedMs }}s ",
+                    "trailing_diamond": "\ue0b0",
+                    "type": "executiontime"
+                },
+                {
+                    "background": "#910000",
+                    "foreground": "#ffffff",
+                    "powerline_symbol": "\ue0b0",
+                    "style": "powerline",
+                    "template": "<transparent> \uf12a</> {{ .Meaning }} ",
+                    "type": "exit"
+                }
+            ],
+            "type": "prompt"
+        },
+        {
+            "alignment": "left",
+            "newline": true,
+            "segments": [
+                {
+                    "foreground": "#ffffff",
+                    "foreground_templates": [
+                        "{{ if gt .Code 0 }}#ff0000{{ end }}"
+                    ],
+                    "properties": {
+                        "always_enabled": true
+                    },
+                    "style": "plain",
+                    "template": "\u276f ",
+                    "type": "exit"
+                }
+            ],
+            "type": "prompt"
+        }
+    ],
+    "console_title_template": "{{if .Root}} \u26a1 {{end}}{{.Folder | replace \"~\" \"🏚\" }} @ {{.HostName}}",
+    "version": 2
+}


### PR DESCRIPTION
### Prerequisites

- [ ] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [ ] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5940254</samp>

This change introduces a new theme file `clean-view.omp.json` for the oh-my-posh tool. The theme file configures the prompt segments and the console title to display icons, colors, and information in a clean and minimal way. The change is part of a pull request that suggests a new theme option for the tool.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5940254</samp>

*  Add a new theme file `clean-view.omp.json` that defines the prompt segments and the console title for oh-my-posh ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3662/files?diff=unified&w=0#diff-5585f5880ad37fcbd5b33f0f5c05502ed80df2caa572a6372b95ade03c3b867bL1-R99))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
