### PR TITLE
sunday funday

### DIFF
--- a/src/platform/shell.go
+++ b/src/platform/shell.go
@@ -3,6 +3,7 @@ package platform
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -345,7 +346,9 @@ func (env *Shell) resolveConfigPath() {
 func (env *Shell) downloadConfig(location string) error {
 	defer env.Trace(time.Now(), location)
 	ext := filepath.Ext(location)
-	configPath := filepath.Join(env.CachePath(), "config.omp"+ext)
+	fileHash := base64.StdEncoding.EncodeToString([]byte(location))
+	filename := fmt.Sprintf("config.%s.omp%s", fileHash, ext)
+	configPath := filepath.Join(env.CachePath(), filename)
 	cfg, err := env.HTTPRequest(location, nil, 5000)
 	if err != nil {
 		return err

--- a/src/segments/project.go
+++ b/src/segments/project.go
@@ -237,8 +237,9 @@ func (n *Project) getPowerShellModuleData(_ ProjectItem) *ProjectData {
 	files := n.env.LsDir(n.env.Pwd())
 	var content string
 	// get the first match only
+	// excluding PSScriptAnalyzerSettings.psd1
 	for _, file := range files {
-		if filepath.Ext(file.Name()) == ".psd1" {
+		if filepath.Ext(file.Name()) == ".psd1" && file.Name() != "PSScriptAnalyzerSettings.psd1" {
 			content = n.env.FileContent(file.Name())
 			break
 		}

--- a/website/docs/segments/project.mdx
+++ b/website/docs/segments/project.mdx
@@ -17,19 +17,23 @@ Supports:
 - Any nuspec based project (`*.nuspec`, first file match info is displayed)
 - .NET project (`*.csproj`, `*.vbproj` or `*.fsproj`, first file match info is displayed)
 - Julia project (`JuliaProject.toml`, `Project.toml`)
+- PowerShell project (`*.psd1`, first file match info is displayed)
 
 ## Sample Configuration
 
-import Config from '@site/src/components/Config.js';
+import Config from "@site/src/components/Config.js";
 
-<Config data={{
-  "type": "project",
-  "style": "powerline",
-  "powerline_symbol": "\uE0B0",
-  "foreground": "#193549",
-  "background": "#ffeb3b",
-  "template": " {{ if .Error }}{{ .Error }}{{ else }}{{ if .Version }}\uf487 {{.Version}}{{ end }} {{ if .Name }}{{ .Name }}{{ end }}{{ end }} "
-}}/>
+<Config
+  data={{
+    type: "project",
+    style: "powerline",
+    powerline_symbol: "\uE0B0",
+    foreground: "#193549",
+    background: "#ffeb3b",
+    template:
+      " {{ if .Error }}{{ .Error }}{{ else }}{{ if .Version }}\uf487 {{.Version}}{{ end }} {{ if .Name }}{{ .Name }}{{ end }}{{ end }} ",
+  }}
+/>
 
 ## Properties
 
@@ -49,12 +53,12 @@ import Config from '@site/src/components/Config.js';
 
 ### Properties
 
-| Name       | Type     | Description                                                                           |
-| ---------- | -------- | ------------------------------------------------------------------------------------- |
-| `.Type`    | `string` | The type of project (`node`, `cargo`, `poetry`, `php`, `nuspec`, `dotnet` or `julia`) |
-| `.Version` | `string` | The version of your project                                                           |
-| `.Target`  | `string` | The target framwork/language version of your project                                  |
-| `.Name`    | `string` | The name of your project                                                              |
-| `.Error`   | `string` | The error context when we can't fetch the project info                                |
+| Name       | Type     | Description                                                                                                                                                        |
+| ---------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `.Type`    | `string` | The type of project:<ul><li>`node`</li><li>`cargo`</li><li>`poetry`</li><li>`php`</li><li>`nuspec`</li><li>`dotnet`</li><li>`julia`</li><li>`powershell`</li></ul> |
+| `.Version` | `string` | The version of your project                                                                                                                                        |
+| `.Target`  | `string` | The target framwork/language version of your project                                                                                                               |
+| `.Name`    | `string` | The name of your project                                                                                                                                           |
+| `.Error`   | `string` | The error context when we can't fetch the project info                                                                                                             |
 
 [templates]: /docs/configuration/templates


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ffd1079</samp>

This pull request adds a new feature to install multiple font families from a ZIP file and show them in the CLI, fixes a bug with caching remote config files, and improves the documentation and logic for the `project` segment.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ffd1079</samp>

* Change the `successMsg` type and the `main` struct to support a list of font families installed from a ZIP file ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4193/files?diff=unified&w=0#diff-587218e4e065a2581ea794cbd9fce8adfa4e5fc9918aef194a3eeadc9cc7325aL32-R32),[link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4193/files?diff=unified&w=0#diff-587218e4e065a2581ea794cbd9fce8adfa4e5fc9918aef194a3eeadc9cc7325aL72-R78),[link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4193/files?diff=unified&w=0#diff-587218e4e065a2581ea794cbd9fce8adfa4e5fc9918aef194a3eeadc9cc7325aR220),[link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4193/files?diff=unified&w=0#diff-587218e4e065a2581ea794cbd9fce8adfa4e5fc9918aef194a3eeadc9cc7325aL254-R262))
* Modify the `installFontZIP` and `InstallZIP` functions to return a list of font families and an error, and avoid adding duplicate font families to the list ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4193/files?diff=unified&w=0#diff-587218e4e065a2581ea794cbd9fce8adfa4e5fc9918aef194a3eeadc9cc7325aL127-R133),[link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4193/files?diff=unified&w=0#diff-314c7bf1ef9f6e836f9871ed89adc6b98d3eb8202f811dc4a78fa2902a947336L13-R28),[link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4193/files?diff=unified&w=0#diff-314c7bf1ef9f6e836f9871ed89adc6b98d3eb8202f811dc4a78fa2902a947336L26-R36),[link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4193/files?diff=unified&w=0#diff-314c7bf1ef9f6e836f9871ed89adc6b98d3eb8202f811dc4a78fa2902a947336L32-R42),[link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4193/files?diff=unified&w=0#diff-314c7bf1ef9f6e836f9871ed89adc6b98d3eb8202f811dc4a78fa2902a947336L54-R72))
* Use base64 encoding to generate a unique local cache filename for a remote config file in the `downloadConfig` function ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4193/files?diff=unified&w=0#diff-7b082f4396f0c936b17e8deb6c4ea8ec54cb48509691b08354c28ef55aa18557R6),[link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4193/files?diff=unified&w=0#diff-7b082f4396f0c936b17e8deb6c4ea8ec54cb48509691b08354c28ef55aa18557L348-R351))
* Exclude the `PSScriptAnalyzerSettings.psd1` file from the PowerShell project files in the `getPowerShellModuleData` function ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4193/files?diff=unified&w=0#diff-a2564640c8fcb96e0b834a18ec38a08e64d6844be5bd60598701acfc185c112aL240-R242))
* Update the documentation for the `project` segment to include PowerShell as a supported project type and list all the possible values for the `.Type` property ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4193/files?diff=unified&w=0#diff-aaaa57fd4fee640058a036404e16b3c623d10c98457e5a63589e410c5af4f7f1L20-R36),[link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4193/files?diff=unified&w=0#diff-aaaa57fd4fee640058a036404e16b3c623d10c98457e5a63589e410c5af4f7f1L52-R62))

- fix: store downloaded config on file name hash
- fix(project): exclude PSScriptAnalyzerSettings.psd1
- feat(font): display font families

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
