### PR TITLE
feat(colors): allow nested overrides

### DIFF
--- a/src/ansi/ansi_writer_hyperlink.go
+++ b/src/ansi/ansi_writer_hyperlink.go
@@ -76,8 +76,9 @@ func (w *Writer) replaceHyperlink(text string) string {
 		return strings.Replace(text, results["ALL"], linkText, 1)
 	}
 
-	// we only care about the length of the text part
-	w.length += runewidth.StringWidth(linkText)
+	// we only care about the length of the actual text part
+	characters := w.trimAnsi(linkText)
+	w.length += runewidth.StringWidth(characters)
 
 	if w.Plain {
 		return linkText

--- a/src/ansi/ansi_writer_test.go
+++ b/src/ansi/ansi_writer_test.go
@@ -195,6 +195,12 @@ func TestWriteANSIColors(t *testing.T) {
 			Expected: "\x1b[40m\x1b[30mtest\x1b[0m",
 			Colors:   &Colors{Foreground: "black", Background: "white"},
 		},
+		{
+			Case:     "Nested override",
+			Input:    "hello, <red>world, <white>rabbit</> hello</>",
+			Expected: "\x1b[47m\x1b[30mhello, \x1b[31mworld, \x1b[37mrabbit\x1b[31m hello\x1b[0m",
+			Colors:   &Colors{Foreground: "black", Background: "white"},
+		},
 	}
 
 	for _, tc := range cases {

--- a/src/ansi/colors.go
+++ b/src/ansi/colors.go
@@ -19,6 +19,61 @@ type ColorString interface {
 	ToColor(colorString string, isBackground bool, trueColor bool) Color
 }
 
+type ColorSet struct {
+	Foreground Color
+	Background Color
+}
+
+type ColorHistory []*ColorSet
+
+func (c *ColorHistory) Len() int {
+	return len(*c)
+}
+
+func (c *ColorHistory) Add(background, foreground Color) {
+	colors := &ColorSet{
+		Foreground: foreground,
+		Background: background,
+	}
+
+	if c.Len() == 0 {
+		*c = append(*c, colors)
+		return
+	}
+
+	last := (*c)[c.Len()-1]
+	// never add the same colors twice
+	if last.Foreground == colors.Foreground && last.Background == colors.Background {
+		return
+	}
+
+	*c = append(*c, colors)
+}
+
+func (c *ColorHistory) Pop() {
+	if c.Len() == 0 {
+		return
+	}
+
+	*c = (*c)[:c.Len()-1]
+}
+
+func (c *ColorHistory) Background() Color {
+	if c.Len() == 0 {
+		return emptyColor
+	}
+
+	return (*c)[c.Len()-1].Background
+}
+
+func (c *ColorHistory) Foreground() Color {
+	if c.Len() == 0 {
+		return emptyColor
+	}
+
+	return (*c)[c.Len()-1].Foreground
+}
+
 // Color is an ANSI color code ready to be printed to the console.
 // Example: "38;2;255;255;255", "48;2;255;255;255", "31", "95".
 type Color string


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c189854</samp>

Refactored the `ansi.Writer` type and its methods to use a `ColorHistory` type to manage color overrides and resets more reliably. Fixed a bug with hyperlink alignment when the link text contained color codes. Added tests and documentation for the new types and functions.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c189854</samp>

*  Refactor the `Writer` type to use a `ColorHistory` stack for storing and retrieving the current colors ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4243/files?diff=unified&w=0#diff-0267d2a06e9c5eab5a04e9625772dd68774a70872a4014630cdb15183ce7dcd9L89-R94), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4243/files?diff=unified&w=0#diff-0267d2a06e9c5eab5a04e9625772dd68774a70872a4014630cdb15183ce7dcd9L306-R306), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4243/files?diff=unified&w=0#diff-0267d2a06e9c5eab5a04e9625772dd68774a70872a4014630cdb15183ce7dcd9L346-R346), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4243/files?diff=unified&w=0#diff-0267d2a06e9c5eab5a04e9625772dd68774a70872a4014630cdb15183ce7dcd9L381-R384), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4243/files?diff=unified&w=0#diff-0267d2a06e9c5eab5a04e9625772dd68774a70872a4014630cdb15183ce7dcd9L411-R410), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4243/files?diff=unified&w=0#diff-0267d2a06e9c5eab5a04e9625772dd68774a70872a4014630cdb15183ce7dcd9L477-R478))
*  Add the `ColorSet` and `ColorHistory` types and methods to the `ansi` package to implement the color stack logic ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4243/files?diff=unified&w=0#diff-30b9d265fa3e36a4cb4221faf43553e0306e258e6c27f55f007da34105896522R22-R76))
*  Update the `writeColorOverrides` function to use local variables for the parsed colors and extract the color reset logic into a separate function ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4243/files?diff=unified&w=0#diff-0267d2a06e9c5eab5a04e9625772dd68774a70872a4014630cdb15183ce7dcd9L419-R417), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4243/files?diff=unified&w=0#diff-0267d2a06e9c5eab5a04e9625772dd68774a70872a4014630cdb15183ce7dcd9L468-R440), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4243/files?diff=unified&w=0#diff-0267d2a06e9c5eab5a04e9625772dd68774a70872a4014630cdb15183ce7dcd9R484-R542))
*  Update the `replaceHyperlink` function to trim any ANSI escape sequences from the link text before calculating its width ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4243/files?diff=unified&w=0#diff-335a93b8a96a2b0f5cfdda59629f5ad2165e45c47a6570c1f5171b051d099071L79-R81))
*  Add a test case to verify that nested color overrides work as expected and are restored properly ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4243/files?diff=unified&w=0#diff-7214a6ffb60e6b167949f626066440b0deabc9698c4e7923aa23478ab773476aR198-R203))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
