### PR TITLE
fix(engine): do not print sequential newlines on no content

### DIFF
--- a/src/engine/prompt.go
+++ b/src/engine/prompt.go
@@ -28,13 +28,23 @@ func (e *Engine) Primary() string {
 
 	// cache a pointer to the color cycle
 	cycle = &e.Config.Cycle
+	var cancelNewline, didRender bool
+
 	for i, block := range e.Config.Blocks {
-		var cancelNewline bool
+		// do not print a leading newline when we're at the first row and the prompt is cleared
 		if i == 0 {
 			row, _ := e.Env.CursorPosition()
 			cancelNewline = e.Env.Flags().Cleared || e.Env.Flags().PromptCount == 1 || row == 1
 		}
-		e.renderBlock(block, cancelNewline)
+
+		// skip setting a newline when we didn't print anything yet
+		if i != 0 {
+			cancelNewline = !didRender
+		}
+
+		if e.renderBlock(block, cancelNewline) {
+			didRender = true
+		}
 	}
 
 	if len(e.Config.ConsoleTitleTemplate) > 0 && !e.Env.Flags().Plain {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at deb64cf</samp>

Fixed a bug where empty or missing blocks would cause unwanted newlines in the prompt. Modified the `renderBlock` function to return a boolean indicating whether the block was rendered or not, and used that value in the `Primary` function to skip newlines accordingly. This improves the alignment and appearance of the prompt.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at deb64cf</samp>

*  Fix issue #1139 by skipping newlines for empty or missing blocks ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4220/files?diff=unified&w=0#diff-2621eae7a3bca7157aca7db673f968d3bd065529cd80f6b32e348807463ff78bL167-R167), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4220/files?diff=unified&w=0#diff-2621eae7a3bca7157aca7db673f968d3bd065529cd80f6b32e348807463ff78bL180-R180), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4220/files?diff=unified&w=0#diff-2621eae7a3bca7157aca7db673f968d3bd065529cd80f6b32e348807463ff78bL192-R192), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4220/files?diff=unified&w=0#diff-2621eae7a3bca7157aca7db673f968d3bd065529cd80f6b32e348807463ff78bL206-R206), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4220/files?diff=unified&w=0#diff-9cbb773ea359cb84f27d7d8a473c1d6a206afb625cd36be225a57c43daa56145L31-R47))
*  Change `renderBlock` function to return a boolean value indicating whether the block was rendered or not ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4220/files?diff=unified&w=0#diff-2621eae7a3bca7157aca7db673f968d3bd065529cd80f6b32e348807463ff78bL167-R167), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4220/files?diff=unified&w=0#diff-2621eae7a3bca7157aca7db673f968d3bd065529cd80f6b32e348807463ff78bL180-R180), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4220/files?diff=unified&w=0#diff-2621eae7a3bca7157aca7db673f968d3bd065529cd80f6b32e348807463ff78bL192-R192), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4220/files?diff=unified&w=0#diff-2621eae7a3bca7157aca7db673f968d3bd065529cd80f6b32e348807463ff78bL206-R206), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4220/files?diff=unified&w=0#diff-2621eae7a3bca7157aca7db673f968d3bd065529cd80f6b32e348807463ff78bL218-R222), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4220/files?diff=unified&w=0#diff-2621eae7a3bca7157aca7db673f968d3bd065529cd80f6b32e348807463ff78bL237-R237), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4220/files?diff=unified&w=0#diff-2621eae7a3bca7157aca7db673f968d3bd065529cd80f6b32e348807463ff78bL249-R249), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4220/files?diff=unified&w=0#diff-2621eae7a3bca7157aca7db673f968d3bd065529cd80f6b32e348807463ff78bR265-R266))
*  Use the return value of `renderBlock` to determine whether to cancel the newline for the next block or not in `prompt.go` ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4220/files?diff=unified&w=0#diff-9cbb773ea359cb84f27d7d8a473c1d6a206afb625cd36be225a57c43daa56145L31-R47))

relates to #4182

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
