### PR TITLE
fix(engine): use concurrent map for Segments

### DIFF
--- a/src/platform/concurrent_map.go
+++ b/src/platform/concurrent_map.go
@@ -37,3 +37,12 @@ func (c *ConcurrentMap) Delete(key string) {
 func (c *ConcurrentMap) List() map[string]interface{} {
 	return c.values
 }
+
+func (c *ConcurrentMap) Contains(key string) bool {
+	c.RLock()
+	defer c.RUnlock()
+	if _, ok := c.values[key]; ok {
+		return true
+	}
+	return false
+}

--- a/src/platform/shell_windows.go
+++ b/src/platform/shell_windows.go
@@ -148,9 +148,12 @@ func (env *Shell) WindowsRegistryKeyValue(path string) (*WindowsRegistryValue, e
 		return nil, err
 	}
 
-	regKey := Base(env, regPath)
-	if len(regKey) != 0 {
-		regPath = strings.TrimSuffix(regPath, `\`+regKey)
+	var regKey string
+	if !strings.HasSuffix(regPath, `\`) {
+		regKey = Base(env, regPath)
+		if len(regKey) != 0 {
+			regPath = strings.TrimSuffix(regPath, `\`+regKey)
+		}
 	}
 
 	var key registry.Key

--- a/src/template/text.go
+++ b/src/template/text.go
@@ -159,6 +159,12 @@ func (t *Text) cleanTemplate() {
 			// end of a variable, needs to be appended
 			if !isKnownVariable(property) {
 				result += ".Data" + property
+			} else if strings.HasPrefix(property, ".Segments") && !strings.HasSuffix(property, ".Contains") {
+				// as we can't provide a clean way to access the list
+				// of segments, we need to replace the property with
+				// the list of segments so they can be accessed directly
+				property = strings.Replace(property, ".Segments", ".Segments.List", 1)
+				result += property
 			} else {
 				// check if we have the same property in Data
 				// and replace it with the Data property so it

--- a/src/template/text_test.go
+++ b/src/template/text_test.go
@@ -320,6 +320,16 @@ func TestCleanTemplate(t *testing.T) {
 			Expected: "{{.Data.OS}}",
 			Template: "{{.OS}}",
 		},
+		{
+			Case:     "Keep .Contains intact for Segments",
+			Expected: `{{.Segments.Contains "Git"}}`,
+			Template: `{{.Segments.Contains "Git"}}`,
+		},
+		{
+			Case:     "Replace a direct call to .Segments with .Segments.List",
+			Expected: `{{.Segments.List.Git.Repo}}`,
+			Template: `{{.Segments.Git.Repo}}`,
+		},
 	}
 	for _, tc := range cases {
 		tmpl := &Text{
@@ -342,11 +352,11 @@ func TestSegmentContains(t *testing.T) {
 	}
 
 	env := &mock.MockedEnvironment{}
+	segments := platform.NewConcurrentMap()
+	segments.Set("Git", "foo")
 	env.On("TemplateCache").Return(&platform.TemplateCache{
-		Env: make(map[string]string),
-		Segments: map[string]interface{}{
-			"Git": nil,
-		},
+		Env:      make(map[string]string),
+		Segments: segments,
 	})
 	for _, tc := range cases {
 		tmpl := &Text{


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c488da7</samp>

This pull request improves the template cache, fixes a Windows registry bug, and adds some tests. It refactors the cache to use a `ConcurrentMap` type for segment data, adds a `Contains` method to the `ConcurrentMap` type, and adjusts the `cleanTemplate` function to handle direct segment property access. It also fixes a bug in the `WindowsRegistryKeyValue` function and updates the tests for the `cleanTemplate` and `SegmentContains` functions.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c488da7</samp>

*  Add a `Contains` method to the `ConcurrentMap` type for checking the existence of segment data in the template cache ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4120/files?diff=unified&w=0#diff-9a5f3d632998854b985388ba59d79add603901020fdbaa4ce5fbe91525ca70fdR40-R48))
*  Fix a bug in the `WindowsRegistryKeyValue` function that caused an empty value to be returned when the registry path ended with a backslash ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4120/files?diff=unified&w=0#diff-c12d6a254cd1eb407597d7b53a48dc76a0e638e413a8f595685f4a8ba9276df8L151-R156))
*  Replace the `SegmentsCache` type and its `Contains` method with the `ConcurrentMap` type for storing segment data in the `TemplateCache` type ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4120/files?diff=unified&w=0#diff-7b082f4396f0c936b17e8deb6c4ea8ec54cb48509691b08354c28ef55aa18557L169-L175), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4120/files?diff=unified&w=0#diff-7b082f4396f0c936b17e8deb6c4ea8ec54cb48509691b08354c28ef55aa18557L191-R184), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4120/files?diff=unified&w=0#diff-7b082f4396f0c936b17e8deb6c4ea8ec54cb48509691b08354c28ef55aa18557L198-R195), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4120/files?diff=unified&w=0#diff-7b082f4396f0c936b17e8deb6c4ea8ec54cb48509691b08354c28ef55aa18557L805-R794))
*  Add a special case to the `cleanTemplate` function to handle direct access to segment properties in the template string, and replace the `.Segments` prefix with `.Segments.List` ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4120/files?diff=unified&w=0#diff-60e26f23be072b1eb4ded5c2b683d40de41021e585df8ae8a996d91a469dddfdR162-R167))
*  Add and modify test cases to cover the new and changed functionality of the `ConcurrentMap` type, the `WindowsRegistryKeyValue` function, and the `cleanTemplate` function ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4120/files?diff=unified&w=0#diff-c60dba0c2a13f04f52591bcea3eebfea6e0efe282dfb127eac699100b6645c08R323-R332), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4120/files?diff=unified&w=0#diff-c60dba0c2a13f04f52591bcea3eebfea6e0efe282dfb127eac699100b6645c08L345-R359))

resolves #4116

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
