### PR TITLE
fix: Remove extra leading space from PackageManagerIcon in node segment

### DIFF
--- a/src/segments/node.go
+++ b/src/segments/node.go
@@ -55,11 +55,11 @@ func (n *Node) loadContext() {
 		return
 	}
 	if n.language.env.HasFiles("yarn.lock") {
-		n.PackageManagerIcon = n.language.props.GetString(YarnIcon, " \uF61A")
+		n.PackageManagerIcon = n.language.props.GetString(YarnIcon, "\uF61A")
 		return
 	}
 	if n.language.env.HasFiles("package-lock.json") || n.language.env.HasFiles("package.json") {
-		n.PackageManagerIcon = n.language.props.GetString(NPMIcon, " \uE71E")
+		n.PackageManagerIcon = n.language.props.GetString(NPMIcon, "\uE71E")
 	}
 }
 


### PR DESCRIPTION
### Prerequisites

- [X] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [X] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description

Removes leading space from the PackageManagerIcon in the node segment. 

This is how it looks in my prompt:

![image](https://github.com/JanDeDobbeleer/oh-my-posh/assets/716334/dc31b113-3f48-465a-8527-fb1c2faa5905)

With this configuration (and same if I remove `template` since this matches the default one):

```json
{
          "type": "node",
          "style": "diamond",
          "foreground": "p:node-green",
          "background": "p:background",
          "leading_diamond": "\ue0b6",
          "trailing_diamond": "\ue0b4",
          "template": "{{ .PackageManagerIcon }} {{ .Full }}",
          "properties": {
            "display_mode": "files",
            "fetch_package_manager": true
          }
},
```` 