### PR TITLE
Fix theme schema & template cache

### DIFF
--- a/src/platform/shell.go
+++ b/src/platform/shell.go
@@ -190,6 +190,7 @@ type TemplateCache struct {
 	SHLVL        int
 	Segments     SegmentsCache
 
+	initialized bool
 	sync.RWMutex
 }
 
@@ -312,6 +313,7 @@ func (env *Shell) Init() {
 	env.cmdCache = &commandCache{
 		commands: NewConcurrentMap(),
 	}
+	env.tmplCache = &TemplateCache{}
 	env.SetPromptCount()
 }
 
@@ -776,6 +778,7 @@ func (env *Shell) LoadTemplateCache() {
 		env.Error(err)
 		return
 	}
+	templateCache.initialized = true
 	env.tmplCache = &templateCache
 }
 
@@ -785,19 +788,21 @@ func (env *Shell) Logs() string {
 
 func (env *Shell) TemplateCache() *TemplateCache {
 	defer env.Trace(time.Now())
-	if env.tmplCache != nil {
-		return env.tmplCache
+	tmplCache := env.tmplCache
+	tmplCache.Lock()
+	defer tmplCache.Unlock()
+
+	if tmplCache.initialized {
+		return tmplCache
 	}
 
-	tmplCache := &TemplateCache{
-		Root:         env.Root(),
-		Shell:        env.Shell(),
-		ShellVersion: env.CmdFlags.ShellVersion,
-		Code:         env.ErrorCode(),
-		WSL:          env.IsWsl(),
-		Segments:     make(map[string]interface{}),
-		PromptCount:  env.CmdFlags.PromptCount,
-	}
+	tmplCache.Root = env.Root()
+	tmplCache.Shell = env.Shell()
+	tmplCache.ShellVersion = env.CmdFlags.ShellVersion
+	tmplCache.Code = env.ErrorCode()
+	tmplCache.WSL = env.IsWsl()
+	tmplCache.Segments = make(map[string]interface{})
+	tmplCache.PromptCount = env.CmdFlags.PromptCount
 	tmplCache.Env = make(map[string]string)
 	tmplCache.Var = make(map[string]interface{})
 
@@ -838,7 +843,7 @@ func (env *Shell) TemplateCache() *TemplateCache {
 		tmplCache.SHLVL = shlvl
 	}
 
-	env.tmplCache = tmplCache
+	tmplCache.initialized = true
 	return tmplCache
 }
 

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -303,6 +303,7 @@
             "terraform",
             "ui5tooling",
             "unity",
+            "upgrade",
             "wakatime",
             "winreg",
             "withings",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added/updated (for bug fixes / features)

### Description

1. Add `upgrade` to the list of valid segment types in the theme schema.
2. Avoid duplicate creations of template cache. Related to #2885.

### How

1. Update the theme schema (`themes/schema.json`).
2. In package `platform`:
   - Add an `initialized` field to `TemplateCache` as an indicator.
   - Assign an initial value to the `tmplCache` field of `Shell` in the `Init` method.
   - When calling `(*Shell).TemplateCache`, use the R/W lock and check the `initialized` flag to determine whether the initialization should be performed.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
