### PR TITLE
Add DefaultURL variable to language templates

### DIFF
--- a/src/segments/language.go
+++ b/src/segments/language.go
@@ -29,6 +29,7 @@ type version struct {
 	Patch         string
 	Prerelease    string
 	BuildMetadata string
+	DefaultURL    string
 	URL           string
 	Executable    string
 	Expected      string
@@ -222,6 +223,7 @@ func (l *language) setVersion() error {
 		if command.versionURLTemplate != "" {
 			l.versionURLTemplate = command.versionURLTemplate
 		}
+		l.buildDefaultVersionURL()
 		l.buildVersionURL()
 		l.version.Executable = command.executable
 		return nil
@@ -244,6 +246,22 @@ func (l *language) inLanguageContext() bool {
 		return false
 	}
 	return l.inContext()
+}
+
+func (l *language) buildDefaultVersionURL() {
+	if len(l.versionURLTemplate) == 0 {
+		return
+	}
+	tmpl := &template.Text{
+		Template: l.versionURLTemplate,
+		Context:  l.version,
+		Env:      l.env,
+	}
+	url, err := tmpl.Render()
+	if err != nil {
+		return
+	}
+	l.version.DefaultURL = url
 }
 
 func (l *language) buildVersionURL() {

--- a/src/segments/language_test.go
+++ b/src/segments/language_test.go
@@ -526,3 +526,24 @@ func TestLanguageHyperlinkTemplatePropertyTakesPriority(t *testing.T) {
 	assert.Equal(t, "https://uni.org/release/1.3.307", lang.version.DefaultURL)
 	assert.Equal(t, "https://custom/url/template/1.3", lang.version.URL)
 }
+
+func TestLanguageHyperlinkTemplateEmpty(t *testing.T) {
+	args := &languageArgs{
+		commands: []*cmd{
+			{
+				executable: "uni",
+				args:       []string{"--version"},
+				regex:      `(?P<version>((?P<major>[0-9]+).(?P<minor>[0-9]+).(?P<patch>[0-9]+)))`,
+			},
+		},
+		extensions:        []string{uni},
+		enabledExtensions: []string{uni},
+		enabledCommands:   []string{"uni"},
+		version:           universion,
+		properties:        properties.Map{},
+	}
+	lang := bootStrapLanguageTest(args)
+	assert.True(t, lang.Enabled())
+	assert.Equal(t, "", lang.version.DefaultURL)
+	assert.Equal(t, "", lang.version.URL)
+}

--- a/src/segments/language_test.go
+++ b/src/segments/language_test.go
@@ -499,6 +499,7 @@ func TestLanguageInnerHyperlink(t *testing.T) {
 	}
 	lang := bootStrapLanguageTest(args)
 	assert.True(t, lang.Enabled())
+	assert.Equal(t, "https://unicor.org/doc/1.3.307", lang.version.DefaultURL)
 	assert.Equal(t, "https://unicor.org/doc/1.3.307", lang.version.URL)
 }
 
@@ -522,5 +523,6 @@ func TestLanguageHyperlinkTemplatePropertyTakesPriority(t *testing.T) {
 	}
 	lang := bootStrapLanguageTest(args)
 	assert.True(t, lang.Enabled())
+	assert.Equal(t, "https://uni.org/release/1.3.307", lang.version.DefaultURL)
 	assert.Equal(t, "https://custom/url/template/1.3", lang.version.URL)
 }

--- a/website/docs/segments/angular.mdx
+++ b/website/docs/segments/angular.mdx
@@ -42,14 +42,15 @@ import Config from '@site/src/components/Config.js';
 
 ### Properties
 
-| Name     | Type     | Description                                        |
-| -------- | -------- | -------------------------------------------------- |
-| `.Full`  | `string` | the full version                                   |
-| `.Major` | `string` | major number                                       |
-| `.Minor` | `string` | minor number                                       |
-| `.Patch` | `string` | patch number                                       |
-| `.URL`   | `string` | URL of the version info / release notes            |
-| `.Error` | `string` | error encountered when fetching the version string |
+| Name          | Type     | Description                                                                      |
+| ------------- | -------- | -------------------------------------------------------------------------------- |
+| `.Full`       | `string` | the full version                                                                 |
+| `.Major`      | `string` | major number                                                                     |
+| `.Minor`      | `string` | minor number                                                                     |
+| `.Patch`      | `string` | patch number                                                                     |
+| `.DefaultURL` | `string` | default URL of the version info / release notes                                  |
+| `.URL`        | `string` | URL of the version info / release notes (`version_url_template` or `DefaultURL`) |
+| `.Error`      | `string` | error encountered when fetching the version string                               |
 
 [go-text-template]: https://golang.org/pkg/text/template/
 [templates]: /docs/configuration/templates

--- a/website/docs/segments/buf.mdx
+++ b/website/docs/segments/buf.mdx
@@ -40,14 +40,15 @@ import Config from '@site/src/components/Config.js';
 
 ### Properties
 
-| Name     | Type     | Description                                        |
-| -------- | -------- | -------------------------------------------------- |
-| `.Full`  | `string` | the full version                                   |
-| `.Major` | `string` | major number                                       |
-| `.Minor` | `string` | minor number                                       |
-| `.Patch` | `string` | patch number                                       |
-| `.URL`   | `string` | URL of the version info / release notes            |
-| `.Error` | `string` | error encountered when fetching the version string |
+| Name          | Type     | Description                                                                      |
+| ------------- | -------- | -------------------------------------------------------------------------------- |
+| `.Full`       | `string` | the full version                                                                 |
+| `.Major`      | `string` | major number                                                                     |
+| `.Minor`      | `string` | minor number                                                                     |
+| `.Patch`      | `string` | patch number                                                                     |
+| `.DefaultURL` | `string` | default URL of the version info / release notes                                  |
+| `.URL`        | `string` | URL of the version info / release notes (`version_url_template` or `DefaultURL`) |
+| `.Error`      | `string` | error encountered when fetching the version string                               |
 
 [go-text-template]: https://golang.org/pkg/text/template/
 [templates]: /docs/configuration/templates

--- a/website/docs/segments/cf.mdx
+++ b/website/docs/segments/cf.mdx
@@ -43,14 +43,15 @@ import Config from '@site/src/components/Config.js';
 
 ### Properties
 
-| Name     | Type     | Description                                        |
-| -------- | -------- | -------------------------------------------------- |
-| `.Full`  | `string` | the full version                                   |
-| `.Major` | `string` | major number                                       |
-| `.Minor` | `string` | minor number                                       |
-| `.Patch` | `string` | patch number                                       |
-| `.URL`   | `string` | URL of the version info / release notes            |
-| `.Error` | `string` | error encountered when fetching the version string |
+| Name          | Type     | Description                                                                      |
+| ------------- | -------- | -------------------------------------------------------------------------------- |
+| `.Full`       | `string` | the full version                                                                 |
+| `.Major`      | `string` | major number                                                                     |
+| `.Minor`      | `string` | minor number                                                                     |
+| `.Patch`      | `string` | patch number                                                                     |
+| `.DefaultURL` | `string` | default URL of the version info / release notes                                  |
+| `.URL`        | `string` | URL of the version info / release notes (`version_url_template` or `DefaultURL`) |
+| `.Error`      | `string` | error encountered when fetching the version string                               |
 
 [go-text-template]: https://golang.org/pkg/text/template/
 [templates]: /docs/configuration/templates

--- a/website/docs/segments/cmake.mdx
+++ b/website/docs/segments/cmake.mdx
@@ -43,14 +43,15 @@ import Config from '@site/src/components/Config.js';
 
 ### Properties
 
-| Name     | Type     | Description                                        |
-| -------- | -------- | -------------------------------------------------- |
-| `.Full`  | `string` | the full version                                   |
-| `.Major` | `string` | major number                                       |
-| `.Minor` | `string` | minor number                                       |
-| `.Patch` | `string` | patch number                                       |
-| `.URL`   | `string` | URL of the version info / release notes            |
-| `.Error` | `string` | error encountered when fetching the version string |
+| Name          | Type     | Description                                                                      |
+| ------------- | -------- | -------------------------------------------------------------------------------- |
+| `.Full`       | `string` | the full version                                                                 |
+| `.Major`      | `string` | major number                                                                     |
+| `.Minor`      | `string` | minor number                                                                     |
+| `.Patch`      | `string` | patch number                                                                     |
+| `.DefaultURL` | `string` | default URL of the version info / release notes                                  |
+| `.URL`        | `string` | URL of the version info / release notes (`version_url_template` or `DefaultURL`) |
+| `.Error`      | `string` | error encountered when fetching the version string                               |
 
 [cmake-github]: https://github.com/Kitware/CMake
 [go-text-template]: https://golang.org/pkg/text/template/

--- a/website/docs/segments/crystal.mdx
+++ b/website/docs/segments/crystal.mdx
@@ -43,14 +43,15 @@ import Config from '@site/src/components/Config.js';
 
 ### Properties
 
-| Name     | Type     | Description                                        |
-| -------- | -------- | -------------------------------------------------- |
-| `.Full`  | `string` | the full version                                   |
-| `.Major` | `string` | major number                                       |
-| `.Minor` | `string` | minor number                                       |
-| `.Patch` | `string` | patch number                                       |
-| `.URL`   | `string` | URL of the version info / release notes            |
-| `.Error` | `string` | error encountered when fetching the version string |
+| Name          | Type     | Description                                                                      |
+| ------------- | -------- | -------------------------------------------------------------------------------- |
+| `.Full`       | `string` | the full version                                                                 |
+| `.Major`      | `string` | major number                                                                     |
+| `.Minor`      | `string` | minor number                                                                     |
+| `.Patch`      | `string` | patch number                                                                     |
+| `.DefaultURL` | `string` | default URL of the version info / release notes                                  |
+| `.URL`        | `string` | URL of the version info / release notes (`version_url_template` or `DefaultURL`) |
+| `.Error`      | `string` | error encountered when fetching the version string                               |
 
 [go-text-template]: https://golang.org/pkg/text/template/
 [templates]: /docs/configuration/templates

--- a/website/docs/segments/dart.mdx
+++ b/website/docs/segments/dart.mdx
@@ -43,14 +43,15 @@ import Config from '@site/src/components/Config.js';
 
 ### Properties
 
-| Name     | Type     | Description                                        |
-| -------- | -------- | -------------------------------------------------- |
-| `.Full`  | `string` | the full version                                   |
-| `.Major` | `string` | major number                                       |
-| `.Minor` | `string` | minor number                                       |
-| `.Patch` | `string` | patch number                                       |
-| `.URL`   | `string` | URL of the version info / release notes            |
-| `.Error` | `string` | error encountered when fetching the version string |
+| Name          | Type     | Description                                                                      |
+| ------------- | -------- | -------------------------------------------------------------------------------- |
+| `.Full`       | `string` | the full version                                                                 |
+| `.Major`      | `string` | major number                                                                     |
+| `.Minor`      | `string` | minor number                                                                     |
+| `.Patch`      | `string` | patch number                                                                     |
+| `.DefaultURL` | `string` | default URL of the version info / release notes                                  |
+| `.URL`        | `string` | URL of the version info / release notes (`version_url_template` or `DefaultURL`) |
+| `.Error`      | `string` | error encountered when fetching the version string                               |
 
 [go-text-template]: https://golang.org/pkg/text/template/
 [templates]: /docs/configuration/templates

--- a/website/docs/segments/deno.mdx
+++ b/website/docs/segments/deno.mdx
@@ -40,14 +40,15 @@ import Config from '@site/src/components/Config.js';
 
 ### Properties
 
-| Name     | Type     | Description                                        |
-| -------- | -------- | -------------------------------------------------- |
-| `.Full`  | `string` | the full version                                   |
-| `.Major` | `string` | major number                                       |
-| `.Minor` | `string` | minor number                                       |
-| `.Patch` | `string` | patch number                                       |
-| `.URL`   | `string` | URL of the version info / release notes            |
-| `.Error` | `string` | error encountered when fetching the version string |
+| Name          | Type     | Description                                                                      |
+| ------------- | -------- | -------------------------------------------------------------------------------- |
+| `.Full`       | `string` | the full version                                                                 |
+| `.Major`      | `string` | major number                                                                     |
+| `.Minor`      | `string` | minor number                                                                     |
+| `.Patch`      | `string` | patch number                                                                     |
+| `.DefaultURL` | `string` | default URL of the version info / release notes                                  |
+| `.URL`        | `string` | URL of the version info / release notes (`version_url_template` or `DefaultURL`) |
+| `.Error`      | `string` | error encountered when fetching the version string                               |
 
 [go-text-template]: https://golang.org/pkg/text/template/
 [templates]: /docs/configuration/templates

--- a/website/docs/segments/dotnet.mdx
+++ b/website/docs/segments/dotnet.mdx
@@ -43,16 +43,17 @@ import Config from '@site/src/components/Config.js';
 
 ### Properties
 
-| Name             | Type     | Description                                        |
-| ---------------- | -------- | -------------------------------------------------- |
-| `.Full`          | `string` | the full version                                   |
-| `.Major`         | `string` | major number                                       |
-| `.Minor`         | `string` | minor number                                       |
-| `.Patch`         | `string` | patch number                                       |
-| `.Prerelease`    | `string` | prerelease info text                               |
-| `.BuildMetadata` | `string` | build metadata                                     |
-| `.URL`           | `string` | URL of the version info / release notes            |
-| `.Error`         | `string` | error encountered when fetching the version string |
+| Name             | Type     | Description                                                                      |
+| ---------------- | -------- | -------------------------------------------------------------------------------- |
+| `.Full`          | `string` | the full version                                                                 |
+| `.Major`         | `string` | major number                                                                     |
+| `.Minor`         | `string` | minor number                                                                     |
+| `.Patch`         | `string` | patch number                                                                     |
+| `.Prerelease`    | `string` | prerelease info text                                                             |
+| `.BuildMetadata` | `string` | build metadata                                                                   |
+| `.DefaultURL`    | `string` | default URL of the version info / release notes                                  |
+| `.URL`           | `string` | URL of the version info / release notes (`version_url_template` or `DefaultURL`) |
+| `.Error`         | `string` | error encountered when fetching the version string                               |
 
 [go-text-template]: https://golang.org/pkg/text/template/
 [templates]: /docs/configuration/templates

--- a/website/docs/segments/elixir.mdx
+++ b/website/docs/segments/elixir.mdx
@@ -43,13 +43,14 @@ import Config from '@site/src/components/Config.js';
 
 ### Properties
 
-| Name     | Type     | Description                                        |
-| -------- | -------- | -------------------------------------------------- |
-| `.Full`  | `string` | the full version                                   |
-| `.Major` | `string` | major number                                       |
-| `.Minor` | `string` | minor number                                       |
-| `.URL`   | `string` | URL of the version info / release notes            |
-| `.Error` | `string` | error encountered when fetching the version string |
+| Name          | Type     | Description                                                                      |
+| ------------- | -------- | -------------------------------------------------------------------------------- |
+| `.Full`       | `string` | the full version                                                                 |
+| `.Major`      | `string` | major number                                                                     |
+| `.Minor`      | `string` | minor number                                                                     |
+| `.DefaultURL` | `string` | default URL of the version info / release notes                                  |
+| `.URL`        | `string` | URL of the version info / release notes (`version_url_template` or `DefaultURL`) |
+| `.Error`      | `string` | error encountered when fetching the version string                               |
 
 [go-text-template]: https://golang.org/pkg/text/template/
 [templates]: /docs/configuration/templates

--- a/website/docs/segments/flutter.mdx
+++ b/website/docs/segments/flutter.mdx
@@ -43,14 +43,15 @@ import Config from '@site/src/components/Config.js';
 
 ### Properties
 
-| Name     | Type     | Description                                        |
-| -------- | -------- | -------------------------------------------------- |
-| `.Full`  | `string` | the full version                                   |
-| `.Major` | `string` | major number                                       |
-| `.Minor` | `string` | minor number                                       |
-| `.Patch` | `string` | patch number                                       |
-| `.URL`   | `string` | URL of the version info / release notes            |
-| `.Error` | `string` | error encountered when fetching the version string |
+| Name          | Type     | Description                                                                      |
+| ------------- | -------- | -------------------------------------------------------------------------------- |
+| `.Full`       | `string` | the full version                                                                 |
+| `.Major`      | `string` | major number                                                                     |
+| `.Minor`      | `string` | minor number                                                                     |
+| `.Patch`      | `string` | patch number                                                                     |
+| `.DefaultURL` | `string` | default URL of the version info / release notes                                  |
+| `.URL`        | `string` | URL of the version info / release notes (`version_url_template` or `DefaultURL`) |
+| `.Error`      | `string` | error encountered when fetching the version string                               |
 
 [go-text-template]: https://golang.org/pkg/text/template/
 [templates]: /docs/configuration/templates

--- a/website/docs/segments/golang.mdx
+++ b/website/docs/segments/golang.mdx
@@ -44,14 +44,15 @@ import Config from '@site/src/components/Config.js';
 
 ### Properties
 
-| Name     | Type     | Description                                        |
-| -------- | -------- | -------------------------------------------------- |
-| `.Full`  | `string` | the full version                                   |
-| `.Major` | `string` | major number                                       |
-| `.Minor` | `string` | minor number                                       |
-| `.Patch` | `string` | patch number                                       |
-| `.URL`   | `string` | URL of the version info / release notes            |
-| `.Error` | `string` | error encountered when fetching the version string |
+| Name          | Type     | Description                                                                      |
+| ------------- | -------- | -------------------------------------------------------------------------------- |
+| `.Full`       | `string` | the full version                                                                 |
+| `.Major`      | `string` | major number                                                                     |
+| `.Minor`      | `string` | minor number                                                                     |
+| `.Patch`      | `string` | patch number                                                                     |
+| `.DefaultURL` | `string` | default URL of the version info / release notes                                  |
+| `.URL`        | `string` | URL of the version info / release notes (`version_url_template` or `DefaultURL`) |
+| `.Error`      | `string` | error encountered when fetching the version string                               |
 
 [go-text-template]: https://golang.org/pkg/text/template/
 [templates]: /docs/configuration/templates

--- a/website/docs/segments/haskell.mdx
+++ b/website/docs/segments/haskell.mdx
@@ -44,15 +44,16 @@ import Config from '@site/src/components/Config.js';
 
 ### Properties
 
-| Name        | Type      | Description                                        |
-| ----------- | --------- | -------------------------------------------------- |
-| `.Full`     | `string`  | the full version                                   |
-| `.Major`    | `string`  | major number                                       |
-| `.Minor`    | `string`  | minor number                                       |
-| `.Patch`    | `string`  | patch number                                       |
-| `.URL`      | `string`  | URL of the version info / release notes            |
-| `.Error`    | `string`  | error encountered when fetching the version string |
-| `.StackGhc` | `boolean` | `true` if `stack ghc` was used, otherwise `false`  |
+| Name          | Type      | Description                                                                      |
+| ------------- | --------- | -------------------------------------------------------------------------------- |
+| `.Full`       | `string`  | the full version                                                                 |
+| `.Major`      | `string`  | major number                                                                     |
+| `.Minor`      | `string`  | minor number                                                                     |
+| `.Patch`      | `string`  | patch number                                                                     |
+| `.DefaultURL` | `string`  | default URL of the version info / release notes                                  |
+| `.URL`        | `string`  | URL of the version info / release notes (`version_url_template` or `DefaultURL`) |
+| `.Error`      | `string`  | error encountered when fetching the version string                               |
+| `.StackGhc`   | `boolean` | `true` if `stack ghc` was used, otherwise `false`                                |
 
 [go-text-template]: https://golang.org/pkg/text/template/
 [templates]: /docs/configuration/templates

--- a/website/docs/segments/julia.mdx
+++ b/website/docs/segments/julia.mdx
@@ -43,14 +43,15 @@ import Config from '@site/src/components/Config.js';
 
 ### Properties
 
-| Name     | Type     | Description                                        |
-| -------- | -------- | -------------------------------------------------- |
-| `.Full`  | `string` | the full version                                   |
-| `.Major` | `string` | major number                                       |
-| `.Minor` | `string` | minor number                                       |
-| `.Patch` | `string` | patch number                                       |
-| `.URL`   | `string` | URL of the version info / release notes            |
-| `.Error` | `string` | error encountered when fetching the version string |
+| Name          | Type     | Description                                                                      |
+| ------------- | -------- | -------------------------------------------------------------------------------- |
+| `.Full`       | `string` | the full version                                                                 |
+| `.Major`      | `string` | major number                                                                     |
+| `.Minor`      | `string` | minor number                                                                     |
+| `.Patch`      | `string` | patch number                                                                     |
+| `.DefaultURL` | `string` | default URL of the version info / release notes                                  |
+| `.URL`        | `string` | URL of the version info / release notes (`version_url_template` or `DefaultURL`) |
+| `.Error`      | `string` | error encountered when fetching the version string                               |
 
 [go-text-template]: https://golang.org/pkg/text/template/
 [templates]: /docs/configuration/templates

--- a/website/docs/segments/kotlin.mdx
+++ b/website/docs/segments/kotlin.mdx
@@ -43,14 +43,15 @@ import Config from '@site/src/components/Config.js';
 
 ### Properties
 
-| Name     | Type     | Description                                        |
-| -------- | -------- | -------------------------------------------------- |
-| `.Full`  | `string` | the full version                                   |
-| `.Major` | `string` | major number                                       |
-| `.Minor` | `string` | minor number                                       |
-| `.Patch` | `string` | patch number                                       |
-| `.URL`   | `string` | URL of the version info / release notes            |
-| `.Error` | `string` | error encountered when fetching the version string |
+| Name          | Type     | Description                                                                      |
+| ------------- | -------- | -------------------------------------------------------------------------------- |
+| `.Full`       | `string` | the full version                                                                 |
+| `.Major`      | `string` | major number                                                                     |
+| `.Minor`      | `string` | minor number                                                                     |
+| `.Patch`      | `string` | patch number                                                                     |
+| `.DefaultURL` | `string` | default URL of the version info / release notes                                  |
+| `.URL`        | `string` | URL of the version info / release notes (`version_url_template` or `DefaultURL`) |
+| `.Error`      | `string` | error encountered when fetching the version string                               |
 
 [go-text-template]: https://golang.org/pkg/text/template/
 [templates]: /docs/configuration/templates

--- a/website/docs/segments/lua.mdx
+++ b/website/docs/segments/lua.mdx
@@ -44,15 +44,16 @@ import Config from '@site/src/components/Config.js';
 
 ### Properties
 
-| Name          | Type     | Description                                        |
-| ------------- | -------- | -------------------------------------------------- |
-| `.Full`       | `string` | the full version                                   |
-| `.Major`      | `string` | major number                                       |
-| `.Minor`      | `string` | minor number                                       |
-| `.Patch`      | `string` | patch number                                       |
-| `.URL`        | `string` | URL of the version info / release notes            |
-| `.Error`      | `string` | error encountered when fetching the version string |
-| `.Executable` | `string` | the executable used to fetch the version           |
+| Name          | Type     | Description                                                                      |
+| ------------- | -------- | -------------------------------------------------------------------------------- |
+| `.Full`       | `string` | the full version                                                                 |
+| `.Major`      | `string` | major number                                                                     |
+| `.Minor`      | `string` | minor number                                                                     |
+| `.Patch`      | `string` | patch number                                                                     |
+| `.DefaultURL` | `string` | default URL of the version info / release notes                                  |
+| `.URL`        | `string` | URL of the version info / release notes (`version_url_template` or `DefaultURL`) |
+| `.Error`      | `string` | error encountered when fetching the version string                               |
+| `.Executable` | `string` | the executable used to fetch the version                                         |
 
 [go-text-template]: https://golang.org/pkg/text/template/
 [templates]: /docs/configuration/templates

--- a/website/docs/segments/node.mdx
+++ b/website/docs/segments/node.mdx
@@ -48,17 +48,18 @@ import Config from "@site/src/components/Config.js";
 
 ### Properties
 
-| Name                  | Type      | Description                                                         |
-| --------------------- | --------- | ------------------------------------------------------------------- |
-| `.Full`               | `string`  | the full version                                                    |
-| `.Major`              | `string`  | major number                                                        |
-| `.Minor`              | `string`  | minor number                                                        |
-| `.Patch`              | `string`  | patch number                                                        |
-| `.URL`                | `string`  | URL of the version info / release notes                             |
-| `.Error`              | `string`  | error encountered when fetching the version string                  |
-| `.PackageManagerIcon` | `string`  | the Yarn or NPM icon when setting `fetch_package_manager` to `true` |
-| `.Mismatch`           | `boolean` | true if the version in `.nvmrc` is not equal to `.Full`             |
-| `.Expected`           | `string`  | the expected version set in `.nvmrc`                                |
+| Name                  | Type      | Description                                                                      |
+| --------------------- | --------- | -------------------------------------------------------------------------------- |
+| `.Full`               | `string`  | the full version                                                                 |
+| `.Major`              | `string`  | major number                                                                     |
+| `.Minor`              | `string`  | minor number                                                                     |
+| `.Patch`              | `string`  | patch number                                                                     |
+| `.DefaultURL`         | `string`  | default URL of the version info / release notes                                  |
+| `.URL`                | `string`  | URL of the version info / release notes (`version_url_template` or `DefaultURL`) |
+| `.Error`              | `string`  | error encountered when fetching the version string                               |
+| `.PackageManagerIcon` | `string`  | the Yarn or NPM icon when setting `fetch_package_manager` to `true`              |
+| `.Mismatch`           | `boolean` | true if the version in `.nvmrc` is not equal to `.Full`                          |
+| `.Expected`           | `string`  | the expected version set in `.nvmrc`                                             |
 
 [go-text-template]: https://golang.org/pkg/text/template/
 [templates]: /docs/configuration/templates

--- a/website/docs/segments/npm.mdx
+++ b/website/docs/segments/npm.mdx
@@ -43,14 +43,15 @@ import Config from '@site/src/components/Config.js';
 
 ### Properties
 
-| Name     | Type     | Description                                        |
-| -------- | -------- | -------------------------------------------------- |
-| `.Full`  | `string` | the full version                                   |
-| `.Major` | `string` | major number                                       |
-| `.Minor` | `string` | minor number                                       |
-| `.Patch` | `string` | patch number                                       |
-| `.URL`   | `string` | URL of the version info / release notes            |
-| `.Error` | `string` | error encountered when fetching the version string |
+| Name          | Type     | Description                                                                      |
+| ------------- | -------- | -------------------------------------------------------------------------------- |
+| `.Full`       | `string` | the full version                                                                 |
+| `.Major`      | `string` | major number                                                                     |
+| `.Minor`      | `string` | minor number                                                                     |
+| `.Patch`      | `string` | patch number                                                                     |
+| `.DefaultURL` | `string` | default URL of the version info / release notes                                  |
+| `.URL`        | `string` | URL of the version info / release notes (`version_url_template` or `DefaultURL`) |
+| `.Error`      | `string` | error encountered when fetching the version string                               |
 
 [go-text-template]: https://golang.org/pkg/text/template/
 [templates]: /docs/configuration/templates

--- a/website/docs/segments/nx.mdx
+++ b/website/docs/segments/nx.mdx
@@ -42,14 +42,15 @@ import Config from '@site/src/components/Config.js';
 
 ### Properties
 
-| Name     | Type     | Description                                        |
-| -------- | -------- | -------------------------------------------------- |
-| `.Full`  | `string` | the full version                                   |
-| `.Major` | `string` | major number                                       |
-| `.Minor` | `string` | minor number                                       |
-| `.Patch` | `string` | patch number                                       |
-| `.URL`   | `string` | URL of the version info / release notes            |
-| `.Error` | `string` | error encountered when fetching the version string |
+| Name          | Type     | Description                                                                      |
+| ------------- | -------- | -------------------------------------------------------------------------------- |
+| `.Full`       | `string` | the full version                                                                 |
+| `.Major`      | `string` | major number                                                                     |
+| `.Minor`      | `string` | minor number                                                                     |
+| `.Patch`      | `string` | patch number                                                                     |
+| `.DefaultURL` | `string` | default URL of the version info / release notes                                  |
+| `.URL`        | `string` | URL of the version info / release notes (`version_url_template` or `DefaultURL`) |
+| `.Error`      | `string` | error encountered when fetching the version string                               |
 
 [go-text-template]: https://golang.org/pkg/text/template/
 [templates]: /docs/configuration/templates

--- a/website/docs/segments/php.mdx
+++ b/website/docs/segments/php.mdx
@@ -43,14 +43,15 @@ import Config from '@site/src/components/Config.js';
 
 ### Properties
 
-| Name     | Type     | Description                                        |
-| -------- | -------- | -------------------------------------------------- |
-| `.Full`  | `string` | the full version                                   |
-| `.Major` | `string` | major number                                       |
-| `.Minor` | `string` | minor number                                       |
-| `.Patch` | `string` | patch number                                       |
-| `.URL`   | `string` | URL of the version info / release notes            |
-| `.Error` | `string` | error encountered when fetching the version string |
+| Name          | Type     | Description                                                                      |
+| ------------- | -------- | -------------------------------------------------------------------------------- |
+| `.Full`       | `string` | the full version                                                                 |
+| `.Major`      | `string` | major number                                                                     |
+| `.Minor`      | `string` | minor number                                                                     |
+| `.Patch`      | `string` | patch number                                                                     |
+| `.DefaultURL` | `string` | default URL of the version info / release notes                                  |
+| `.URL`        | `string` | URL of the version info / release notes (`version_url_template` or `DefaultURL`) |
+| `.Error`      | `string` | error encountered when fetching the version string                               |
 
 [go-text-template]: https://golang.org/pkg/text/template/
 [templates]: /docs/configuration/templates

--- a/website/docs/segments/python.mdx
+++ b/website/docs/segments/python.mdx
@@ -46,15 +46,16 @@ import Config from '@site/src/components/Config.js';
 
 ### Properties
 
-| Name     | Type     | Description                                        |
-| -------- | -------- | -------------------------------------------------- |
-| `.Venv`  | `string` | the virtual environment name (if present)          |
-| `.Full`  | `string` | the full version                                   |
-| `.Major` | `string` | major number                                       |
-| `.Minor` | `string` | minor number                                       |
-| `.Patch` | `string` | patch number                                       |
-| `.URL`   | `string` | URL of the version info / release notes            |
-| `.Error` | `string` | error encountered when fetching the version string |
+| Name          | Type     | Description                                                                      |
+| ------------- | -------- | -------------------------------------------------------------------------------- |
+| `.Full`       | `string` | the full version                                                                 |
+| `.Major`      | `string` | major number                                                                     |
+| `.Minor`      | `string` | minor number                                                                     |
+| `.Patch`      | `string` | patch number                                                                     |
+| `.DefaultURL` | `string` | default URL of the version info / release notes                                  |
+| `.URL`        | `string` | URL of the version info / release notes (`version_url_template` or `DefaultURL`) |
+| `.Error`      | `string` | error encountered when fetching the version string                               |
+| `.Venv`       | `string` | the virtual environment name (if present)                                        |
 
 [go-text-template]: https://golang.org/pkg/text/template/
 [templates]: /docs/configuration/templates

--- a/website/docs/segments/quasar.mdx
+++ b/website/docs/segments/quasar.mdx
@@ -46,16 +46,17 @@ import Config from "@site/src/components/Config.js";
 
 ### Properties
 
-| Name       | Type         | Description                                        |
-| ---------- | ------------ | -------------------------------------------------- |
-| `.Full`    | `string`     | the full version                                   |
-| `.Major`   | `string`     | major number                                       |
-| `.Minor`   | `string`     | minor number                                       |
-| `.Patch`   | `string`     | patch number                                       |
-| `.URL`     | `string`     | URL of the version info / release notes            |
-| `.Error`   | `string`     | error encountered when fetching the version string |
-| `.Vite`    | `Dependency` | the `vite` dependency, if found                    |
-| `.AppVite` | `Dependency` | the `@quasar/app-vite` dependency, if found        |
+| Name          | Type         | Description                                                                      |
+| ------------- | ------------ | -------------------------------------------------------------------------------- |
+| `.Full`       | `string`     | the full version                                                                 |
+| `.Major`      | `string`     | major number                                                                     |
+| `.Minor`      | `string`     | minor number                                                                     |
+| `.Patch`      | `string`     | patch number                                                                     |
+| `.DefaultURL` | `string`     | default URL of the version info / release notes                                  |
+| `.URL`        | `string`     | URL of the version info / release notes (`version_url_template` or `DefaultURL`) |
+| `.Error`      | `string`     | error encountered when fetching the version string                               |
+| `.Vite`       | `Dependency` | the `vite` dependency, if found                                                  |
+| `.AppVite`    | `Dependency` | the `@quasar/app-vite` dependency, if found                                      |
 
 #### Dependency
 

--- a/website/docs/segments/r.mdx
+++ b/website/docs/segments/r.mdx
@@ -43,14 +43,15 @@ import Config from '@site/src/components/Config.js';
 
 ### Properties
 
-| Name     | Type     | Description                                        |
-| -------- | -------- | -------------------------------------------------- |
-| `.Full`  | `string` | the full version                                   |
-| `.Major` | `string` | major number                                       |
-| `.Minor` | `string` | minor number                                       |
-| `.Patch` | `string` | patch number                                       |
-| `.URL`   | `string` | URL of the version info / release notes            |
-| `.Error` | `string` | error encountered when fetching the version string |
+| Name          | Type     | Description                                                                      |
+| ------------- | -------- | -------------------------------------------------------------------------------- |
+| `.Full`       | `string` | the full version                                                                 |
+| `.Major`      | `string` | major number                                                                     |
+| `.Minor`      | `string` | minor number                                                                     |
+| `.Patch`      | `string` | patch number                                                                     |
+| `.DefaultURL` | `string` | default URL of the version info / release notes                                  |
+| `.URL`        | `string` | URL of the version info / release notes (`version_url_template` or `DefaultURL`) |
+| `.Error`      | `string` | error encountered when fetching the version string                               |
 
 [go-text-template]: https://golang.org/pkg/text/template/
 [templates]: /docs/configuration/templates

--- a/website/docs/segments/swift.mdx
+++ b/website/docs/segments/swift.mdx
@@ -43,14 +43,15 @@ import Config from '@site/src/components/Config.js';
 
 ### Properties
 
-| Name     | Type     | Description                                        |
-| -------- | -------- | -------------------------------------------------- |
-| `.Full`  | `string` | the full version                                   |
-| `.Major` | `string` | major number                                       |
-| `.Minor` | `string` | minor number                                       |
-| `.Patch` | `string` | patch number                                       |
-| `.URL`   | `string` | URL of the version info / release notes            |
-| `.Error` | `string` | error encountered when fetching the version string |
+| Name          | Type     | Description                                                                      |
+| ------------- | -------- | -------------------------------------------------------------------------------- |
+| `.Full`       | `string` | the full version                                                                 |
+| `.Major`      | `string` | major number                                                                     |
+| `.Minor`      | `string` | minor number                                                                     |
+| `.Patch`      | `string` | patch number                                                                     |
+| `.DefaultURL` | `string` | default URL of the version info / release notes                                  |
+| `.URL`        | `string` | URL of the version info / release notes (`version_url_template` or `DefaultURL`) |
+| `.Error`      | `string` | error encountered when fetching the version string                               |
 
 [go-text-template]: https://golang.org/pkg/text/template/
 [templates]: /docs/configuration/templates

--- a/website/docs/segments/ui5tooling.mdx
+++ b/website/docs/segments/ui5tooling.mdx
@@ -44,14 +44,15 @@ import Config from '@site/src/components/Config.js';
 
 ### Properties
 
-| Name     | Type     | Description                                        |
-| -------- | -------- | -------------------------------------------------- |
-| `.Full`  | `string` | the full version                                   |
-| `.Major` | `string` | major number                                       |
-| `.Minor` | `string` | minor number                                       |
-| `.Patch` | `string` | patch number                                       |
-| `.URL`   | `string` | URL of the version info / release notes            |
-| `.Error` | `string` | error encountered when fetching the version string |
+| Name          | Type     | Description                                                                      |
+| ------------- | -------- | -------------------------------------------------------------------------------- |
+| `.Full`       | `string` | the full version                                                                 |
+| `.Major`      | `string` | major number                                                                     |
+| `.Minor`      | `string` | minor number                                                                     |
+| `.Patch`      | `string` | patch number                                                                     |
+| `.DefaultURL` | `string` | default URL of the version info / release notes                                  |
+| `.URL`        | `string` | URL of the version info / release notes (`version_url_template` or `DefaultURL`) |
+| `.Error`      | `string` | error encountered when fetching the version string                               |
 
 [go-text-template]: https://golang.org/pkg/text/template/
 [templates]: /docs/configuration/templates

--- a/website/docs/segments/vala.mdx
+++ b/website/docs/segments/vala.mdx
@@ -43,13 +43,15 @@ import Config from '@site/src/components/Config.js';
 
 ### Properties
 
-| Name     | Type     | Description                                        |
-| -------- | -------- | -------------------------------------------------- |
-| `.Full`  | `string` | the full version                                   |
-| `.Major` | `string` | major number                                       |
-| `.Minor` | `string` | minor number                                       |
-| `.URL`   | `string` | URL of the version info / release notes            |
-| `.Error` | `string` | error encountered when fetching the version string |
+| Name          | Type     | Description                                                                      |
+| ------------- | -------- | -------------------------------------------------------------------------------- |
+| `.Full`       | `string` | the full version                                                                 |
+| `.Major`      | `string` | major number                                                                     |
+| `.Minor`      | `string` | minor number                                                                     |
+| `.Patch`      | `string` | patch number                                                                     |
+| `.DefaultURL` | `string` | default URL of the version info / release notes                                  |
+| `.URL`        | `string` | URL of the version info / release notes (`version_url_template` or `DefaultURL`) |
+| `.Error`      | `string` | error encountered when fetching the version string                               |
 
 [go-text-template]: https://golang.org/pkg/text/template/
 [templates]: /docs/configuration/templates


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Own description

Adds `.DefaultURL`  variable to language templates.

Why? To:
- have a way to enhance the default URL in the custom URL template
- possibly use 2 URLs, if needed

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b7d752d</samp>

This pull request adds a new feature to the language segments of oh-my-posh, which allows users to click on the segment and open a URL with more information about the language version or release notes. It also adds tests and documentation for this feature. The URL is either specified by the user in the `version_url_template` property, or generated by a default template based on the language name and version. The default templates are stored in the `DefaultURL` property of each language segment. The files `src/segments/language_test.go` and `src/segments/language.go` contain the core logic of the feature, while the files in `website/docs/segments` update the documentation for each language segment.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b7d752d</samp>

*  Add a new field `DefaultURL` to the `version` type and populate it with a default URL based on the `versionURLTemplate` property and the version data ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4239/files?diff=unified&w=0#diff-b64c6e05098674b655f9bacc5da51ba9c36636218ce6da4fbd5e856f55603617R32), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4239/files?diff=unified&w=0#diff-b64c6e05098674b655f9bacc5da51ba9c36636218ce6da4fbd5e856f55603617R226), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4239/files?diff=unified&w=0#diff-b64c6e05098674b655f9bacc5da51ba9c36636218ce6da4fbd5e856f55603617R251-R266))
* Update the documentation for various language segments in the website to include the new `DefaultURL` property and explain how the `URL` property is determined by either the `version_url_template` property or the `DefaultURL` property ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4239/files?diff=unified&w=0#diff-1cd52a5e160ece8ac466144a3234a0b808bacf006c9fe219582f04cbb6b52308L45-R53), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4239/files?diff=unified&w=0#diff-aadddf724c696400a4292f5a5711f2c84e9bd3abc08572eb61db3b7681053795L43-R51), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4239/files?diff=unified&w=0#diff-0cb5ed7b470f1c98f1497f7152dfcfdb7c60295bb6820f5cb47abdf4f2933abbL46-R54), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4239/files?diff=unified&w=0#diff-34865a96860207f9f50c3a3029637d4001f4e64cfe0dea8e157040d0e37cc6d4L46-R54), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4239/files?diff=unified&w=0#diff-ab1d818231786dfb05ece46f7aeeb19c69d1e97c63e5caa36cbaa7f4db8f6b1dL46-R54), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4239/files?diff=unified&w=0#diff-c4f901661162854dae99dd712890a5bd27c427c0f7002252f5f792dd41deb19aL46-R54), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4239/files?diff=unified&w=0#diff-d34ce2220f54711491330ea52c5f77610477b563ca394a918f34ab33497ff4b8L43-R51), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4239/files?diff=unified&w=0#diff-17be18b4b58d96fe69b0885639a2790f5f8a642fba3b6b3e940659ed44954fc1L46-R56), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4239/files?diff=unified&w=0#diff-c1b58c6e3f4e213461166fea37f3b163eeb92a3665877c56383796107648d033L46-R53), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4239/files?diff=unified&w=0#diff-be54b6c6dc51e53cd688a64bd8c8e663cda1077173733f7048f942e030657121L46-R54), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4239/files?diff=unified&w=0#diff-d529ec9347690876559ec079d3521140e13e841d63bd5293abfa3c5b4e4651f4L47-R55), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4239/files?diff=unified&w=0#diff-5d837cb82dd03c1e75211b5dafad92228f7f8b347b694b67c708e2b75dcad9a4L47-R56), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4239/files?diff=unified&w=0#diff-ee884796f462d0fb88cb0228f62154f986d5859e64ff26eccf17000f1283b67fL46-R54), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4239/files?diff=unified&w=0#diff-9da446054f6a2182d891775e6ba61592532760f034787cd3356d447bd32432d6L46-R54), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4239/files?diff=unified&w=0#diff-8d50e95f0e7b3e3d9fced5d842c7e7dcd120ae65f63d8aea480a87e52073dd61L47-R56), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4239/files?diff=unified&w=0#diff-0bc8a214ce0e6a9e8231767014c2dc4ce47c685c30224a45e219d23915614e38L51-R62), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4239/files?diff=unified&w=0#diff-2b7f5c9b7e4da80c8962b1c2eba1717088dbb2846f391fbf2a1374bc92146f4cL46-R54), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4239/files?diff=unified&w=0#diff-70e864c67ecda3be2442f2e059ef20da520960f6aa82eeb9b74caf3723f34acaL45-R53))

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary