### PR TITLE
fix(xonsh): do not use cat to capture string output

### DIFF
--- a/src/shell/scripts/omp.py
+++ b/src/shell/scripts/omp.py
@@ -13,11 +13,11 @@ def get_command_context():
 
 def posh_primary():
     status, duration = get_command_context()
-    return $(::OMP:: print primary --config=@($POSH_THEME) --shell=xonsh --error=@(status) --execution-time=@(duration) --shell-version=@($POSH_SHELL_VERSION) | cat)
+    return $(::OMP:: print primary --config=@($POSH_THEME) --shell=xonsh --error=@(status) --execution-time=@(duration) --shell-version=@($POSH_SHELL_VERSION))
 
 def posh_right():
     status, duration = get_command_context()
-    return $(::OMP:: print right --config=@($POSH_THEME) --shell=xonsh --error=@(status) --execution-time=@(duration) --shell-version=@($POSH_SHELL_VERSION) | cat)
+    return $(::OMP:: print right --config=@($POSH_THEME) --shell=xonsh --error=@(status) --execution-time=@(duration) --shell-version=@($POSH_SHELL_VERSION))
 
 
 $PROMPT = posh_primary


### PR DESCRIPTION
fix(xonsh): do not use cat to capture string output

resolves #3739

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/JanDeDobbeleer/oh-my-posh/pull/3742).
* __->__ #3742
* #3741