### PR TITLE
docs: fix dead exit link

### DIFF
--- a/website/docs/configuration/templates.mdx
+++ b/website/docs/configuration/templates.mdx
@@ -177,7 +177,7 @@ use them.
 To use another segment's template properties in a template, you can make use of `{{ .Segments.Segment }}`
 in your template where `.Segment` is the name of the segment you want to use with the first letter uppercased.
 
-If you want to for example use the [git][git] segment's `.UpstreamGone` property in the [exit][exit] segment, you can
+If you want to for example use the [git][git] segment's `.UpstreamGone` property in the [status][status] segment, you can
 do so like this:
 
 ```json
@@ -255,7 +255,7 @@ This can be used in templates and icons/text inside your config.
 [sprig]: https://masterminds.github.io/sprig/
 [glob]: https://pkg.go.dev/path/filepath#Glob
 [git]: /docs/segments/git
-[exit]: /docs/segments/exit
+[status]: /docs/segments/status
 [templates]: /docs/configuration/segment#templates
 [regexpms]: https://pkg.go.dev/regexp#Regexp.MatchString
 [regexpra]: https://pkg.go.dev/regexp#Regexp.ReplaceAllString


### PR DESCRIPTION
Fix a dead doc link.
Context: #4084 renamed segment exit -> status.

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
    - n/a
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fb6f2e8</samp>

Updated the documentation for the `status` segment in the templates configuration. Fixed the code examples and the reference links to use the correct segment name.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fb6f2e8</samp>

* Fix documentation error and improve clarity of status segment example ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4190/files?diff=unified&w=0#diff-258349fd4a67f21d91c0fbbfd1e6f28a7ee422af8f1b445022bd8eb5cc4e2d48L180-R180))
* Add missing reference link for status segment ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4190/files?diff=unified&w=0#diff-258349fd4a67f21d91c0fbbfd1e6f28a7ee422af8f1b445022bd8eb5cc4e2d48L258-R258))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
