### PR TITLE
feat: shell integration using FinalTerm's OSC sequences

### DIFF
--- a/src/ansi/ansi_writer.go
+++ b/src/ansi/ansi_writer.go
@@ -122,6 +122,7 @@ type Writer struct {
 func (w *Writer) Init(shellName string) {
 	w.hyperlinkState = OTHER
 	w.shell = shellName
+	w.format = "%s"
 	switch w.shell {
 	case shell.BASH:
 		w.format = "\\[%s\\]"
@@ -269,6 +270,22 @@ func (w *Writer) SaveCursorPosition() string {
 
 func (w *Writer) RestoreCursorPosition() string {
 	return w.restoreCursorPosition
+}
+
+func (w *Writer) PromptStart() string {
+	return fmt.Sprintf(w.format, "\x1b]133;A\007")
+}
+
+func (w *Writer) CommandStart() string {
+	return fmt.Sprintf(w.format, "\x1b]133;B\007")
+}
+
+func (w *Writer) CommandFinished(code int, ignore bool) string {
+	if ignore {
+		return fmt.Sprintf(w.format, "\x1b]133;D\007")
+	}
+	mark := fmt.Sprintf("\x1b]133;D;%d\007", code)
+	return fmt.Sprintf(w.format, mark)
 }
 
 func (w *Writer) LineBreak() string {

--- a/src/cli/init.go
+++ b/src/cli/init.go
@@ -68,6 +68,7 @@ func runInit(shellName string) {
 	shell.Transient = cfg.TransientPrompt != nil
 	shell.ErrorLine = cfg.ErrorLine != nil || cfg.ValidLine != nil
 	shell.Tooltips = len(cfg.Tooltips) > 0
+	shell.ShellIntegration = cfg.ShellIntegration
 	for i, block := range cfg.Blocks {
 		// only fetch cursor position when relevant
 		if i == 0 && block.Newline {

--- a/src/cli/print.go
+++ b/src/cli/print.go
@@ -22,6 +22,7 @@ var (
 	command      string
 	shellVersion string
 	plain        bool
+	noExitCode   bool
 )
 
 // printCmd represents the prompt command
@@ -60,6 +61,7 @@ var printCmd = &cobra.Command{
 			Plain:         plain,
 			Primary:       args[0] == "primary",
 			Cleared:       cleared,
+			NoExitCode:    noExitCode,
 		}
 
 		eng := engine.New(flags)
@@ -101,5 +103,6 @@ func init() { //nolint:gochecknoinits
 	printCmd.Flags().BoolVarP(&plain, "plain", "p", false, "plain text output (no ANSI)")
 	printCmd.Flags().BoolVar(&cleared, "cleared", false, "do we have a clear terminal or not")
 	printCmd.Flags().BoolVar(&eval, "eval", false, "output the prompt for eval")
+	printCmd.Flags().BoolVar(&noExitCode, "no-exit-code", false, "no valid exit code (cancelled or no command yet)")
 	RootCmd.AddCommand(printCmd)
 }

--- a/src/engine/config.go
+++ b/src/engine/config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jandedobbeleer/oh-my-posh/src/platform"
 	"github.com/jandedobbeleer/oh-my-posh/src/properties"
 	"github.com/jandedobbeleer/oh-my-posh/src/segments"
+	"github.com/jandedobbeleer/oh-my-posh/src/shell"
 	"github.com/jandedobbeleer/oh-my-posh/src/template"
 
 	"github.com/gookit/config/v2"
@@ -48,6 +49,7 @@ type Config struct {
 	Palette              ansi.Palette           `json:"palette,omitempty"`
 	Palettes             *ansi.Palettes         `json:"palettes,omitempty"`
 	Cycle                ansi.Cycle             `json:"cycle,omitempty"`
+	ShellIntegration     bool                   `json:"shell_integration,omitempty"`
 	PWD                  string                 `json:"pwd,omitempty"`
 	Var                  map[string]interface{} `json:"var,omitempty"`
 
@@ -90,10 +92,30 @@ func (cfg *Config) getPalette() ansi.Palette {
 // LoadConfig returns the default configuration including possible user overrides
 func LoadConfig(env platform.Environment) *Config {
 	cfg := loadConfig(env)
+
 	// only migrate automatically when the switch isn't set
 	if !env.Flags().Migrate && cfg.Version < configVersion {
 		cfg.BackupAndMigrate()
 	}
+
+	if !cfg.ShellIntegration {
+		return cfg
+	}
+
+	// bash  - ok
+	// fish  - ok
+	// pwsh  - ok
+	// zsh   - ok
+	// cmd   - ok, as of v1.4.25 (chrisant996/clink#457, fixed in chrisant996/clink@8a5d7ea)
+	// nu    - built-in (and bugged) feature - nushell/nushell#5585, https://www.nushell.sh/blog/2022-08-16-nushell-0_67.html#shell-integration-fdncred-and-tyriar
+	// elv   - broken OSC sequences
+	// xonsh - broken OSC sequences
+	// tcsh  - overall broken, FTCS_COMMAND_EXECUTED could be added to POSH_POSTCMD in the future
+	switch env.Shell() {
+	case shell.ELVISH, shell.XONSH, shell.TCSH, shell.NU:
+		cfg.ShellIntegration = false
+	}
+
 	return cfg
 }
 

--- a/src/engine/prompt.go
+++ b/src/engine/prompt.go
@@ -46,7 +46,7 @@ func (e *Engine) Primary() string {
 		e.write(" ")
 	}
 
-	if e.Config.ShellIntegration {
+	if e.Config.ShellIntegration && e.Config.TransientPrompt == nil {
 		e.write(e.Writer.CommandStart())
 	}
 

--- a/src/engine/prompt.go
+++ b/src/engine/prompt.go
@@ -20,6 +20,12 @@ const (
 )
 
 func (e *Engine) Primary() string {
+	if e.Config.ShellIntegration {
+		exitCode := e.Env.ErrorCode()
+		e.write(e.Writer.CommandFinished(exitCode, e.Env.Flags().NoExitCode))
+		e.write(e.Writer.PromptStart())
+	}
+
 	// cache a pointer to the color cycle
 	cycle = &e.Config.Cycle
 	for i, block := range e.Config.Blocks {
@@ -38,6 +44,10 @@ func (e *Engine) Primary() string {
 
 	if e.Config.FinalSpace {
 		e.write(" ")
+	}
+
+	if e.Config.ShellIntegration {
+		e.write(e.Writer.CommandStart())
 	}
 
 	e.pwd()
@@ -139,6 +149,12 @@ func (e *Engine) ExtraPrompt(promptType ExtraPromptType) string {
 		promptText = err.Error()
 	}
 
+	if promptType == Transient && e.Config.ShellIntegration {
+		exitCode := e.Env.ErrorCode()
+		e.write(e.Writer.CommandFinished(exitCode, e.Env.Flags().NoExitCode))
+		e.write(e.Writer.PromptStart())
+	}
+
 	foreground := prompt.ForegroundTemplates.FirstMatch(nil, e.Env, prompt.Foreground)
 	background := prompt.BackgroundTemplates.FirstMatch(nil, e.Env, prompt.Background)
 	e.Writer.SetColors(background, foreground)
@@ -149,6 +165,10 @@ func (e *Engine) ExtraPrompt(promptType ExtraPromptType) string {
 		if padText, OK := e.shouldFill(prompt.Filler, length); OK {
 			str += padText
 		}
+	}
+
+	if promptType == Transient && e.Config.ShellIntegration {
+		str += e.Writer.CommandStart()
 	}
 
 	switch e.Env.Shell() {

--- a/src/platform/shell.go
+++ b/src/platform/shell.go
@@ -72,6 +72,7 @@ type Flags struct {
 	Cleared       bool
 	Version       string
 	TrueColor     bool
+	NoExitCode    bool
 }
 
 type CommandError struct {

--- a/src/shell/init.go
+++ b/src/shell/init.go
@@ -46,11 +46,12 @@ const (
 )
 
 var (
-	Transient bool
-	ErrorLine bool
-	Tooltips  bool
-	RPrompt   bool
-	Cursor    bool
+	Transient        bool
+	ErrorLine        bool
+	Tooltips         bool
+	ShellIntegration bool
+	RPrompt          bool
+	Cursor           bool
 )
 
 func getExecutablePath(env platform.Environment) (string, error) {
@@ -267,6 +268,7 @@ func PrintInit(env platform.Environment) string {
 		"::TRANSIENT::", toggleSetting(Transient),
 		"::ERROR_LINE::", toggleSetting(ErrorLine),
 		"::TOOLTIPS::", toggleSetting(Tooltips),
+		"::FTCS_MARKS::", toggleSetting(ShellIntegration),
 		"::RPROMPT::", strconv.FormatBool(RPrompt),
 		"::CURSOR::", strconv.FormatBool(Cursor),
 		"::UPGRADE::", strconv.FormatBool(hasNotice),

--- a/src/shell/scripts/omp.bash
+++ b/src/shell/scripts/omp.bash
@@ -6,7 +6,7 @@ export CONDA_PROMPT_MODIFIER=false
 omp_start_time=""
 
 # start timer on command start
-PS0='${omp_start_time:0:$((omp_start_time="$(_omp_start_timer)",0))}'
+PS0='${omp_start_time:0:$((omp_start_time="$(_omp_start_timer)",0))}$(_omp_ftcs_command_start)'
 # set secondary prompt
 PS2="$(::OMP:: print secondary --config="$POSH_THEME" --shell=bash --shell-version="$BASH_VERSION")"
 
@@ -34,6 +34,12 @@ function _omp_start_timer() {
     ::OMP:: get millis
 }
 
+function _omp_ftcs_command_start() {
+    if [ "::FTCS_MARKS::" == "true" ]; then
+        printf "\e]133;C\a"
+    fi
+}
+
 # template function for context loading
 function set_poshcontext() {
     return
@@ -43,14 +49,16 @@ function _omp_hook() {
     local ret=$?
     local omp_stack_count=$((${#DIRSTACK[@]} - 1))
     local omp_elapsed=-1
+    local no_exit_code="true"
     if [[ -n "$omp_start_time" ]]; then
         local omp_now=$(::OMP:: get millis --shell=bash)
         omp_elapsed=$((omp_now-omp_start_time))
         omp_start_time=""
+        no_exit_code="false"
     fi
     set_poshcontext
     _set_posh_cursor_position
-    PS1="$(::OMP:: print primary --config="$POSH_THEME" --shell=bash --shell-version="$BASH_VERSION" --error="$ret" --execution-time="$omp_elapsed" --stack-count="$omp_stack_count" | tr -d '\0')"
+    PS1="$(::OMP:: print primary --config="$POSH_THEME" --shell=bash --shell-version="$BASH_VERSION" --error="$ret" --execution-time="$omp_elapsed" --stack-count="$omp_stack_count" --no-exit-code="$no_exit_code" | tr -d '\0')"
     return $ret
 }
 

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -36,6 +36,9 @@ function set_poshcontext() {
 }
 
 function prompt_ohmyposh_preexec() {
+  if [[ "::FTCS_MARKS::" = "true" ]]; then
+    printf "\033]133;C\007"
+  fi
   omp_start_time=$(::OMP:: get millis)
 }
 
@@ -43,15 +46,17 @@ function prompt_ohmyposh_precmd() {
   omp_last_error=$?
   omp_stack_count=${#dirstack[@]}
   omp_elapsed=-1
+  no_exit_code="true"
   if [ $omp_start_time ]; then
     local omp_now=$(::OMP:: get millis --shell=zsh)
     omp_elapsed=$(($omp_now-$omp_start_time))
+    no_exit_code="false"
   fi
   count=$((POSH_PROMPT_COUNT+1))
   export POSH_PROMPT_COUNT=$count
   set_poshcontext
   _set_posh_cursor_position
-  eval "$(::OMP:: print primary --config="$POSH_THEME" --error="$omp_last_error" --execution-time="$omp_elapsed" --stack-count="$omp_stack_count" --eval --shell=zsh --shell-version="$ZSH_VERSION")"
+  eval "$(::OMP:: print primary --config="$POSH_THEME" --error="$omp_last_error" --execution-time="$omp_elapsed" --stack-count="$omp_stack_count" --eval --shell=zsh --shell-version="$ZSH_VERSION"  --no-exit-code="$no_exit_code")"
   unset omp_start_time
 }
 
@@ -109,7 +114,7 @@ function _posh-zle-line-init() {
     local -i ret=$?
     (( $+zle_bracketed_paste )) && print -r -n - $zle_bracketed_paste[2]
 
-    eval "$(::OMP:: print transient --error="$omp_last_error" --execution-time="$omp_elapsed" --stack-count="$omp_stack_count" --config="$POSH_THEME" --eval --shell=zsh --shell-version="$ZSH_VERSION")"
+    eval "$(::OMP:: print transient --error="$omp_last_error" --execution-time="$omp_elapsed" --stack-count="$omp_stack_count" --config="$POSH_THEME" --eval --shell=zsh --shell-version="$ZSH_VERSION" --no-exit-code="$no_exit_code")"
     zle .reset-prompt
 
     # If we received EOT, we exit the shell

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -3131,6 +3131,11 @@
       "description": "https://ohmyposh.dev/docs/configuration/overview#general-settings",
       "default": true
     },
+    "shell_integration": {
+      "type": "boolean",
+      "title": "FTCS command marks for shell integration",
+      "default": false
+    },
     "pwd": {
       "type": "string",
       "title": "Enable OSC99/7/51",

--- a/website/docs/configuration/overview.mdx
+++ b/website/docs/configuration/overview.mdx
@@ -133,6 +133,7 @@ For example, the following is a valid `--config` flag:
 | `terminal_background` | `string`         | [color][colors] - terminal background color, set to your terminal's background color when you notice black elements in Windows Terminal or the Visual Studio Code integrated terminal |
 | `accent_color`        | `string`         | [color][colors] - accent color, used as a fallback when the `accent` [color][accent] is not supported                                                                                 |
 | `var`                 | `map[string]any` | config variables to use in [templates][templates]. Can be any value                                                                                                                   |
+| `shell_integration`   | `boolean`        | enable shell integration using FinalTerm's OSC sequences. Works in bash, cmd (Clink v1.14.25+), fish, powershell and zsh                                                              |
 
 ### JSON Schema Validation
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description

An attempt at adding shell integration using FinalTerm escape sequences (#3795).

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b3d8186</samp>

This pull request adds support for the FinalTerm's Command Status Control (FTCS) protocol to oh-my-posh, a cross-platform prompt engine. The FTCS protocol allows the shell and the terminal emulator to communicate about the prompt and the command boundaries, improving the accuracy of the cursor position and the command history. The pull request introduces a new `ftcs_marks` property to the theme configuration file, a new `--no-exit-code` flag to the `print` command, and modifies the `Writer` type and the initialization scripts for different shells to implement the FTCS protocol. The pull request also updates the theme schema and the website documentation to reflect the new feature.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b3d8186</samp>

*  Add support for the FinalTerm's Command Status Control (FTCS) protocol, which allows the shell to send information about the prompt, the command start, and the command finish to the terminal emulator ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-0267d2a06e9c5eab5a04e9625772dd68774a70872a4014630cdb15183ce7dcd9R114-R116), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-0267d2a06e9c5eab5a04e9625772dd68774a70872a4014630cdb15183ce7dcd9R146-R148), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-0267d2a06e9c5eab5a04e9625772dd68774a70872a4014630cdb15183ce7dcd9R166-R168), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-0267d2a06e9c5eab5a04e9625772dd68774a70872a4014630cdb15183ce7dcd9R186-R188), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-0267d2a06e9c5eab5a04e9625772dd68774a70872a4014630cdb15183ce7dcd9R286-R301), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-25963a790b4b92626029512213de64d81d974f422e9789c33bbe890eadfccb6aR38), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-9cbb773ea359cb84f27d7d8a473c1d6a206afb625cd36be225a57c43daa56145R23-R46), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-9cbb773ea359cb84f27d7d8a473c1d6a206afb625cd36be225a57c43daa56145R66-R68), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-0faaddc70290b391ca2b260082b1001d53ec472eda91a6b9735ad01c3fff42b9R52), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-892c540c9bfebcb3bb8a0be1714201cd17eb6f0d40367c09f80d56e883b7335eR3134-R3138), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-498067c71ffdbf7df2222ccd09254985d84ed65e45050023e8dc53c2d7338e90R136))
*  Add a `FtcsMarks` field to the `Config` type in the `engine` package and the `shell` package, and assign it based on the theme configuration file ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-25963a790b4b92626029512213de64d81d974f422e9789c33bbe890eadfccb6aR38), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-0faaddc70290b391ca2b260082b1001d53ec472eda91a6b9735ad01c3fff42b9R52), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-892c540c9bfebcb3bb8a0be1714201cd17eb6f0d40367c09f80d56e883b7335eR3134-R3138))
*  Add a `FtcsMarks` field to the `shell` package and pass it to the `cli` package in the `runInit` function ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-41866dd0fff74d090d8a5e797c35d633f337b67f67c570056468de4eda13edf9R71), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-0faaddc70290b391ca2b260082b1001d53ec472eda91a6b9735ad01c3fff42b9R52))
*  Add a `FtcsMarks` placeholder to the `PrintInit` function in the `shell` package and replace it with the `FtcsMarks` field value when printing the initialization script for the shell ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-0faaddc70290b391ca2b260082b1001d53ec472eda91a6b9735ad01c3fff42b9R271))
*  Add a `noExitCode` field to the `cli` package and the `platform` package, and assign it based on a command-line option (`--no-exit-code`) that is passed by the shell scripts when printing the prompt ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-3a225e739581049cba57996cf4f3aa2e2d475220989f0a7f93f48d9a9498d693R25), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-3a225e739581049cba57996cf4f3aa2e2d475220989f0a7f93f48d9a9498d693R64), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-3a225e739581049cba57996cf4f3aa2e2d475220989f0a7f93f48d9a9498d693R106), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-7b082f4396f0c936b17e8deb6c4ea8ec54cb48509691b08354c28ef55aa18557R75))
*  Add a `noExitCode` flag to the `FtcsCommandFinished` method of the `Writer` type in the `ansi` package, and decide whether to include the exit code in the FTCS command finish sequence based on the flag ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-0267d2a06e9c5eab5a04e9625772dd68774a70872a4014630cdb15183ce7dcd9R286-R301))
*  Add the FTCS escape sequences for bash, zsh, fish, cmd, and powershell to the `Writer` fields in the `Init` function in the `ansi` package ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-0267d2a06e9c5eab5a04e9625772dd68774a70872a4014630cdb15183ce7dcd9R146-R148), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-0267d2a06e9c5eab5a04e9625772dd68774a70872a4014630cdb15183ce7dcd9R166-R168), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-0267d2a06e9c5eab5a04e9625772dd68774a70872a4014630cdb15183ce7dcd9R186-R188))
*  Add the FTCS prompt sequence, the FTCS command finish sequence, and the FTCS command start sequence to the output in the `Primary` function in the `engine` package, if the FTCS protocol is enabled ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-9cbb773ea359cb84f27d7d8a473c1d6a206afb625cd36be225a57c43daa56145R66-R68))
*  Add a `ftcsMarksEnabled` local variable to the `Primary` function in the `engine` package, and set it based on the `FtscMarks` field of the `Config` type and the `Shell` type of the `Env` type ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-9cbb773ea359cb84f27d7d8a473c1d6a206afb625cd36be225a57c43daa56145R23-R46))
*  Add a `_omp_ftcs_command_start` function to the `omp.bash` script, and call it in the `PS0` variable, if the FTCS protocol is enabled ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-590b8f91b009622e545601ce3ead7c82981499d4d15a0f0eadc837f727288d3fL9-R9), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-590b8f91b009622e545601ce3ead7c82981499d4d15a0f0eadc837f727288d3fR37-R42))
*  Add a `no_exit_code` local variable to the `omp_prompt` function in the `omp.bash` script, and pass it as a command-line option (`--no-exit-code`) to the `print` command ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-590b8f91b009622e545601ce3ead7c82981499d4d15a0f0eadc837f727288d3fL46-R61))
*  Add a `no_exit_code` local variable to the `omp_prompt` function in the `omp.fish` script, and pass it as a command-line option (`--no-exit-code`) to the `print` command ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-46360978d2c694be7c9f884ed468ffadc14e53ae489810d1efa42bdb6783641bL28-R40))
*  Add the FTCS prompt sequence, the FTCS command finish sequence, and the FTCS command start sequence to the output in the `omp_prompt` function in the `omp.fish` script, if the FTCS protocol is enabled ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-46360978d2c694be7c9f884ed468ffadc14e53ae489810d1efa42bdb6783641bL46-R52))
*  Add a `preexec_omp` function to the `omp.fish` script, and register it as an event handler for the `fish_preexec` event, if the FTCS protocol is enabled ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-46360978d2c694be7c9f884ed468ffadc14e53ae489810d1efa42bdb6783641bR83-R88))
*  Add a `no_exit_code` local variable to the `omp.lua` script, and set it by a `command_executed_mark` function that is called after each command is executed in cmd (Clink) ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-7e7459989162fbcef766c31c2bbfa7de2df318501b919a8f141cd0df0c07bf5bR41), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-7e7459989162fbcef766c31c2bbfa7de2df318501b919a8f141cd0df0c07bf5bR197-R207), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-7e7459989162fbcef766c31c2bbfa7de2df318501b919a8f141cd0df0c07bf5bR285))
*  Add a `no_exit_code_str` variable to the `get_posh_prompt` function in the `omp.lua` script, and pass it as a command-line option (`--no-exit-code`) to the `print` command ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-7e7459989162fbcef766c31c2bbfa7de2df318501b919a8f141cd0df0c07bf5bL154-R159))
*  Add a `no_exit_code` local variable to the `omp.ps1` script, and set it by the `lastHistory` variable or the `LastHistoryId` variable ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-878b46f4ae6c1a83e8ee23b152cb60b8d8292218d8c268485633454ac42580c8L341-R361))
*  Add a `standardOut` variable to the `omp.ps1` script, and pass it as a command-line option (`--no-exit-code`) to the `print` command ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-878b46f4ae6c1a83e8ee23b152cb60b8d8292218d8c268485633454ac42580c8L395-R414))
*  Add a custom key handler (`OhMyPoshEnterKeyHandler`) for the Enter key to the `omp.ps1` script, and register it with the `Set-PSReadLineKeyHandler` cmdlet, if the FTCS protocol is enabled ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-878b46f4ae6c1a83e8ee23b152cb60b8d8292218d8c268485633454ac42580c8R193-R209))
*  Add a `no_exit_code` local variable to the `omp_prompt` function in the `omp.zsh` script, and pass it as a command-line option (`--no-exit-code`) to the `print` command ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-64dbc74b4c034b9ecc1eb57393502d1bbc315b100b6a6f1e164dd1b80776d248L46-R53))
*  Add the FTCS command start sequence to the output in the `omp.zsh` script, if the FTCS protocol is enabled ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-64dbc74b4c034b9ecc1eb57393502d1bbc315b100b6a6f1e164dd1b80776d248R39-R41))
*  Add a documentation entry for the `ftcs_marks` property to the website in `website/docs/configuration/overview.mdx` ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3842/files?diff=unified&w=0#diff-498067c71ffdbf7df2222ccd09254985d84ed65e45050023e8dc53c2d7338e90R136))

### TODO:

- [x] Testing - I didn't have enough time to test it properly
- [x] Code clean-up
- [ ] Possibly extending documentation

#### Bugs in the current implementation

- [ ] Prompts and commands are marked twice in CMD, because the prompt is printed twice (Clink v1.4.25+ required for testing, older versions don't output `FTCS` sequences at all - chrisant996/clink#457)
- [x] Escape sequences are printed as text in Elvish and Xonsh (force disabled in code at this moment)

### Other notes

- Nushell has shell integration built-in
- `tcsh` was too bugged for me to even try implementing this feature
- Saving and restoring cursor position when writing the escape codes feels like a workaround for problems with cursor/prompt position - there probably is a better way to do it

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary

resolves #3795
