### PR TITLE
chore: filter known contributions

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           github-token: ${{ secrets.GH_PAT }}
           script: |
+            const fs = require('fs');
             const { repo: { owner, repo } } = context;
             const pr = context.payload.pull_request;
 
@@ -52,7 +53,20 @@ jobs:
             }
 
             if (contributions.length === 0) {
-              console.log('No relevant additions found');
+              console.log('No relevant contributions found');
+              return;
+            }
+
+            var data = fs.readFileSync('.all-contributorsrc', 'utf8');
+            let json = JSON.parse(data);
+            const contributor = json.contributors.find(contributor => contributor.login === pr.user.login);
+            if (contributor) {
+              console.log(contributor);
+              contributions = contributions.filter(contribution => !contributor.contributions.includes(contribution));
+            }
+
+            if (contributions.length === 0) {
+              console.log('No new contributions found');
               return;
             }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0b2a926</samp>

Improve the contributors workflow by reading `.all-contributorsrc` with `fs` and avoiding duplicate requests.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0b2a926</samp>

* Import and parse the `.all-contributorsrc` file to get the existing contributors and their contributions ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3694/files?diff=unified&w=0#diff-95d9918a064bf8d3c5f2ddd14de321c91065ee6d836a1541e39780d5ecab983fR19))
* Filter out the contributions that the pull request author already has and log a message if no new contributions are found ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3694/files?diff=unified&w=0#diff-95d9918a064bf8d3c5f2ddd14de321c91065ee6d836a1541e39780d5ecab983fL55-R72))