### PR TITLE
feat(Sitecore): upgraded Sitecore segment to support Sitecore CLI context switching 

### DIFF
--- a/src/segments/sitecore.go
+++ b/src/segments/sitecore.go
@@ -2,39 +2,64 @@ package segments
 
 import (
 	"encoding/json"
-	"path/filepath"
-	"strings"
+	"path"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/platform"
 	"github.com/jandedobbeleer/oh-my-posh/src/properties"
 )
 
-type Sitecore struct {
-	props properties.Properties
-	env   platform.Environment
+const (
+	sitecoreFileName = "sitecore.json"
+	sitecoreFolderName = ".sitecore"
+	userFileName = "user.json"
+	defaultEnpointName = "default"
+)
 
-	Environment string
-	Cloud       bool
+type Sitecore struct {
+    props   	properties.Properties
+    env     	platform.Environment
+
+    EndpointName 	string
+	CmHost 			string
 }
 
-type SitecoreConfig struct {
-	Endpoints struct {
-		Default struct {
-			Ref        string `json:"ref"`
-			AllowWrite bool   `json:"allowWrite"`
-			Host       string `json:"host"`
-			Variables  struct {
-			} `json:"variables"`
-		} `json:"default"`
-	} `json:"endpoints"`
+type EndpointConfig struct {
+	Host string `json:"host"`
+}
+
+type UserConfig struct {
+	DefaultEndpoint string 						`json:"defaultEndpoint"`
+	Endpoints 		map[string]EndpointConfig 	`json:"endpoints"`
 }
 
 func (s *Sitecore) Enabled() bool {
-	return s.shouldDisplay()
+	if s.env.HasFiles(sitecoreFileName) && s.env.HasFiles(path.Join(sitecoreFolderName, userFileName)) {
+		var userConfig = getUserConfig(s)
+
+		if (userConfig == nil) {
+			return false
+		}		
+
+		s.EndpointName = userConfig.getDefaultEndpoint()
+		
+		displayDefault := s.props.GetBool(properties.DisplayDefault, true)
+        
+		if !displayDefault && s.EndpointName == defaultEnpointName {
+			return false
+		} 
+
+		if endpoint := userConfig.getEndpoint(s.EndpointName); endpoint != nil && len(endpoint.Host) > 0 {
+			s.CmHost = endpoint.Host
+		}
+		
+		return true
+	}
+
+	return false
 }
 
 func (s *Sitecore) Template() string {
-	return " {{ if .Cloud }}\uf65e{{ else }}\uf98a{{ end }} {{ .Environment }} "
+    return "{{ .EndpointName }} {{ if .CmHost }}({{ .CmHost }}){{ end }}"
 }
 
 func (s *Sitecore) Init(props properties.Properties, env platform.Environment) {
@@ -42,37 +67,31 @@ func (s *Sitecore) Init(props properties.Properties, env platform.Environment) {
 	s.env = env
 }
 
-func (s *Sitecore) shouldDisplay() bool {
-	sitecoreDir, err := s.env.HasParentFilePath(".sitecore")
-	if err != nil {
-		return false
+func getUserConfig(s *Sitecore) *UserConfig {
+	userJson := s.env.FileContent(path.Join(sitecoreFolderName, userFileName))
+	var userConfig UserConfig
+
+	if err := json.Unmarshal([]byte(userJson), &userConfig); err != nil {
+		return nil
 	}
 
-	if !sitecoreDir.IsDir {
-		return false
+	return &userConfig
+}
+
+func (u *UserConfig) getDefaultEndpoint() string {
+	if len(u.DefaultEndpoint) > 0  {
+		return u.DefaultEndpoint
+	} 
+	
+	return defaultEnpointName
+}
+
+func (u *UserConfig) getEndpoint(name string) *EndpointConfig {
+	endpoint, exists := u.Endpoints[name]
+
+	if exists {
+		return &endpoint
 	}
 
-	if !s.env.HasFilesInDir(sitecoreDir.Path, "user.json") {
-		return false
-	}
-
-	sitecoreConfigFile := filepath.Join(sitecoreDir.Path, "user.json")
-
-	if len(sitecoreConfigFile) == 0 {
-		return false
-	}
-
-	content := s.env.FileContent(sitecoreConfigFile)
-
-	var config SitecoreConfig
-	if err := json.Unmarshal([]byte(content), &config); err != nil {
-		return false
-	}
-
-	// sitecore xm cloud always has sitecorecloud.io as domain
-	s.Cloud = strings.Contains(config.Endpoints.Default.Host, "sitecorecloud.io")
-
-	s.Environment = config.Endpoints.Default.Host
-
-	return true
+	return nil
 }

--- a/src/segments/sitecore.go
+++ b/src/segments/sitecore.go
@@ -33,29 +33,29 @@ type UserConfig struct {
 }
 
 func (s *Sitecore) Enabled() bool {
-	if s.env.HasFiles(sitecoreFileName) && s.env.HasFiles(path.Join(sitecoreFolderName, userFileName)) {
-		var userConfig = getUserConfig(s)
-
-		if (userConfig == nil) {
-			return false
-		}		
-
-		s.EndpointName = userConfig.getDefaultEndpoint()
-		
-		displayDefault := s.props.GetBool(properties.DisplayDefault, true)
-        
-		if !displayDefault && s.EndpointName == defaultEnpointName {
-			return false
-		} 
-
-		if endpoint := userConfig.getEndpoint(s.EndpointName); endpoint != nil && len(endpoint.Host) > 0 {
-			s.CmHost = endpoint.Host
-		}
-		
-		return true
+	if !s.env.HasFiles(sitecoreFileName) || !s.env.HasFiles(path.Join(sitecoreFolderName, userFileName)) {
+		return false
 	}
 
-	return false
+	var userConfig = getUserConfig(s)
+
+	if (userConfig == nil) {
+		return false
+	}		
+
+	s.EndpointName = userConfig.getDefaultEndpoint()
+	
+	displayDefault := s.props.GetBool(properties.DisplayDefault, true)
+	
+	if !displayDefault && s.EndpointName == defaultEnpointName {
+		return false
+	} 
+
+	if endpoint := userConfig.getEndpoint(s.EndpointName); endpoint != nil && len(endpoint.Host) > 0 {
+		s.CmHost = endpoint.Host
+	}
+	
+	return true
 }
 
 func (s *Sitecore) Template() string {

--- a/src/segments/sitecore.go
+++ b/src/segments/sitecore.go
@@ -39,7 +39,7 @@ func (s *Sitecore) Enabled() bool {
 
 	var userConfig, err = getUserConfig(s)
 
-	if (err != nil) {
+	if err != nil {
 		return false;
 	}
 

--- a/src/segments/sitecore.go
+++ b/src/segments/sitecore.go
@@ -16,20 +16,20 @@ const (
 )
 
 type Sitecore struct {
-    props   	properties.Properties
-    env     	platform.Environment
+	props properties.Properties
+	env   platform.Environment
 
-    EndpointName 	string
-	CmHost 			string
+	EndpointName string
+	CmHost       string
 }
 
 type EndpointConfig struct {
-	Host string `json:"host"`
+	Host string	`json:"host"`
 }
 
 type UserConfig struct {
-	DefaultEndpoint string 						`json:"defaultEndpoint"`
-	Endpoints 		map[string]EndpointConfig 	`json:"endpoints"`
+	DefaultEndpoint string                    `json:"defaultEndpoint"`
+	Endpoints       map[string]EndpointConfig `json:"endpoints"`
 }
 
 func (s *Sitecore) Enabled() bool {
@@ -37,16 +37,16 @@ func (s *Sitecore) Enabled() bool {
 		return false
 	}
 
-	var userConfig = getUserConfig(s)
+	var userConfig, err = getUserConfig(s)
 
-	if (userConfig == nil) {
-		return false
-	}		
+	if (err != nil) {
+		return false;
+	}
 
 	s.EndpointName = userConfig.getDefaultEndpoint()
-	
+
 	displayDefault := s.props.GetBool(properties.DisplayDefault, true)
-	
+
 	if !displayDefault && s.EndpointName == defaultEnpointName {
 		return false
 	} 
@@ -67,15 +67,15 @@ func (s *Sitecore) Init(props properties.Properties, env platform.Environment) {
 	s.env = env
 }
 
-func getUserConfig(s *Sitecore) *UserConfig {
+func getUserConfig(s *Sitecore) (*UserConfig, error) {
 	userJson := s.env.FileContent(path.Join(sitecoreFolderName, userFileName))
 	var userConfig UserConfig
 
 	if err := json.Unmarshal([]byte(userJson), &userConfig); err != nil {
-		return nil
+		return nil, err
 	}
 
-	return &userConfig
+	return &userConfig, nil
 }
 
 func (u *UserConfig) getDefaultEndpoint() string {

--- a/src/segments/sitecore.go
+++ b/src/segments/sitecore.go
@@ -9,9 +9,9 @@ import (
 )
 
 const (
-	sitecoreFileName = "sitecore.json"
+	sitecoreFileName   = "sitecore.json"
 	sitecoreFolderName = ".sitecore"
-	userFileName = "user.json"
+	userFileName       = "user.json"
 	defaultEnpointName = "default"
 )
 
@@ -24,7 +24,7 @@ type Sitecore struct {
 }
 
 type EndpointConfig struct {
-	Host string	`json:"host"`
+	Host string `json:"host"`
 }
 
 type UserConfig struct {
@@ -40,7 +40,7 @@ func (s *Sitecore) Enabled() bool {
 	var userConfig, err = getUserConfig(s)
 
 	if err != nil {
-		return false;
+		return false
 	}
 
 	s.EndpointName = userConfig.getDefaultEndpoint()
@@ -49,17 +49,17 @@ func (s *Sitecore) Enabled() bool {
 
 	if !displayDefault && s.EndpointName == defaultEnpointName {
 		return false
-	} 
+	}
 
 	if endpoint := userConfig.getEndpoint(s.EndpointName); endpoint != nil && len(endpoint.Host) > 0 {
 		s.CmHost = endpoint.Host
 	}
-	
+
 	return true
 }
 
 func (s *Sitecore) Template() string {
-    return "{{ .EndpointName }} {{ if .CmHost }}({{ .CmHost }}){{ end }}"
+	return "{{ .EndpointName }} {{ if .CmHost }}({{ .CmHost }}){{ end }}"
 }
 
 func (s *Sitecore) Init(props properties.Properties, env platform.Environment) {
@@ -68,10 +68,10 @@ func (s *Sitecore) Init(props properties.Properties, env platform.Environment) {
 }
 
 func getUserConfig(s *Sitecore) (*UserConfig, error) {
-	userJson := s.env.FileContent(path.Join(sitecoreFolderName, userFileName))
+	userJSON := s.env.FileContent(path.Join(sitecoreFolderName, userFileName))
 	var userConfig UserConfig
 
-	if err := json.Unmarshal([]byte(userJson), &userConfig); err != nil {
+	if err := json.Unmarshal([]byte(userJSON), &userConfig); err != nil {
 		return nil, err
 	}
 
@@ -79,10 +79,10 @@ func getUserConfig(s *Sitecore) (*UserConfig, error) {
 }
 
 func (u *UserConfig) getDefaultEndpoint() string {
-	if len(u.DefaultEndpoint) > 0  {
+	if len(u.DefaultEndpoint) > 0 {
 		return u.DefaultEndpoint
-	} 
-	
+	}
+
 	return defaultEnpointName
 }
 

--- a/src/segments/sitecore_test.go
+++ b/src/segments/sitecore_test.go
@@ -1,93 +1,162 @@
 package segments
 
 import (
-	"errors"
-	"os"
-	"path/filepath"
 	"testing"
+	"path"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/mock"
-	"github.com/jandedobbeleer/oh-my-posh/src/platform"
+	"github.com/jandedobbeleer/oh-my-posh/src/properties"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSitecoreSegment(t *testing.T) {
 	cases := []struct {
-		Case            string
-		ExpectedEnabled bool
-		ExpectedString  string
-		Template        string
-		IsCloud         bool
+		Case				string
+		ExpectedString  	string
+		ExpectedEnabled 	bool
+		SitecoreFileExists 	bool
+		UserFileExists 		bool
+		UserFileContent		string
+		DisplayDefault  	bool
 	}{
-		{
-			Case:            "no config files found",
-			ExpectedEnabled: false,
+		{ Case: "Disabled, no sitecore.json file and user.json file", ExpectedString: "", ExpectedEnabled: false, SitecoreFileExists: false, UserFileExists: false },
+		{ Case: "Disabled, only sitecore.json file exists", ExpectedString: "", ExpectedEnabled: false, SitecoreFileExists: true, UserFileExists: false },
+		{ Case: "Disabled, only user.json file exists", ExpectedString: "", ExpectedEnabled: false, SitecoreFileExists: false, UserFileExists: true },
+		{ 
+			Case: "Disabled, user.json is empty", 
+			ExpectedString: "", 
+			ExpectedEnabled: false, 
+			SitecoreFileExists: true, 
+			UserFileExists: true,
+			UserFileContent: "",
 		},
-		{
-			Case:            "Sitecore local config",
-			ExpectedEnabled: true,
-			ExpectedString:  "https://xmcloudcm.local false",
-			Template:        "{{ .Environment }} {{ .Cloud }}",
-			IsCloud:         false,
+		{ 
+			Case: "Disabled, user.json contains non-json text", 
+			ExpectedString: "", 
+			ExpectedEnabled: false, 
+			SitecoreFileExists: true, 
+			UserFileExists: true,
+			UserFileContent: testUserJsonNotJsonFormat,
 		},
-		{
-			Case:            "Sitecore cloud config",
-			ExpectedEnabled: true,
-			ExpectedString:  "https://xmc-sitecore<someID>-projectName-environmentName.sitecorecloud.io true",
-			Template:        "{{ .Environment }} {{ .Cloud }}",
-			IsCloud:         true,
+		{ 
+			Case: "Disabled with default endpoint", 
+			ExpectedString: "default", 
+			ExpectedEnabled: false, 
+			SitecoreFileExists: true, 
+			UserFileExists: true,
+			UserFileContent: testUserJsonOnlyDefaultEnv,
+			DisplayDefault: false,
 		},
-		{
-			Case:            "Sitecore cloud config - advanced template",
-			ExpectedEnabled: true,
-			ExpectedString:  "sitecore<someID> - projectName - environmentName",
-			Template:        "{{ if .Cloud }} {{ $splittedHostName := split \".\" .Environment }} {{ $myList := split \"-\" $splittedHostName._0 }} {{ $myList._1 }} - {{ $myList._2 }} - {{ $myList._3 }} {{ end }}", //nolint:lll
-			IsCloud:         true,
+		{ 
+			Case: "Enabled, user.json initial state", 
+			ExpectedString: "default", 
+			ExpectedEnabled: true, 
+			SitecoreFileExists: true, 
+			UserFileExists: true,
+			UserFileContent: testUserJsonDefaultEmpty,
+			DisplayDefault: true,
+		},
+		{ 
+			Case: "Enabled, user.json with custom default endpoint and without endpoints", 
+			ExpectedString: "MySuperEnv", 
+			ExpectedEnabled: true, 
+			SitecoreFileExists: true, 
+			UserFileExists: true,
+			UserFileContent: testUserJsonCustomDefaultEnvWithoutEndpoints,
+		},
+		{ 
+			Case: "Enabled, user.json with custom default endpoint and configured endpoints", 
+			ExpectedString: "myEnv (https://host.com)", 
+			ExpectedEnabled: true, 
+			SitecoreFileExists: true, 
+			UserFileExists: true,
+			UserFileContent: testUserJsonCustomDefaultEnv,
+		},
+		{ 
+			Case: "Enabled, user.json with custom default endpoint and empty host", 
+			ExpectedString: "envWithEmptyHost", 
+			ExpectedEnabled: true, 
+			SitecoreFileExists: true, 
+			UserFileExists: true,
+			UserFileContent: testUserJsonCustomDefaultEnvAndEmptyHost,
 		},
 	}
 
 	for _, tc := range cases {
 		env := new(mock.MockedEnvironment)
-		env.On("Home").Return(poshHome)
-		var sitecoreConfigFile string
-
-		if tc.IsCloud {
-			content, _ := os.ReadFile("../test/sitecoreUser1.json")
-			sitecoreConfigFile = string(content)
+		env.On("HasFiles", "sitecore.json").Return(tc.SitecoreFileExists)
+		env.On("HasFiles", path.Join(".sitecore", "user.json")).Return(tc.UserFileExists)
+		env.On("FileContent", path.Join(".sitecore", "user.json")).Return(tc.UserFileContent)
+		
+		props := properties.Map{
+			properties.DisplayDefault: tc.DisplayDefault,
 		}
 
-		if !tc.IsCloud {
-			content, _ := os.ReadFile("../test/sitecoreUser2.json")
-			sitecoreConfigFile = string(content)
-		}
-
-		var projectDir *platform.FileInfo
-		var err error
-
-		if !tc.ExpectedEnabled {
-			err = errors.New("no config directory")
-			projectDir = nil
-		}
-
-		if tc.ExpectedEnabled {
-			err = nil
-			projectDir = &platform.FileInfo{
-				ParentFolder: "SitecoreProjectRoot",
-				Path:         filepath.Join("SitecoreProjectRoot", ".sitecore"),
-				IsDir:        true,
-			}
-		}
-
-		env.On("HasParentFilePath", ".sitecore").Return(projectDir, err)
-		env.On("HasFilesInDir", filepath.Join("SitecoreProjectRoot", ".sitecore"), "user.json").Return(true)
-		env.On("FileContent", filepath.Join("SitecoreProjectRoot", ".sitecore", "user.json")).Return(sitecoreConfigFile)
-
-		sitecore := &Sitecore{
-			env: env,
-		}
-
+		sitecore := &Sitecore{}
+		sitecore.Init(props, env)
 		assert.Equal(t, tc.ExpectedEnabled, sitecore.Enabled(), tc.Case)
-		assert.Equal(t, tc.ExpectedString, renderTemplate(env, tc.Template, sitecore), tc.Case)
+		assert.Equal(t, tc.ExpectedString, renderTemplate(env, sitecore.Template(), sitecore), tc.Case)
 	}
 }
+
+var testUserJsonDefaultEmpty = `
+{
+	"endpoints": {}
+}`
+
+var testUserJsonCustomDefaultEnvWithoutEndpoints = `
+{
+	"endpoints": {},
+	"defaultEndpoint": "MySuperEnv"
+}`
+
+var testUserJsonCustomDefaultEnv = `
+{
+	"endpoints": {
+		"myEnv": {
+			"host": "https://host.com"
+		}
+	},
+	"defaultEndpoint": "myEnv"
+}`
+
+var testUserJsonCustomDefaultEnvAndEmptyHost = `
+{
+	"endpoints": {
+		"myEnv": {
+			"host": ""
+		}
+	},
+	"defaultEndpoint": "envWithEmptyHost"
+}`
+
+var testUserJsonNotJsonFormat = `
+---
+ doe: "a deer, a female deer"
+ ray: "a drop of golden sun"
+ pi: 3.14159
+ xmas: true
+ french-hens: 3
+ calling-birds:
+   - huey
+   - dewey
+   - louie
+   - fred
+ xmas-fifth-day:
+   calling-birds: four
+   french-hens: 3
+   golden-rings: 5
+   partridges:
+     count: 1
+     location: "a pear tree"
+   turtle-doves: two`
+
+var testUserJsonOnlyDefaultEnv = `
+{
+	"endpoints": {
+		"default": {
+			"host": "https://host.com"
+		}
+	}
+}`

--- a/src/segments/sitecore_test.go
+++ b/src/segments/sitecore_test.go
@@ -1,8 +1,8 @@
 package segments
 
 import (
-	"testing"
 	"path"
+	"testing"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/mock"
 	"github.com/jandedobbeleer/oh-my-posh/src/properties"
@@ -12,74 +12,74 @@ import (
 
 func TestSitecoreSegment(t *testing.T) {
 	cases := []struct {
-		Case				string
-		ExpectedString  	string
-		ExpectedEnabled 	bool
-		SitecoreFileExists 	bool
-		UserFileExists 		bool
-		UserFileContent		string
-		DisplayDefault  	bool
+		Case               string
+		ExpectedString     string
+		ExpectedEnabled    bool
+		SitecoreFileExists bool
+		UserFileExists     bool
+		UserFileContent    string
+		DisplayDefault     bool
 	}{
-		{ Case: "Disabled, no sitecore.json file and user.json file", ExpectedString: "", ExpectedEnabled: false, SitecoreFileExists: false, UserFileExists: false },
-		{ Case: "Disabled, only sitecore.json file exists", ExpectedString: "", ExpectedEnabled: false, SitecoreFileExists: true, UserFileExists: false },
-		{ Case: "Disabled, only user.json file exists", ExpectedString: "", ExpectedEnabled: false, SitecoreFileExists: false, UserFileExists: true },
-		{ 
-			Case: "Disabled, user.json is empty", 
-			ExpectedString: "", 
-			ExpectedEnabled: false, 
-			SitecoreFileExists: true, 
-			UserFileExists: true,
-			UserFileContent: "",
+		{Case: "Disabled, no sitecore.json file and user.json file", ExpectedString: "", ExpectedEnabled: false, SitecoreFileExists: false, UserFileExists: false},
+		{Case: "Disabled, only sitecore.json file exists", ExpectedString: "", ExpectedEnabled: false, SitecoreFileExists: true, UserFileExists: false},
+		{Case: "Disabled, only user.json file exists", ExpectedString: "", ExpectedEnabled: false, SitecoreFileExists: false, UserFileExists: true},
+		{
+			Case:               "Disabled, user.json is empty",
+			ExpectedString:     "",
+			ExpectedEnabled:    false,
+			SitecoreFileExists: true,
+			UserFileExists:     true,
+			UserFileContent:    "",
 		},
-		{ 
-			Case: "Disabled, user.json contains non-json text", 
-			ExpectedString: "", 
-			ExpectedEnabled: false, 
-			SitecoreFileExists: true, 
-			UserFileExists: true,
-			UserFileContent: testUserJsonNotJsonFormat,
+		{
+			Case:               "Disabled, user.json contains non-json text",
+			ExpectedString:     "",
+			ExpectedEnabled:    false,
+			SitecoreFileExists: true,
+			UserFileExists:     true,
+			UserFileContent:    testUserJSONNotJSONFormat,
 		},
-		{ 
-			Case: "Disabled with default endpoint", 
-			ExpectedString: "default", 
-			ExpectedEnabled: false, 
-			SitecoreFileExists: true, 
-			UserFileExists: true,
-			UserFileContent: testUserJsonOnlyDefaultEnv,
-			DisplayDefault: false,
+		{
+			Case:               "Disabled with default endpoint",
+			ExpectedString:     "default",
+			ExpectedEnabled:    false,
+			SitecoreFileExists: true,
+			UserFileExists:     true,
+			UserFileContent:    testUserJSONOnlyDefaultEnv,
+			DisplayDefault:     false,
 		},
-		{ 
-			Case: "Enabled, user.json initial state", 
-			ExpectedString: "default", 
-			ExpectedEnabled: true, 
-			SitecoreFileExists: true, 
-			UserFileExists: true,
-			UserFileContent: testUserJsonDefaultEmpty,
-			DisplayDefault: true,
+		{
+			Case:               "Enabled, user.json initial state",
+			ExpectedString:     "default",
+			ExpectedEnabled:    true,
+			SitecoreFileExists: true,
+			UserFileExists:     true,
+			UserFileContent:    testUserJSONDefaultEmpty,
+			DisplayDefault:     true,
 		},
-		{ 
-			Case: "Enabled, user.json with custom default endpoint and without endpoints", 
-			ExpectedString: "MySuperEnv", 
-			ExpectedEnabled: true, 
-			SitecoreFileExists: true, 
-			UserFileExists: true,
-			UserFileContent: testUserJsonCustomDefaultEnvWithoutEndpoints,
+		{
+			Case:               "Enabled, user.json with custom default endpoint and without endpoints",
+			ExpectedString:     "MySuperEnv",
+			ExpectedEnabled:    true,
+			SitecoreFileExists: true,
+			UserFileExists:     true,
+			UserFileContent:    testUserJSONCustomDefaultEnvWithoutEndpoints,
 		},
-		{ 
-			Case: "Enabled, user.json with custom default endpoint and configured endpoints", 
-			ExpectedString: "myEnv (https://host.com)", 
-			ExpectedEnabled: true, 
-			SitecoreFileExists: true, 
-			UserFileExists: true,
-			UserFileContent: testUserJsonCustomDefaultEnv,
+		{
+			Case:               "Enabled, user.json with custom default endpoint and configured endpoints",
+			ExpectedString:     "myEnv (https://host.com)",
+			ExpectedEnabled:    true,
+			SitecoreFileExists: true,
+			UserFileExists:     true,
+			UserFileContent:    testUserJSONCustomDefaultEnv,
 		},
-		{ 
-			Case: "Enabled, user.json with custom default endpoint and empty host", 
-			ExpectedString: "envWithEmptyHost", 
-			ExpectedEnabled: true, 
-			SitecoreFileExists: true, 
-			UserFileExists: true,
-			UserFileContent: testUserJsonCustomDefaultEnvAndEmptyHost,
+		{
+			Case:               "Enabled, user.json with custom default endpoint and empty host",
+			ExpectedString:     "envWithEmptyHost",
+			ExpectedEnabled:    true,
+			SitecoreFileExists: true,
+			UserFileExists:     true,
+			UserFileContent:    testUserJSONCustomDefaultEnvAndEmptyHost,
 		},
 	}
 
@@ -88,7 +88,7 @@ func TestSitecoreSegment(t *testing.T) {
 		env.On("HasFiles", "sitecore.json").Return(tc.SitecoreFileExists)
 		env.On("HasFiles", path.Join(".sitecore", "user.json")).Return(tc.UserFileExists)
 		env.On("FileContent", path.Join(".sitecore", "user.json")).Return(tc.UserFileContent)
-		
+
 		props := properties.Map{
 			properties.DisplayDefault: tc.DisplayDefault,
 		}
@@ -100,18 +100,18 @@ func TestSitecoreSegment(t *testing.T) {
 	}
 }
 
-var testUserJsonDefaultEmpty = `
+var testUserJSONDefaultEmpty = `
 {
 	"endpoints": {}
 }`
 
-var testUserJsonCustomDefaultEnvWithoutEndpoints = `
+var testUserJSONCustomDefaultEnvWithoutEndpoints = `
 {
 	"endpoints": {},
 	"defaultEndpoint": "MySuperEnv"
 }`
 
-var testUserJsonCustomDefaultEnv = `
+var testUserJSONCustomDefaultEnv = `
 {
 	"endpoints": {
 		"myEnv": {
@@ -121,7 +121,7 @@ var testUserJsonCustomDefaultEnv = `
 	"defaultEndpoint": "myEnv"
 }`
 
-var testUserJsonCustomDefaultEnvAndEmptyHost = `
+var testUserJSONCustomDefaultEnvAndEmptyHost = `
 {
 	"endpoints": {
 		"myEnv": {
@@ -131,7 +131,7 @@ var testUserJsonCustomDefaultEnvAndEmptyHost = `
 	"defaultEndpoint": "envWithEmptyHost"
 }`
 
-var testUserJsonNotJsonFormat = `
+var testUserJSONNotJSONFormat = `
 ---
  doe: "a deer, a female deer"
  ray: "a drop of golden sun"
@@ -152,7 +152,7 @@ var testUserJsonNotJsonFormat = `
      location: "a pear tree"
    turtle-doves: two`
 
-var testUserJsonOnlyDefaultEnv = `
+var testUserJSONOnlyDefaultEnv = `
 {
 	"endpoints": {
 		"default": {

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -292,6 +292,7 @@
             "r",
             "sapling",
             "session",
+            "sitecore",
             "spotify",
             "shell",
             "sysinfo",
@@ -1944,7 +1945,19 @@
           },
           "then": {
             "title": "Sitecore Segment",
-            "description": "https://ohmyposh.dev/docs/segments/sitecore"
+            "description": "https://ohmyposh.dev/docs/segments/sitecore",
+            "properties": {
+              "properties": {
+                "properties": {
+                  "display_default": {
+                    "type": "boolean",
+                    "title": "Display Default",
+                    "description": "Display the segment or not when the Sitecore environment name matches `default`",
+                    "default": true
+                  }
+                }
+              }
+            }
           }
         },
         {

--- a/website/docs/segments/sitecore.mdx
+++ b/website/docs/segments/sitecore.mdx
@@ -6,52 +6,39 @@ sidebar_label: Sitecore
 
 ## What
 
-Show the current active Sitecore environment
+Display current Sitecore environment. Will not be active when sitecore.json and user.json don't exist.
 
 ## Sample Configuration
 
-import Config from "@site/src/components/Config.js";
-
-<Config
-  data={{
-    type: "sitecore",
-    style: "powerline",
-    powerline_symbol: "\uE0B0",
-    foreground: "#ffffff",
-    background: "#0077c2",
-    template:
-      " {{ if .Cloud }}\uf65e{{ else }}\uf98a{{ end }} {{ .Environment }} ",
-  }}
-/>
+```json
+{
+  "type": "sitecore",
+  "style": "plain",
+  "foreground": "#000000",
+  "background": "#FFFFFF",
+  "template": "Env: {{ .EndpointName }}{{ if .CmHost }} CM: {{ .CmHost }}{{ end }}"
+}
+```
 
 ## Properties
 
-There are no properties that can be set
+| Name              | Type      | Description                                                                                        |
+| ----------------- | --------- | -------------------------------------------------------------------------------------------------- |
+| `display_default` | `boolean` | display the segment or not when the Sitecore environment name matches `default` - defaults to true |
 
 ## Template ([info][templates])
 
 :::note default template
 
 ```template
-{{ if .Cloud }}\uf65e{{ else }}\uf98a{{ end }} {{ .Environment }}
+{{ .EndpointName }} {{ if .CmHost }}({{ .CmHost }}){{ end }}
 ```
 
 :::
 
-:::note advanced xmcloud template
-When using xmcloud, the hostname can become very long. You can shorten `.Environment` by using the following template:
+## Properties
 
-```template
- {{ if .Cloud }}\uf65e{{ else }}\uf98a{{ end }} {{ if .Cloud }}{{ $splittedHostName := split \".\" .Environment }}{{ $myList := split \"-\" $splittedHostName._0 }} {{ $myList._1 }} - {{ $myList._2 }} - {{ $myList._3 }}{{ else }} {{ .Environment }} {{ end }}
-```
-
-:::
-
-### Properties
-
-| Name           | Type     | Description                                                                                                   |
-| -------------- | -------- | ------------------------------------------------------------------------------------------------------------- |
-| `.Environment` | `string` | The hostname of the environment                                                                               |
-| `.Cloud`       | `bool`   | Used to determine if the environment is a cloud environment. Is true when hostname contains "sitecorecloud.io |
-
-[templates]: /docs/configuration/templates
+| Name           | Type     | Description                              |
+| -------------- | -------- | ---------------------------------------- |
+| `EndpointName` | `string` | name of the current Sitecore environment |
+| `CmHost`       | `string` | host of the current Sitecore environment |


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c14f4a8</samp>

Refactored and improved the `sitecore` segment to use a new logic based on the user.json file and added a new option to display the default icon. Updated the tests, schema, and documentation accordingly.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c14f4a8</samp>

*  Simplify import statements and remove unused packages in `sitecore.go` and `sitecore_test.go` ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3926/files?diff=unified&w=0#diff-e4e61b9f252fb291a7129580c917d7dfe5178f2d12c9bdb8c3a28a0fdcfe802dL5-R5), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3926/files?diff=unified&w=0#diff-7ba0e717460746e6e69e829d8abb6927bc2834beb817f3da6948f25f2285b80dL4-R8))
*  Modify `Sitecore` and `SitecoreConfig` structs to use different fields and types for Sitecore environment configuration ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3926/files?diff=unified&w=0#diff-e4e61b9f252fb291a7129580c917d7dfe5178f2d12c9bdb8c3a28a0fdcfe802dL12-R62))
*  Replace `shouldDisplay` method with `Enabled` method that implements new logic for checking and parsing sitecore.json and user.json files and setting `EndpointName` and `CmHost` fields ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3926/files?diff=unified&w=0#diff-e4e61b9f252fb291a7129580c917d7dfe5178f2d12c9bdb8c3a28a0fdcfe802dL45-R96))
*  Rewrite `TestSitecoreSegment` function to use different test cases and mock data for the new logic of the segment ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3926/files?diff=unified&w=0#diff-7ba0e717460746e6e69e829d8abb6927bc2834beb817f3da6948f25f2285b80dL17-R161))
*  Add `sitecore` segment name to the list of valid segment names in `themes/schema.json` ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3926/files?diff=unified&w=0#diff-892c540c9bfebcb3bb8a0be1714201cd17eb6f0d40367c09f80d56e883b7335eR295))
*  Add `display_default` property to the schema of the `sitecore` segment in `themes/schema.json` with description, type, and default value ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3926/files?diff=unified&w=0#diff-892c540c9bfebcb3bb8a0be1714201cd17eb6f0d40367c09f80d56e883b7335eL1941-R1954))
*  Update sample configuration and properties sections of the `sitecore` segment documentation in `website/docs/segments/sitecore.mdx` to match the new logic and output of the segment ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3926/files?diff=unified&w=0#diff-3af710d4f9882cc603875c32893b1e701198ef8218f9be38d2a4ffb3a1348819L9-R27))
*  Simplify template section of the `sitecore` segment documentation in `website/docs/segments/sitecore.mdx` to use `EndpointName` and `CmHost` fields and remove advanced xmcloud template and `.Cloud` and `.Environment` properties ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3926/files?diff=unified&w=0#diff-3af710d4f9882cc603875c32893b1e701198ef8218f9be38d2a4ffb3a1348819L36-R44))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
