### PR TITLE
feat(path): respect `folder_separator_icon` in a colon-trailed root

### DIFF
--- a/src/segments/path.go
+++ b/src/segments/path.go
@@ -145,7 +145,7 @@ func (pt *Path) setStyle() {
 	if len(pt.relative) == 0 {
 		pt.Path = pt.root
 		if strings.HasSuffix(pt.Path, ":") {
-			pt.Path += pt.env.PathSeparator()
+			pt.Path += pt.getFolderSeparator()
 		}
 		return
 	}

--- a/src/segments/path_test.go
+++ b/src/segments/path_test.go
@@ -14,7 +14,7 @@ import (
 	mock2 "github.com/stretchr/testify/mock"
 )
 
-func renderTemplate(env *mock.MockedEnvironment, segmentTemplate string, context interface{}) string {
+func renderTemplateNoTrimSpace(env *mock.MockedEnvironment, segmentTemplate string, context interface{}) string {
 	found := false
 	for _, call := range env.Mock.ExpectedCalls {
 		if call.Method == "TemplateCache" {
@@ -38,7 +38,11 @@ func renderTemplate(env *mock.MockedEnvironment, segmentTemplate string, context
 	if err != nil {
 		return err.Error()
 	}
-	return strings.TrimSpace(text)
+	return text
+}
+
+func renderTemplate(env *mock.MockedEnvironment, segmentTemplate string, context interface{}) string {
+	return strings.TrimSpace(renderTemplateNoTrimSpace(env, segmentTemplate, context))
 }
 
 const (
@@ -333,7 +337,7 @@ func TestAgnosterPathStyles(t *testing.T) {
 		},
 		{
 			Style:               Letter,
-			Expected:            "C:\\",
+			Expected:            "C: > ",
 			HomePath:            homeDirWindows,
 			Pwd:                 "C:\\",
 			GOOS:                platform.WINDOWS,
@@ -610,7 +614,7 @@ func TestAgnosterPathStyles(t *testing.T) {
 		},
 		{
 			Style:               AgnosterShort,
-			Expected:            "C:/",
+			Expected:            "C: | ",
 			HomePath:            homeDir,
 			Pwd:                 "/mnt/c",
 			Pswd:                "C:",
@@ -641,7 +645,7 @@ func TestAgnosterPathStyles(t *testing.T) {
 		},
 		{
 			Style:               AgnosterShort,
-			Expected:            "C:\\",
+			Expected:            "C: > ",
 			HomePath:            homeDirWindows,
 			Pwd:                 "C:",
 			GOOS:                platform.WINDOWS,
@@ -747,7 +751,7 @@ func TestAgnosterPathStyles(t *testing.T) {
 		}
 		path.setPaths()
 		path.setStyle()
-		got := renderTemplate(env, "{{ .Path }}", path)
+		got := renderTemplateNoTrimSpace(env, "{{ .Path }}", path)
 		assert.Equal(t, tc.Expected, got)
 	}
 }
@@ -877,7 +881,7 @@ func TestFullAndFolderPath(t *testing.T) {
 		}
 		path.setPaths()
 		path.setStyle()
-		got := renderTemplate(env, tc.Template, path)
+		got := renderTemplateNoTrimSpace(env, tc.Template, path)
 		assert.Equal(t, tc.Expected, got)
 	}
 }
@@ -932,7 +936,7 @@ func TestFullPathCustomMappedLocations(t *testing.T) {
 		}
 		path.setPaths()
 		path.setStyle()
-		got := renderTemplate(env, "{{ .Path }}", path)
+		got := renderTemplateNoTrimSpace(env, "{{ .Path }}", path)
 		assert.Equal(t, tc.Expected, got)
 	}
 }
@@ -960,7 +964,7 @@ func TestFolderPathCustomMappedLocations(t *testing.T) {
 	}
 	path.setPaths()
 	path.setStyle()
-	got := renderTemplate(env, "{{ .Path }}", path)
+	got := renderTemplateNoTrimSpace(env, "{{ .Path }}", path)
 	assert.Equal(t, "#", got)
 }
 
@@ -1141,7 +1145,7 @@ func TestAgnosterPath(t *testing.T) {
 		}
 		path.setPaths()
 		path.setStyle()
-		got := renderTemplate(env, "{{ .Path }}", path)
+		got := renderTemplateNoTrimSpace(env, "{{ .Path }}", path)
 		assert.Equal(t, tc.Expected, got, tc.Case)
 	}
 }
@@ -1295,7 +1299,7 @@ func TestAgnosterLeftPath(t *testing.T) {
 		}
 		path.setPaths()
 		path.setStyle()
-		got := renderTemplate(env, "{{ .Path }}", path)
+		got := renderTemplateNoTrimSpace(env, "{{ .Path }}", path)
 		assert.Equal(t, tc.Expected, got, tc.Case)
 	}
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

A user-defined path separator (`folder_separator_icon`) should be respected in a colon-trailed root path. E.g., if we set the path separator to `/`, OMP should show `C:/` instead of `C:\` in a root drive `C:` on **Windows**.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
