### PR TITLE
fix: remove ANSI for right positioning

### DIFF
--- a/src/ansi/ansi_writer.go
+++ b/src/ansi/ansi_writer.go
@@ -97,7 +97,6 @@ type Writer struct {
 	shell                 string
 	format                string
 	left                  string
-	right                 string
 	title                 string
 	linechange            string
 	clearBelow            string
@@ -127,7 +126,6 @@ func (w *Writer) Init(shellName string) {
 	case shell.BASH:
 		w.format = "\\[%s\\]"
 		w.linechange = "\\[\x1b[%d%s\\]"
-		w.right = "\\[\x1b[%dC\\]"
 		w.left = "\\[\x1b[%dD\\]"
 		w.clearBelow = "\\[\x1b[0J\\]"
 		w.clearLine = "\\[\x1b[K\\]"
@@ -144,7 +142,6 @@ func (w *Writer) Init(shellName string) {
 	case shell.ZSH, shell.TCSH:
 		w.format = "%%{%s%%}"
 		w.linechange = "%%{\x1b[%d%s%%}"
-		w.right = "%%{\x1b[%dC%%}"
 		w.left = "%%{\x1b[%dD%%}"
 		w.clearBelow = "%{\x1b[0J%}"
 		w.clearLine = "%{\x1b[K%}"
@@ -160,7 +157,6 @@ func (w *Writer) Init(shellName string) {
 		w.osc51 = "%%{\x1b]51;A%s@%s:%s\x1b\\%%}"
 	default:
 		w.linechange = "\x1b[%d%s"
-		w.right = "\x1b[%dC"
 		w.left = "\x1b[%dD"
 		w.clearBelow = "\x1b[0J"
 		w.clearLine = "\x1b[K"
@@ -193,15 +189,6 @@ func (w *Writer) SetParentColors(background, foreground string) {
 		Background: background,
 		Foreground: foreground,
 	}}, w.ParentColors...)
-}
-
-func (w *Writer) CarriageForward() string {
-	return fmt.Sprintf(w.right, 1000)
-}
-
-func (w *Writer) GetCursorForRightWrite(length, offset int) string {
-	strippedLen := length + (-offset)
-	return fmt.Sprintf(w.left, strippedLen)
 }
 
 func (w *Writer) ChangeLine(numberOfLines int) string {

--- a/src/cli/print.go
+++ b/src/cli/print.go
@@ -24,6 +24,7 @@ var (
 	shellVersion string
 	plain        bool
 	noStatus     bool
+	column       int
 )
 
 // printCmd represents the prompt command
@@ -64,6 +65,7 @@ var printCmd = &cobra.Command{
 			Primary:       args[0] == "primary",
 			Cleared:       cleared,
 			NoExitCode:    noStatus,
+			Column:        column,
 		}
 
 		eng := engine.New(flags)
@@ -107,6 +109,7 @@ func init() { //nolint:gochecknoinits
 	printCmd.Flags().BoolVarP(&plain, "plain", "p", false, "plain text output (no ANSI)")
 	printCmd.Flags().BoolVar(&cleared, "cleared", false, "do we have a clear terminal or not")
 	printCmd.Flags().BoolVar(&eval, "eval", false, "output the prompt for eval")
+	printCmd.Flags().IntVar(&column, "column", 0, "the column position of the cursor")
 	// Deprecated flags
 	printCmd.Flags().IntVarP(&status, "error", "e", 0, "last exit code")
 	printCmd.Flags().BoolVar(&noStatus, "no-exit-code", false, "no valid exit code (cancelled or no command yet)")

--- a/src/engine/engine_test.go
+++ b/src/engine/engine_test.go
@@ -21,7 +21,7 @@ func TestCanWriteRPrompt(t *testing.T) {
 		PromptLength       int
 		RPromptLength      int
 	}{
-		{Case: "Width Error", Expected: true, TerminalWidthError: errors.New("burp")},
+		{Case: "Width Error", Expected: false, TerminalWidthError: errors.New("burp")},
 		{Case: "Terminal > Prompt enabled", Expected: true, TerminalWidth: 200, PromptLength: 100, RPromptLength: 10},
 		{Case: "Terminal > Prompt enabled edge", Expected: true, TerminalWidth: 200, PromptLength: 100, RPromptLength: 70},
 		{Case: "Prompt > Terminal enabled", Expected: true, TerminalWidth: 200, PromptLength: 300, RPromptLength: 70},
@@ -39,7 +39,7 @@ func TestCanWriteRPrompt(t *testing.T) {
 			currentLineLength: tc.PromptLength,
 			rprompt:           "hello",
 		}
-		got := engine.canWriteRightBlock(true)
+		_, got := engine.canWriteRightBlock(true)
 		assert.Equal(t, tc.Expected, got, tc.Case)
 	}
 }

--- a/src/engine/prompt.go
+++ b/src/engine/prompt.go
@@ -152,8 +152,11 @@ func (e *Engine) ExtraPrompt(promptType ExtraPromptType) string {
 
 	str, length := e.Writer.String()
 	if promptType == Transient {
-		if padText, OK := e.shouldFill(prompt.Filler, length); OK {
-			str += padText
+		consoleWidth, err := e.Env.TerminalWidth()
+		if err == nil || consoleWidth != 0 {
+			if padText, OK := e.shouldFill(prompt.Filler, consoleWidth, length); OK {
+				str += padText
+			}
 		}
 	}
 

--- a/src/engine/tooltip.go
+++ b/src/engine/tooltip.go
@@ -49,12 +49,22 @@ func (e *Engine) Tooltip(tip string) string {
 		if !block.Enabled() {
 			return ""
 		}
+
+		consoleWidth, err := e.Env.TerminalWidth()
+		if err != nil || consoleWidth == 0 {
+			return ""
+		}
+
 		text, length := block.RenderSegments()
+
+		space := consoleWidth - e.Env.Flags().Column - length
+		if space <= 0 {
+			return ""
+		}
 		// clear from cursor to the end of the line in case a previous tooltip
 		// is cut off and partially preserved, if the new one is shorter
 		e.write(e.Writer.ClearAfter())
-		e.write(e.Writer.CarriageForward())
-		e.write(e.Writer.GetCursorForRightWrite(length, 0))
+		e.write(strings.Repeat(" ", space))
 		e.write(text)
 		return e.string()
 	}

--- a/src/platform/shell.go
+++ b/src/platform/shell.go
@@ -73,6 +73,7 @@ type Flags struct {
 	Cleared       bool
 	TrueColor     bool
 	NoExitCode    bool
+	Column        int
 }
 
 type CommandError struct {

--- a/src/platform/shell_unix.go
+++ b/src/platform/shell_unix.go
@@ -55,15 +55,20 @@ func (env *Shell) IsWsl2() bool {
 
 func (env *Shell) TerminalWidth() (int, error) {
 	defer env.Trace(time.Now())
+
 	if env.CmdFlags.TerminalWidth > 0 {
 		env.DebugF("terminal width: %d", env.CmdFlags.TerminalWidth)
 		return env.CmdFlags.TerminalWidth, nil
 	}
+
 	width, err := terminal.Width()
 	if err != nil {
 		env.Error(err)
 	}
-	return int(width), err
+
+	env.DebugF("terminal width: %d", width)
+	env.CmdFlags.TerminalWidth = int(width)
+	return env.CmdFlags.TerminalWidth, err
 }
 
 func (env *Shell) Platform() string {

--- a/src/platform/shell_unix.go
+++ b/src/platform/shell_unix.go
@@ -55,7 +55,8 @@ func (env *Shell) IsWsl2() bool {
 
 func (env *Shell) TerminalWidth() (int, error) {
 	defer env.Trace(time.Now())
-	if env.CmdFlags.TerminalWidth != 0 {
+	if env.CmdFlags.TerminalWidth > 0 {
+		env.DebugF("terminal width: %d", env.CmdFlags.TerminalWidth)
 		return env.CmdFlags.TerminalWidth, nil
 	}
 	width, err := terminal.Width()

--- a/src/platform/shell_windows.go
+++ b/src/platform/shell_windows.go
@@ -87,7 +87,8 @@ func (env *Shell) IsWsl2() bool {
 
 func (env *Shell) TerminalWidth() (int, error) {
 	defer env.Trace(time.Now())
-	if env.CmdFlags.TerminalWidth != 0 {
+	if env.CmdFlags.TerminalWidth > 0 {
+		env.DebugF("terminal width: %d", env.CmdFlags.TerminalWidth)
 		return env.CmdFlags.TerminalWidth, nil
 	}
 	handle, err := syscall.Open("CONOUT$", syscall.O_RDWR, 0)

--- a/src/platform/shell_windows.go
+++ b/src/platform/shell_windows.go
@@ -87,22 +87,27 @@ func (env *Shell) IsWsl2() bool {
 
 func (env *Shell) TerminalWidth() (int, error) {
 	defer env.Trace(time.Now())
+
 	if env.CmdFlags.TerminalWidth > 0 {
 		env.DebugF("terminal width: %d", env.CmdFlags.TerminalWidth)
 		return env.CmdFlags.TerminalWidth, nil
 	}
+
 	handle, err := syscall.Open("CONOUT$", syscall.O_RDWR, 0)
 	if err != nil {
 		env.Error(err)
 		return 0, err
 	}
+
 	info, err := winterm.GetConsoleScreenBufferInfo(uintptr(handle))
 	if err != nil {
 		env.Error(err)
 		return 0, err
 	}
-	// return int(float64(info.Size.X) * 0.57), nil
-	return int(info.Size.X), nil
+
+	env.CmdFlags.TerminalWidth = int(info.Size.X)
+	env.DebugF("terminal width: %d", env.CmdFlags.TerminalWidth)
+	return env.CmdFlags.TerminalWidth, nil
 }
 
 func (env *Shell) Platform() string {

--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -131,8 +131,9 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
                 return
             }
             $position = $host.UI.RawUI.CursorPosition
+            $terminalWidth = $Host.UI.RawUI.WindowSize.Width
             $cleanPSWD = Get-CleanPSWD
-            $standardOut = @(Start-Utf8Process $script:OMPExecutable @("print", "tooltip", "--status=$script:ErrorCode", "--shell=$script:ShellName", "--pswd=$cleanPSWD", "--config=$env:POSH_THEME", "--command=$command", "--shell-version=$script:PSVersion"))
+            $standardOut = @(Start-Utf8Process $script:OMPExecutable @("print", "tooltip", "--status=$script:ErrorCode", "--shell=$script:ShellName", "--pswd=$cleanPSWD", "--config=$env:POSH_THEME", "--command=$command", "--shell-version=$script:PSVersion", "--column=$($position.X)", "--terminal-width=$terminalWidth"))
             # ignore an empty tooltip
             if ($standardOut -eq '') {
                 return

--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -417,6 +417,13 @@ Example:
             $terminalWidth = 0
         }
 
+        # in some cases we have an empty $script:NoExitCode
+        # this is a workaround to make sure we always have a value
+        # see https://github.com/JanDeDobbeleer/oh-my-posh/issues/4128
+        if ($null -eq $script:NoExitCode) {
+            $script:NoExitCode = $true
+        }
+
         # set the cursor positions, they are zero based so align with other platforms
         $env:POSH_CURSOR_LINE = $Host.UI.RawUI.CursorPosition.Y + 1
         $env:POSH_CURSOR_COLUMN = $Host.UI.RawUI.CursorPosition.X + 1


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9bb2162</samp>

This pull request improves the rendering of the right prompt and the tooltip in `oh-my-posh` by simplifying the ANSI writer, adding a `--column` flag, refining the space calculation, and caching the terminal width. It also fixes some bugs and enhances the performance and the logging of the prompt generation. It modifies the `src/ansi/ansi_writer.go`, `src/cli/print.go`, `src/engine/engine.go`, `src/engine/prompt.go`, `src/platform/shell_windows.go`, `src/engine/engine_test.go`, `src/engine/tooltip.go`, `src/platform/shell_unix.go`, `src/platform/shell.go`, and `src/shell/scripts/omp.ps1` files.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9bb2162</samp>

*  Remove the `right` field and the related methods from the `Writer` type, which were used to generate the ANSI escape sequences for moving the cursor to the right ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4127/files?diff=unified&w=0#diff-0267d2a06e9c5eab5a04e9625772dd68774a70872a4014630cdb15183ce7dcd9L100), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4127/files?diff=unified&w=0#diff-0267d2a06e9c5eab5a04e9625772dd68774a70872a4014630cdb15183ce7dcd9L130), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4127/files?diff=unified&w=0#diff-0267d2a06e9c5eab5a04e9625772dd68774a70872a4014630cdb15183ce7dcd9L147), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4127/files?diff=unified&w=0#diff-0267d2a06e9c5eab5a04e9625772dd68774a70872a4014630cdb15183ce7dcd9L163), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4127/files?diff=unified&w=0#diff-0267d2a06e9c5eab5a04e9625772dd68774a70872a4014630cdb15183ce7dcd9L198-L206)).

- fix: print rprompt using spaces
- fix(prompt): print right block using spaces
- fix(tooltip): position with spaces instead of ANSI
- refactor(terminalwidth): add debug info

resolves #4117

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
