### PR TITLE
fix(font): improve font download timeouts

### DIFF
--- a/src/font/download.go
+++ b/src/font/download.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"time"
@@ -37,10 +38,16 @@ func isZipFile(data []byte) bool {
 }
 
 func getRemoteFile(location string) (data []byte, err error) {
-	client := &http.Client{}
-	ctx, cancelF := context.WithTimeout(context.Background(), time.Second*time.Duration(60))
-	defer cancelF()
-	req, err := http.NewRequestWithContext(ctx, "GET", location, nil)
+	client := &http.Client{
+		Transport: &http.Transport{
+			Dial: (&net.Dialer{
+				Timeout: 10 * time.Second,
+			}).Dial,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ResponseHeaderTimeout: 10 * time.Second,
+		},
+	}
+	req, err := http.NewRequestWithContext(context.Background(), "GET", location, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

Instead of deadlineing whole download process (which in case of large files would inevitably break on slow links) this PR introduces more fine grained timeouts.

fixes #3061

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0e3a5b0</samp>

*  Add timeouts for HTTP requests when downloading font files ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3736/files?diff=unified&w=0#diff-e7939dae62ba5baff84280f7ffcd1deca6848f0b8b1b62531e773f0f9e64e7c6L7-R10), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3736/files?diff=unified&w=0#diff-e7939dae62ba5baff84280f7ffcd1deca6848f0b8b1b62531e773f0f9e64e7c6L40-R49))

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
