### PR TITLE
feat(chips): update theme to `v1.2.4`

### DIFF
--- a/themes/chips.omp.json
+++ b/themes/chips.omp.json
@@ -13,7 +13,10 @@
           ],
           "leading_diamond": "\uE0B6",
           "properties": {
-            "style": "folder"
+            "style": "agnoster_short",
+            "folder_separator_icon": "/",
+            "hide_root_location": true,
+            "max_depth": 2
           },
           "style": "diamond",
           "template": "\uF07B {{ .Path }}",
@@ -73,11 +76,11 @@
         },
         {
           "background_templates": [
-            "{{ if lt (.CummulativeTotal.Seconds | int64) 3600 }}p:c-wakatime-undertime{{ end }}",
-            "{{ if lt (.CummulativeTotal.Seconds | int64) 10800 }}p:c-wakatime-warm-up{{ end }}",
-            "{{ if lt (.CummulativeTotal.Seconds | int64) 25200 }}p:c-wakatime-working{{ end }}",
-            "{{ if lt (.CummulativeTotal.Seconds | int64) 28000 }}p:c-wakatime-quota{{ end }}",
-            "{{ if ge (.CummulativeTotal.Seconds | int64) 28800 }}p:c-wakatime-overtime{{ end }}"
+            "{{ if lt .CumulativeTotal.Seconds 3600 }}p:c-wakatime-undertime{{ end }}",
+            "{{ if lt .CumulativeTotal.Seconds 10800 }}p:c-wakatime-warm-up{{ end }}",
+            "{{ if lt .CumulativeTotal.Seconds 25200 }}p:c-wakatime-working{{ end }}",
+            "{{ if lt .CumulativeTotal.Seconds 28000 }}p:c-wakatime-quota{{ end }}",
+            "{{ if ge .CumulativeTotal.Seconds 28800 }}p:c-wakatime-overtime{{ end }}"
           ],
           "foreground": "p:c-badge-text",
           "leading_diamond": "\uE0B6",
@@ -87,7 +90,7 @@
             "cache_timeout": 5
           },
           "style": "diamond",
-          "template": "{{ if and (.Env.WAKATIME_API_KEY) (eq \"False\" (title (default \"False\" .Env.DISABLE_SEGMENT_WAKATIME))) (gt (.CummulativeTotal.Seconds | int64) 0) }}\uFA19 {{ secondsRound .CummulativeTotal.Seconds }}.{{ end }}",
+          "template": "{{ if and (.Env.WAKATIME_API_KEY) (eq \"False\" (title (default \"False\" .Env.DISABLE_SEGMENT_WAKATIME))) (gt .CumulativeTotal.Seconds 0) }}\uFA19 {{ secondsRound .CumulativeTotal.Seconds }}.{{ end }}",
           "trailing_diamond": "\uE0B4 ",
           "type": "wakatime"
         },
@@ -123,7 +126,7 @@
           "foreground": "p:c-badge-text",
           "leading_diamond": "\uE0B6",
           "style": "diamond",
-          "template": "{{ if eq \"True\" (title (default \"False\" .Env.DISABLE_SEGMENT_BATTERY)) }}{{ else }}{{ if not .Error }}{{ if eq \"Charging\" .State.String }}\uE315 {{ else if eq \"Discharging\" .State.String }}\uF062 {{ else if eq \"Full\" .State.String }}~ {{ else }}? {{ end }}{{ if le .Percentage 15 }}\uF579{{ else if and (ge .Percentage 16) (le .Percentage 30) }}\uF57A{{ else if and (ge .Percentage 31) (le .Percentage 45) }}\uF57C{{ else if and (ge .Percentage 46) (le .Percentage 55)}}\uF57D{{ else if and (ge .Percentage 56) (le .Percentage 70) }}\uF57E{{ else if and (ge .Percentage 71) (le .Percentage 80) }}\uF580{{ else if and (ge .Percentage 81) (le .Percentage 95) }}\uF581{{ else }}\uF578{{ end }} {{ .Percentage }}%{{ else }}!{{ end }}{{ end }}",
+          "template": "{{ if eq \"True\" (title (default \"False\" .Env.DISABLE_SEGMENT_BATTERY)) }}{{ else }}{{ if not .Error }}{{ if eq \"Charging\" .State.String }}\uE315 {{ else if eq \"Discharging\" .State.String }}{{ else if eq \"Full\" .State.String }}~ {{ else }}? {{ end }}{{ if le .Percentage 15 }}\uF579{{ else if and (ge .Percentage 16) (le .Percentage 30) }}\uF57A{{ else if and (ge .Percentage 31) (le .Percentage 45) }}\uF57C{{ else if and (ge .Percentage 46) (le .Percentage 55)}}\uF57D{{ else if and (ge .Percentage 56) (le .Percentage 70) }}\uF57E{{ else if and (ge .Percentage 71) (le .Percentage 80) }}\uF580{{ else if and (ge .Percentage 81) (le .Percentage 95) }}\uF581{{ else }}\uF578{{ end }} {{ .Percentage }}%{{ else }}!{{ end }}{{ end }}",
           "trailing_diamond": "\uE0B4",
           "type": "battery"
         }

--- a/website/export_themes.js
+++ b/website/export_themes.js
@@ -29,7 +29,7 @@ themeConfigOverrrides.set('amro.omp.json', newThemeConfig(40, 100, 'AmRo', '#1C2
 themeConfigOverrrides.set('avit.omp.json', newThemeConfig(40, 80));
 themeConfigOverrrides.set('blueish.omp.json', newThemeConfig(40, 100));
 themeConfigOverrrides.set('cert.omp.json', newThemeConfig(40, 50));
-themeConfigOverrrides.set('chips.omp.json', newThemeConfig(25, 30, 'CodexLink | v1.2.2 (02/09/2023) | https://github.com/CodexLink/chips.omp.json'));
+themeConfigOverrrides.set('chips.omp.json', newThemeConfig(25, 30, 'CodexLink | v1.2.4, Single Width (07/11/2023) | https://github.com/CodexLink/chips.omp.json'));
 themeConfigOverrrides.set('cinnamon.omp.json', newThemeConfig(40, 80));
 themeConfigOverrrides.set('craver.omp.json', newThemeConfig(40, 80, 'Nick Craver', '#282c34'));
 themeConfigOverrrides.set('darkblood.omp.json', newThemeConfig(40, 40));


### PR DESCRIPTION
### Prerequisites

- [X] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [X] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [X] Docs have been added/updated (for bug fixes / features).

### Description
- Apply changes from the dedicated repository's PR (https://github.com/CodexLink/chips.omp.json/pull/10) to this repository.
  - Theme
    - Changed `style` from `folder` to `agnoster_short` with `max_depth` of `2` and etc. (Motivation: https://github.com/JanDeDobbeleer/oh-my-posh/pull/3990)
    - Removed (_the misrepresented_) discharging icon from the battery segment to avoid repeating visual context.
    - Added spacing on `?` for the unknown state on Battery Segment.
    - Removed casting of `int64` to battery segment variables as it was seen as not needed (_this was an old change_)
  - Metadata
    - from `v1.2.2` to `v1.2.4` 
    - Implied **Single Width** on `export_themes.js` in the description.
    > This implies that there are other variants, but I haven't decided if I wanna push them here (those are `simple` (_planned_) and `double-width` (_implemented_) variants I'm talking about) since I haven't sure if there's a rule for that since there are no themes added anymore.
    >
    > Since then, my solution was to do the indirect redirection, which was implied to the `export_themes` indicating there's a dedicated repo for those other variants, which was done.

CC: @junhan-z, just want to let you know I'm pushing your proposed changes for the `path` segment. Thank you.

_**Please let me know if there are changes you want to contest.**_

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4219ec1</samp>

This pull request improves the chips theme for `oh-my-posh` by making it more compact, customizable, and accurate. It also updates the website export script to reflect the latest changes in the theme.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4219ec1</samp>

* Fix typo in wakatime segment of chips theme ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4048/files?diff=unified&w=0#diff-d6f44ea85e61865b70c07cc65a2577a45dad4d68d3f9f421cd96e515111b6b49L76-R83), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4048/files?diff=unified&w=0#diff-d6f44ea85e61865b70c07cc65a2577a45dad4d68d3f9f421cd96e515111b6b49L90-R93))
* Add custom properties to path segment of chips theme ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4048/files?diff=unified&w=0#diff-d6f44ea85e61865b70c07cc65a2577a45dad4d68d3f9f421cd96e515111b6b49L16-R19))
* Remove battery icon for discharging state in battery segment of chips theme ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4048/files?diff=unified&w=0#diff-d6f44ea85e61865b70c07cc65a2577a45dad4d68d3f9f421cd96e515111b6b49L126-R129))
* Update version, date, and description of chips theme in `website/export_themes.js` ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4048/files?diff=unified&w=0#diff-7470b21e3b8f8e3e7cea770222b576c0caec45c3be6dfc693980cc0f94a5dd5eL32-R32))