### PR TITLE
style: add a space in a theme

### DIFF
--- a/themes/jandedobbeleer.omp.json
+++ b/themes/jandedobbeleer.omp.json
@@ -146,7 +146,7 @@
             "always_enabled": true
           },
           "style": "plain",
-          "template": "<transparent>\ue0b0</> \ueba2{{ .FormattedMs }}\u2800",
+          "template": "<transparent>\ue0b0</> \ueba2 {{ .FormattedMs }}\u2800",
           "type": "executiontime"
         },
         {


### PR DESCRIPTION
add a space to executiontime segment in
line 149 of jandedobbeleer.omp.json

### Prerequisites

- [ √ ] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [ √ ] The commit message follows the [conventional commits][cc] guidelines.
- [ - ] Tests for the changes have been added (for bug fixes / features).
- [ - ] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 60c3760</samp>

Fixed spacing and alignment issues in the `jandedobbeleer` theme. Updated the template of the `executiontime` segment in `themes/jandedobbeleer.omp.json`.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 60c3760</samp>

* Add a space between the execution time icon and value in the jandedobbeleer theme ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3967/files?diff=unified&w=0#diff-e7d844df179d12ee0786b69cfaf9c29ec9e3b3e40c7717cb199cab6b1aa9e3acL149-R149))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
