### PR TITLE
fix(compare): support int64

### DIFF
--- a/src/template/compare.go
+++ b/src/template/compare.go
@@ -30,6 +30,9 @@ func gt(e1, e2 interface{}) bool {
 	if val, OK := e1.(int); OK {
 		return val > interFaceToInt(e2)
 	}
+	if val, OK := e1.(int64); OK {
+		return val > int64(interFaceToInt(e2))
+	}
 	if val, OK := e1.(float64); OK {
 		return val > interfaceToFloat64(e2)
 	}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 250cb00</samp>

Add support for int64 comparisons in templates. Fix a bug in the `gt` function that caused incorrect results for int64 values in `src/template/compare.go`.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 250cb00</samp>

*  Add support for int64 comparisons in templates ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4246/files?diff=unified&w=0#diff-37ca761b0b699ea711fc1e940225cd16d9af95808222826422dcf1e79371a7d1R33-R35))

relates to #3309

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
