### PR TITLE
fix: installer should treat aarch64 as arm64

### DIFF
--- a/website/static/install.sh
+++ b/website/static/install.sh
@@ -154,6 +154,7 @@ detect_arch() {
     x86_64) arch="amd64" ;;
     armv*) arch="arm" ;;
     arm64) arch="arm64" ;;
+    aarch64) arch="arm64" ;;
   esac
 
   if [ "${arch}" = "arm64" ] && [ "$(getconf LONG_BIT)" -eq 32 ]; then


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)

### Description

Fix #3898

Linux arm64 is detected as aarch64 because _naming things are hard & standard_ 🤷 

I'm running a dev container from macOS/arm64 and the linux container says it's `aarch64` which the installer doesn't support.

### How

Added aarch64 to the switch statement