### PR TITLE
adventure time

### DIFF
--- a/src/engine/prompt.go
+++ b/src/engine/prompt.go
@@ -42,6 +42,17 @@ func (e *Engine) Primary() string {
 			cancelNewline = !didRender
 		}
 
+		// only render rprompt for shells where we need it from the primary prompt
+		renderRPrompt := true
+		switch e.Env.Shell() {
+		case shell.ELVISH, shell.FISH, shell.NU, shell.XONSH, shell.CMD:
+			renderRPrompt = false
+		}
+
+		if block.Type == RPrompt && !renderRPrompt {
+			continue
+		}
+
 		if e.renderBlock(block, cancelNewline) {
 			didRender = true
 		}
@@ -79,7 +90,7 @@ func (e *Engine) Primary() string {
 		prompt := fmt.Sprintf("PS1=\"%s\"", strings.ReplaceAll(e.string(), `"`, `\"`))
 		prompt += fmt.Sprintf("\nRPROMPT=\"%s\"", e.rprompt)
 		return prompt
-	case shell.PWSH, shell.PWSH5, shell.GENERIC, shell.NU:
+	case shell.PWSH, shell.PWSH5, shell.GENERIC:
 		e.writeRPrompt()
 	case shell.BASH:
 		space, OK := e.canWriteRightBlock(true)

--- a/src/font/install_windows.go
+++ b/src/font/install_windows.go
@@ -29,6 +29,13 @@ func install(font *Font, admin bool) error {
 		fontsDir = filepath.Join(os.Getenv("USERPROFILE"), "AppData", "Local", "Microsoft", "Windows", "Fonts")
 	}
 
+	// check if the Fonts folder exists, if not, create it
+	if _, err := os.Stat(fontsDir); os.IsNotExist(err) {
+		if err = os.MkdirAll(fontsDir, 0755); err != nil {
+			return fmt.Errorf("Unable to create fonts directory: %s", err.Error())
+		}
+	}
+
 	fullPath := filepath.Join(fontsDir, font.FileName)
 	// validate if font is already installed, remove it in case it is
 	if _, err := os.Stat(fullPath); err == nil {

--- a/src/shell/scripts/omp.nu
+++ b/src/shell/scripts/omp.nu
@@ -1,30 +1,36 @@
-export-env {
-    $env.POWERLINE_COMMAND = 'oh-my-posh'
-    $env.POSH_THEME = ::CONFIG::
-    $env.PROMPT_INDICATOR = ""
-    $env.POSH_PID = (random uuid)
-    # By default displays the right prompt on the first line
-    # making it annoying when you have a multiline prompt
-    # making the behavior different compared to other shells
-    $env.PROMPT_COMMAND_RIGHT = ''
-    $env.POSH_SHELL_VERSION = (version | get version)
+$env.config = ($env.config | upsert render_right_prompt_on_last_line true)
 
-    # PROMPTS
-    $env.PROMPT_MULTILINE_INDICATOR = (^::OMP:: print secondary $"--config=($env.POSH_THEME)" --shell=nu $"--shell-version=($env.POSH_SHELL_VERSION)")
+$env.POWERLINE_COMMAND = 'oh-my-posh'
+$env.POSH_THEME = ::CONFIG::
+$env.PROMPT_INDICATOR = ""
+$env.POSH_PID = (random uuid)
+$env.POSH_SHELL_VERSION = (version | get version)
 
-    $env.PROMPT_COMMAND = { ||
-        # We have to do this because the initial value of `$env.CMD_DURATION_MS` is always `0823`,
-        # which is an official setting.
-        # See https://github.com/nushell/nushell/discussions/6402#discussioncomment-3466687.
-        let cmd_duration = if $env.CMD_DURATION_MS == "0823" { 0 } else { $env.CMD_DURATION_MS }
+# PROMPTS
+$env.PROMPT_MULTILINE_INDICATOR = (^::OMP:: print secondary $"--config=($env.POSH_THEME)" --shell=nu $"--shell-version=($env.POSH_SHELL_VERSION)")
 
-        # hack to set the cursor line to 1 when the user clears the screen
-        # this obviously isn't bulletproof, but it's a start
-        let clear = (history | last 1 | get 0.command) == "clear"
+$env.PROMPT_COMMAND = { ||
+    # We have to do this because the initial value of `$env.CMD_DURATION_MS` is always `0823`,
+    # which is an official setting.
+    # See https://github.com/nushell/nushell/discussions/6402#discussioncomment-3466687.
+    let cmd_duration = if $env.CMD_DURATION_MS == "0823" { 0 } else { $env.CMD_DURATION_MS }
 
-        let width = ((term size).columns | into string)
-        ^::OMP:: print primary $"--config=($env.POSH_THEME)" --shell=nu $"--shell-version=($env.POSH_SHELL_VERSION)" $"--execution-time=($cmd_duration)" $"--status=($env.LAST_EXIT_CODE)" $"--terminal-width=($width)" $"--cleared=($clear)"
-    }
+    # hack to set the cursor line to 1 when the user clears the screen
+    # this obviously isn't bulletproof, but it's a start
+    let clear = (history | last 1 | get 0.command) == "clear"
+
+    let width = ((term size).columns | into string)
+    ^::OMP:: print primary $"--config=($env.POSH_THEME)" --shell=nu $"--shell-version=($env.POSH_SHELL_VERSION)" $"--execution-time=($cmd_duration)" $"--status=($env.LAST_EXIT_CODE)" $"--terminal-width=($width)" $"--cleared=($clear)"
+}
+
+$env.PROMPT_COMMAND_RIGHT = { ||
+    # We have to do this because the initial value of `$env.CMD_DURATION_MS` is always `0823`,
+    # which is an official setting.
+    # See https://github.com/nushell/nushell/discussions/6402#discussioncomment-3466687.
+    let cmd_duration = if $env.CMD_DURATION_MS == "0823" { 0 } else { $env.CMD_DURATION_MS }
+
+    let width = ((term size).columns | into string)
+    ^::OMP:: print right $"--config=($env.POSH_THEME)" --shell=nu $"--shell-version=($env.POSH_SHELL_VERSION)" $"--execution-time=($cmd_duration)" $"--status=($env.LAST_EXIT_CODE)" $"--terminal-width=($width)"
 }
 
 if "::UPGRADE::" == "true" {

--- a/website/docs/installation/customize.mdx
+++ b/website/docs/installation/customize.mdx
@@ -158,7 +158,7 @@ Once altered, reload your config for the changes to take effect.
 <TabItem value="nu">
 
 :::caution
-Oh My Posh requires Nushell v0.78.0 or higher.
+Oh My Posh requires Nushell v0.84.0 or higher.
 :::
 
 Adjust the Oh My Posh init line in the Nushell env file (`$nu.env-path`) by adding the `--config` flag

--- a/website/docs/installation/prompt.mdx
+++ b/website/docs/installation/prompt.mdx
@@ -104,7 +104,7 @@ exec fish
 <TabItem value="nu">
 
 :::caution
-Oh My Posh requires Nushell v0.78.0 or higher.
+Oh My Posh requires Nushell v0.84.0 or higher.
 :::
 
 Add the following line to the Nushell env file (`$nu.env-path`):


### PR DESCRIPTION
- fix(nu): use native right prompt command
- fix(font): create Fonts folder when non-existant

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0db6437</samp>

This pull request fixes a right prompt duplication bug for some shells, adds a Fonts folder check for Windows font installation, and introduces a new option to customize the right prompt position for nu shell. These changes aim to improve the compatibility, reliability, and usability of oh-my-posh across different shells and platforms.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0db6437</samp>

*  Fix right prompt duplication for some shells ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4258/files?diff=unified&w=0#diff-9cbb773ea359cb84f27d7d8a473c1d6a206afb625cd36be225a57c43daa56145R45-R55))
*  Simplify right prompt file handling for nu shell ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4258/files?diff=unified&w=0#diff-9cbb773ea359cb84f27d7d8a473c1d6a206afb625cd36be225a57c43daa56145L82-R93))
*  Add option to render right prompt on last line for nu shell ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4258/files?diff=unified&w=0#diff-b4e6f5d564c90b8bcff9623c6cae46e5a6fe4379bd352f7e188c3c09d1289c02L1-R35))
*  Create Fonts folder if missing on Windows ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4258/files?diff=unified&w=0#diff-0fb1cd433036960283343e1a07e4b3ebe00f5a5271e426899f5d305d91aa43daR32-R38))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
