### PR TITLE
docs: add sudo error tip to linux install section

### DIFF
--- a/website/docs/installation/linux.mdx
+++ b/website/docs/installation/linux.mdx
@@ -43,6 +43,15 @@ If you want to install to a different location you can specify it using the `-d`
 curl -s https://ohmyposh.dev/install.sh | bash -s -- -d ~/bin
 ```
 
+:::tip
+If you get this error: "Cannot write to /usr/local/bin. Please run the script with sudo and try again: sudo ./install.sh"
+
+Try running the following command instead:
+```bash
+curl -s https://ohmyposh.dev/install.sh | sudo bash -s
+```
+:::
+
 </TabItem>
 <TabItem value="homebrew">
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Found that when I have installed oh-my-posh on WSL Ubuntu twice now I have ran into the error of needing to run the installation script as sudo. I wanted to provide a tip in case other people run into this issue and show them how to run the script with sudo.

### How

Just added a new section of the documentation for the linux manual installation section

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
