### PR TITLE
feat(tooltips zsh): match aliases

### DIFF
--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -68,6 +68,10 @@ if [[ "$(zle -lL zle-line-init)" = *"_posh-zle-line-init"* ]]; then
   zle -N zle-line-init
 fi
 
+function get_alias_from_buffer() {
+  printf '%s' $aliases[$1]
+}
+
 function _posh-tooltip() {
   # ignore an empty buffer
   if [[ -z  "$BUFFER"  ]]; then
@@ -75,7 +79,15 @@ function _posh-tooltip() {
     return
   fi
 
-  local tooltip=$(::OMP:: print tooltip --config="$POSH_THEME" --shell=zsh --error="$omp_last_error" --command="$BUFFER" --shell-version="$ZSH_VERSION")
+  # expand alias for first word
+  local -a split_buffer=(${(s: :)BUFFER})
+  local first=${split_buffer[1]}
+  local alias=$(get_alias_from_buffer $first)
+  if [[ -z "$alias" ]]; then
+    alias=$first
+  fi
+
+  local tooltip=$(::OMP:: print tooltip --config="$POSH_THEME" --shell=zsh --error="$omp_last_error" --command="$alias" --shell-version="$ZSH_VERSION")
   # ignore an empty tooltip
   if [[ -n "$tooltip" ]]; then
     RPROMPT=$tooltip


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description

When using zsh, show tooltips even on aliases of specified tips

### How

Get the first word of the command line and get its alias if possible before feeding tooltips engine

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
