### PR TITLE
fix(git): initialize status correctly

### DIFF
--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -146,9 +146,6 @@ func (g *Git) Template() string {
 }
 
 func (g *Git) Enabled() bool {
-	statusFormats := g.props.GetKeyValueMap(StatusFormats, map[string]string{})
-	g.Working = &GitStatus{ScmStatus: ScmStatus{Formats: statusFormats}}
-	g.Staging = &GitStatus{ScmStatus: ScmStatus{Formats: statusFormats}}
 	g.User = &User{}
 
 	if !g.shouldDisplay() {
@@ -489,8 +486,9 @@ func (g *Git) setGitStatus() {
 	)
 	// firstly assume that upstream is gone
 	g.UpstreamGone = true
-	g.Working = &GitStatus{}
-	g.Staging = &GitStatus{}
+	statusFormats := g.props.GetKeyValueMap(StatusFormats, map[string]string{})
+	g.Working = &GitStatus{ScmStatus: ScmStatus{Formats: statusFormats}}
+	g.Staging = &GitStatus{ScmStatus: ScmStatus{Formats: statusFormats}}
 	untrackedMode := g.getUntrackedFilesMode()
 	args := []string{"status", untrackedMode, "--branch", "--porcelain=2"}
 	ignoreSubmodulesMode := g.getIgnoreSubmodulesMode()

--- a/src/segments/git_test.go
+++ b/src/segments/git_test.go
@@ -554,6 +554,8 @@ func TestSetGitStatus(t *testing.T) {
 		if tc.ExpectedStaging == nil {
 			tc.ExpectedStaging = &GitStatus{}
 		}
+		tc.ExpectedStaging.Formats = map[string]string{}
+		tc.ExpectedWorking.Formats = map[string]string{}
 		g.setGitStatus()
 		assert.Equal(t, tc.ExpectedStaging, g.Staging, tc.Case)
 		assert.Equal(t, tc.ExpectedWorking, g.Working, tc.Case)


### PR DESCRIPTION
relates to #3992

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f7c7e71</samp>

Refactor the `Git` segment to allow custom status formats and update the corresponding tests. This improves the flexibility and configurability of the `Git` segment for the user.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f7c7e71</samp>

*  Initialize `Working` and `Staging` fields of `Git` struct with custom status formats in `setGitStatus` function ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4000/files?diff=unified&w=0#diff-5ca08bba45ba772ce1cbd182429db15292b228ac7c5dc0cf370dcbe55611fd92L492-R491))
*  Remove redundant initialization of `Working` and `Staging` fields of `Git` struct in `Template` function ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4000/files?diff=unified&w=0#diff-5ca08bba45ba772ce1cbd182429db15292b228ac7c5dc0cf370dcbe55611fd92L149-L151))
*  Update `TestSetGitStatus` function in `git_test.go` to match the new `Formats` fields of `ExpectedWorking` and `ExpectedStaging` ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4000/files?diff=unified&w=0#diff-7290b1c5198130d19c091496b4368edbcfd2b10d49813e6f92f01fbe26a56122R557-R558))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
