### PR TITLE
feat(git): fetch user information

### DIFF
--- a/themes/schema.json
+++ b/themes/schema.json
@@ -1007,6 +1007,12 @@
                     "items": {
                       "type": "string"
                     }
+                  },
+                  "fetch_user": {
+                    "type": "boolean",
+                    "title": "Fetch the user",
+                    "description": "Fetch the current configured user for the repository",
+                    "default": false
                   }
                 }
               }

--- a/website/docs/segments/git.mdx
+++ b/website/docs/segments/git.mdx
@@ -35,30 +35,33 @@ You can then use the `POSH_GIT_STRING` environment variable in a [text segment][
 
 ## Sample Configuration
 
-import Config from '@site/src/components/Config.js';
+import Config from "@site/src/components/Config.js";
 
-<Config data={{
-  "type": "git",
-  "style": "powerline",
-  "powerline_symbol": "\uE0B0",
-  "foreground": "#193549",
-  "background": "#ffeb3b",
-  "background_templates": [
-    "{{ if or (.Working.Changed) (.Staging.Changed) }}#FFEB3B{{ end }}",
-    "{{ if and (gt .Ahead 0) (gt .Behind 0) }}#FFCC80{{ end }}",
-    "{{ if gt .Ahead 0 }}#B388FF{{ end }}",
-    "{{ if gt .Behind 0 }}#B388FB{{ end }}"
-  ],
-  "template": "{{ .UpstreamIcon }}{{ .HEAD }}{{if .BranchStatus }} {{ .BranchStatus }}{{ end }}{{ if .Working.Changed }} \uF044 {{ .Working.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }} \uF046 {{ .Staging.String }}{{ end }}{{ if gt .StashCount 0 }} \uF692 {{ .StashCount }}{{ end }}",
-  "properties": {
-    "fetch_status": true,
-    "fetch_stash_count": true,
-    "fetch_upstream_icon": true,
-    "untracked_modes": {
-      "/Users/user/Projects/oh-my-posh/": "no"
-    }
-  }
-}}/>
+<Config
+  data={{
+    type: "git",
+    style: "powerline",
+    powerline_symbol: "\uE0B0",
+    foreground: "#193549",
+    background: "#ffeb3b",
+    background_templates: [
+      "{{ if or (.Working.Changed) (.Staging.Changed) }}#FFEB3B{{ end }}",
+      "{{ if and (gt .Ahead 0) (gt .Behind 0) }}#FFCC80{{ end }}",
+      "{{ if gt .Ahead 0 }}#B388FF{{ end }}",
+      "{{ if gt .Behind 0 }}#B388FB{{ end }}",
+    ],
+    template:
+      "{{ .UpstreamIcon }}{{ .HEAD }}{{if .BranchStatus }} {{ .BranchStatus }}{{ end }}{{ if .Working.Changed }} \uF044 {{ .Working.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }} \uF046 {{ .Staging.String }}{{ end }}{{ if gt .StashCount 0 }} \uF692 {{ .StashCount }}{{ end }}",
+    properties: {
+      fetch_status: true,
+      fetch_stash_count: true,
+      fetch_upstream_icon: true,
+      untracked_modes: {
+        "/Users/user/Projects/oh-my-posh/": "no",
+      },
+    },
+  }}
+/>
 
 ## Properties
 
@@ -76,6 +79,7 @@ You can set the following properties to `true` to enable fetching additional inf
 | `untracked_modes`     | `map[string]string` | map of repo's where to override the default [untracked files mode][untracked]:<ul><li>`no`</li><li>`normal`</li><li>`all`</li></ul>For example `"untracked_modes": { "/Users/me/repos/repo1": "no" }` - defaults to `normal` for all repo's. If you want to override for all repo's, use `*` to set the mode instead of the repo path |
 | `ignore_submodules`   | `map[string]string` | map of repo's where to change the [--ignore-submodules][submodules] flag (`none`, `untracked`, `dirty` or `all`). For example `"ignore_submodules": { "/Users/me/repos/repo1": "all" }`. If you want to override for all repo's, use `*` to set the mode instead of the repo path                                                     |
 | `native_fallback`     | `boolean`           | when set to `true` and `git.exe` is not available when inside a WSL2 shared Windows drive, we will fallback to the native git executable to fetch data. Not all information can be displayed in this case. Defaults to `false`                                                                                                        |
+| `fetch_user`          | [`User`](#user)     | fetch the current configured user for the repository - defaults to `false`                                                                                                                                                                                                                                                            |
 
 ### Icons
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md]
- [x] The commit message follows the [conventional commits][cc] guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 49f8d73</samp>

This pull request adds a new feature to the git segment that allows showing the user name and email for the current git repository. It modifies the `src/segments/git.go` file to implement the feature, the `website/docs/segments/git.mdx` file to document it, and the `themes/schema.json` file to validate it.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 49f8d73</samp>

*  Add `FetchUser` property to enable fetching user information for git repository ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3934/files?diff=unified&w=0#diff-5ca08bba45ba772ce1cbd182429db15292b228ac7c5dc0cf370dcbe55611fd92R66-R67), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3934/files?diff=unified&w=0#diff-892c540c9bfebcb3bb8a0be1714201cd17eb6f0d40367c09f80d56e883b7335eR1010-R1015), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3934/files?diff=unified&w=0#diff-8396c4caea4be2af52706d5b8d5f1ff73062c8b0274d540d6a4cace1ffa277caR82))
*  Add `User` field to `Git` type to store user name and email ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3934/files?diff=unified&w=0#diff-5ca08bba45ba772ce1cbd182429db15292b228ac7c5dc0cf370dcbe55611fd92R134))
*  Initialize `User` field to empty struct in `Enabled` function of `Git` type ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3934/files?diff=unified&w=0#diff-5ca08bba45ba772ce1cbd182429db15292b228ac7c5dc0cf370dcbe55611fd92R151))
*  Read `FetchUser` property and call `setUser` function to set user name and email in `User` field ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3934/files?diff=unified&w=0#diff-5ca08bba45ba772ce1cbd182429db15292b228ac7c5dc0cf370dcbe55611fd92R157-R161))
*  Add `setUser` function to `Git` type to run git commands and assign output to `User` fields ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3934/files?diff=unified&w=0#diff-5ca08bba45ba772ce1cbd182429db15292b228ac7c5dc0cf370dcbe55611fd92R293-R297))
*  Reformat sample configuration code in `website/docs/segments/git.mdx` file for readability and consistency ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3934/files?diff=unified&w=0#diff-8396c4caea4be2af52706d5b8d5f1ff73062c8b0274d540d6a4cace1ffa277caL38-R64))

resolves #3933

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
