### PR TITLE
Update legacy folder icon `f74a`

### DIFF
--- a/themes/jandedobbeleer.omp.json
+++ b/themes/jandedobbeleer.omp.json
@@ -23,7 +23,7 @@
             "style": "folder"
           },
           "style": "powerline",
-          "template": " \uf74a  {{ .Path }} ",
+          "template": " \udb80\ude4b  {{ .Path }} ",
           "type": "path"
         },
         {


### PR DESCRIPTION
`f74a` (nf-mdi-folder) has been removed from Nerd Fonts, see https://www.nerdfonts.com/cheat-sheet. It is replaced with `\udb80\ude4b` (nf-md-folder).