### PR TITLE
Fix/Realign tooltip behaviors

### DIFF
--- a/src/shell/scripts/omp.fish
+++ b/src/shell/scripts/omp.fish
@@ -86,12 +86,13 @@ end
 
 function _render_tooltip
   commandline --function expand-abbr
-  set omp_tooltip_command (commandline --current-buffer | string split --allow-empty -f1 ' ' | string collect)
+  commandline --insert " "
+  # get the first word of command line as tip
+  set omp_tooltip_command (commandline --current-buffer | string trim -l | string split --allow-empty -f1 ' ' | string collect)
   if not test -n "$omp_tooltip_command"
     return
   end
   set omp_tooltip_prompt (::OMP:: print tooltip --config $POSH_THEME --shell fish --error $omp_status_cache --shell-version $FISH_VERSION --command $omp_tooltip_command)
-  commandline --insert " "
   if not test -n "$omp_tooltip_prompt"
     if test "$has_omp_tooltip" = "true"
       commandline --function repaint

--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -127,7 +127,7 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
             $cleanPSWD = Get-CleanPSWD
             $command = $null
             [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$command, [ref]$null)
-            $command = $command.Trim().Split(" ", 2) | Select-Object -First 1
+            $command = $command.TrimStart().Split(" ", 2) | Select-Object -First 1
             if ($command -eq $script:ToolTipCommand) {
                 return
             }
@@ -396,6 +396,9 @@ Example:
 
         # remove any posh-git status
         $env:POSH_GIT_STATUS = $null
+
+        # remove cached tip command
+        $script:ToolTipCommand = ""
 
         # restore the orignal last exit code
         $global:LASTEXITCODE = $script:OriginalLastExitCode

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -69,19 +69,6 @@ if [[ "$(zle -lL zle-line-init)" = *"_posh-zle-line-init"* ]]; then
 fi
 
 function _posh-tooltip() {
-  # ignore an empty buffer
-  if [[ -z  "$BUFFER"  ]]; then
-    zle .self-insert
-    return
-  fi
-
-  local tooltip=$(::OMP:: print tooltip --config="$POSH_THEME" --shell=zsh --error="$omp_last_error" --command="$BUFFER" --shell-version="$ZSH_VERSION")
-  # ignore an empty tooltip
-  if [[ -n "$tooltip" ]]; then
-    RPROMPT=$tooltip
-    zle .reset-prompt
-  fi
-
   # https://github.com/zsh-users/zsh-autosuggestions - clear suggestion to avoid keeping it after the newly inserted space
   if [[ -n "$(zle -lL autosuggest-clear)" ]]; then
     # only if suggestions not disabled (variable not set)
@@ -97,6 +84,20 @@ function _posh-tooltip() {
       zle autosuggest-fetch
     fi
   fi
+
+  # get the first word of command line as tip
+  local tip=${${(MS)BUFFER##[[:graph:]]*}%%[[:space:]]*}
+  # ignore an empty tip
+  if [[ -z "$tip" ]]; then
+    return
+  fi
+  local tooltip=$(::OMP:: print tooltip --config="$POSH_THEME" --shell=zsh --error="$omp_last_error" --command="$tip" --shell-version="$ZSH_VERSION")
+  # ignore an empty tooltip
+  if [[ -z "$tooltip" ]]; then
+    return
+  fi
+  RPROMPT=$tooltip
+  zle .reset-prompt
 }
 
 function _posh-zle-line-init() {

--- a/website/docs/configuration/tooltips.mdx
+++ b/website/docs/configuration/tooltips.mdx
@@ -44,7 +44,7 @@ import Config from '@site/src/components/Config.js';
 }}/>
 
 This configuration will render a right-aligned git segment when you type `git` or `g` followed by a space.
-A tip should not include any leading or trailing space but an interpolated one can be used, e.g., `g s`.
-Keep in mind that this is a blocking call, meaning that if the segment renders slow, you can't type until it's visible. Optimizations in this space are being explored.
+A tip should not include any spaces. Keep in mind that this is a blocking call, meaning that if the segment renders slow,
+you can't type until it's visible. Optimizations in this space are being explored.
 
 [clink]: https://chrisant996.github.io/clink/


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description

- Fix a bug that prevents entering space characters when the command line buffer is empty in Fish.
- Fix a bug that an empty tooltip will be cached in Windows CMD.
- Fix a bug that a cached tip command persists across prompts in PowerShell so a tooltip will not be rendered for the same tip in the next spawned prompt.
- The commit fccdfe5306e5c4644f85bd876e24fe58bf4706a1 and 820e28c85cded49a5a13dc380b81b828a60029f7 made OMP check the full command line for a tip. However, this behavior has no longer persisted in Fish since the commit 2609aa2aea5c031a6a002cdf393fc4efe2d365ae or in PowerShell since the commit d124909912b8cd13e9c1ab8bb3bd18f0a27bcd2b. Considering that using multiple words (containing space characters) as a tip is not a very common use case, we have to realign tooltip behaviors and re-clarify it in the docs.

### How

- Revert/rework related commits.
- Revise the docs.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
