### PR TITLE
fix(ansi): only clear background on inline overrides

### DIFF
--- a/src/ansi/ansi_writer.go
+++ b/src/ansi/ansi_writer.go
@@ -24,7 +24,8 @@ var (
 		{AnchorStart: `<f>`, AnchorEnd: `</f>`, Start: "\x1b[5m", End: "\x1b[25m"},
 		{AnchorStart: `<r>`, AnchorEnd: `</r>`, Start: "\x1b[7m", End: "\x1b[27m"},
 	}
-	colorStyle = &style{AnchorStart: "COLOR", AnchorEnd: `</>`, End: "\x1b[0m"}
+	resetStyle      = &style{AnchorStart: "RESET", AnchorEnd: `</>`, End: "\x1b[0m"}
+	backgroundStyle = &style{AnchorStart: "BACKGROUND", AnchorEnd: `</>`, End: "\x1b[49m"}
 )
 
 type style struct {
@@ -335,7 +336,7 @@ func (w *Writer) Write(background, foreground, text string) {
 	w.hyperlinkState = OTHER
 
 	// reset colors
-	w.writeEscapedAnsiString(colorStyle.End)
+	w.writeEscapedAnsiString(resetStyle.End)
 
 	// reset current
 	w.currentBackground = ""
@@ -410,9 +411,9 @@ func (w *Writer) writeSegmentColors() {
 func (w *Writer) writeColorOverrides(match map[string]string, background string, i int) (position int) {
 	position = i
 	// check color reset first
-	if match[ANCHOR] == colorStyle.AnchorEnd {
+	if match[ANCHOR] == resetStyle.AnchorEnd {
 		// make sure to reset the colors if needed
-		position += len([]rune(colorStyle.AnchorEnd)) - 1
+		position += len([]rune(resetStyle.AnchorEnd)) - 1
 
 		// do not reset when colors are identical
 		if w.currentBackground == w.background && w.currentForeground == w.foreground {
@@ -429,7 +430,7 @@ func (w *Writer) writeColorOverrides(match map[string]string, background string,
 		}
 
 		if w.background.IsClear() {
-			w.writeEscapedAnsiString(colorStyle.End)
+			w.writeEscapedAnsiString(backgroundStyle.End)
 		}
 
 		if w.currentBackground != w.background && !w.background.IsClear() {

--- a/src/ansi/ansi_writer_test.go
+++ b/src/ansi/ansi_writer_test.go
@@ -32,7 +32,7 @@ func TestWriteANSIColors(t *testing.T) {
 		{
 			Case:     "Bold with color override",
 			Input:    "<b><#ffffff>test</></b>",
-			Expected: "\x1b[1m\x1b[30m\x1b[38;2;255;255;255mtest\x1b[0m\x1b[30m\x1b[22m\x1b[0m",
+			Expected: "\x1b[1m\x1b[30m\x1b[38;2;255;255;255mtest\x1b[49m\x1b[30m\x1b[22m\x1b[0m",
 			Colors:   &Colors{Foreground: "black", Background: ParentBackground},
 		},
 		{


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1b65754</samp>

This pull request enhances the `ansi_writer` package to support better background color handling and output consistency. It adds new styles for setting and resetting the background color, and updates the existing functions and tests to use them.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1b65754</samp>

*  Introduce new styles for resetting and setting the background color ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3702/files?diff=unified&w=0#diff-0267d2a06e9c5eab5a04e9625772dd68774a70872a4014630cdb15183ce7dcd9L27-R28))
*  Use `resetStyle` instead of `colorStyle` to end color overrides in `Write` and `writeColorOverrides` functions ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3702/files?diff=unified&w=0#diff-0267d2a06e9c5eab5a04e9625772dd68774a70872a4014630cdb15183ce7dcd9L338-R339), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3702/files?diff=unified&w=0#diff-0267d2a06e9c5eab5a04e9625772dd68774a70872a4014630cdb15183ce7dcd9L413-R416))
*  Use `backgroundStyle` instead of `colorStyle` to reset background color when clear in `writeColorOverrides` function ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3702/files?diff=unified&w=0#diff-0267d2a06e9c5eab5a04e9625772dd68774a70872a4014630cdb15183ce7dcd9L432-R433))
*  Update test case for writing ANSI colors with bold and color override to include `backgroundStyle` in expected output ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3702/files?diff=unified&w=0#diff-7214a6ffb60e6b167949f626066440b0deabc9698c4e7923aa23478ab773476aL35-R35))