### PR TITLE
fix(pwsh): erase a previous tooltip before a new one is rendered

### DIFF
--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -133,7 +133,12 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
             }
             $script:ToolTipCommand = $command
             $standardOut = @(Start-Utf8Process $script:OMPExecutable @("print", "tooltip", "--error=$script:ErrorCode", "--shell=$script:ShellName", "--pswd=$cleanPSWD", "--config=$env:POSH_THEME", "--command=$command", "--shell-version=$script:PSVersion"))
-            Write-Host $standardOut -NoNewline
+            if ($standardOut -ne '') {
+                # clear from cursor to the end of the line in case a previous tooltip is cut off and partially preserved,
+                # if the new one is shorter
+                Write-Host "`e[K" -NoNewline
+                Write-Host $standardOut -NoNewline
+            }
             $host.UI.RawUI.CursorPosition = $position
             # we need this workaround to prevent the text after cursor from disappearing when the tooltip is rendered
             [Microsoft.PowerShell.PSConsoleReadLine]::Insert(' ')


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

Fix a bug that a previous tooltip can be cut off and partially preserved in PowerShell, if the new one is shorter.

### How

Use the "CSI K" escape sequence to clear from cursor to the end of the line but preserve the cursor position so that a previous tooltip can be completely erased before a new one is rendered.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
