### PR TITLE
Add "Get it on Pi-Apps" badge to Linux install guide and project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This repo was made with love using GitKraken.
 
 [![GitKraken shield][kraken]][kraken-ref]
 
-[![badge](https://github.com/Botspot/pi-apps/blob/master/icons/badge-light.png?raw=true)](https://github.com/Botspot/pi-apps)
+[![Get it on Pi-Apps](https://github.com/Botspot/pi-apps/blob/master/icons/badge-light.png?raw=true)](https://github.com/Botspot/pi-apps)
 <!-- markdownlint-disable first-header-h1 -->
 
 ## Join the community

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
 This repo was made with love using GitKraken.
 
 [![GitKraken shield][kraken]][kraken-ref]
+
+[![badge](https://github.com/Botspot/pi-apps/blob/master/icons/badge-light.png?raw=true)](https://github.com/Botspot/pi-apps)
 <!-- markdownlint-disable first-header-h1 -->
 
 ## Join the community

--- a/website/docs/installation/linux.mdx
+++ b/website/docs/installation/linux.mdx
@@ -20,6 +20,8 @@ To display all icons, we recommend the use of a [Nerd Font][fonts].
 
 ## Installation
 
+[![Get it on Pi-Apps](https://github.com/Botspot/pi-apps/blob/master/icons/badge-light.png?raw=true)](https://github.com/Botspot/pi-apps)
+
 <Tabs
   defaultValue="homebrew"
   groupId="install"


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Added a "Get it on Pi-Apps" badge to the README and Linux install guide, as there is now an install script for OMP there

### How

Pasted the official Badge into README and Linux.mdx
```md
[![Get it on Pi-Apps](https://github.com/Botspot/pi-apps/blob/master/icons/badge-light.png?raw=true)](https://github.com/Botspot/pi-apps)
```
[![Get it on Pi-Apps](https://github.com/Botspot/pi-apps/blob/master/icons/badge-light.png?raw=true)](https://github.com/Botspot/pi-apps)

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->