### PR TITLE
chore(install): fail install on curl errors

### DIFF
--- a/website/static/install.sh
+++ b/website/static/install.sh
@@ -126,7 +126,11 @@ install() {
 
     info "⬇️  Downloading oh-my-posh from ${url}"
 
-    curl -s -L https://github.com/JanDeDobbeleer/oh-my-posh/releases/latest/download/posh-${target} -o $executable
+    http_response=$(curl -s -f -L $url -o $executable -w "%{http_code}")
+    if [ $http_response != "200" ]; then
+        error "Unable to download executable at ${url}\nPlease validate your connection and/or proxy settings"
+    fi
+
     chmod +x $executable
 
     # install themes in cache
@@ -135,16 +139,23 @@ install() {
     info "🎨 Installing oh-my-posh themes in ${cache_dir}/themes\n"
 
     theme_dir="${cache_dir}/themes"
+    url="https://github.com/JanDeDobbeleer/oh-my-posh/releases/latest/download/themes.zip"
     mkdir -p $theme_dir
-    curl -s -L https://github.com/JanDeDobbeleer/oh-my-posh/releases/latest/download/themes.zip -o ${cache_dir}/themes.zip
-    unzip -o -q ${cache_dir}/themes.zip -d $theme_dir
-    chmod u+rw ${theme_dir}/*.omp.*
-    rm ${cache_dir}/themes.zip
+    http_response=$(curl -s -f -L $url -o ${cache_dir}/themes.zip -w "%{http_code}")
+    if [ $http_response == "200" ]; then
+        unzip -o -q ${cache_dir}/themes.zip -d $theme_dir
+        chmod u+rw ${theme_dir}/*.omp.*
+        rm ${cache_dir}/themes.zip
+    else
+        warn "Unable to download themes at ${url}\nPlease validate your connection and/or proxy settings"
+    fi
 
     info "🚀 Installation complete.\n\nYou can follow the instructions at https://ohmyposh.dev/docs/installation/prompt"
-    info "to setup your shell to use oh-my-posh.\n"
-    info "If you want to use a built-in theme, you can find them in the ${theme_dir} directory:"
-    info "  oh-my-posh init {shell} --config ${theme_dir}/{theme}.omp.json\n"
+    info "to setup your shell to use oh-my-posh."
+    if [ $http_response == "200" ]; then
+        info "\nIf you want to use a built-in theme, you can find them in the ${theme_dir} directory:"
+        info "  oh-my-posh init {shell} --config ${theme_dir}/{theme}.omp.json\n"
+    fi
 }
 
 detect_arch() {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 27fbd64</samp>

Add error handling for `curl` commands in `install.sh`. This prevents the script from failing silently or partially if the downloads fail.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 27fbd64</samp>

* Add error handling for curl commands that download oh-my-posh executable and themes zip file ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4197/files?diff=unified&w=0#diff-72cd6af69c1a958194793b5b6e3c2e799830084925263fd71b3bb84808ea978dL129-R133), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4197/files?diff=unified&w=0#diff-72cd6af69c1a958194793b5b6e3c2e799830084925263fd71b3bb84808ea978dL138-R158))
* Unzip and chmod themes files if themes download succeeds ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4197/files?diff=unified&w=0#diff-72cd6af69c1a958194793b5b6e3c2e799830084925263fd71b3bb84808ea978dL138-R158))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
