### PR TITLE
fix: make no silly mistakes

### DIFF
--- a/src/engine/block.go
+++ b/src/engine/block.go
@@ -3,7 +3,6 @@ package engine
 import (
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/ansi"
 	"github.com/jandedobbeleer/oh-my-posh/src/platform"
@@ -77,9 +76,6 @@ func (b *Block) InitPlain(env platform.Environment, config *Config) {
 }
 
 func (b *Block) executeSegmentLogic() {
-	if b.env.Flags().Debug {
-		return
-	}
 	if shouldHideForWidth(b.env, b.MinWidth, b.MaxWidth) {
 		return
 	}
@@ -265,30 +261,4 @@ func (b *Block) getPowerlineColor() string {
 		return ansi.Transparent
 	}
 	return b.previousActiveSegment.background()
-}
-
-func (b *Block) Debug() (int, []*SegmentTiming) {
-	var segmentTimings []*SegmentTiming
-	largestSegmentNameLength := 0
-	for _, segment := range b.Segments {
-		var segmentTiming SegmentTiming
-		segmentTiming.name = string(segment.Type)
-		segmentTiming.nameLength = len(segmentTiming.name)
-		if segmentTiming.nameLength > largestSegmentNameLength {
-			largestSegmentNameLength = segmentTiming.nameLength
-		}
-		b.env.DebugF("Segment: %s", segmentTiming.name)
-		start := time.Now()
-		segment.SetEnabled(b.env)
-		segment.SetText()
-		segmentTiming.active = segment.Enabled
-		if segmentTiming.active || segment.style() == Accordion {
-			b.setActiveSegment(segment)
-			b.renderActiveSegment()
-			segmentTiming.text, _ = b.writer.String()
-		}
-		segmentTiming.duration = time.Since(start)
-		segmentTimings = append(segmentTimings, &segmentTiming)
-	}
-	return largestSegmentNameLength, segmentTimings
 }

--- a/src/engine/engine.go
+++ b/src/engine/engine.go
@@ -36,7 +36,7 @@ func (e *Engine) string() string {
 }
 
 func (e *Engine) canWriteRightBlock(rprompt bool) (int, bool) {
-	if rprompt && (len(e.rprompt) == 0 || e.Plain) {
+	if rprompt && (len(e.rprompt) == 0) {
 		return 0, false
 	}
 
@@ -248,7 +248,7 @@ func (e *Engine) renderBlock(block *Block, cancelNewline bool) {
 		space -= length
 
 		if space > 0 {
-			prompt += strings.Repeat(" ", space-length)
+			prompt += strings.Repeat(" ", space)
 		}
 
 		prompt += text

--- a/src/engine/prompt.go
+++ b/src/engine/prompt.go
@@ -37,7 +37,7 @@ func (e *Engine) Primary() string {
 		e.renderBlock(block, cancelNewline)
 	}
 
-	if len(e.Config.ConsoleTitleTemplate) > 0 {
+	if len(e.Config.ConsoleTitleTemplate) > 0 && !e.Env.Flags().Plain {
 		title := e.getTitleTemplateText()
 		e.write(e.Writer.FormatTitle(title))
 	}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 87e4565</samp>

This pull request refactors and improves the debug mode and the right prompt rendering in the `engine` package. It removes unused or redundant code, fixes some bugs, and adds more debug information. It also fixes a missing plain flag check for the console title in the `prompt` package.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 87e4565</samp>

*  Remove unused import of `time` package from `engine` package ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4138/files?diff=unified&w=0#diff-88a08b290b6321ea570d290d5ef5524c1d57feac559c1f9de7598ea22581d001L6))
*  Move segment timing and debug logic from `Block` type to `Engine` type ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4138/files?diff=unified&w=0#diff-88a08b290b6321ea570d290d5ef5524c1d57feac559c1f9de7598ea22581d001L269-L294), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4138/files?diff=unified&w=0#diff-04ca855758b912ef3e6029e6e4fdb0d6dc485f83cfffedc82d3c1444dc018a19L25-R47), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4138/files?diff=unified&w=0#diff-cd158856c1b1aa6b2acece8041eb07352e4247b700e0fc62798a6be35d5f1c7dL52-R55), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4138/files?diff=unified&w=0#diff-cd158856c1b1aa6b2acece8041eb07352e4247b700e0fc62798a6be35d5f1c7dL483-R495))
*  Remove conditional return statement that skipped segment initialization in debug mode ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4138/files?diff=unified&w=0#diff-88a08b290b6321ea570d290d5ef5524c1d57feac559c1f9de7598ea22581d001L80-L82))
*  Remove segment text from debug output and add prompt rendering ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4138/files?diff=unified&w=0#diff-04ca855758b912ef3e6029e6e4fdb0d6dc485f83cfffedc82d3c1444dc018a19L50-R62), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4138/files?diff=unified&w=0#diff-2621eae7a3bca7157aca7db673f968d3bd065529cd80f6b32e348807463ff78bL251-R251))
*  Remove redundant line that wrote "Segments" header to debug output ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4138/files?diff=unified&w=0#diff-04ca855758b912ef3e6029e6e4fdb0d6dc485f83cfffedc82d3c1444dc018a19L19))
*  Remove check for plain flag from right prompt rendering ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4138/files?diff=unified&w=0#diff-2621eae7a3bca7157aca7db673f968d3bd065529cd80f6b32e348807463ff78bL39-R39))
*  Add check for plain flag before writing console title ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4138/files?diff=unified&w=0#diff-9cbb773ea359cb84f27d7d8a473c1d6a206afb625cd36be225a57c43daa56145L40-R40))
*  Remove extra blank line from `SetEnabled` method of `Segment` type ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4138/files?diff=unified&w=0#diff-cd158856c1b1aa6b2acece8041eb07352e4247b700e0fc62798a6be35d5f1c7dL496-R509))

- feat(debug): use actual prompt logic
- fix(rprompt): print when plain
- fix(plain): do not print title

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
