### PR TITLE
fix: Update the Open Weather Map icons to remove blank spaces…

### DIFF
--- a/src/segments/owm.go
+++ b/src/segments/owm.go
@@ -112,13 +112,13 @@ func (d *Owm) setStatus() error {
 	icon := ""
 	switch id {
 	case "01n":
-		fallthrough
+		icon = "\ue32b"
 	case "01d":
-		icon = "\U000f0599"
+		icon = "\ue30d"
 	case "02n":
-		fallthrough
+		icon = "\ue37e"
 	case "02d":
-		icon = "\ufa94"
+		icon = "\ue302"
 	case "03n":
 		fallthrough
 	case "03d":
@@ -130,15 +130,15 @@ func (d *Owm) setStatus() error {
 	case "09n":
 		fallthrough
 	case "09d":
-		icon = "\U000f0596"
+		icon = "\ue319"
 	case "10n":
-		fallthrough
+		icon = "\ue325"
 	case "10d":
 		icon = "\ue308"
 	case "11n":
-		fallthrough
+		icon = "\ue32a"
 	case "11d":
-		icon = "\ue31d"
+		icon = "\ue30f"
 	case "13n":
 		fallthrough
 	case "13d":

--- a/src/segments/owm_test.go
+++ b/src/segments/owm_test.go
@@ -27,20 +27,20 @@ func TestOWMSegmentSingle(t *testing.T) {
 		{
 			Case:            "Sunny Display",
 			JSONResponse:    `{"weather":[{"icon":"01d"}],"main":{"temp":20}}`,
-			ExpectedString:  "\U000f0599 (20°C)",
+			ExpectedString:  "\ue30d (20°C)",
 			ExpectedEnabled: true,
 		},
 		{
 			Case:            "Sunny Display",
 			JSONResponse:    `{"weather":[{"icon":"01d"}],"main":{"temp":20}}`,
-			ExpectedString:  "\U000f0599 (20°C)",
+			ExpectedString:  "\ue30d (20°C)",
 			ExpectedEnabled: true,
 			Template:        "{{.Weather}} ({{.Temperature}}{{.UnitIcon}})",
 		},
 		{
 			Case:            "Sunny Display",
 			JSONResponse:    `{"weather":[{"icon":"01d"}],"main":{"temp":20}}`,
-			ExpectedString:  "\U000f0599",
+			ExpectedString:  "\ue30d",
 			ExpectedEnabled: true,
 			Template:        "{{.Weather}} ",
 		},
@@ -90,12 +90,12 @@ func TestOWMSegmentIcons(t *testing.T) {
 		{
 			Case:               "Sunny Display day",
 			IconID:             "01d",
-			ExpectedIconString: "\U000f0599",
+			ExpectedIconString: "\ue30d",
 		},
 		{
 			Case:               "Light clouds Display day",
 			IconID:             "02d",
-			ExpectedIconString: "\ufa94",
+			ExpectedIconString: "\ue302",
 		},
 		{
 			Case:               "Cloudy Display day",
@@ -110,7 +110,7 @@ func TestOWMSegmentIcons(t *testing.T) {
 		{
 			Case:               "Shower Rain Display day",
 			IconID:             "09d",
-			ExpectedIconString: "\U000f0596",
+			ExpectedIconString: "\ue319",
 		},
 		{
 			Case:               "Rain Display day",
@@ -120,7 +120,7 @@ func TestOWMSegmentIcons(t *testing.T) {
 		{
 			Case:               "Thunderstorm Display day",
 			IconID:             "11d",
-			ExpectedIconString: "\ue31d",
+			ExpectedIconString: "\ue30f",
 		},
 		{
 			Case:               "Snow Display day",
@@ -136,12 +136,12 @@ func TestOWMSegmentIcons(t *testing.T) {
 		{
 			Case:               "Sunny Display night",
 			IconID:             "01n",
-			ExpectedIconString: "\U000f0599",
+			ExpectedIconString: "\ue32b",
 		},
 		{
 			Case:               "Light clouds Display night",
 			IconID:             "02n",
-			ExpectedIconString: "\ufa94",
+			ExpectedIconString: "\ue37e",
 		},
 		{
 			Case:               "Cloudy Display night",
@@ -156,17 +156,17 @@ func TestOWMSegmentIcons(t *testing.T) {
 		{
 			Case:               "Shower Rain Display night",
 			IconID:             "09n",
-			ExpectedIconString: "\U000f0596",
+			ExpectedIconString: "\ue319",
 		},
 		{
 			Case:               "Rain Display night",
 			IconID:             "10n",
-			ExpectedIconString: "\ue308",
+			ExpectedIconString: "\ue325",
 		},
 		{
 			Case:               "Thunderstorm Display night",
 			IconID:             "11n",
-			ExpectedIconString: "\ue31d",
+			ExpectedIconString: "\ue32a",
 		},
 		{
 			Case:               "Snow Display night",
@@ -227,7 +227,7 @@ func TestOWMSegmentIcons(t *testing.T) {
 }
 func TestOWMSegmentFromCache(t *testing.T) {
 	response := fmt.Sprintf(`{"weather":[{"icon":"%s"}],"main":{"temp":20}}`, "01d")
-	expectedString := fmt.Sprintf("%s (20°C)", "\U000f0599")
+	expectedString := fmt.Sprintf("%s (20°C)", "\ue30d")
 
 	env := &mock.MockedEnvironment{}
 	cache := &mock.MockedCache{}
@@ -250,7 +250,7 @@ func TestOWMSegmentFromCache(t *testing.T) {
 
 func TestOWMSegmentFromCacheWithHyperlink(t *testing.T) {
 	response := fmt.Sprintf(`{"weather":[{"icon":"%s"}],"main":{"temp":20}}`, "01d")
-	expectedString := fmt.Sprintf("«%s (20°C)»(http://api.openweathermap.org/data/2.5/weather?q=AMSTERDAM,NL&units=metric&appid=key)", "\U000f0599")
+	expectedString := fmt.Sprintf("«%s (20°C)»(http://api.openweathermap.org/data/2.5/weather?q=AMSTERDAM,NL&units=metric&appid=key)", "\ue30d")
 
 	env := &mock.MockedEnvironment{}
 	cache := &mock.MockedCache{}


### PR DESCRIPTION
Update the Open Weather Map segment icons to remove blank spaces. Also, add night variants to some icons to better match the Open Weather Map icon list

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e9ba79f</samp>

Changed the weather icons in the `owm` segment to improve the visual appearance and accuracy of the weather status. Used a different font that supports more weather symbols.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e9ba79f</samp>

*  Update weather status icons to use Material Design Icons font for more consistency and variety ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3819/files?diff=unified&w=0#diff-f3466da260bee7c26f73ce616c897cbbd74feea39e1005bfbd08d24ce4b30660L115-R121), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3819/files?diff=unified&w=0#diff-f3466da260bee7c26f73ce616c897cbbd74feea39e1005bfbd08d24ce4b30660L133-R141))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
