### PR TITLE
stuff

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,7 +12,8 @@ jobs:
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
     - name: Build
       run: |
-        VERSION="${${{ github.event.release.name }}:1}"
+        VERSION="${{ github.event.release.name }}"
+        VERSION="${VERSION:1}"
         echo "Building version ${VERSION}"
         cd src
         go build -o dist/posh-android-arm -ldflags="-s -w -X 'github.com/jandedobbeleer/oh-my-posh/src/build.Version=${VERSION}' -X 'github.com/jandedobbeleer/oh-my-posh/src/build.Date=$(date)'"

--- a/src/segments/kubectl_test.go
+++ b/src/segments/kubectl_test.go
@@ -34,6 +34,7 @@ func TestKubectlSegment(t *testing.T) {
 		ExpectedEnabled bool
 		ExpectedString  string
 		Files           map[string]string
+		ContextAliases  map[string]string
 	}{
 		{
 			Case:            "kubeconfig incomplete",
@@ -58,6 +59,16 @@ func TestKubectlSegment(t *testing.T) {
 		},
 		{Case: "no namespace", Template: standardTemplate, KubectlExists: true, Context: "aaa", ExpectedString: "aaa", ExpectedEnabled: true},
 		{
+			Case:            "kubectl context alias",
+			Template:        standardTemplate,
+			KubectlExists:   true,
+			Context:         "aaa",
+			Namespace:       "bbb",
+			ContextAliases:  map[string]string{"aaa": "ccc"},
+			ExpectedString:  "ccc :: bbb",
+			ExpectedEnabled: true,
+		},
+		{
 			Case:            "kubectl error",
 			Template:        standardTemplate,
 			DisplayError:    true,
@@ -75,6 +86,15 @@ func TestKubectlSegment(t *testing.T) {
 			ParseKubeConfig: true,
 			Files:           testKubeConfigFiles,
 			ExpectedString:  "aaa :: bbb :: ccc :: ddd",
+			ExpectedEnabled: true,
+		},
+		{
+			Case:            "kubeconfig context alias",
+			Template:        standardTemplate,
+			ParseKubeConfig: true,
+			Files:           testKubeConfigFiles,
+			ContextAliases:  map[string]string{"aaa": "ccc"},
+			ExpectedString:  "ccc :: bbb",
 			ExpectedEnabled: true,
 		},
 		{
@@ -135,6 +155,7 @@ func TestKubectlSegment(t *testing.T) {
 			props: properties.Map{
 				properties.DisplayError: tc.DisplayError,
 				ParseKubeConfig:         tc.ParseKubeConfig,
+				ContextAliases:          tc.ContextAliases,
 			},
 		}
 		assert.Equal(t, tc.ExpectedEnabled, k.Enabled(), tc.Case)

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -1416,6 +1416,12 @@
                     "title": "Parse kubeconfig",
                     "description": "Parse kubeconfig files instead of calling out to kubectl to improve performance.",
                     "default": false
+                  },
+                  "context_aliases": {
+                    "type": "object",
+                    "title": "Context aliases",
+                    "description": "Custom context names.",
+                    "default": {}
                   }
                 }
               }

--- a/website/docs/segments/kubectl.mdx
+++ b/website/docs/segments/kubectl.mdx
@@ -10,16 +10,23 @@ Display the currently active Kubernetes context name and namespace name.
 
 ## Sample Configuration
 
-import Config from '@site/src/components/Config.js';
+import Config from "@site/src/components/Config.js";
 
-<Config data={{
-  "type": "kubectl",
-  "style": "powerline",
-  "powerline_symbol": "\uE0B0",
-  "foreground": "#000000",
-  "background": "#ebcc34",
-  "template": " \uFD31 {{.Context}}{{if .Namespace}} :: {{.Namespace}}{{end}} "
-}}/>
+<Config
+  data={{
+    type: "kubectl",
+    style: "powerline",
+    powerline_symbol: "\uE0B0",
+    foreground: "#000000",
+    background: "#ebcc34",
+    template: " \uFD31 {{.Context}}{{if .Namespace}} :: {{.Namespace}}{{end}} ",
+    properties: {
+      context_aliases: {
+        "arn:aws:eks:eu-west-1:1234567890:cluster/posh": "posh",
+      },
+    },
+  }}
+/>
 
 ## Properties
 
@@ -27,6 +34,7 @@ import Config from '@site/src/components/Config.js';
 | ------------------ | --------- | ----------------------------------------------------------------------------------------------------- |
 | `display_error`    | `boolean` | show the error context when failing to retrieve the kubectl information - defaults to `false`         |
 | `parse_kubeconfig` | `boolean` | parse kubeconfig files instead of calling out to kubectl to improve performance - defaults to `false` |
+| `context_aliases`  | `object`  | custom context names                                                                                  |
 
 ## Template ([info][templates])
 
@@ -47,11 +55,14 @@ import Config from '@site/src/components/Config.js';
 | `.User`      | `string` | the current kubectl context user      |
 | `.Cluster`   | `string` | the current kubectl context cluster   |
 
-## Tips
+:::tip
 
 It is common for the Kubernetes "default" namespace to be used when no namespace is provided. If you want your prompt to
 render an empty current namespace using the word "default", you can use something like this for the template:
 
-`{{.Context}} :: {{if .Namespace}}{{.Namespace}}{{else}}default{{end}}`
+```
+{{.Context}} :: {{if .Namespace}}{{.Namespace}}{{else}}default{{end}}
+```
+:::
 
 [templates]: /docs/configuration/templates


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 55342f6</samp>

This pull request adds context alias support to the `kubectl` segment, fixes a workflow error for the Android app, and updates the documentation and schema files accordingly. Context aliases allow users to customize the names of their kubectl contexts in the prompt. The feature is implemented in `src/segments/kubectl.go` and tested in `src/segments/kubectl_test.go`.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 55342f6</samp>

*  Add a new feature to the kubectl segment of the oh-my-posh prompt that allows users to define custom context aliases ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4060/files?diff=unified&w=0#diff-493e5874792b481bf81056cb7670d61b5485126744039735c308a1dc852ab94fL13-R16), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4060/files?diff=unified&w=0#diff-493e5874792b481bf81056cb7670d61b5485126744039735c308a1dc852ab94fL91-R100), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4060/files?diff=unified&w=0#diff-493e5874792b481bf81056cb7670d61b5485126744039735c308a1dc852ab94fR133), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4060/files?diff=unified&w=0#diff-493e5874792b481bf81056cb7670d61b5485126744039735c308a1dc852ab94fR148-R154), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4060/files?diff=unified&w=0#diff-c3ea5e58c2642172a74da72f39ffaf82c0ade1b6c2af82c198f1fc020995d242R37), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4060/files?diff=unified&w=0#diff-c3ea5e58c2642172a74da72f39ffaf82c0ade1b6c2af82c198f1fc020995d242R62-R71), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4060/files?diff=unified&w=0#diff-c3ea5e58c2642172a74da72f39ffaf82c0ade1b6c2af82c198f1fc020995d242R92-R100), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4060/files?diff=unified&w=0#diff-892c540c9bfebcb3bb8a0be1714201cd17eb6f0d40367c09f80d56e883b7335eR1419-R1424), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4060/files?diff=unified&w=0#diff-376242a1055a247f36fe53c432951d988f185f6ad99baf4a2f0dc6a6df24cbdeL13-R29), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4060/files?diff=unified&w=0#diff-376242a1055a247f36fe53c432951d988f185f6ad99baf4a2f0dc6a6df24cbdeR37), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4060/files?diff=unified&w=0#diff-376242a1055a247f36fe53c432951d988f185f6ad99baf4a2f0dc6a6df24cbdeL50-R66))
  * Define a new constant for the context alias property name in `src/segments/kubectl.go` ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4060/files?diff=unified&w=0#diff-493e5874792b481bf81056cb7670d61b5485126744039735c308a1dc852ab94fL13-R16))
  * Add a new method `SetContextAlias` to the kubectl struct that replaces the context name with the alias if defined in the properties ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4060/files?diff=unified&w=0#diff-493e5874792b481bf81056cb7670d61b5485126744039735c308a1dc852ab94fR148-R154))
  * Call `SetContextAlias` after obtaining the context name from either kubectl or kubeconfig, or before disabling the segment if kubectl fails ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4060/files?diff=unified&w=0#diff-493e5874792b481bf81056cb7670d61b5485126744039735c308a1dc852ab94fL91-R100), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4060/files?diff=unified&w=0#diff-493e5874792b481bf81056cb7670d61b5485126744039735c308a1dc852ab94fR133))
  * Add a new field to the test case struct for the context aliases in `src/segments/kubectl_test.go` ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4060/files?diff=unified&w=0#diff-c3ea5e58c2642172a74da72f39ffaf82c0ade1b6c2af82c198f1fc020995d242R37))
  * Add two new test cases that check the segment output when using context aliases with kubectl or kubeconfig ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4060/files?diff=unified&w=0#diff-c3ea5e58c2642172a74da72f39ffaf82c0ade1b6c2af82c198f1fc020995d242R62-R71), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4060/files?diff=unified&w=0#diff-c3ea5e58c2642172a74da72f39ffaf82c0ade1b6c2af82c198f1fc020995d242R92-R100))
  * Add the context alias field to the properties of the segment in the test setup function ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4060/files?diff=unified&w=0#diff-c3ea5e58c2642172a74da72f39ffaf82c0ade1b6c2af82c198f1fc020995d242R158))
  * Add the schema definition for the context alias property to `themes/schema.json` ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4060/files?diff=unified&w=0#diff-892c540c9bfebcb3bb8a0be1714201cd17eb6f0d40367c09f80d56e883b7335eR1419-R1424))
  * Update the sample configuration, the table of properties, and the tip section for the kubectl segment in `website/docs/segments/kubectl.mdx` ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4060/files?diff=unified&w=0#diff-376242a1055a247f36fe53c432951d988f185f6ad99baf4a2f0dc6a6df24cbdeL13-R29), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4060/files?diff=unified&w=0#diff-376242a1055a247f36fe53c432951d988f185f6ad99baf4a2f0dc6a6df24cbdeR37), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4060/files?diff=unified&w=0#diff-376242a1055a247f36fe53c432951d988f185f6ad99baf4a2f0dc6a6df24cbdeL50-R66))
* Fix a syntax error in the GitHub workflow file for building the Android app in `.github/workflows/android.yml` ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4060/files?diff=unified&w=0#diff-b46b6cdc887427355980140454172d7b5ff3dd1f68523667bdd4947358d927d8L15-R16))
  * Split the expression for extracting the version number from the release name into two steps: assign the release name to a variable and remove the first character using bash parameter expansion ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4060/files?diff=unified&w=0#diff-b46b6cdc887427355980140454172d7b5ff3dd1f68523667bdd4947358d927d8L15-R16))

- fix(android): correct version number trimming
- feat(kubectl): specify context aliases

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
