### PR TITLE
chore(go): cache dependencies

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -23,6 +23,7 @@ jobs:
       uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753
       with:
         go-version: 1.20.5
+        cache-dependency-path: src/go.sum
     - name: Checkout code
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
     - name: Golang CI

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,6 +23,7 @@ jobs:
       uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753
       with:
         go-version: 1.20.5
+        cache-dependency-path: src/go.sum
     - name: Checkout code
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
     - name: Initialize CodeQL

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753
         with:
           go-version: 1.20.5
+          cache-dependency-path: src/go.sum
       - uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8
         with:
           node-version: 17.6.0

--- a/.github/workflows/gomod.yml
+++ b/.github/workflows/gomod.yml
@@ -13,6 +13,7 @@ jobs:
       uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753
       with:
         go-version: 1.20.5
+        cache-dependency-path: src/go.sum
     - name: Checkout code
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
     - name: Check for unused dependencies


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ad8eb98</samp>

Add `cache-dependency-path` option to all workflows that use `actions/setup-go`. This improves the performance and reliability of the Go module installation steps.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ad8eb98</samp>

*  Add `cache-dependency-path` option to `actions/setup-go` step in four workflows to speed up Go module installation ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4047/files?diff=unified&w=0#diff-2d2301c62da7f04adcadfbd43fa4063e9ad651296b6f190974b99e72a00017a2R26), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4047/files?diff=unified&w=0#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27R26), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4047/files?diff=unified&w=0#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cR29), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4047/files?diff=unified&w=0#diff-d8665025cb64a288d186ad43102af8b02a89a181b9619b430c9b5ab718a6a230R16))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
