### PR TITLE
feat(themes): updated devious-diamonds

### DIFF
--- a/themes/devious-diamonds.omp.yaml
+++ b/themes/devious-diamonds.omp.yaml
@@ -43,123 +43,123 @@ blocks:
         background: magenta
         foreground: black
         template: " {{ if .SSHSession }} {{ end }}{{ .UserName }}@{{ .HostName }} "
-      # - type: angular
-      #   style: powerline
-      #   powerline_symbol: 
-      #   background: lightRed
-      #   foreground: black
-      #   properties:
-      #     fetch_version: true
-      #   template: " ﮰ {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
-      # - type: aws
-      #   style: powerline
-      #   powerline_symbol: 
-      #   background: yellow
-      #   foreground: black
-      #   properties:
-      #     display_default: false
-      #   template: "  {{ .Profile }}{{ if .Region }}@{{ .Region }}{{ end }} "
-      # - type: az
-      #   style: powerline
-      #   powerline_symbol: 
-      #   background: lightBlue
-      #   foreground: black
-      #   properties:
-      #     display_default: false
-      #   template: " ﴃ Subscription {{ .Name }} ({{ if .EnvironmentName | contains 'AzureCloud' }}{{ 'Global' }}{{ else }}{{ .EnvironmentName }}{{ end }}) "
-      # - type: azfunc
-      #   style: powerline
-      #   powerline_symbol: 
-      #   background: yellow
-      #   foreground: black
-      #   properties:
-      #     display_mode: files
-      #     fetch_version: false
-      #   template: " ﴃ {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
-      # - type: go
-      #   style: powerline
-      #   powerline_symbol: 
-      #   background: lightCyan
-      #   foreground: black
-      #   properties:
-      #     fetch_version: true
-      #   template: " ﳑ {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
-      # - type: java
-      #   style: powerline
-      #   powerline_symbol: 
-      #   background: lightCyan
-      #   foreground: black
-      #   template: "  {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
-      # - type: julia
-      #   style: powerline
-      #   powerline_symbol: 
-      #   background: lightCyan
-      #   foreground: black
-      #   properties:
-      #     fetch_version: true
-      #   template: "  {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
-      # - type: kubectl
-      #   style: powerline
-      #   powerline_symbol: 
-      #   background: lightYellow
-      #   foreground: black
-      #   template: " ﴱ {{.Context}}{{if .Namespace}} :: {{.Namespace}}{{end}} "
-      # - type: node
-      #   style: powerline
-      #   powerline_symbol: 
-      #   background: lightGreen
-      #   foreground: black
-      #   properties:
-      #     fetch_version: true
-      #   template: "  {{ if .PackageManagerIcon }}{{ .PackageManagerIcon }} {{ end }}{{ .Full }} "
-      # - type: php
-      #   style: powerline
-      #   powerline_symbol: 
-      #   background: lightCyan
-      #   foreground: black
-      #   template: "  {{ if .PackageManagerIcon }}{{ .PackageManagerIcon }} {{ end }}{{ .Full }} "
+      - type: angular
+        style: powerline
+        powerline_symbol: 
+        background: lightRed
+        foreground: black
+        properties:
+          fetch_version: true
+        template: " ﮰ {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
+      - type: aws
+        style: powerline
+        powerline_symbol: 
+        background: yellow
+        foreground: black
+        properties:
+          display_default: false
+        template: "  {{ .Profile }}{{ if .Region }}@{{ .Region }}{{ end }} "
+      - type: az
+        style: powerline
+        powerline_symbol: 
+        background: lightBlue
+        foreground: black
+        properties:
+          display_default: false
+        template: " ﴃ Subscription {{ .Name }} ({{ if .EnvironmentName | contains \"AzureCloud\" }}{{ \"Global\" }}{{ else }}{{ .EnvironmentName }}{{ end }}) "
+      - type: azfunc
+        style: powerline
+        powerline_symbol: 
+        background: yellow
+        foreground: black
+        properties:
+          display_mode: files
+          fetch_version: false
+        template: " ﴃ {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
+      - type: go
+        style: powerline
+        powerline_symbol: 
+        background: lightCyan
+        foreground: black
+        properties:
+          fetch_version: true
+        template: " ﳑ {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
+      - type: java
+        style: powerline
+        powerline_symbol: 
+        background: lightCyan
+        foreground: black
+        template: "  {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
+      - type: julia
+        style: powerline
+        powerline_symbol: 
+        background: lightCyan
+        foreground: black
+        properties:
+          fetch_version: true
+        template: "  {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
+      - type: kubectl
+        style: powerline
+        powerline_symbol: 
+        background: lightYellow
+        foreground: black
+        template: " ﴱ {{.Context}}{{if .Namespace}} :: {{.Namespace}}{{end}} "
+      - type: node
+        style: powerline
+        powerline_symbol: 
+        background: lightGreen
+        foreground: black
+        properties:
+          fetch_version: true
+        template: "  {{ if .PackageManagerIcon }}{{ .PackageManagerIcon }} {{ end }}{{ .Full }} "
+      - type: php
+        style: powerline
+        powerline_symbol: 
+        background: lightCyan
+        foreground: black
+        template: "  {{ if .PackageManagerIcon }}{{ .PackageManagerIcon }} {{ end }}{{ .Full }} "
       - type: project
         style: powerline
         powerline_symbol: 
         background: lightYellow
         foreground: black
         template: " {{ if .Error }}{{ .Error }}{{ else }}{{ if .Version }} {{.Version}}{{ end }} {{ if .Name }}{{ .Name }}{{ end }}{{ end }} "
-      # - type: python
-      #   style: powerline
-      #   powerline_symbol: 
-      #   background: lightYellow
-      #   foreground: black
-      #   properties:
-      #     display_mode: files
-      #     fetch_virtual_env: false
-      #   template: "  {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
-      # - type: ruby
-      #   style: powerline
-      #   powerline_symbol: 
-      #   background: red
-      #   foreground: black
-      #   properties:
-      #     display_mode: files
-      #     fetch_version: true
-      #   template: "  {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
-      # - type: rust
-      #   style: powerline
-      #   powerline_symbol: 
-      #   background: lightRed
-      #   foreground: black
-      #   properties:
-      #     display_mode: files
-      #     fetch_version: true
-      #   template: "  {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
-      # - type: swift
-      #   style: powerline
-      #   powerline_symbol: 
-      #   background: blue
-      #   foreground: black
-      #   properties:
-      #     display_mode: files
-      #     fetch_version: true
-      #   template: "  {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
+      - type: python
+        style: powerline
+        powerline_symbol: 
+        background: lightYellow
+        foreground: black
+        properties:
+          display_mode: files
+          fetch_virtual_env: false
+        template: "  {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
+      - type: ruby
+        style: powerline
+        powerline_symbol: 
+        background: red
+        foreground: black
+        properties:
+          display_mode: files
+          fetch_version: true
+        template: "  {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
+      - type: rust
+        style: powerline
+        powerline_symbol: 
+        background: lightRed
+        foreground: black
+        properties:
+          display_mode: files
+          fetch_version: true
+        template: "  {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
+      - type: swift
+        style: powerline
+        powerline_symbol: 
+        background: blue
+        foreground: black
+        properties:
+          display_mode: files
+          fetch_version: true
+        template: "  {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
       - type: time
         style: powerline
         powerline_symbol: 

--- a/themes/devious-diamonds.omp.yaml
+++ b/themes/devious-diamonds.omp.yaml
@@ -11,7 +11,6 @@ blocks:
         template: "{{ .PromptMark }}"
       - type: os
         style: diamond
-        trailing_diamond: <transparent,></>
         foreground: cyan
         properties:
           alpine: 
@@ -44,105 +43,123 @@ blocks:
         background: magenta
         foreground: black
         template: " {{ if .SSHSession }} {{ end }}{{ .UserName }}@{{ .HostName }} "
-      - type: angular
-        style: powerline
-        powerline_symbol: 
-        background: lightRed
-        foreground: black
-        properties:
-          fetch_version: true
-        template: " ﮰ {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
-      - type: aws
-        style: powerline
-        powerline_symbol: 
-        background: yellow
-        foreground: black
-        properties:
-          display_default: false
-        template: "  {{ .Profile }}{{ if .Region }}@{{ .Region }}{{ end }} "
-      - type: az
-        style: powerline
-        powerline_symbol: 
-        background: lightBlue
-        foreground: black
-        properties:
-          display_default: false
-        template: " ﴃ Subscription {{ .Name }} ({{ if .EnvironmentName | contains 'AzureCloud' }}{{ 'Global' }}{{ else }}{{ .EnvironmentName }}{{ end }}) "
-      - type: azfunc
-        style: powerline
-        powerline_symbol: 
-        background: yellow
-        foreground: black
-        properties:
-          display_mode: files
-          fetch_version: false
-        template: " ﴃ {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
-      - type: go
-        style: powerline
-        powerline_symbol: 
-        background: lightCyan
-        foreground: black
-        properties:
-          fetch_version: true
-        template: "  {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
-      - type: java
-        style: powerline
-        powerline_symbol: 
-        background: lightCyan
-        foreground: black
-        template: "  {{ .Full }}"
-      - type: julia
-        style: powerline
-        powerline_symbol: 
-        background: lightCyan
-        foreground: black
-        properties:
-          fetch_version: true
-        template: "  {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
-      - type: kubectl
-        style: powerline
-        powerline_symbol: 
-        background: lightYellow
-        foreground: black
-        template: " ﴱ {{.Context}}{{if .Namespace}} :: {{.Namespace}}{{end}} "
-      - type: node
-        style: powerline
-        powerline_symbol: 
-        background: lightGreen
-        foreground: black
-        properties:
-          fetch_version: true
-        template: "  {{ if .PackageManagerIcon }}{{ .PackageManagerIcon }} {{ end }}{{ .Full }} "
-      - type: php
-        style: powerline
-        powerline_symbol: 
-        background: lightCyan
-        foreground: black
-        template: "  {{ .Full }} "
+      # - type: angular
+      #   style: powerline
+      #   powerline_symbol: 
+      #   background: lightRed
+      #   foreground: black
+      #   properties:
+      #     fetch_version: true
+      #   template: " ﮰ {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
+      # - type: aws
+      #   style: powerline
+      #   powerline_symbol: 
+      #   background: yellow
+      #   foreground: black
+      #   properties:
+      #     display_default: false
+      #   template: "  {{ .Profile }}{{ if .Region }}@{{ .Region }}{{ end }} "
+      # - type: az
+      #   style: powerline
+      #   powerline_symbol: 
+      #   background: lightBlue
+      #   foreground: black
+      #   properties:
+      #     display_default: false
+      #   template: " ﴃ Subscription {{ .Name }} ({{ if .EnvironmentName | contains 'AzureCloud' }}{{ 'Global' }}{{ else }}{{ .EnvironmentName }}{{ end }}) "
+      # - type: azfunc
+      #   style: powerline
+      #   powerline_symbol: 
+      #   background: yellow
+      #   foreground: black
+      #   properties:
+      #     display_mode: files
+      #     fetch_version: false
+      #   template: " ﴃ {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
+      # - type: go
+      #   style: powerline
+      #   powerline_symbol: 
+      #   background: lightCyan
+      #   foreground: black
+      #   properties:
+      #     fetch_version: true
+      #   template: " ﳑ {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
+      # - type: java
+      #   style: powerline
+      #   powerline_symbol: 
+      #   background: lightCyan
+      #   foreground: black
+      #   template: "  {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
+      # - type: julia
+      #   style: powerline
+      #   powerline_symbol: 
+      #   background: lightCyan
+      #   foreground: black
+      #   properties:
+      #     fetch_version: true
+      #   template: "  {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
+      # - type: kubectl
+      #   style: powerline
+      #   powerline_symbol: 
+      #   background: lightYellow
+      #   foreground: black
+      #   template: " ﴱ {{.Context}}{{if .Namespace}} :: {{.Namespace}}{{end}} "
+      # - type: node
+      #   style: powerline
+      #   powerline_symbol: 
+      #   background: lightGreen
+      #   foreground: black
+      #   properties:
+      #     fetch_version: true
+      #   template: "  {{ if .PackageManagerIcon }}{{ .PackageManagerIcon }} {{ end }}{{ .Full }} "
+      # - type: php
+      #   style: powerline
+      #   powerline_symbol: 
+      #   background: lightCyan
+      #   foreground: black
+      #   template: "  {{ if .PackageManagerIcon }}{{ .PackageManagerIcon }} {{ end }}{{ .Full }} "
       - type: project
         style: powerline
         powerline_symbol: 
         background: lightYellow
         foreground: black
         template: " {{ if .Error }}{{ .Error }}{{ else }}{{ if .Version }} {{.Version}}{{ end }} {{ if .Name }}{{ .Name }}{{ end }}{{ end }} "
-      - type: python
-        style: powerline
-        powerline_symbol: 
-        background: lightYellow
-        foreground: black
-        properties:
-          display_mode: files
-          fetch_virtual_env: false
-        template: "  {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
-      - type: ruby
-        style: powerline
-        powerline_symbol: 
-        background: red
-        foreground: black
-        properties:
-          display_mode: files
-          fetch_version: true
-        template: "  {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
+      # - type: python
+      #   style: powerline
+      #   powerline_symbol: 
+      #   background: lightYellow
+      #   foreground: black
+      #   properties:
+      #     display_mode: files
+      #     fetch_virtual_env: false
+      #   template: "  {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
+      # - type: ruby
+      #   style: powerline
+      #   powerline_symbol: 
+      #   background: red
+      #   foreground: black
+      #   properties:
+      #     display_mode: files
+      #     fetch_version: true
+      #   template: "  {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
+      # - type: rust
+      #   style: powerline
+      #   powerline_symbol: 
+      #   background: lightRed
+      #   foreground: black
+      #   properties:
+      #     display_mode: files
+      #     fetch_version: true
+      #   template: "  {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
+      # - type: swift
+      #   style: powerline
+      #   powerline_symbol: 
+      #   background: blue
+      #   foreground: black
+      #   properties:
+      #     display_mode: files
+      #     fetch_version: true
+      #   template: "  {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
       - type: time
         style: powerline
         powerline_symbol: 
@@ -184,7 +201,7 @@ blocks:
         style: plain
         foreground: cyan
         template: " ╚"
-      - type: exit
+      - type: status
         style: diamond
         leading_diamond: 
         background: blue


### PR DESCRIPTION
### Prerequisites

- [✔️] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [✔️] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

Trimmed down a number of optional sections (which can be uncommented if desired), changed "exit" to "status", and deleted an old workaround which caused an extra character to be rendered.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 196b6c5</samp>

*  Simplify the devious-diamonds theme by commenting out irrelevant segments ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4241/files?diff=unified&w=0#diff-5870c1bcf4c43c0ef90d088c0f40b3cae27ba087c790929f17a357a5d4ccbbe7L47-R120), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4241/files?diff=unified&w=0#diff-5870c1bcf4c43c0ef90d088c0f40b3cae27ba087c790929f17a357a5d4ccbbe7L128-R162))
*  Remove the trailing diamond segment from the prompt for consistency ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4241/files?diff=unified&w=0#diff-5870c1bcf4c43c0ef90d088c0f40b3cae27ba087c790929f17a357a5d4ccbbe7L14))
*  Replace the exit segment with the status segment for more feedback ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4241/files?diff=unified&w=0#diff-5870c1bcf4c43c0ef90d088c0f40b3cae27ba087c790929f17a357a5d4ccbbe7L187-R204))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
