### PR TITLE
docs: remove ruby version properties

### DIFF
--- a/website/docs/segments/ruby.mdx
+++ b/website/docs/segments/ruby.mdx
@@ -45,9 +45,6 @@ import Config from '@site/src/components/Config.js';
 | Name     | Type     | Description                                        |
 | -------- | -------- | -------------------------------------------------- |
 | `.Full`  | `string` | the full version                                   |
-| `.Major` | `string` | major number                                       |
-| `.Minor` | `string` | minor number                                       |
-| `.Patch` | `string` | patch number                                       |
 | `.Error` | `string` | error encountered when fetching the version string |
 
 [templates]: /docs/configuration/templates


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4a9eb98</samp>

Removed obsolete properties from the `version` segment documentation for Ruby. This aligns the docs with the latest segment code that fixes a bug in version detection.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4a9eb98</samp>

* Remove `.Major`, `.Minor` and `.Patch` properties from the `version` segment documentation for Ruby ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4164/files?diff=unified&w=0#diff-b1de9f65f0b3ad77a34fd21a22fea750ca4a7c7d36180b59b98ccb7372257855L48-L50)). This reflects the segment update that uses `ruby -v` to get the version information and fixes a bug with incorrect version detection for some Ruby installations.

resolves #4163

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
