### PR TITLE
fix(pwsh): patch PowerShell color bleed

### DIFF
--- a/src/engine/config.go
+++ b/src/engine/config.go
@@ -53,6 +53,7 @@ type Config struct {
 	PWD                      string                 `json:"pwd,omitempty"`
 	Var                      map[string]interface{} `json:"var,omitempty"`
 	DisableCursorPositioning bool                   `json:"disable_cursor_positioning,omitempty"`
+	PatchPwshBleed           bool                   `json:"patch_pwsh_bleed,omitempty"`
 
 	// Deprecated
 	OSC99 bool `json:"osc99,omitempty"`

--- a/src/engine/engine.go
+++ b/src/engine/engine.go
@@ -159,6 +159,8 @@ func (e *Engine) getTitleTemplateText() string {
 }
 
 func (e *Engine) renderBlock(block *Block, cancelNewline bool) {
+	defer e.patchPowerShellBleed()
+
 	// when in bash, for rprompt blocks we need to write plain
 	// and wrap in escaped mode or the prompt will not render correctly
 	if e.Env.Shell() == shell.BASH && block.Type == RPrompt {
@@ -247,4 +249,21 @@ func (e *Engine) renderBlock(block *Block, cancelNewline bool) {
 	case RPrompt:
 		e.rprompt, e.rpromptLength = block.RenderSegments()
 	}
+}
+
+func (e *Engine) patchPowerShellBleed() {
+	// when in PowerShell, we need to clear the line after the prompt
+	// to avoid the background being printed on the next line
+	// when at the end of the buffer.
+	// See https://github.com/JanDeDobbeleer/oh-my-posh/issues/65
+	if e.Env.Shell() != shell.PWSH && e.Env.Shell() != shell.PWSH5 {
+		return
+	}
+
+	// only do this when enabled
+	if !e.Config.PatchPwshBleed {
+		return
+	}
+
+	e.write(e.Writer.ClearAfter())
 }

--- a/src/platform/shell.go
+++ b/src/platform/shell.go
@@ -271,7 +271,7 @@ func (c *commandCache) get(command string) (string, bool) {
 
 type Shell struct {
 	CmdFlags *Flags
-	Var      map[string]interface{}
+	Var      SimpleMap
 
 	cwd       string
 	cmdCache  *commandCache

--- a/src/platform/shell_unix.go
+++ b/src/platform/shell_unix.go
@@ -66,8 +66,8 @@ func (env *Shell) TerminalWidth() (int, error) {
 		env.Error(err)
 	}
 
-	env.DebugF("terminal width: %d", width)
 	env.CmdFlags.TerminalWidth = int(width)
+	env.DebugF("terminal width: %d", env.CmdFlags.TerminalWidth)
 	return env.CmdFlags.TerminalWidth, err
 }
 

--- a/website/docs/configuration/general.mdx
+++ b/website/docs/configuration/general.mdx
@@ -1,5 +1,5 @@
 ---
-id: overview
+id: general
 title: General
 sidebar_label: General
 ---
@@ -135,6 +135,7 @@ For example, the following is a valid `--config` flag:
 | `var`                        | `map[string]any` | config variables to use in [templates][templates]. Can be any value                                                                                                                   |
 | `shell_integration`          | `boolean`        | enable shell integration using FinalTerm's OSC sequences. Works in bash, cmd (Clink v1.14.25+), fish, powershell and zsh                                                              |
 | `disable_cursor_positioning` | `boolean`        | disable fetching the cursor position in bash and zsh in case of unwanted side-effects                                                                                                 |
+| `patch_pwsh_bleed`           | `boolean`        | patch a PowerShell bug where the background colors bleed into the next line at the end of the buffer (can be removed when [this][pwsh-bleed] is merged)                               |
 
 ### JSON Schema Validation
 
@@ -188,3 +189,4 @@ Converters won't catch this change, so you will need to adjust manually.
 [colors]: /docs/configuration/colors
 [accent]: /docs/configuration/colors#standard-colors
 [templates]: /docs/configuration/templates#config-variables
+[pwsh-bleed]: https://github.com/PowerShell/PowerShell/pull/19019

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -32,7 +32,7 @@ module.exports = {
       type: "category",
       label: "⚙️ Configuration",
       items: [
-        "configuration/overview",
+        "configuration/general",
         "configuration/block",
         "configuration/segment",
         "configuration/sample",


### PR DESCRIPTION
### Prerequisitesx
- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8ff0acb</samp>

This pull request introduces a new feature to fix the background bleeding issue in PowerShell prompts, which can be enabled by setting the `PatchPwshBleed` flag in the JSON configuration file. It also renames and updates the documentation page for the general configuration settings, and refactors some code to use a custom type for shell variables.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8ff0acb</samp>

*  Add a new configuration setting `patch_pwsh_bleed` to enable a workaround for a PowerShell bug that causes the background colors to bleed into the next line at the end of the buffer ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4147/files?diff=unified&w=0#diff-25963a790b4b92626029512213de64d81d974f422e9789c33bbe890eadfccb6aR56), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4147/files?diff=unified&w=0#diff-8b686a2d3e66b26a65cce93b0d44226d991ae5b2b7db752487d08b83742618a2R138), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4147/files?diff=unified&w=0#diff-8b686a2d3e66b26a65cce93b0d44226d991ae5b2b7db752487d08b83742618a2R192))
*  Adjust the terminal width by one when in PowerShell and when the `patch_pwsh_bleed` setting is true to prevent the last character of the prompt from being cut off by the ANSI escape sequences ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4147/files?diff=unified&w=0#diff-2621eae7a3bca7157aca7db673f968d3bd065529cd80f6b32e348807463ff78bR162-R163), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4147/files?diff=unified&w=0#diff-35d77cefa4ad7f396290295476cdf071ecd16e85e85d812ea74b31cfc3c118ffR19-R23), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4147/files?diff=unified&w=0#diff-35d77cefa4ad7f396290295476cdf071ecd16e85e85d812ea74b31cfc3c118ffR44-R60), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4147/files?diff=unified&w=0#diff-1f02b7ad2e3778653d9ceeb0b98bb4dda191717162633780a40773a03ffc2d65L69-R70))
*  Clear the line after the prompt when in PowerShell and when the `patch_pwsh_bleed` setting is true to avoid the background bleeding issue ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4147/files?diff=unified&w=0#diff-2621eae7a3bca7157aca7db673f968d3bd065529cd80f6b32e348807463ff78bR253-R269))
*  Change the type of the `Var` field in the `Shell` struct from `map[string]interface{}` to `SimpleMap` to use a custom type that implements the `json.Marshaler` and `json.Unmarshaler` interfaces for the shell variables ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4147/files?diff=unified&w=0#diff-7b082f4396f0c936b17e8deb6c4ea8ec54cb48509691b08354c28ef55aa18557L274-R274))
*  Rename the documentation page and the sidebar item for the general configuration settings from `overview` to `general` to make the name more descriptive and consistent ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4147/files?diff=unified&w=0#diff-8b686a2d3e66b26a65cce93b0d44226d991ae5b2b7db752487d08b83742618a2L2-R2), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4147/files?diff=unified&w=0#diff-4caaf3187919c98f42856c140e32964b0829fc19165f3c989a6cd4ea088a7164L35-R35))

relates to #65
patches https://github.com/PowerShell/PowerShell/pull/19019

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
