### PR TITLE
fix(platform): use built-in sync.Map

### DIFF
--- a/src/platform/concurrent_map.go
+++ b/src/platform/concurrent_map.go
@@ -2,47 +2,35 @@ package platform
 
 import "sync"
 
-type ConcurrentMap struct {
-	values map[string]interface{}
-	sync.RWMutex
-}
-
 func NewConcurrentMap() *ConcurrentMap {
-	return &ConcurrentMap{
-		values: make(map[string]interface{}),
-	}
+	var cm ConcurrentMap
+	return &cm
 }
 
-func (c *ConcurrentMap) Set(key string, value interface{}) {
-	c.Lock()
-	defer c.Unlock()
-	c.values[key] = value
+type ConcurrentMap sync.Map
+
+func (cm *ConcurrentMap) Set(key string, value any) {
+	(*sync.Map)(cm).Store(key, value)
 }
 
-func (c *ConcurrentMap) Get(key string) (interface{}, bool) {
-	c.RLock()
-	defer c.RUnlock()
-	if val, ok := c.values[key]; ok {
-		return val, true
-	}
-	return "", false
+func (cm *ConcurrentMap) Get(key string) (any, bool) {
+	return (*sync.Map)(cm).Load(key)
 }
 
-func (c *ConcurrentMap) Delete(key string) {
-	c.RLock()
-	defer c.RUnlock()
-	delete(c.values, key)
+func (cm *ConcurrentMap) Delete(key string) {
+	(*sync.Map)(cm).Delete(key)
 }
 
-func (c *ConcurrentMap) List() map[string]interface{} {
-	return c.values
+func (cm *ConcurrentMap) Contains(key string) bool {
+	_, ok := (*sync.Map)(cm).Load(key)
+	return ok
 }
 
-func (c *ConcurrentMap) Contains(key string) bool {
-	c.RLock()
-	defer c.RUnlock()
-	if _, ok := c.values[key]; ok {
+func (cm *ConcurrentMap) List() map[string]any {
+	list := make(map[string]any)
+	(*sync.Map)(cm).Range(func(key, value any) bool {
+		list[key.(string)] = value
 		return true
-	}
-	return false
+	})
+	return list
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5a5b18a</samp>

Use `sync.Map` for concurrent-safe map operations. Refactor `ConcurrentMap` type and remove locks and map field from `src/platform/concurrent_map.go`.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5a5b18a</samp>

*  Replace `ConcurrentMap` type with `sync.Map` alias ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4124/files?diff=unified&w=0#diff-9a5f3d632998854b985388ba59d79add603901020fdbaa4ce5fbe91525ca70fdL5-R35))

relates to #4116

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
