### PR TITLE
chore(install): correct arch for amd64

### DIFF
--- a/website/static/install.sh
+++ b/website/static/install.sh
@@ -128,7 +128,7 @@ detect_arch() {
   arch="$(uname -m | tr '[:upper:]' '[:lower:]')"
 
   case "${arch}" in
-    amd64) arch="386" ;;
+    x86_64) arch="amd64" ;;
     armv*) arch="arm" ;;
     arm64) arch="arm64" ;;
   esac


### PR DESCRIPTION
chore(install): correct arch for amd64

resolves #3838
