### PR TITLE
fix(os): use correct Android platform name

### DIFF
--- a/src/segments/os.go
+++ b/src/segments/os.go
@@ -19,50 +19,6 @@ const (
 	Linux properties.Property = "linux"
 	// Windows the string/icon to use for windows
 	Windows properties.Property = "windows"
-	// Alma the string/icon to use for Alma
-	Alma properties.Property = "alma"
-	// Alpine the string/icon to use for Alpine
-	Alpine properties.Property = "alpine"
-	// Aosc the string/icon to use for Aosc
-	Aosc properties.Property = "aosc"
-	// Arch the string/icon to use for Arch
-	Arch properties.Property = "arch"
-	// Centos the string/icon to use for Centos
-	Centos properties.Property = "centos"
-	// Coreos the string/icon to use for Coreos
-	Coreos properties.Property = "coreos"
-	// Debian the string/icon to use for Debian
-	Debian properties.Property = "debian"
-	// Devuan the string/icon to use for Devuan
-	Devuan properties.Property = "devuan"
-	// Raspbian the string/icon to use for Raspbian
-	Raspbian properties.Property = "raspbian"
-	// Elementary the string/icon to use for Elementary
-	Elementary properties.Property = "elementary"
-	// Fedora the string/icon to use for Fedora
-	Fedora properties.Property = "fedora"
-	// Gentoo the string/icon to use for Gentoo
-	Gentoo properties.Property = "gentoo"
-	// Mageia the string/icon to use for Mageia
-	Mageia properties.Property = "mageia"
-	// Manjaro the string/icon to use for Manjaro
-	Manjaro properties.Property = "manjaro"
-	// Mint the string/icon to use for Mint
-	Mint properties.Property = "mint"
-	// Nixos the string/icon to use for Nixos
-	Nixos properties.Property = "nixos"
-	// Opensuse the string/icon to use for Opensuse
-	Opensuse properties.Property = "opensuse"
-	// Redhat the string/icon to use for Redhat
-	Redhat properties.Property = "redhat"
-	// Rocky the string/icon to use for Rocky linux
-	Rocky properties.Property = "rocky"
-	// Sabayon the string/icon to use for Sabayon
-	Sabayon properties.Property = "sabayon"
-	// Slackware the string/icon to use for Slackware
-	Slackware properties.Property = "slackware"
-	// Ubuntu the string/icon to use for Ubuntu
-	Ubuntu properties.Property = "ubuntu"
 	// DisplayDistroName display the distro name or not
 	DisplayDistroName properties.Property = "display_distro_name"
 )
@@ -93,54 +49,42 @@ func (oi *Os) Enabled() bool {
 }
 
 func (oi *Os) getDistroIcon(distro string) string {
-	switch distro {
-	case "alma":
-		return oi.props.GetString(Alma, "\uF31D")
-	case "alpine":
-		return oi.props.GetString(Alpine, "\uF300")
-	case "aosc":
-		return oi.props.GetString(Aosc, "\uF301")
-	case "arch":
-		return oi.props.GetString(Arch, "\uF303")
-	case "centos":
-		return oi.props.GetString(Centos, "\uF304")
-	case "coreos":
-		return oi.props.GetString(Coreos, "\uF305")
-	case "debian":
-		return oi.props.GetString(Debian, "\uF306")
-	case "devuan":
-		return oi.props.GetString(Devuan, "\uF307")
-	case "raspbian":
-		return oi.props.GetString(Raspbian, "\uF315")
-	case "elementary":
-		return oi.props.GetString(Elementary, "\uF309")
-	case "fedora":
-		return oi.props.GetString(Fedora, "\uF30a")
-	case "gentoo":
-		return oi.props.GetString(Gentoo, "\uF30d")
-	case "mageia":
-		return oi.props.GetString(Mageia, "\uF310")
-	case "manjaro":
-		return oi.props.GetString(Manjaro, "\uF312")
-	case "mint":
-		return oi.props.GetString(Mint, "\uF30e")
-	case "nixos":
-		return oi.props.GetString(Nixos, "\uF313")
-	case "opensuse", "opensuse-tumbleweed":
-		return oi.props.GetString(Opensuse, "\uF314")
-	case "redhat":
-		return oi.props.GetString(Redhat, "\uF316")
-	case "rocky":
-		return oi.props.GetString(Rocky, "\uF32B")
-	case "sabayon":
-		return oi.props.GetString(Sabayon, "\uF317")
-	case "slackware":
-		return oi.props.GetString(Slackware, "\uF319")
-	case "ubuntu":
-		return oi.props.GetString(Ubuntu, "\uF31b")
-	case "android":
-		return oi.props.GetString(Ubuntu, "\uf17b")
+	iconMap := map[string]string{
+		"alma":                "\uF31D",
+		"alpine":              "\uF300",
+		"aosc":                "\uF301",
+		"arch":                "\uF303",
+		"centos":              "\uF304",
+		"coreos":              "\uF305",
+		"debian":              "\uF306",
+		"devuan":              "\uF307",
+		"raspbian":            "\uF315",
+		"elementary":          "\uF309",
+		"fedora":              "\uF30a",
+		"gentoo":              "\uF30d",
+		"mageia":              "\uF310",
+		"manjaro":             "\uF312",
+		"mint":                "\uF30e",
+		"nixos":               "\uF313",
+		"opensuse":            "\uF314",
+		"opensuse-tumbleweed": "\uF314",
+		"redhat":              "\uF316",
+		"rocky":               "\uF32B",
+		"sabayon":             "\uF317",
+		"slackware":           "\uF319",
+		"ubuntu":              "\uF31b",
+		"android":             "\uf17b",
 	}
+
+	if icon, ok := iconMap[distro]; ok {
+		return oi.props.GetString(properties.Property(distro), icon)
+	}
+
+	icon := oi.props.GetString(properties.Property(distro), "")
+	if len(icon) > 0 {
+		return icon
+	}
+
 	return oi.props.GetString(Linux, "\uF17C")
 }
 

--- a/src/segments/os_test.go
+++ b/src/segments/os_test.go
@@ -18,6 +18,7 @@ func TestOSInfo(t *testing.T) {
 		IsWSL             bool
 		Platform          string
 		DisplayDistroName bool
+		Icon              string
 	}{
 		{
 			Case:           "WSL debian - icon",
@@ -62,6 +63,19 @@ func TestOSInfo(t *testing.T) {
 			ExpectedString: "unknown",
 			GOOS:           "unknown",
 		},
+		{
+			Case:           "crazy distro, specific icon",
+			ExpectedString: "crazy distro",
+			GOOS:           "linux",
+			Platform:       "crazy",
+			Icon:           "crazy distro",
+		},
+		{
+			Case:           "crazy distro, not mapped",
+			ExpectedString: "\uf17c",
+			GOOS:           "linux",
+			Platform:       "crazy",
+		},
 	}
 	for _, tc := range cases {
 		env := new(mock.MockedEnvironment)
@@ -71,14 +85,22 @@ func TestOSInfo(t *testing.T) {
 			Env: make(map[string]string),
 			WSL: tc.IsWSL,
 		})
-		osInfo := &Os{
-			env: env,
-			props: properties.Map{
-				DisplayDistroName: tc.DisplayDistroName,
-				Windows:           "windows",
-				MacOS:             "darwin",
-			},
+
+		props := properties.Map{
+			DisplayDistroName: tc.DisplayDistroName,
+			Windows:           "windows",
+			MacOS:             "darwin",
 		}
+
+		if len(tc.Icon) != 0 {
+			props[properties.Property(tc.Platform)] = tc.Icon
+		}
+
+		osInfo := &Os{
+			env:   env,
+			props: props,
+		}
+
 		_ = osInfo.Enabled()
 		assert.Equal(t, tc.ExpectedString, renderTemplate(env, osInfo.Template(), osInfo), tc.Case)
 	}

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -1705,6 +1705,12 @@
                     "title": "Alma Icon",
                     "description": "The icon to use for Alma",
                     "default": "\uF31D"
+                  },
+                  "android": {
+                    "type": "string",
+                    "title": "Android Icon",
+                    "description": "The icon to use for Alma",
+                    "default": "\uf17b"
                   }
                 }
               }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 045296c</samp>

Add Android OS icon support and fix OS icon bug in `os.go`. This improves the accuracy and appearance of the OS segment.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 045296c</samp>

*  Add `Android` property to `segments` package for customizing OS segment icon ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4063/files?diff=unified&w=0#diff-25d2d3a196de8a763b743864932280c9946ce16b8a6cb1376aee4d6b7d027ff5R66-R67))
*  Fix bug in `getDistroIcon` function that returned wrong icon for Android OS ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4063/files?diff=unified&w=0#diff-25d2d3a196de8a763b743864932280c9946ce16b8a6cb1376aee4d6b7d027ff5L142-R144))

resolves #4062 
<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
