### PR TITLE
fix(prompt): only pad on positive count

### DIFF
--- a/src/engine/engine.go
+++ b/src/engine/engine.go
@@ -244,7 +244,13 @@ func (e *Engine) renderBlock(block *Block, cancelNewline bool) {
 			return
 		}
 
-		prompt := strings.Repeat(" ", space-length)
+		var prompt string
+		space -= length
+
+		if space > 0 {
+			prompt += strings.Repeat(" ", space-length)
+		}
+
 		prompt += text
 		e.write(prompt)
 	case RPrompt:


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ff9247b</samp>

Fix prompt misalignment bug in `engine.go`. Ensure that the space between blocks is positive and consistent when using different alignment options.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ff9247b</samp>

* Fix prompt misalignment bug when text length exceeds available space ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4134/files?diff=unified&w=0#diff-2621eae7a3bca7157aca7db673f968d3bd065529cd80f6b32e348807463ff78bL247-R253))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
