### PR TITLE
chore: Use invisible spacing char in theme

### DIFF
--- a/themes/powerlevel10k_rainbow.omp.json
+++ b/themes/powerlevel10k_rainbow.omp.json
@@ -203,7 +203,7 @@
         {
           "foreground": "#d3d7cf",
           "style": "plain",
-          "template": "\u2500\u256f",
+          "template": "\u2500\u256f\u2800",
           "type": "text"
         }
       ],


### PR DESCRIPTION
The `powerlevel10k_rainbow` theme is affected by the [Windows Terminal: Unexpected space between segments/text](https://ohmyposh.dev/docs/faq#windows-terminal-unexpected-space-between-segmentstext) problem. Inserting the invisible spacing character fixes it.

![image](https://user-images.githubusercontent.com/1934506/233857991-5433b30e-fcad-4166-bd1e-8b79800804fb.png)

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c2476de</samp>

Fixed a visual glitch in the `powerlevel10k_rainbow` theme by adding a Braille blank character to the text segment template. This change affects the file `themes/powerlevel10k_rainbow.omp.json`.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c2476de</samp>

*  Add a Braille blank character to the text segment template of the powerlevel10k_rainbow theme to fix a visual glitch ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3748/files?diff=unified&w=0#diff-05e57f257a2b49c90e7213a6cd811008d851da3786834b0b890e638b79107553L206-R206))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
