### PR TITLE
Change the Chips Theme .Path to agnoster_short with 2 levels

### DIFF
--- a/themes/chips.omp.json
+++ b/themes/chips.omp.json
@@ -13,7 +13,8 @@
           ],
           "leading_diamond": "\uE0B6",
           "properties": {
-            "style": "folder"
+            "style": "agnoster_short",
+            "max_depth": 2
           },
           "style": "diamond",
           "template": "\uF07B {{ .Path }}",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description
I really like the chips theme, however, I think the path part can be improved - to include 2 levels instead of just current directory, which provides much more information and not too long meanwhile.

**As I'm not the original author of this theme, I'm not sure if this PR is appropriate**. On the other hand, I don't want to create yet another theme that is highly similar with this theme.

Any suggestions are welcome, thanks.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9ea227c</samp>

Adjusted the `leading_diamond` segment style and folder depth in the `chips` theme. This improves the prompt appearance and usability.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9ea227c</samp>

*  Modify the `properties` of the `leading_diamond` segment in the `chips` theme to use the `agnoster_short` style and limit the folder depth to 2 ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/3990/files?diff=unified&w=0#diff-d6f44ea85e61865b70c07cc65a2577a45dad4d68d3f9f421cd96e515111b6b49L16-R17)). This change makes the prompt more compact and readable when navigating deep directories in the `themes/chips.omp.json` file.

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
