### PR TITLE
fix(doc): remove outdated content for Scoop

### DIFF
--- a/website/docs/installation/windows.mdx
+++ b/website/docs/installation/windows.mdx
@@ -130,37 +130,10 @@ Set-ExecutionPolicy Bypass -Scope Process -Force; Invoke-Expression ((New-Object
 
 ## Default themes
 
-<Tabs
-  defaultValue="winget"
-  groupId="install"
-  values={[
-    { label: 'winget', value: 'winget', },
-    { label: 'scoop', value: 'scoop', },
-    { label: 'manual', value: 'manual', },
-  ]
-}>
-<TabItem value="winget">
-
 You can find the themes in the folder indicated by the environment variable `POSH_THEMES_PATH`.
 For example, you can use `oh-my-posh init pwsh --config "$env:POSH_THEMES_PATH\jandedobbeleer.omp.json"`
 for the prompt initialization in PowerShell.
 
-</TabItem>
-<TabItem value="scoop">
-
-You can find the themes in the `$(scoop prefix oh-my-posh)\themes` folder.
-For example, you can use `oh-my-posh init pwsh --config "$(scoop prefix oh-my-posh)\themes\jandedobbeleer.omp.json"`
-for the prompt initialization in PowerShell.
-
-</TabItem>
-<TabItem value="manual">
-
-You can find the themes in the folder indicated by the environment variable `POSH_THEMES_PATH`.
-For example, you can use `oh-my-posh init pwsh --config "$env:POSH_THEMES_PATH\jandedobbeleer.omp.json"`
-for the prompt initialization in PowerShell.
-
-</TabItem>
-</Tabs>
 
 [fonts]: /docs/installation/fonts
 [scoop]: https://scoop.sh/


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description

Nowdays, we can use `$env:POSH_THEMES_PATH` to configure themes for any installation ways. On the other hand, we cannot use `"$(scoop prefix oh-my-posh)\themes` to get the themes path, which will return wrong path.

### How

I removed the tabs and reserve the correct paragraph

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
