### PR TITLE
Follow-up to the new `upgrade` segment

### DIFF
--- a/src/segments/upgrade_test.go
+++ b/src/segments/upgrade_test.go
@@ -21,7 +21,7 @@ func TestUpgrade(t *testing.T) {
 		HasCache        bool
 		CurrentVersion  string
 		LatestVersion   string
-		CacheVersion    string
+		CachedVersion   string
 		Error           error
 	}{
 		{
@@ -36,7 +36,7 @@ func TestUpgrade(t *testing.T) {
 			LatestVersion:  "1.0.1",
 		},
 		{
-			Case:  "Version error",
+			Case:  "Error on update check",
 			Error: errors.New("error"),
 		},
 		{
@@ -44,7 +44,7 @@ func TestUpgrade(t *testing.T) {
 			HasCache:        true,
 			CurrentVersion:  "1.0.2",
 			LatestVersion:   "1.0.3",
-			CacheVersion:    "1.0.2",
+			CachedVersion:   "1.0.2",
 			ExpectedEnabled: true,
 		},
 		{
@@ -52,14 +52,14 @@ func TestUpgrade(t *testing.T) {
 			HasCache:       true,
 			CurrentVersion: "1.0.2",
 			LatestVersion:  "1.0.2",
-			CacheVersion:   "1.0.1",
+			CachedVersion:  "1.0.1",
 		},
 		{
 			Case:            "On previous, version changed",
 			HasCache:        true,
 			CurrentVersion:  "1.0.2",
 			LatestVersion:   "1.0.3",
-			CacheVersion:    "1.0.1",
+			CachedVersion:   "1.0.1",
 			ExpectedEnabled: true,
 		},
 	}
@@ -69,10 +69,10 @@ func TestUpgrade(t *testing.T) {
 		cache := &mock.MockedCache{}
 
 		env.On("Cache").Return(cache)
-		if len(tc.CacheVersion) == 0 {
-			tc.CacheVersion = tc.CurrentVersion
+		if len(tc.CachedVersion) == 0 {
+			tc.CachedVersion = tc.CurrentVersion
 		}
-		cacheData := fmt.Sprintf(`{"latest":"v%s", "current": "v%s"}`, tc.LatestVersion, tc.CacheVersion)
+		cacheData := fmt.Sprintf(`{"latest":"%s", "current": "%s"}`, tc.LatestVersion, tc.CachedVersion)
 		cache.On("Get", UPGRADECACHEKEY).Return(cacheData, tc.HasCache)
 		cache.On("Set", mock2.Anything, mock2.Anything, mock2.Anything)
 

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -432,7 +432,7 @@
           },
           "then": {
             "title": "Project Segment",
-            "description": "https://ohmyposh.dev/docs/project"
+            "description": "https://ohmyposh.dev/docs/segments/project"
           }
         },
         {
@@ -445,7 +445,7 @@
           },
           "then": {
             "title": "NPM Segment",
-            "description": "https://ohmyposh.dev/docs/npm",
+            "description": "https://ohmyposh.dev/docs/segments/npm",
             "properties": {
               "properties": {
                 "properties": {
@@ -529,14 +529,14 @@
           },
           "then": {
             "title": "Azure Segment",
-            "description": "https://ohmyposh.dev/docs/az",
+            "description": "https://ohmyposh.dev/docs/segments/az",
             "properties": {
               "properties": {
                 "properties": {
                   "source": {
                     "type": "string",
                     "title": "Source",
-                    "description": "https://ohmyposh.dev/docs/az#properties",
+                    "description": "https://ohmyposh.dev/docs/segments/az#properties",
                     "default": "first_match",
                     "enum": [
                       "first_match",
@@ -2567,7 +2567,7 @@
           },
           "then": {
             "title": "Brewfather Batch Status",
-            "description": "https://ohmyposh.dev/docs/brewfather",
+            "description": "https://ohmyposh.dev/docs/segments/brewfather",
             "properties": {
               "properties": {
                 "properties": {
@@ -2804,12 +2804,34 @@
           },
           "then": {
             "title": "Unity Segment",
-            "description": "https://ohmyposh.dev/docs/unity",
+            "description": "https://ohmyposh.dev/docs/segments/unity",
             "properties": {
               "properties": {
                 "properties": {
                   "http_timeout": {
                     "$ref": "#/definitions/http_timeout"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "upgrade"
+              }
+            }
+          },
+          "then": {
+            "title": "Upgrade Segment",
+            "description": "https://ohmyposh.dev/docs/segments/upgrade",
+            "properties": {
+              "properties": {
+                "properties": {
+                  "cache_timeout": {
+                    "$ref": "#/definitions/cache_timeout"
                   }
                 }
               }
@@ -3116,7 +3138,7 @@
           },
           "then": {
             "title": "Mercurial Segment",
-            "description": "https://ohmyposh.dev/docs/mercurial",
+            "description": "https://ohmyposh.dev/docs/segments/mercurial",
             "properties": {
               "properties": {
                 "properties": {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added/updated (for bug fixes / features)

### Description

- Add definitions of `upgrade` segments to the theme schema and correct outdated links.
- For an `upgrade` segment, always update the `upgrade_segment` cache after a update check is performed. This avoids underlying duplicate HTTP requests for update checks, e.g., when the current version is the latest but a `upgrade_segment` cache does not exist or the cached version is a previous one.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
