### PR TITLE
fix(azure): correct Azure icon

### DIFF
--- a/src/engine/config.go
+++ b/src/engine/config.go
@@ -508,7 +508,7 @@ func defaultConfig(env platform.Environment, warning bool) *Config {
 				TrailingDiamond: "\ue0b4",
 				Background:      "p:blue",
 				Foreground:      "p:white",
-				Template:        " \ufd03 {{ .Name }} ",
+				Template:        " \uebd8 {{ .Name }} ",
 				Properties: properties.Map{
 					properties.DisplayDefault: true,
 				},

--- a/themes/cloud-context.omp.json
+++ b/themes/cloud-context.omp.json
@@ -54,7 +54,7 @@
           },
           "style": "powerline",
           "powerline_symbol": "\ue0b4",
-          "template": " <p:symbol-color>\ufd03</> {{ .Name }}",
+          "template": " <p:symbol-color>\uebd8</> {{ .Name }}",
           "type": "az"
         },
         {
@@ -65,7 +65,7 @@
           },
           "style": "powerline",
           "powerline_symbol": "\ue0b4",
-          "template": " <p:symbol-color>\ufd03</> (PS) {{ .Name }}",
+          "template": " <p:symbol-color>\uebd8</> (PS) {{ .Name }}",
           "type": "az"
         },
         {

--- a/themes/cloud-native-azure.omp.json
+++ b/themes/cloud-native-azure.omp.json
@@ -121,7 +121,7 @@
           "foreground": "#000000",
           "powerline_symbol": "\ue0b0",
           "style": "powerline",
-          "template": " \ufd03 Subscription {{ .Name }} ({{ if .EnvironmentName | contains \"AzureCloud\" }}{{ \"Global\" }}{{ else }}{{ .EnvironmentName }}{{ end }}) ",
+          "template": " \uebd8 Subscription {{ .Name }} ({{ if .EnvironmentName | contains \"AzureCloud\" }}{{ \"Global\" }}{{ else }}{{ .EnvironmentName }}{{ end }}) ",
           "type": "az"
         }
       ],

--- a/themes/jonnychipz.omp.json
+++ b/themes/jonnychipz.omp.json
@@ -25,7 +25,7 @@
           "foreground": "#ffffff",
           "powerline_symbol": "\ue0b0",
           "style": "powerline",
-          "template": " \ufd03 {{ .Name }} ",
+          "template": " \uebd8 {{ .Name }} ",
           "type": "az"
         },
         {

--- a/themes/markbull.omp.json
+++ b/themes/markbull.omp.json
@@ -52,7 +52,7 @@
           "foreground": "#100e23",
           "powerline_symbol": "\ue0b0",
           "properties": {
-            "azure_devops_icon": "\ufd03 ",
+            "azure_devops_icon": "\uebd8 ",
             "bitbucket_icon": "\uf171 ",
             "branch_gone_icon": "\uebcc ",
             "branch_icon": "\ue0a0 ",

--- a/themes/pixelrobots.omp.json
+++ b/themes/pixelrobots.omp.json
@@ -26,7 +26,7 @@
             "source": "cli"
           },
           "style": "powerline",
-          "template": " \ufd03 {{ .Name }} [ {{ .Origin }} ] ",
+          "template": " \uebd8 {{ .Name }} [ {{ .Origin }} ] ",
           "type": "az"
         },
         {
@@ -37,7 +37,7 @@
             "source": "pwsh"
           },
           "style": "powerline",
-          "template": " \ufd03 {{ .Name }} [ {{ .Origin }} ] ",
+          "template": " \uebd8 {{ .Name }} [ {{ .Origin }} ] ",
           "type": "az"
         }
       ],


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 498e835</samp>

This pull request updates the icons for the Azure segment in several themes and the default configuration to use a more distinctive and recognizable icon (`\uebd8`). This improves the consistency and clarity of the themes and the prompt.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 498e835</samp>

*  Update the icon for the Azure segment in the prompt to use a more representative symbol (\uebd8) in the default template and six themes ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4059/files?diff=unified&w=0#diff-25963a790b4b92626029512213de64d81d974f422e9789c33bbe890eadfccb6aL511-R511), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4059/files?diff=unified&w=0#diff-ac56a2f2d86dc14cfceb8efc41a76c08ca454e0c4e8bc670bc5c90972e57810cL57-R57), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4059/files?diff=unified&w=0#diff-ac56a2f2d86dc14cfceb8efc41a76c08ca454e0c4e8bc670bc5c90972e57810cL68-R68), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4059/files?diff=unified&w=0#diff-72e10a41fad451316441a5abc5739bef91ff68c8b06e9d8098f870ed28ec0659L124-R124), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4059/files?diff=unified&w=0#diff-4ca92c092f0e85b4ef763641da84f8eca5ef26000fc6a8d07af935f09ee4a7f4L28-R28), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4059/files?diff=unified&w=0#diff-85ba07564645e1bc43225390d84bfd95e839291422ff38bde38c47b6b7bea28cL55-R55), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4059/files?diff=unified&w=0#diff-d3e504d329e8e804c316978d13c7644f7ac4c5a50591ae224cf1c4188c704d53L29-R29), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4059/files?diff=unified&w=0#diff-d3e504d329e8e804c316978d13c7644f7ac4c5a50591ae224cf1c4188c704d53L40-R40))
*  Remove a trailing whitespace in the `cloud-context.omp.json` theme file ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4059/files?diff=unified&w=0#diff-ac56a2f2d86dc14cfceb8efc41a76c08ca454e0c4e8bc670bc5c90972e57810cL188-R188))

resolves #4056

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
