### PR TITLE
fix(windows): escape PWD in emulated shells

### DIFF
--- a/src/engine/engine.go
+++ b/src/engine/engine.go
@@ -91,6 +91,12 @@ func (e *Engine) pwd() {
 	}
 
 	cwd := e.Env.Pwd()
+
+	// in BASH, we need to escape the path
+	if e.Env.Shell() == shell.BASH {
+		cwd = strings.ReplaceAll(cwd, `\`, `\\`)
+	}
+
 	// Backwards compatibility for deprecated OSC99
 	if e.Config.OSC99 {
 		e.write(e.Writer.ConsolePwd(ansi.OSC99, "", "", cwd))


### PR DESCRIPTION
relates to #4208

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aa87795</samp>

This pull request fixes the OSC99 sequence for emulated shells on Windows, which allows oh-my-posh to set the terminal title based on the cwd. It adds tests and escapes backslashes in `engine.go` and `engine_test.go`.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at aa87795</samp>

*  Escape backslashes in cwd for emulated shells on Windows to fix OSC99 sequence issue ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4210/files?diff=unified&w=0#diff-2621eae7a3bca7157aca7db673f968d3bd065529cd80f6b32e348807463ff78bR94-R100))
*  Rename `PWD` field to `Config` in test cases to allow different cwd formats ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4210/files?diff=unified&w=0#diff-beaf37732bb1e5f3820bb2574265e0152f53347cb77a6ae3c1fa9d5eda58a2b3L52-R91))
*  Update engine configuration to use `Config` field from test cases ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4210/files?diff=unified&w=0#diff-beaf37732bb1e5f3820bb2574265e0152f53347cb77a6ae3c1fa9d5eda58a2b3L81-R104))
*  Add test cases for OSC99 sequence on Windows with Git Bash and ZSH ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4210/files?diff=unified&w=0#diff-beaf37732bb1e5f3820bb2574265e0152f53347cb77a6ae3c1fa9d5eda58a2b3L52-R91))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
