### PR TITLE
chore: update Nushell support to use $env updates

### DIFF
--- a/src/shell/scripts/omp.nu
+++ b/src/shell/scripts/omp.nu
@@ -1,18 +1,18 @@
 export-env {
-    let-env POWERLINE_COMMAND = 'oh-my-posh'
-    let-env POSH_THEME = ::CONFIG::
-    let-env PROMPT_INDICATOR = ""
-    let-env POSH_PID = (random uuid)
+    $env.POWERLINE_COMMAND = 'oh-my-posh'
+    $env.POSH_THEME = ::CONFIG::
+    $env.PROMPT_INDICATOR = ""
+    $env.POSH_PID = (random uuid)
     # By default displays the right prompt on the first line
     # making it annoying when you have a multiline prompt
     # making the behavior different compared to other shells
-    let-env PROMPT_COMMAND_RIGHT = ''
-    let-env POSH_SHELL_VERSION = (version | get version)
+    $env.PROMPT_COMMAND_RIGHT = ''
+    $env.POSH_SHELL_VERSION = (version | get version)
 
     # PROMPTS
-    let-env PROMPT_MULTILINE_INDICATOR = (^::OMP:: print secondary $"--config=($env.POSH_THEME)" --shell=nu $"--shell-version=($env.POSH_SHELL_VERSION)")
+    $env.PROMPT_MULTILINE_INDICATOR = (^::OMP:: print secondary $"--config=($env.POSH_THEME)" --shell=nu $"--shell-version=($env.POSH_SHELL_VERSION)")
 
-    let-env PROMPT_COMMAND = { ||
+    $env.PROMPT_COMMAND = { ||
         # We have to do this because the initial value of `$env.CMD_DURATION_MS` is always `0823`,
         # which is an official setting.
         # See https://github.com/nushell/nushell/discussions/6402#discussioncomment-3466687.


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

Greetings!

The Nushell team is currently working to remove the `let-env FOO = ...` syntax and move to using `$env.FOO = ...` in the future. This PR moves omp to using that new syntax and doesn't add/change any existing functionality.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cb30daa</samp>

* Replace `let-env` command with direct assignment to `$env` variables to avoid using deprecated syntax ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4011/files?diff=unified&w=0#diff-b4e6f5d564c90b8bcff9623c6cae46e5a6fe4379bd352f7e188c3c09d1289c02L2-R15),                            F0L29

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
