### PR TITLE
feat: build for android

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,36 @@
+name: Android
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-android:
+    runs-on: ubuntu-latest
+    container: ghcr.io/jandedobbeleer/golang-android-container:latest
+    steps:
+    - name: Checkout code 👋
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+    - name: Build
+      run: |
+        VERSION="${${{ github.event.release.name }}:1}"
+        echo "Building version ${VERSION}"
+        cd src
+        go build -o dist/posh-android-arm -ldflags="-s -w -X 'github.com/jandedobbeleer/oh-my-posh/src/build.Version=${VERSION}' -X 'github.com/jandedobbeleer/oh-my-posh/src/build.Date=$(date)'"
+    - name: Upload artifacts 🆙
+      uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          console.log('environment', process.versions);
+
+          const fs = require('fs').promises;
+
+          const { repo: { owner, repo }, sha } = context;
+          console.log({ owner, repo, sha });
+
+          await github.rest.repos.uploadReleaseAsset({
+            owner, repo,
+            release_id: ${{ github.event.release.id }},
+            name: 'posh-android-arm',
+            data: await fs.readFile('./src/dist/posh-android-arm')
+          });

--- a/src/segments/os.go
+++ b/src/segments/os.go
@@ -138,6 +138,8 @@ func (oi *Os) getDistroIcon(distro string) string {
 		return oi.props.GetString(Slackware, "\uF319")
 	case "ubuntu":
 		return oi.props.GetString(Ubuntu, "\uF31b")
+	case "android":
+		return oi.props.GetString(Ubuntu, "\uf17b")
 	}
 	return oi.props.GetString(Linux, "\uF17C")
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a8ed2a8</samp>

This pull request enables binary builds of `oh-my-posh` for android devices and updates the `.goreleaser.yml` file with more OS and architecture options.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a8ed2a8</samp>

*  Add support for android binary builds ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4040/files?diff=unified&w=0#diff-107f8a530a936d499769641b3bab12988441052d939e7f7a8bcf7765cdb1d254R26), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4040/files?diff=unified&w=0#diff-107f8a530a936d499769641b3bab12988441052d939e7f7a8bcf7765cdb1d254L34-R44))
   * Include android in the list of `goos` values in `.goreleaser.yml` ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4040/files?diff=unified&w=0#diff-107f8a530a936d499769641b3bab12988441052d939e7f7a8bcf7765cdb1d254R26))
   * Add two new `goarch` values for android: `amd64` and `386` ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4040/files?diff=unified&w=0#diff-107f8a530a936d499769641b3bab12988441052d939e7f7a8bcf7765cdb1d254L34-R44))
   * Reorder the existing `goos` and `goarch` combinations for readability and consistency ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4040/files?diff=unified&w=0#diff-107f8a530a936d499769641b3bab12988441052d939e7f7a8bcf7765cdb1d254L34-R44))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
