### PR TITLE
fix(path): add last element when only 1 level deep

### DIFF
--- a/src/segments/path.go
+++ b/src/segments/path.go
@@ -317,6 +317,7 @@ func (pt *Path) getLetterPath() string {
 func (pt *Path) getUniqueLettersPath(maxWidth int) string {
 	separator := pt.getFolderSeparator()
 	splitted := strings.Split(pt.relative, pt.env.PathSeparator())
+
 	if pt.root == pt.env.PathSeparator() {
 		pt.root = splitted[0]
 		splitted = splitted[1:]
@@ -360,7 +361,7 @@ func (pt *Path) getUniqueLettersPath(maxWidth int) string {
 		}
 	}
 
-	if len(elements) > 0 {
+	if len(splitted) > 0 {
 		elements = append(elements, splitted[n-1])
 	}
 

--- a/src/segments/path_test.go
+++ b/src/segments/path_test.go
@@ -908,11 +908,11 @@ func TestFullPathCustomMappedLocations(t *testing.T) {
 		env := new(mock.MockedEnvironment)
 		env.On("Home").Return(homeDir)
 		env.On("Pwd").Return(tc.Pwd)
-		if tc.GOOS == "" {
+		if len(tc.GOOS) == 0 {
 			tc.GOOS = platform.DARWIN
 		}
 		env.On("GOOS").Return(tc.GOOS)
-		if tc.PathSeparator == "" {
+		if len(tc.PathSeparator) == 0 {
 			tc.PathSeparator = "/"
 		}
 		env.On("PathSeparator").Return(tc.PathSeparator)
@@ -932,6 +932,36 @@ func TestFullPathCustomMappedLocations(t *testing.T) {
 				properties.Style:       Full,
 				MappedLocationsEnabled: false,
 				MappedLocations:        tc.MappedLocations,
+			},
+		}
+		path.setPaths()
+		path.setStyle()
+		got := renderTemplateNoTrimSpace(env, "{{ .Path }}", path)
+		assert.Equal(t, tc.Expected, got)
+	}
+}
+
+func TestPowerlevelMappedLocations(t *testing.T) {
+	cases := []struct {
+		Pwd             string
+		MappedLocations map[string]string
+		Expected        string
+	}{
+		{Pwd: "/Users/michal/Applications", MappedLocations: map[string]string{"~": "#"}, Expected: "#/Applications"},
+	}
+
+	for _, tc := range cases {
+		env := new(mock.MockedEnvironment)
+		env.On("Home").Return("/Users/michal")
+		env.On("Pwd").Return(tc.Pwd)
+		env.On("GOOS").Return(platform.DARWIN)
+		env.On("PathSeparator").Return("/")
+		env.On("Shell").Return(shell.GENERIC)
+		path := &Path{
+			env: env,
+			props: properties.Map{
+				properties.Style: Powerlevel,
+				MappedLocations:  tc.MappedLocations,
 			},
 		}
 		path.setPaths()


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a1fb9ee</samp>

This pull request enhances the path segment with a new feature and a bug fix. It allows users to define `MappedLocations` to replace certain directories with custom strings in the `Powerlevel` style, and it fixes a bug that caused incorrect shortening of some paths. It also improves the test coverage for the path segment.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a1fb9ee</samp>

*  Add `MappedLocations` property for customizing path segment with user-defined mappings ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4165/files?diff=unified&w=0#diff-7241cbf0d8682e7c867776d1aeb1c07a0deb58bacb7d6f2ff371d8c4f1e5ee09R320), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4165/files?diff=unified&w=0#diff-aa603356267e7fdaa699c49f047552a020509f6da4df2d15535f9f32ddfa3959L911-R915), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4165/files?diff=unified&w=0#diff-aa603356267e7fdaa699c49f047552a020509f6da4df2d15535f9f32ddfa3959R944-R973))
   - Define constant `MappedLocations` in `src/segments/path.go` ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4165/files?diff=unified&w=0#diff-7241cbf0d8682e7c867776d1aeb1c07a0deb58bacb7d6f2ff371d8c4f1e5ee09R320))
   - Refactor test function `TestFullPathCustomMappedLocations` in `src/segments/path_test.go` to use `len() == 0` for empty strings ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4165/files?diff=unified&w=0#diff-aa603356267e7fdaa699c49f047552a020509f6da4df2d15535f9f32ddfa3959L911-R915))
   - Add test function `TestPowerlevelMappedLocations` in `src/segments/path_test.go` to check `MappedLocations` with `Powerlevel` style ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4165/files?diff=unified&w=0#diff-aa603356267e7fdaa699c49f047552a020509f6da4df2d15535f9f32ddfa3959R944-R973))
* Fix bug in `getUniqueLettersPath` that could cause panic with empty or separator-less paths ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4165/files?diff=unified&w=0#diff-7241cbf0d8682e7c867776d1aeb1c07a0deb58bacb7d6f2ff371d8c4f1e5ee09L363-R364))
   - Check length of `splitted` instead of `elements` in `src/segments/path.go` ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4165/files?diff=unified&w=0#diff-7241cbf0d8682e7c867776d1aeb1c07a0deb58bacb7d6f2ff371d8c4f1e5ee09L363-R364))
   - Ensure last element of path is always added to segment, unless path is empty ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4165/files?diff=unified&w=0#diff-7241cbf0d8682e7c867776d1aeb1c07a0deb58bacb7d6f2ff371d8c4f1e5ee09L363-R364))

resolves #4162

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
