### PR TITLE
fix(fonts): register user fonts correctly on Windows

### DIFF
--- a/src/font/install_windows.go
+++ b/src/font/install_windows.go
@@ -42,9 +42,11 @@ func install(font *Font, admin bool) error {
 	}
 
 	// Add registry entry
-	reg := registry.LOCAL_MACHINE
+	var reg = registry.LOCAL_MACHINE
+	var regValue = font.FileName
 	if !admin {
 		reg = registry.CURRENT_USER
+		regValue = fullPath
 	}
 
 	k, err := registry.OpenKey(reg, `SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts`, registry.WRITE)
@@ -59,7 +61,7 @@ func install(font *Font, admin bool) error {
 	defer k.Close()
 
 	name := fmt.Sprintf("%v (TrueType)", font.Name)
-	if err = k.SetStringValue(name, font.FileName); err != nil {
+	if err = k.SetStringValue(name, regValue); err != nil {
 		// If this fails, remove the font file as well.
 		if nexterr := os.Remove(fullPath); nexterr != nil {
 			return errors.New("Unable to delete font file after registry key set error")


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

Fix #4169

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 84298e3</samp>

Fix font installation bug for non-admin Windows users. Use different registry values for `src/font/install_windows.go` based on user privileges.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 84298e3</samp>

* Fix font installation for non-admin users on Windows by using different registry values based on user privileges ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4170/files?diff=unified&w=0#diff-0fb1cd433036960283343e1a07e4b3ebe00f5a5271e426899f5d305d91aa43daL45-R51))
* Use consistent font name for registry value in both cases ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4170/files?diff=unified&w=0#diff-0fb1cd433036960283343e1a07e4b3ebe00f5a5271e426899f5d305d91aa43daL62-R66))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
