### PR TITLE
Add AWS CodeCommit upstream for git segment

### DIFF
--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -428,7 +428,7 @@ func (g *Git) cleanUpstreamURL(url string) string {
 		return fmt.Sprintf("https://%s/%s", match["URL"], path)
 	}
 	// codecommit::region-identifier-id://repo-name
-	match = regex.FindNamedRegexMatch(`codecommit::(?P<URL>[a-z0-9-]+)://(?P<PATH>[a-z0-9+-./]+)`, url)
+	match = regex.FindNamedRegexMatch(`codecommit::(?P<URL>[a-z0-9-]+)://(?P<PATH>[\w\.@\:/\-~]+)`, url)
 	if len(match) != 0 {
 		return fmt.Sprintf("https://%s.console.aws.amazon.com/codesuite/codecommit/repositories/%s/browse?region=%s", match["URL"], match["PATH"], match["URL"])
 	}

--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -93,7 +93,7 @@ const (
 	MergeIcon properties.Property = "merge_icon"
 	// UpstreamIcons allows to add custom upstream icons
 	UpstreamIcons properties.Property = "upstream_icons"
-	// GithubIcon shows√ when upstream is github
+	// GithubIcon shows when upstream is github
 	GithubIcon properties.Property = "github_icon"
 	// BitbucketIcon shows  when upstream is bitbucket
 	BitbucketIcon properties.Property = "bitbucket_icon"

--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -99,8 +99,8 @@ const (
 	BitbucketIcon properties.Property = "bitbucket_icon"
 	// AzureDevOpsIcon shows  when upstream is azure devops
 	AzureDevOpsIcon properties.Property = "azure_devops_icon"
-	// AwsCodecommitIcon shows  when upstream is aws codecommit
-	AwsCodecommitIcon properties.Property = "aws_codecommit_icon"
+	// CodeCommit shows  when upstream is aws codecommit
+	CodeCommit properties.Property = "codecommit_icon"
 	// GitlabIcon shows when upstream is gitlab
 	GitlabIcon properties.Property = "gitlab_icon"
 	// GitIcon shows when the upstream can't be identified
@@ -464,7 +464,7 @@ func (g *Git) getUpstreamIcon() string {
 		"bitbucket":        {BitbucketIcon, "\uF171 "},
 		"dev.azure.com":    {AzureDevOpsIcon, "\uEBE8 "},
 		"visualstudio.com": {AzureDevOpsIcon, "\uEBE8 "},
-		"codecommit":       {AwsCodecommitIcon, "\uF270 "},
+		"codecommit":       {CodeCommit, "\uF270 "},
 	}
 	for key, value := range defaults {
 		if strings.Contains(g.UpstreamURL, key) {

--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -99,6 +99,8 @@ const (
 	BitbucketIcon properties.Property = "bitbucket_icon"
 	// AzureDevOpsIcon shows  when upstream is azure devops
 	AzureDevOpsIcon properties.Property = "azure_devops_icon"
+	// AwsCodecommitIcon shows  when upstream is aws codecommit
+	AwsCodecommitIcon properties.Property = "aws_codecommit_icon"
 	// GitlabIcon shows when upstream is gitlab
 	GitlabIcon properties.Property = "gitlab_icon"
 	// GitIcon shows when the upstream can't be identified
@@ -425,6 +427,11 @@ func (g *Git) cleanUpstreamURL(url string) string {
 		path = strings.TrimSuffix(path, ".git")
 		return fmt.Sprintf("https://%s/%s", match["URL"], path)
 	}
+	// codecommit::region-identifier-id://repo-name
+	match = regex.FindNamedRegexMatch(`codecommit::(?P<URL>[a-z0-9-]+)://(?P<PATH>[a-z0-9+-./]+)`, url)
+	if len(match) != 0 {
+		return fmt.Sprintf("https://%s.console.aws.amazon.com/codesuite/codecommit/repositories/%s/browse?region=%s", match["URL"], match["PATH"], match["URL"])
+	}
 	// user@host.xz:/path/to/repo.git
 	match = regex.FindNamedRegexMatch(`.*@(?P<URL>.*):(?P<PATH>.*).git`, url)
 	if len(match) == 0 {
@@ -457,6 +464,7 @@ func (g *Git) getUpstreamIcon() string {
 		"bitbucket":        {BitbucketIcon, "\uF171 "},
 		"dev.azure.com":    {AzureDevOpsIcon, "\uEBE8 "},
 		"visualstudio.com": {AzureDevOpsIcon, "\uEBE8 "},
+		"codecommit":       {AwsCodecommitIcon, "\uF270 "},
 	}
 	for key, value := range defaults {
 		if strings.Contains(g.UpstreamURL, key) {

--- a/src/segments/git_test.go
+++ b/src/segments/git_test.go
@@ -630,6 +630,7 @@ func TestGitUpstream(t *testing.T) {
 		{Case: "Bitbucket", Expected: "BB", Upstream: "bitbucket.org/test"},
 		{Case: "Azure DevOps", Expected: "AD", Upstream: "dev.azure.com/test"},
 		{Case: "Azure DevOps Dos", Expected: "AD", Upstream: "test.visualstudio.com"},
+		{Case: "AWS CodeCommit", Expected: "AC", Upstream: "codecommit::eu-west-1://test-repository"},
 		{Case: "Gitstash", Expected: "G", Upstream: "gitstash.com/test"},
 		{Case: "My custom server", Expected: "CU", Upstream: "mycustom.server/test"},
 	}
@@ -640,11 +641,12 @@ func TestGitUpstream(t *testing.T) {
 			"-c", "color.status=false", "remote", "get-url", "origin"}).Return(tc.Upstream, nil)
 		env.On("GOOS").Return("unix")
 		props := properties.Map{
-			GithubIcon:      "GH",
-			GitlabIcon:      "GL",
-			BitbucketIcon:   "BB",
-			AzureDevOpsIcon: "AD",
-			GitIcon:         "G",
+			GithubIcon:        "GH",
+			GitlabIcon:        "GL",
+			BitbucketIcon:     "BB",
+			AzureDevOpsIcon:   "AD",
+			AwsCodecommitIcon: "AC",
+			GitIcon:           "G",
 			UpstreamIcons: map[string]string{
 				"mycustom.server": "CU",
 				"src.example.com": "EX",

--- a/src/segments/git_test.go
+++ b/src/segments/git_test.go
@@ -630,7 +630,7 @@ func TestGitUpstream(t *testing.T) {
 		{Case: "Bitbucket", Expected: "BB", Upstream: "bitbucket.org/test"},
 		{Case: "Azure DevOps", Expected: "AD", Upstream: "dev.azure.com/test"},
 		{Case: "Azure DevOps Dos", Expected: "AD", Upstream: "test.visualstudio.com"},
-		{Case: "AWS CodeCommit", Expected: "AC", Upstream: "codecommit::eu-west-1://test-repository"},
+		{Case: "CodeCommit", Expected: "AC", Upstream: "codecommit::eu-west-1://test-repository"},
 		{Case: "Gitstash", Expected: "G", Upstream: "gitstash.com/test"},
 		{Case: "My custom server", Expected: "CU", Upstream: "mycustom.server/test"},
 	}
@@ -641,12 +641,12 @@ func TestGitUpstream(t *testing.T) {
 			"-c", "color.status=false", "remote", "get-url", "origin"}).Return(tc.Upstream, nil)
 		env.On("GOOS").Return("unix")
 		props := properties.Map{
-			GithubIcon:        "GH",
-			GitlabIcon:        "GL",
-			BitbucketIcon:     "BB",
-			AzureDevOpsIcon:   "AD",
-			AwsCodecommitIcon: "AC",
-			GitIcon:           "G",
+			GithubIcon:      "GH",
+			GitlabIcon:      "GL",
+			BitbucketIcon:   "BB",
+			AzureDevOpsIcon: "AD",
+			CodeCommit:      "AC",
+			GitIcon:         "G",
 			UpstreamIcons: map[string]string{
 				"mycustom.server": "CU",
 				"src.example.com": "EX",

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -982,10 +982,10 @@
                     "description": "Icon/text to display when the upstream is Azure DevOps",
                     "default": "\uEBE8"
                   },
-                  "aws_codecommit_icon": {
+                  "codecommit_icon": {
                     "type": "string",
-                    "title": "AWS CodeCommit Icon",
-                    "description": "Icon/text to display when the upstream is AWS CodeCommit",
+                    "title": "CodeCommit Icon",
+                    "description": "Icon/text to display when the upstream is CodeCommit",
                     "default": "\uF270"
                   },
                   "git_icon": {

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -982,6 +982,12 @@
                     "description": "Icon/text to display when the upstream is Azure DevOps",
                     "default": "\uEBE8"
                   },
+                  "aws_codecommit_icon": {
+                    "type": "string",
+                    "title": "AWS CodeCommit Icon",
+                    "description": "Icon/text to display when the upstream is AWS CodeCommit",
+                    "default": "\uF270"
+                  },
                   "git_icon": {
                     "type": "string",
                     "title": "Git Icon",

--- a/website/docs/segments/git.mdx
+++ b/website/docs/segments/git.mdx
@@ -110,14 +110,15 @@ You can set the following properties to `true` to enable fetching additional inf
 
 #### Upstream
 
-| Name                | Type                | Description                                                                                                                                                                  |
-| ------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `github_icon`       | `string`            | icon/text to display when the upstream is Github - defaults to `\uF408 `                                                                                                     |
-| `gitlab_icon`       | `string`            | icon/text to display when the upstream is Gitlab - defaults to `\uF296 `                                                                                                     |
-| `bitbucket_icon`    | `string`            | icon/text to display when the upstream is Bitbucket - defaults to `\uF171 `                                                                                                  |
-| `azure_devops_icon` | `string`            | icon/text to display when the upstream is Azure DevOps - defaults to `\uEBE8 `                                                                                               |
-| `git_icon`          | `string`            | icon/text to display when the upstream is not known/mapped - defaults to `\uE5FB `                                                                                           |
-| `upstream_icons`    | `map[string]string` | a key, value map representing the remote URL (or a part of that URL) and icon to use in case the upstream URL contains the key. These get precedence over the standard icons |
+| Name                  | Type                | Description                                                                                                                                                                  |
+| --------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `github_icon`         | `string`            | icon/text to display when the upstream is Github - defaults to `\uF408 `                                                                                                     |
+| `gitlab_icon`         | `string`            | icon/text to display when the upstream is Gitlab - defaults to `\uF296 `                                                                                                     |
+| `bitbucket_icon`      | `string`            | icon/text to display when the upstream is Bitbucket - defaults to `\uF171 `                                                                                                  |
+| `azure_devops_icon`   | `string`            | icon/text to display when the upstream is Azure DevOps - defaults to `\uEBE8 `                                                                                               |
+| `aws_codecommit_icon` | `string`            | icon/text to display when the upstream is Azure DevOps - defaults to `\uF270 `                                                                                               |
+| `git_icon`            | `string`            | icon/text to display when the upstream is not known/mapped - defaults to `\uE5FB `                                                                                           |
+| `upstream_icons`      | `map[string]string` | a key, value map representing the remote URL (or a part of that URL) and icon to use in case the upstream URL contains the key. These get precedence over the standard icons |
 
 ## Template ([info][templates])
 

--- a/website/docs/segments/git.mdx
+++ b/website/docs/segments/git.mdx
@@ -110,15 +110,15 @@ You can set the following properties to `true` to enable fetching additional inf
 
 #### Upstream
 
-| Name                  | Type                | Description                                                                                                                                                                  |
-| --------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `github_icon`         | `string`            | icon/text to display when the upstream is Github - defaults to `\uF408 `                                                                                                     |
-| `gitlab_icon`         | `string`            | icon/text to display when the upstream is Gitlab - defaults to `\uF296 `                                                                                                     |
-| `bitbucket_icon`      | `string`            | icon/text to display when the upstream is Bitbucket - defaults to `\uF171 `                                                                                                  |
-| `azure_devops_icon`   | `string`            | icon/text to display when the upstream is Azure DevOps - defaults to `\uEBE8 `                                                                                               |
-| `aws_codecommit_icon` | `string`            | icon/text to display when the upstream is Azure DevOps - defaults to `\uF270 `                                                                                               |
-| `git_icon`            | `string`            | icon/text to display when the upstream is not known/mapped - defaults to `\uE5FB `                                                                                           |
-| `upstream_icons`      | `map[string]string` | a key, value map representing the remote URL (or a part of that URL) and icon to use in case the upstream URL contains the key. These get precedence over the standard icons |
+| Name                | Type                | Description                                                                                                                                                                  |
+| ------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `github_icon`       | `string`            | icon/text to display when the upstream is Github - defaults to `\uF408 `                                                                                                     |
+| `gitlab_icon`       | `string`            | icon/text to display when the upstream is Gitlab - defaults to `\uF296 `                                                                                                     |
+| `bitbucket_icon`    | `string`            | icon/text to display when the upstream is Bitbucket - defaults to `\uF171 `                                                                                                  |
+| `azure_devops_icon` | `string`            | icon/text to display when the upstream is Azure DevOps - defaults to `\uEBE8 `                                                                                               |
+| `codecommit_icon`   | `string`            | icon/text to display when the upstream is Azure DevOps - defaults to `\uF270 `                                                                                               |
+| `git_icon`          | `string`            | icon/text to display when the upstream is not known/mapped - defaults to `\uE5FB `                                                                                           |
+| `upstream_icons`    | `map[string]string` | a key, value map representing the remote URL (or a part of that URL) and icon to use in case the upstream URL contains the key. These get precedence over the standard icons |
 
 ## Template ([info][templates])
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Add AWS CodeCommit upstream for git segment, and fix a typo

### How

Adding a regex to match appropriate URL, and fix a typo

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

### Notes

I did not find a better NF icon, however I would be happy if someone finds one. I'm also getting a space after the icon, I do not know why, help would be appreciated in order to fix this !

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
