### PR TITLE
schema support for `lucky7` execution time

### DIFF
--- a/themes/schema.json
+++ b/themes/schema.json
@@ -2247,7 +2247,8 @@
                       "galvestonms",
                       "houston",
                       "amarillo",
-                      "round"
+                      "round",
+                      "lucky7"
                     ],
                     "default": "austin"
                   }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

For some reason I thought `schema.json` was automatically built using a workflow. Well, it turns out thats not the case. 

Related: #3974

### How

Update enum field on `schema.json`

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
