### PR TITLE
fix(theme): updating pixelrobots theme

### DIFF
--- a/themes/pixelrobots.omp.json
+++ b/themes/pixelrobots.omp.json
@@ -15,7 +15,7 @@
           "background": "#ffea00",
           "foreground": "#000000",
           "style": "powerline",
-          "template": " \uf308{{.Context}}{{if .Namespace}} :: {{.Namespace}}{{end}} ",
+          "template": " \udb84\udcfe {{.Context}}{{if .Namespace}} :: {{.Namespace}}{{end}} ",
           "type": "kubectl"
         },
         {
@@ -39,6 +39,17 @@
           "style": "powerline",
           "template": " \uebd8 {{ .Name }} [ {{ .Origin }} ] ",
           "type": "az"
+        },
+        {
+          "type": "aws",
+          "style": "powerline",
+          "powerline_symbol": "",
+          "properties": {
+            "display_default": true
+          },
+          "foreground": "#000000",
+          "background": "#FFA400",
+          "template": " \udb83\ude0f {{.Profile}}{{if .Region}}@{{.Region}}{{end}}"
         }
       ],
       "type": "prompt"
@@ -66,10 +77,10 @@
             "opensuse": "\uf314",
             "raspbian": "\uf315",
             "ubuntu": "\uf31c",
-            "windows": "\ue70f"
+            "windows": "\ue62a"
           },
           "style": "diamond",
-          "template": " {{ if .WSL }}{{ .Icon }} on \ue70f{{ end }} <#ffea00>\ue0b1</>",
+          "template": " {{ if .WSL }}{{ .Icon }} on \ue62a{{ end }} <#ffea00>\ue0b1</>",
           "type": "os"
         },
         {
@@ -92,7 +103,7 @@
           "properties": {
             "folder_icon": "<#B5B2C2>\ue5fe </>",
             "folder_separator_icon": "<#ffea00>\ue0b1 </>",
-            "home_icon": "\ueb06 ",
+            "home_icon": " \uf015 ",
             "style": "agnoster_short"
           },
           "style": "diamond",
@@ -113,7 +124,7 @@
             "fetch_upstream_icon": true
           },
           "style": "diamond",
-          "template": "<#ffea00>\ue0b1 </>{{ .UpstreamIcon }}{{ .HEAD }}{{if .BranchStatus }} {{ .BranchStatus }}{{ end }}{{ if .Working.Changed }}<#E84855> \uf044 {{ .Working.String }}</>{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }}<#2FDA4E> \uf046 {{ .Staging.String }}</>{{ end }}{{ if gt .StashCount 0 }} \ueb4b {{ .StashCount }}{{ end }} ",
+          "template": "<#ffea00>\ue0b1 </>{{ .UpstreamIcon }}{{ .HEAD }}{{ .BranchStatus }}{{ if .Working.Changed }}<#E84855> \uf044 {{ .Working.String }}</>{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }}<#2FDA4E> \uf046 {{ .Staging.String }}</>{{ end }}{{ if gt .StashCount 0 }} \uf692 {{ .StashCount }}{{ end }} ",
           "type": "git"
         },
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0f51a8e</samp>

This pull request enhances the `pixelrobots` theme for `oh-my-posh` with new icons, an AWS segment, and a simpler git segment. The goal is to make the theme more attractive and useful.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0f51a8e</samp>

* Change the kubectl segment icon to a whale emoji ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4181/files?diff=unified&w=0#diff-d3e504d329e8e804c316978d13c7644f7ac4c5a50591ae224cf1c4188c704d53L18-R18))
* Add a new AWS segment with profile, region, and monkey icon ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4181/files?diff=unified&w=0#diff-d3e504d329e8e804c316978d13c7644f7ac4c5a50591ae224cf1c4188c704d53R42-R52))
* Change the Windows OS segment icon to a terminal emoji ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4181/files?diff=unified&w=0#diff-d3e504d329e8e804c316978d13c7644f7ac4c5a50591ae224cf1c4188c704d53L69-R83))
* Change the home directory segment icon to a font awesome icon ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4181/files?diff=unified&w=0#diff-d3e504d329e8e804c316978d13c7644f7ac4c5a50591ae224cf1c4188c704d53L95-R106))
* Simplify the git segment template and change the stash icon to a font awesome icon ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4181/files?diff=unified&w=0#diff-d3e504d329e8e804c316978d13c7644f7ac4c5a50591ae224cf1c4188c704d53L116-R127))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
