### PR TITLE
docs(status): use correct template

### DIFF
--- a/website/docs/segments/status.mdx
+++ b/website/docs/segments/status.mdx
@@ -42,7 +42,7 @@ import Config from "@site/src/components/Config.js";
 :::note default template
 
 ```template
-{{ if .Error }}\uf00d {{ reason .Code }}{{ else }}\uf42e{{ end }}
+{{ .String }}
 ```
 
 :::


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ab2fd22</samp>

Simplify the status segment template to use the `.String` property. This improves code readability and consistency with other segments.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ab2fd22</samp>

*  Simplify the template for rendering the status segment to use the `.String` property ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4112/files?diff=unified&w=0#diff-f09bd5b9ad37560ab01302e9078d852f2e7669f8f92908850208318d141fbef9L45-R45))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
