### PR TITLE
fix(sysinfo): remove CPU context

### DIFF
--- a/src/platform/shell.go
+++ b/src/platform/shell.go
@@ -24,7 +24,6 @@ import (
 	"github.com/jandedobbeleer/oh-my-posh/src/platform/cmd"
 	"github.com/jandedobbeleer/oh-my-posh/src/regex"
 
-	cpu "github.com/shirou/gopsutil/v3/cpu"
 	disk "github.com/shirou/gopsutil/v3/disk"
 	load "github.com/shirou/gopsutil/v3/load"
 	process "github.com/shirou/gopsutil/v3/process"
@@ -157,9 +156,6 @@ type Memory struct {
 type SystemInfo struct {
 	// mem
 	Memory
-	// cpu
-	Times float64
-	CPU   []cpu.InfoStat
 	// load
 	Load1  float64
 	Load5  float64
@@ -921,16 +917,6 @@ func (env *Shell) SystemInfo() (*SystemInfo, error) {
 		s.Load1 = loadStat.Load1
 		s.Load5 = loadStat.Load5
 		s.Load15 = loadStat.Load15
-	}
-
-	processorTimes, err := cpu.Percent(0, false)
-	if err == nil && len(processorTimes) > 0 {
-		s.Times = processorTimes[0]
-	}
-
-	processors, err := cpu.Info()
-	if err == nil {
-		s.CPU = processors
 	}
 
 	diskIO, err := disk.IOCounters()

--- a/src/segments/sysinfo_test.go
+++ b/src/segments/sysinfo_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/jandedobbeleer/oh-my-posh/src/platform"
 	"github.com/jandedobbeleer/oh-my-posh/src/properties"
 
-	"github.com/shirou/gopsutil/v3/cpu"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -74,12 +73,6 @@ func TestSysInfo(t *testing.T) {
 					SwapPercentUsed:     0,
 				},
 			},
-		},
-		{
-			Case:           "2 physical cpus",
-			ExpectedString: "1200 1200",
-			Template:       "{{range $cpu := .CPU}}{{round $cpu.Mhz 2 }} {{end}}",
-			SysInfo:        platform.SystemInfo{CPU: []cpu.InfoStat{{Mhz: 1200}, {Mhz: 1200}}},
 		},
 	}
 

--- a/website/docs/segments/sysinfo.mdx
+++ b/website/docs/segments/sysinfo.mdx
@@ -54,7 +54,6 @@ import Config from '@site/src/components/Config.js';
 | `.Load1`                   | `float64`  | is the current load1 (can be empty on windows)                                                                            |
 | `.Load5`                   | `float64`  | is the current load5 (can be empty on windows)                                                                            |
 | `.Load15`                  | `float64`  | is the current load15 (can be empty on windows)                                                                           |
-| `.CPU`                     | `[]struct` | an array of [InfoStat][cpuinfo] object, you can use any property it has e.g. `(index .CPU 0).Cores`                       |
 | `.Disks`                   | `[]struct` | an array of [IOCountersStat][ioinfo] object, you can use any property it has e.g. `.Disks.disk0.IoTime`                   |
 
 [cpuinfo]: https://github.com/shirou/gopsutil/blob/78065a7ce2021f6a78c8d6f586a2683ba501dcec/cpu/cpu.go#L32


### PR DESCRIPTION
fix(sysinfo): remove CPU context

BREAKING CHANGE: this property isn't used in any of the themes and it's
incorrect as fetching CPU information requires a timer which we don't
want to use as it will make rendering the prompt slower

For users who migrate to this version, remove the .CPU property from
the sysinfo segment's template in case you have that set.

resolves #3730

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/JanDeDobbeleer/oh-my-posh/pull/3752).
* #3753
* __->__ #3752