### PR TITLE
Edit one error (CPU IS NOT MEMORY)

### DIFF
--- a/themes/1_shell.omp.json
+++ b/themes/1_shell.omp.json
@@ -69,13 +69,7 @@
         {
           "foreground": "#94ffa2",
           "style": "diamond",
-          "template": " <#ffffff>MEM:</> {{ round .PhysicalPercentUsed .Precision }}% ",
-          "type": "sysinfo"
-        },
-        {
-          "foreground": "#81ff91",
-          "style": "diamond",
-          "template": "<#ffffff>\ue266</> <#ffffff>RAM:</> {{ (div ((sub .PhysicalTotalMemory .PhysicalFreeMemory)|float64) 1000000000.0) }}/{{ (div .PhysicalTotalMemory 1000000000.0) }}GB ",
+          "template": " <#ffffff>MEM:</> {{ round .PhysicalPercentUsed .Precision }}% ({{ (div ((sub .PhysicalTotalMemory .PhysicalFreeMemory)|float64) 1000000000.0) }}/{{ (div .PhysicalTotalMemory 1000000000.0) }}GB)",
           "type": "sysinfo"
         }
       ],

--- a/themes/1_shell.omp.json
+++ b/themes/1_shell.omp.json
@@ -69,7 +69,7 @@
         {
           "foreground": "#94ffa2",
           "style": "diamond",
-          "template": " <#ffffff>CPU:</> {{ round .PhysicalPercentUsed .Precision }}% ",
+          "template": " <#ffffff>MEM:</> {{ round .PhysicalPercentUsed .Precision }}% ",
           "type": "sysinfo"
         },
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

I've corrected a small error: you were displaying "CPU" information when you were displaying the percentage of RAM.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8d76ca4</samp>

Updated the sysinfo segment in the `1_shell.omp.json` theme to show memory usage. This makes the theme consistent with the README screenshot.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8d76ca4</samp>

* Change the sysinfo segment template to show memory usage instead of CPU usage in the shell theme ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4248/files?diff=unified&w=0#diff-ff4dc81a0e89bd5723ae0c6b192ce1e2fa0bf514573b2e19eac8f50a5d560c31L72-R72))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
