### PR TITLE
fix(schema): replace $id with canonical URI

### DIFF
--- a/themes/schema.json
+++ b/themes/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "http://example.com/example.json",
+  "$id": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
   "type": "object",
   "title": "The Oh My Posh theme definition",
   "description": "https://ohmyposh.dev/docs/configuration/overview",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

This updates the root `$id` property to one that uniquely identifies the JSON schema in accordance to the specification.

See [section 8.2.1](https://json-schema.org/draft/2020-12/json-schema-core.html#name-base-uri-anchors-and-derefe) for reference:
> The "$id" keyword identifies a schema resource with its canonical [RFC6596] URI.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
