### PR TITLE
chore: remove pinned golangci-lint

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -28,9 +28,6 @@ jobs:
     - name: Golang CI
       uses: golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299
       with:
-        # version: latest
-        # Pinning the version until https://github.com/golangci/golangci-lint/issues/3862 is solved
-        version: v1.52.2
         working-directory: src
     - name: Unit Tests
       run: go test -v ./...


### PR DESCRIPTION
chore: remove pinned golangci-lint

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/JanDeDobbeleer/oh-my-posh/pull/3964).
* __->__ #3964
* #3962