### PR TITLE
refactor(pwsh): move tooltip erasure logic to engine

### DIFF
--- a/src/engine/engine.go
+++ b/src/engine/engine.go
@@ -398,6 +398,9 @@ func (e *Engine) PrintTooltip(tip string) string {
 			return ""
 		}
 		text, length := block.RenderSegments()
+		// clear from cursor to the end of the line in case a previous tooltip is cut off and partially preserved,
+		// if the new one is shorter
+		e.write(e.Writer.ClearAfter())
 		e.write(e.Writer.CarriageForward())
 		e.write(e.Writer.GetCursorForRightWrite(length, 0))
 		e.write(text)


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

Refactor the workaround for erasing a previous tooltip. Related: #3743.

### How

Use `(*ansi.Writer).ClearAfter` in the engine logic (`engine.go`) instead of a raw CSI sequence in the initialization script (`omp.ps1`) for PowerShell.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
