### PR TITLE
fix(template): save Segments correctly

### DIFF
--- a/src/platform/cache.go
+++ b/src/platform/cache.go
@@ -56,7 +56,7 @@ func (fc *fileCache) Close() {
 	if !fc.dirty {
 		return
 	}
-	cache := fc.cache.List()
+	cache := fc.cache.SimpleMap()
 	if dump, err := json.MarshalIndent(cache, "", "    "); err == nil {
 		cacheFilePath := filepath.Join(fc.cachePath, CacheFile)
 		_ = os.WriteFile(cacheFilePath, dump, 0644)

--- a/src/platform/map.go
+++ b/src/platform/map.go
@@ -26,11 +26,21 @@ func (cm *ConcurrentMap) Contains(key string) bool {
 	return ok
 }
 
-func (cm *ConcurrentMap) List() map[string]any {
+func (cm *ConcurrentMap) SimpleMap() SimpleMap {
 	list := make(map[string]any)
 	(*sync.Map)(cm).Range(func(key, value any) bool {
 		list[key.(string)] = value
 		return true
 	})
 	return list
+}
+
+type SimpleMap map[string]any
+
+func (m SimpleMap) ConcurrentMap() *ConcurrentMap {
+	var cm ConcurrentMap
+	for k, v := range m {
+		cm.Set(k, v)
+	}
+	return &cm
 }

--- a/src/platform/shell.go
+++ b/src/platform/shell.go
@@ -168,21 +168,22 @@ type SystemInfo struct {
 }
 
 type TemplateCache struct {
-	Root         bool
-	PWD          string
-	Folder       string
-	Shell        string
-	ShellVersion string
-	UserName     string
-	HostName     string
-	Code         int
-	Env          map[string]string
-	Var          map[string]interface{}
-	OS           string
-	WSL          bool
-	PromptCount  int
-	SHLVL        int
-	Segments     *ConcurrentMap
+	Root          bool
+	PWD           string
+	Folder        string
+	Shell         string
+	ShellVersion  string
+	UserName      string
+	HostName      string
+	Code          int
+	Env           map[string]string
+	Var           SimpleMap
+	OS            string
+	WSL           bool
+	PromptCount   int
+	SHLVL         int
+	Segments      *ConcurrentMap
+	SegmentsCache SimpleMap
 
 	initialized bool
 	sync.RWMutex
@@ -745,7 +746,9 @@ func (env *Shell) saveTemplateCache() {
 	if !canSave {
 		return
 	}
-	templateCache, err := json.Marshal(env.TemplateCache())
+	cache := env.TemplateCache()
+	cache.SegmentsCache = cache.Segments.SimpleMap()
+	templateCache, err := json.Marshal(cache)
 	if err == nil {
 		env.fileCache.Set(TEMPLATECACHE, string(templateCache), 1440)
 	}
@@ -769,6 +772,7 @@ func (env *Shell) LoadTemplateCache() {
 		env.Error(err)
 		return
 	}
+	tmplCache.Segments = tmplCache.SegmentsCache.ConcurrentMap()
 	tmplCache.initialized = true
 	env.tmplCache = &tmplCache
 }

--- a/src/template/text.go
+++ b/src/template/text.go
@@ -163,7 +163,7 @@ func (t *Text) cleanTemplate() {
 				// as we can't provide a clean way to access the list
 				// of segments, we need to replace the property with
 				// the list of segments so they can be accessed directly
-				property = strings.Replace(property, ".Segments", ".Segments.List", 1)
+				property = strings.Replace(property, ".Segments", ".Segments.SimpleMap", 1)
 				result += property
 			} else {
 				// check if we have the same property in Data

--- a/src/template/text_test.go
+++ b/src/template/text_test.go
@@ -327,7 +327,7 @@ func TestCleanTemplate(t *testing.T) {
 		},
 		{
 			Case:     "Replace a direct call to .Segments with .Segments.List",
-			Expected: `{{.Segments.List.Git.Repo}}`,
+			Expected: `{{.Segments.SimpleMap.Git.Repo}}`,
 			Template: `{{.Segments.Git.Repo}}`,
 		},
 	}


### PR DESCRIPTION
resolves #4143

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3296e58</samp>

This pull request enhances the file caching mechanism for the prompt segments by introducing a segments cache and a concurrent map. This improves the performance and consistency of the `oh-my-posh` tool across different shell environments.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3296e58</samp>

*  Add a new function `ToConcurrentMap` to convert a regular map to a thread-safe map ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4145/files?diff=unified&w=0#diff-9a5f3d632998854b985388ba59d79add603901020fdbaa4ce5fbe91525ca70fdR10-R17))
*  Change the `TemplateCache` type to include a `SegmentsCache` field and use the `any` alias for values ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4145/files?diff=unified&w=0#diff-7b082f4396f0c936b17e8deb6c4ea8ec54cb48509691b08354c28ef55aa18557L171-R186))
*  Update the `saveTemplateCache` function to copy the segments to the cache before marshaling to JSON ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4145/files?diff=unified&w=0#diff-7b082f4396f0c936b17e8deb6c4ea8ec54cb48509691b08354c28ef55aa18557L748-R751))
*  Update the `LoadTemplateCache` function to create a concurrent map from the cache after unmarshaling from JSON ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4145/files?diff=unified&w=0#diff-7b082f4396f0c936b17e8deb6c4ea8ec54cb48509691b08354c28ef55aa18557R775))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
