### PR TITLE
fix(tooltips): improve behaviour when using zsh-autosuggestions

### DIFF
--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -82,7 +82,21 @@ function _posh-tooltip() {
     zle .reset-prompt
   fi
 
+  # https://github.com/zsh-users/zsh-autosuggestions - clear suggestion to avoid keeping it after the newly inserted space
+  if [[ -n "$(zle -lL autosuggest-clear)" ]]; then
+    # only if suggestions not disabled (variable not set)
+    if ! [[ -v _ZSH_AUTOSUGGEST_DISABLED ]]; then
+      zle autosuggest-clear
+    fi
+  fi
   zle .self-insert
+  # https://github.com/zsh-users/zsh-autosuggestions - fetch new suggestion after the space
+  if [[ -n "$(zle -lL autosuggest-fetch)" ]]; then
+    # only if suggestions not disabled (variable not set)
+    if ! [[ -v _ZSH_AUTOSUGGEST_DISABLED ]]; then
+      zle autosuggest-fetch
+    fi
+  fi
 }
 
 function _posh-zle-line-init() {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description

I am using oh-my-posh with zsh, with [zsh-autosuggestions](https://github.com/zsh-users/zsh-autosuggestions) plugin enabled. I had problems using tooltips (as you can see [there](https://asciinema.org/a/577185)), where suggestions were displaced when a space was inserted. This behaviour was also causing issues with syntax-highlighting.

### How

Some checks and zle calls have been added in order to rewrite suggestion (if enabled) at the appropriate place, as you can see [there](https://asciinema.org/a/577186).

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
