### PR TITLE
fix(android): update version based on bash capabilities

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,8 +12,7 @@ jobs:
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
     - name: Build
       run: |
-        VERSION="${{ github.event.release.name }}"
-        VERSION="${VERSION:1}"
+        VERSION=$(echo "${{ github.event.release.name }}" | cut -c2-)
         echo "Building version ${VERSION}"
         cd src
         go build -o dist/posh-android-arm -ldflags="-s -w -X 'github.com/jandedobbeleer/oh-my-posh/src/build.Version=${VERSION}' -X 'github.com/jandedobbeleer/oh-my-posh/src/build.Date=$(date)'"


### PR DESCRIPTION
### Prerequisites

- [ ] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [ ] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2a3512c</samp>

Simplified `VERSION` variable assignment in `.github/workflows/android.yml` to fix version number bug for Android app releases.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2a3512c</samp>

*  Simplify the `VERSION` variable assignment by using the `cut` command instead of string slicing ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4061/files?diff=unified&w=0#diff-b46b6cdc887427355980140454172d7b5ff3dd1f68523667bdd4947358d927d8L15-R15)). This fixes a bug that caused the version number to be incorrect when the release name started with a character other than `v` in `.github/workflows/android.yml`. The `VERSION` variable is used to set the `OHMYPOSH_VERSION` environment variable, which is then used by the `build.ps1` script to generate the binary files for the Android app.

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
