### PR TITLE
fix Nushell init script

### DIFF
--- a/src/shell/scripts/omp.nu
+++ b/src/shell/scripts/omp.nu
@@ -6,13 +6,13 @@ export-env {
     # By default displays the right prompt on the first line
     # making it annoying when you have a multiline prompt
     # making the behavior different compared to other shells
-    let-env PROMPT_COMMAND_RIGHT = {''}
+    let-env PROMPT_COMMAND_RIGHT = ''
     let-env POSH_SHELL_VERSION = (version | get version)
 
     # PROMPTS
     let-env PROMPT_MULTILINE_INDICATOR = (^::OMP:: print secondary $"--config=($env.POSH_THEME)" --shell=nu $"--shell-version=($env.POSH_SHELL_VERSION)")
 
-    let-env PROMPT_COMMAND = {
+    let-env PROMPT_COMMAND = { ||
         # We have to do this because the initial value of `$env.CMD_DURATION_MS` is always `0823`,
         # which is an official setting.
         # See https://github.com/nushell/nushell/discussions/6402#discussioncomment-3466687.


### PR DESCRIPTION
Closes https://github.com/JanDeDobbeleer/oh-my-posh/issues/3675

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e0533ba</samp>

Improved `omp.nu` script for Nushell prompt by fixing and simplifying environment variables.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e0533ba</samp>

*  Simplify `let-env` commands to use string literals instead of blocks ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3676/files?diff=unified&w=0#diff-b4e6f5d564c90b8bcff9623c6cae46e5a6fe4379bd352f7e188c3c09d1289c02L9-R9), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3676/files?diff=unified&w=0#diff-b4e6f5d564c90b8bcff9623c6cae46e5a6fe4379bd352f7e188c3c09d1289c02L15-R15))
*  Fix bug that caused prompt to show incorrect command duration and information by using blocks with empty parameter lists for `let-env` commands ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3676/files?diff=unified&w=0#diff-b4e6f5d564c90b8bcff9623c6cae46e5a6fe4379bd352f7e188c3c09d1289c02L15-R15))

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
