### PR TITLE
fix: lucky7 formatting in markdown

### DIFF
--- a/website/docs/segments/executiontime.mdx
+++ b/website/docs/segments/executiontime.mdx
@@ -48,7 +48,7 @@ Style specifies the format in which the time will be displayed. The table below 
 | `houston`     | `00:00:00.001` | `00:00:02.1`   | `00:03:02.1`   | `04:03:02.1`     |
 | `amarillo`    | `0.001s`       | `2.1s`         | `182.1s`       | `14,582.1s`      |
 | `round`       | `1ms`          | `2s`           | `3m 2s`        | `4h 3m`          |
-| `lucky7`      | `    1ms`      | `    2s `      | ` 3m  2s`      | ` 4h  3m`        |
+| `lucky7`      | `    1ms`      | ` 2.00s `      | ` 3m  2s`      | ` 4h  3m`        |
 
 ## Template ([info][templates])
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 264144f</samp>

Fixed formatting and alignment issues in the `lucky7` row of the `executiontime` segment table in the website docs.


[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
