### PR TITLE
chore: fix function typo

### DIFF
--- a/src/engine/config.go
+++ b/src/engine/config.go
@@ -34,26 +34,26 @@ const (
 
 // Config holds all the theme for rendering the prompt
 type Config struct {
-	Version                  int                    `json:"version"`
-	FinalSpace               bool                   `json:"final_space,omitempty"`
-	ConsoleTitleTemplate     string                 `json:"console_title_template,omitempty"`
-	TerminalBackground       string                 `json:"terminal_background,omitempty"`
-	AccentColor              string                 `json:"accent_color,omitempty"`
-	Blocks                   []*Block               `json:"blocks,omitempty"`
-	Tooltips                 []*Segment             `json:"tooltips,omitempty"`
-	TransientPrompt          *Segment               `json:"transient_prompt,omitempty"`
-	ValidLine                *Segment               `json:"valid_line,omitempty"`
-	ErrorLine                *Segment               `json:"error_line,omitempty"`
-	SecondaryPrompt          *Segment               `json:"secondary_prompt,omitempty"`
-	DebugPrompt              *Segment               `json:"debug_prompt,omitempty"`
-	Palette                  ansi.Palette           `json:"palette,omitempty"`
-	Palettes                 *ansi.Palettes         `json:"palettes,omitempty"`
-	Cycle                    ansi.Cycle             `json:"cycle,omitempty"`
-	ShellIntegration         bool                   `json:"shell_integration,omitempty"`
-	PWD                      string                 `json:"pwd,omitempty"`
-	Var                      map[string]interface{} `json:"var,omitempty"`
-	DisableCursorPositioning bool                   `json:"disable_cursor_positioning,omitempty"`
-	PatchPwshBleed           bool                   `json:"patch_pwsh_bleed,omitempty"`
+	Version                  int            `json:"version"`
+	FinalSpace               bool           `json:"final_space,omitempty"`
+	ConsoleTitleTemplate     string         `json:"console_title_template,omitempty"`
+	TerminalBackground       string         `json:"terminal_background,omitempty"`
+	AccentColor              string         `json:"accent_color,omitempty"`
+	Blocks                   []*Block       `json:"blocks,omitempty"`
+	Tooltips                 []*Segment     `json:"tooltips,omitempty"`
+	TransientPrompt          *Segment       `json:"transient_prompt,omitempty"`
+	ValidLine                *Segment       `json:"valid_line,omitempty"`
+	ErrorLine                *Segment       `json:"error_line,omitempty"`
+	SecondaryPrompt          *Segment       `json:"secondary_prompt,omitempty"`
+	DebugPrompt              *Segment       `json:"debug_prompt,omitempty"`
+	Palette                  ansi.Palette   `json:"palette,omitempty"`
+	Palettes                 *ansi.Palettes `json:"palettes,omitempty"`
+	Cycle                    ansi.Cycle     `json:"cycle,omitempty"`
+	ShellIntegration         bool           `json:"shell_integration,omitempty"`
+	PWD                      string         `json:"pwd,omitempty"`
+	Var                      map[string]any `json:"var,omitempty"`
+	DisableCursorPositioning bool           `json:"disable_cursor_positioning,omitempty"`
+	PatchPwshBleed           bool           `json:"patch_pwsh_bleed,omitempty"`
 
 	// Deprecated
 	OSC99 bool `json:"osc99,omitempty"`
@@ -174,7 +174,7 @@ func (cfg *Config) sync() {
 	if !cfg.updated {
 		return
 	}
-	var structMap map[string]interface{}
+	var structMap map[string]any
 	inrec, err := json2.Marshal(cfg)
 	if err != nil {
 		return
@@ -185,7 +185,7 @@ func (cfg *Config) sync() {
 	}
 	// remove empty structs
 	for k, v := range structMap {
-		if smap, OK := v.(map[string]interface{}); OK && len(smap) == 0 {
+		if smap, OK := v.(map[string]any); OK && len(smap) == 0 {
 			delete(structMap, k)
 		}
 	}

--- a/src/engine/migrate.go
+++ b/src/engine/migrate.go
@@ -183,7 +183,7 @@ func (segment *Segment) hasProperty(property properties.Property) bool {
 	return false
 }
 
-func (segment *Segment) migratePropertyValue(property properties.Property, value interface{}) {
+func (segment *Segment) migratePropertyValue(property properties.Property, value any) {
 	if !segment.hasProperty(property) {
 		return
 	}

--- a/src/engine/migrate_test.go
+++ b/src/engine/migrate_test.go
@@ -41,7 +41,7 @@ func TestHasProperty(t *testing.T) {
 func TestMigratePropertyValue(t *testing.T) {
 	cases := []struct {
 		Case     string
-		Expected interface{}
+		Expected any
 		Property properties.Property
 		Props    properties.Map
 	}{
@@ -60,7 +60,7 @@ func TestMigratePropertyValue(t *testing.T) {
 func TestMigratePropertyKey(t *testing.T) {
 	cases := []struct {
 		Case        string
-		Expected    interface{}
+		Expected    any
 		OldProperty properties.Property
 		NewProperty properties.Property
 		Props       properties.Map

--- a/src/engine/segment.go
+++ b/src/engine/segment.go
@@ -65,7 +65,7 @@ type SegmentWriter interface {
 // SegmentStyle the style of segment, for more information, see the constants
 type SegmentStyle string
 
-func (s *SegmentStyle) Resolve(env platform.Environment, context interface{}) SegmentStyle {
+func (s *SegmentStyle) Resolve(env platform.Environment, context any) SegmentStyle {
 	txtTemplate := &template.Text{
 		Context: context,
 		Env:     env,

--- a/src/http/oauth_test.go
+++ b/src/http/oauth_test.go
@@ -143,7 +143,7 @@ func TestOauthResult(t *testing.T) {
 		url := "https://www.strava.com/api/v3/athlete/activities?page=1&per_page=1"
 		tokenURL := fmt.Sprintf("https://ohmyposh.dev/api/refresh?segment=test&token=%s", tc.RefreshToken)
 
-		var props properties.Map = map[properties.Property]interface{}{
+		var props properties.Map = map[properties.Property]any{
 			properties.CacheTimeout: tc.CacheTimeout,
 			properties.AccessToken:  tc.AccessToken,
 			properties.RefreshToken: tc.RefreshToken,

--- a/src/http/request_test.go
+++ b/src/http/request_test.go
@@ -62,7 +62,7 @@ func TestRequestResult(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		var props properties.Map = map[properties.Property]interface{}{
+		var props properties.Map = map[properties.Property]any{
 			properties.CacheTimeout: tc.CacheTimeout,
 		}
 

--- a/src/platform/battery/battery_openbsd.go
+++ b/src/platform/battery/battery_openbsd.go
@@ -50,8 +50,8 @@ func Get() (*Info, error) {
 	apm_status, err := cmd.Run("apm", "-b")
 	if err != nil {
 		return nil, err
-	}  
+	}
 
-  return parseBatteryOutput(apm_percentage, apm_status)
+	return parseBatteryOutput(apm_percentage, apm_status)
 
 }

--- a/src/platform/battery/battery_openbsd_test.go
+++ b/src/platform/battery/battery_openbsd_test.go
@@ -8,45 +8,45 @@ import (
 
 func TestParseBatteryOutput(t *testing.T) {
 	cases := []struct {
-		Case                string
-		PercentOutput       string
-    StatusOutput        string
-		ExpectedState       State
-		ExpectedPercentage  int
+		Case               string
+		PercentOutput      string
+		StatusOutput       string
+		ExpectedState      State
+		ExpectedPercentage int
 		ExpectError        bool
 	}{
 		{
 			Case:               "charging",
 			PercentOutput:      "99",
-      StatusOutput:       "3",
+			StatusOutput:       "3",
 			ExpectedState:      Charging,
 			ExpectedPercentage: 99,
 		},
 		{
 			Case:               "charging 1%",
 			PercentOutput:      "1",
-      StatusOutput:       "3",
+			StatusOutput:       "3",
 			ExpectedState:      Charging,
 			ExpectedPercentage: 1,
 		},
 		{
 			Case:               "removed",
 			PercentOutput:      "0",
-      StatusOutput:       "4",
+			StatusOutput:       "4",
 			ExpectedState:      Unknown,
 			ExpectedPercentage: 0,
 		},
 		{
 			Case:               "charged",
 			PercentOutput:      "100",
-      StatusOutput:       "0",
+			StatusOutput:       "0",
 			ExpectedState:      Full,
 			ExpectedPercentage: 100,
 		},
 		{
 			Case:               "discharging",
 			PercentOutput:      "25",
-      StatusOutput:       "1",
+			StatusOutput:       "1",
 			ExpectedState:      Discharging,
 			ExpectedPercentage: 25,
 		},

--- a/src/platform/shell.go
+++ b/src/platform/shell.go
@@ -190,7 +190,7 @@ type TemplateCache struct {
 	sync.RWMutex
 }
 
-func (t *TemplateCache) AddSegmentData(key string, value interface{}) {
+func (t *TemplateCache) AddSegmentData(key string, value any) {
 	t.Segments.Set(key, value)
 }
 
@@ -802,7 +802,7 @@ func (env *Shell) TemplateCache() *TemplateCache {
 	tmplCache.Segments = NewConcurrentMap()
 	tmplCache.PromptCount = env.CmdFlags.PromptCount
 	tmplCache.Env = make(map[string]string)
-	tmplCache.Var = make(map[string]interface{})
+	tmplCache.Var = make(map[string]any)
 
 	if env.Var != nil {
 		tmplCache.Var = env.Var

--- a/src/properties/map.go
+++ b/src/properties/map.go
@@ -54,7 +54,7 @@ const (
 	CacheTimeout Property = "cache_timeout"
 )
 
-type Map map[Property]interface{}
+type Map map[Property]any
 
 func (m Map) GetString(property Property, defaultValue string) string {
 	val, found := m[property]
@@ -158,11 +158,11 @@ func (m Map) GetStringArray(property Property, defaultValue []string) []string {
 	return keyValues
 }
 
-func ParseStringArray(param interface{}) []string {
+func ParseStringArray(param any) []string {
 	switch v := param.(type) {
 	default:
 		return []string{}
-	case []interface{}:
+	case []any:
 		list := make([]string, len(v))
 		for i, v := range v {
 			list[i] = fmt.Sprint(v)
@@ -173,11 +173,11 @@ func ParseStringArray(param interface{}) []string {
 	}
 }
 
-func parseKeyValueArray(param interface{}) map[string]string {
+func parseKeyValueArray(param any) map[string]string {
 	switch v := param.(type) {
 	default:
 		return map[string]string{}
-	case map[interface{}]interface{}:
+	case map[any]any:
 		keyValueArray := make(map[string]string)
 		for key, value := range v {
 			val := value.(string)
@@ -185,14 +185,14 @@ func parseKeyValueArray(param interface{}) map[string]string {
 			keyValueArray[keyString] = val
 		}
 		return keyValueArray
-	case map[string]interface{}:
+	case map[string]any:
 		keyValueArray := make(map[string]string)
 		for key, value := range v {
 			val := value.(string)
 			keyValueArray[key] = val
 		}
 		return keyValueArray
-	case []interface{}:
+	case []any:
 		keyValueArray := make(map[string]string)
 		for _, s := range v {
 			l := ParseStringArray(s)

--- a/src/properties/map_test.go
+++ b/src/properties/map_test.go
@@ -89,7 +89,7 @@ func TestGetFloat64(t *testing.T) {
 	cases := []struct {
 		Case     string
 		Expected float64
-		Input    interface{}
+		Input    any
 	}{
 		{Case: "int", Expected: 1337, Input: 1337},
 		{Case: "float64", Expected: 1337, Input: float64(1337)},

--- a/src/segments/az.go
+++ b/src/segments/az.go
@@ -33,15 +33,15 @@ type AzureConfig struct {
 }
 
 type AzureSubscription struct {
-	ID               string        `json:"id"`
-	Name             string        `json:"name"`
-	State            string        `json:"state"`
-	User             *AzureUser    `json:"user"`
-	IsDefault        bool          `json:"isDefault"`
-	TenantID         string        `json:"tenantId"`
-	EnvironmentName  string        `json:"environmentName"`
-	HomeTenantID     string        `json:"homeTenantId"`
-	ManagedByTenants []interface{} `json:"managedByTenants"`
+	ID               string     `json:"id"`
+	Name             string     `json:"name"`
+	State            string     `json:"state"`
+	User             *AzureUser `json:"user"`
+	IsDefault        bool       `json:"isDefault"`
+	TenantID         string     `json:"tenantId"`
+	EnvironmentName  string     `json:"environmentName"`
+	HomeTenantID     string     `json:"homeTenantId"`
+	ManagedByTenants []any      `json:"managedByTenants"`
 }
 
 type AzureUser struct {

--- a/src/segments/path_test.go
+++ b/src/segments/path_test.go
@@ -14,7 +14,7 @@ import (
 	mock2 "github.com/stretchr/testify/mock"
 )
 
-func renderTemplateNoTrimSpace(env *mock.MockedEnvironment, segmentTemplate string, context interface{}) string {
+func renderTemplateNoTrimSpace(env *mock.MockedEnvironment, segmentTemplate string, context any) string {
 	found := false
 	for _, call := range env.Mock.ExpectedCalls {
 		if call.Method == "TemplateCache" {
@@ -42,7 +42,7 @@ func renderTemplateNoTrimSpace(env *mock.MockedEnvironment, segmentTemplate stri
 	return text
 }
 
-func renderTemplate(env *mock.MockedEnvironment, segmentTemplate string, context interface{}) string {
+func renderTemplate(env *mock.MockedEnvironment, segmentTemplate string, context any) string {
 	return strings.TrimSpace(renderTemplateNoTrimSpace(env, segmentTemplate, context))
 }
 

--- a/src/segments/scm_test.go
+++ b/src/segments/scm_test.go
@@ -111,7 +111,7 @@ func TestTruncateBranch(t *testing.T) {
 		Expected   string
 		Branch     string
 		FullBranch bool
-		MaxLength  interface{}
+		MaxLength  any
 	}{
 		{Case: "No limit", Expected: "are-belong-to-us", Branch: "/all-your-base/are-belong-to-us", FullBranch: false},
 		{Case: "No limit - larger", Expected: "are-belong", Branch: "/all-your-base/are-belong-to-us", FullBranch: false, MaxLength: 10.0},
@@ -146,8 +146,8 @@ func TestTruncateBranchWithSymbol(t *testing.T) {
 		Expected       string
 		Branch         string
 		FullBranch     bool
-		MaxLength      interface{}
-		TruncateSymbol interface{}
+		MaxLength      any
+		TruncateSymbol any
 	}{
 		{Case: "No limit", Expected: "are-belong-to-us", Branch: "/all-your-base/are-belong-to-us", FullBranch: false, TruncateSymbol: "..."},
 		{Case: "No limit - larger", Expected: "are-belong...", Branch: "/all-your-base/are-belong-to-us", FullBranch: false, MaxLength: 10.0, TruncateSymbol: "..."},

--- a/src/segments/withings.go
+++ b/src/segments/withings.go
@@ -29,8 +29,8 @@ type Body struct {
 }
 
 type MeasureGroup struct {
-	Measures []*Measure  `json:"measures"`
-	Comment  interface{} `json:"comment"`
+	Measures []*Measure `json:"measures"`
+	Comment  any        `json:"comment"`
 }
 
 type Measure struct {

--- a/src/template/compare.go
+++ b/src/template/compare.go
@@ -1,19 +1,36 @@
 package template
 
-func interFaceToInt(e interface{}) int {
-	if val, OK := e.(int); OK {
-		return val
+import (
+	"errors"
+	"strconv"
+)
+
+func toIntOrZero(e any) int {
+	if value, err := toInt(e); err == nil {
+		return value
 	}
-	if val, OK := e.(float64); OK {
-		return int(val)
-	}
-	if val, OK := e.(int64); OK {
-		return int(val)
-	}
+
 	return 0
 }
 
-func interfaceToFloat64(e interface{}) float64 {
+func toInt(integer any) (int, error) {
+	switch seconds := integer.(type) {
+	default:
+		return 0, errors.New("invalid integer type")
+	case string:
+		return strconv.Atoi(seconds)
+	case int:
+		return seconds, nil
+	case int64:
+		return int(seconds), nil
+	case uint64:
+		return int(seconds), nil
+	case float64:
+		return int(seconds), nil
+	}
+}
+
+func toFloat64(e any) float64 {
 	if val, OK := e.(float64); OK {
 		return val
 	}
@@ -26,19 +43,19 @@ func interfaceToFloat64(e interface{}) float64 {
 	return 0
 }
 
-func gt(e1, e2 interface{}) bool {
+func gt(e1, e2 any) bool {
 	if val, OK := e1.(int); OK {
-		return val > interFaceToInt(e2)
+		return val > toIntOrZero(e2)
 	}
 	if val, OK := e1.(int64); OK {
-		return val > int64(interFaceToInt(e2))
+		return val > int64(toIntOrZero(e2))
 	}
 	if val, OK := e1.(float64); OK {
-		return val > interfaceToFloat64(e2)
+		return val > toFloat64(e2)
 	}
 	return false
 }
 
-func lt(e1, e2 interface{}) bool {
+func lt(e1, e2 any) bool {
 	return gt(e2, e1)
 }

--- a/src/template/compare_test.go
+++ b/src/template/compare_test.go
@@ -10,8 +10,8 @@ func TestGt(t *testing.T) {
 	cases := []struct {
 		Case     string
 		Expected bool
-		E1       interface{}
-		E2       interface{}
+		E1       any
+		E2       any
 	}{
 		{Case: "Float vs int", Expected: false, E1: float64(3), E2: 4},
 		{Case: "Int vs float", Expected: false, E1: 3, E2: float64(4)},
@@ -33,8 +33,8 @@ func TestLt(t *testing.T) {
 	cases := []struct {
 		Case     string
 		Expected bool
-		E1       interface{}
-		E2       interface{}
+		E1       any
+		E2       any
 	}{
 		{Case: "Float vs int", Expected: true, E1: float64(3), E2: 4},
 		{Case: "Int vs float", Expected: true, E1: 3, E2: float64(4)},

--- a/src/template/func_map.go
+++ b/src/template/func_map.go
@@ -7,7 +7,7 @@ import (
 )
 
 func funcMap() template.FuncMap {
-	funcMap := map[string]interface{}{
+	funcMap := map[string]any{
 		"secondsRound": secondsRound,
 		"url":          url,
 		"path":         path,

--- a/src/template/list.go
+++ b/src/template/list.go
@@ -19,7 +19,7 @@ func (l List) Empty() bool {
 	return len(l) == 0
 }
 
-func (l List) Resolve(context interface{}, env platform.Environment, defaultValue string, logic Logic) string {
+func (l List) Resolve(context any, env platform.Environment, defaultValue string, logic Logic) string {
 	switch logic {
 	case FirstMatch:
 		return l.FirstMatch(context, env, defaultValue)
@@ -30,7 +30,7 @@ func (l List) Resolve(context interface{}, env platform.Environment, defaultValu
 	}
 }
 
-func (l List) Join(context interface{}, env platform.Environment) string {
+func (l List) Join(context any, env platform.Environment) string {
 	if len(l) == 0 {
 		return ""
 	}
@@ -50,7 +50,7 @@ func (l List) Join(context interface{}, env platform.Environment) string {
 	return buffer.String()
 }
 
-func (l List) FirstMatch(context interface{}, env platform.Environment, defaultValue string) string {
+func (l List) FirstMatch(context any, env platform.Environment, defaultValue string) string {
 	if len(l) == 0 {
 		return defaultValue
 	}

--- a/src/template/round.go
+++ b/src/template/round.go
@@ -1,27 +1,9 @@
 package template
 
 import (
-	"errors"
 	"strconv"
 	"strings"
 )
-
-func toInt(integer any) (int, error) {
-	switch seconds := integer.(type) {
-	default:
-		return 0, errors.New("invalid integer type")
-	case string:
-		return strconv.Atoi(seconds)
-	case int:
-		return seconds, nil
-	case int64:
-		return int(seconds), nil
-	case uint64:
-		return int(seconds), nil
-	case float64:
-		return int(seconds), nil
-	}
-}
 
 func secondsRound(seconds any) string {
 	s, err := toInt(seconds)

--- a/src/template/text.go
+++ b/src/template/text.go
@@ -42,12 +42,12 @@ var (
 
 type Text struct {
 	Template        string
-	Context         interface{}
+	Context         any
 	Env             platform.Environment
 	TemplatesResult string
 }
 
-type Data interface{}
+type Data any
 
 type Context struct {
 	*platform.TemplateCache
@@ -91,7 +91,7 @@ func (t *Text) Render() (string, error) {
 		return "", errors.New(msg["MSG"])
 	}
 	text := buffer.String()
-	// issue with missingkey=zero ignored for map[string]interface{}
+	// issue with missingkey=zero ignored for map[string]any
 	// https://github.com/golang/go/issues/24963
 	text = strings.ReplaceAll(text, "<no value>", "")
 	return text, nil
@@ -195,7 +195,7 @@ func (t *Text) cleanTemplate() {
 
 type fields map[string]bool
 
-func (f *fields) init(data interface{}) {
+func (f *fields) init(data any) {
 	if data == nil {
 		return
 	}
@@ -208,7 +208,7 @@ func (f *fields) init(data interface{}) {
 			(*f)[val.Field(i).Name] = true
 		}
 	case reflect.Map:
-		m, ok := data.(map[string]interface{})
+		m, ok := data.(map[string]any)
 		if !ok {
 			return
 		}

--- a/src/template/text_test.go
+++ b/src/template/text_test.go
@@ -19,7 +19,7 @@ func TestRenderTemplate(t *testing.T) {
 		Expected    string
 		Template    string
 		ShouldError bool
-		Context     interface{}
+		Context     any
 	}{
 		{
 			Case:     "dot literal",
@@ -184,7 +184,7 @@ func TestRenderTemplateEnvVar(t *testing.T) {
 		Template    string
 		ShouldError bool
 		Env         map[string]string
-		Context     interface{}
+		Context     any
 	}{
 		{
 			Case:        "nil struct with env var",
@@ -197,7 +197,7 @@ func TestRenderTemplateEnvVar(t *testing.T) {
 			Case:     "map with env var",
 			Expected: "hello world",
 			Template: "{{.Env.HELLO}} {{.World}}",
-			Context:  map[string]interface{}{"World": "world"},
+			Context:  map[string]any{"World": "world"},
 			Env:      map[string]string{"HELLO": "hello"},
 		},
 		{
@@ -208,7 +208,7 @@ func TestRenderTemplateEnvVar(t *testing.T) {
 			Env:      map[string]string{"HELLO": "hello"},
 		},
 		{Case: "no env var", Expected: "hello world", Template: "{{.Text}} world", Context: struct{ Text string }{Text: "hello"}},
-		{Case: "map", Expected: "hello world", Template: "{{.Text}} world", Context: map[string]interface{}{"Text": "hello"}},
+		{Case: "map", Expected: "hello world", Template: "{{.Text}} world", Context: map[string]any{"Text": "hello"}},
 		{Case: "empty map", Expected: " world", Template: "{{.Text}} world", Context: map[string]string{}},
 		{
 			Case:     "Struct with duplicate property",
@@ -228,14 +228,14 @@ func TestRenderTemplateEnvVar(t *testing.T) {
 			Case:     "Map with duplicate property",
 			Expected: "posh",
 			Template: "{{ .OS }}",
-			Context:  map[string]interface{}{"OS": "posh"},
+			Context:  map[string]any{"OS": "posh"},
 			Env:      map[string]string{"HELLO": "hello"},
 		},
 		{
 			Case:     "Non-supported map",
 			Expected: "darwin",
 			Template: "{{ .OS }}",
-			Context:  map[int]interface{}{},
+			Context:  map[int]any{},
 			Env:      map[string]string{"HELLO": "hello"},
 		},
 	}
@@ -336,7 +336,7 @@ func TestCleanTemplate(t *testing.T) {
 	for _, tc := range cases {
 		tmpl := &Text{
 			Template: tc.Template,
-			Context:  map[string]interface{}{"OS": "posh"},
+			Context:  map[string]any{"OS": "posh"},
 		}
 		tmpl.cleanTemplate()
 		assert.Equal(t, tc.Expected, tmpl.Template, tc.Case)


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ef66d0a</samp>

This pull request replaces the use of `interface{}` with a type alias `any` in various places in the codebase, to simplify the code and avoid importing conflicts. It also refactors some type conversion functions in the `template` package and fixes some minor typos and formatting issues in the tests. The affected files are mostly in the `src` directory, and include `config.go`, `migrate.go`, `migrate_test.go`, `shell.go`, `map.go`, `map_test.go`, `path_test.go`, `scm_test.go`, `compare.go`, `compare_test.go`, `list.go`, `segment.go`, `oauth_test.go`, `request_test.go`, `battery_openbsd.go`, `battery_openbsd_test.go`, `az.go`, `withings.go`, `func_map.go`, and `round.go`.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ef66d0a</samp>

*  Replace `interface{}` type with `any` type alias for consistency and simplicity ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-25963a790b4b92626029512213de64d81d974f422e9789c33bbe890eadfccb6aL37-R56), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-25963a790b4b92626029512213de64d81d974f422e9789c33bbe890eadfccb6aL177-R177), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-25963a790b4b92626029512213de64d81d974f422e9789c33bbe890eadfccb6aL188-R188), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-6904ccffc0b1c3fcf977c70a12e731c9f30fbfd18bd6e6f0e7beedef255195b9L44-R44), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-6904ccffc0b1c3fcf977c70a12e731c9f30fbfd18bd6e6f0e7beedef255195b9L63-R63), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-4dc8564adef53b078cb7db85f7695adaf782a08080a802afe00e883523a9a19eL186-R186), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-cd158856c1b1aa6b2acece8041eb07352e4247b700e0fc62798a6be35d5f1c7dL68-R68), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-e8f0f250e56958d00d1994e4453aa1e2566a77e3227f898371f517ffc0fc9e9dL146-R146), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-f1f7e3e0d133037e9f1ad20ff52e9153ad3a10047c0b6f75323ab41af4a24d9bL65-R65), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-7b082f4396f0c936b17e8deb6c4ea8ec54cb48509691b08354c28ef55aa18557L193-R193), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-7b082f4396f0c936b17e8deb6c4ea8ec54cb48509691b08354c28ef55aa18557L805-R805), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-0044a9a19ca72098e39ba3b1f785dccd5badeabaa8c933f201f9e09a5d1cf863L92-R92), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-4520f5edb1858f47eb8d0587569b2c946ce24059b37775b3e3aff2f58c0bdc5fL57-R57), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-4520f5edb1858f47eb8d0587569b2c946ce24059b37775b3e3aff2f58c0bdc5fL161-R165), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-4520f5edb1858f47eb8d0587569b2c946ce24059b37775b3e3aff2f58c0bdc5fL176-R180), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-4520f5edb1858f47eb8d0587569b2c946ce24059b37775b3e3aff2f58c0bdc5fL188-R188), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-4520f5edb1858f47eb8d0587569b2c946ce24059b37775b3e3aff2f58c0bdc5fL195-R195), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-a93d1da7b913cd6e04afc0dc7d2a8f768551cacad4605cdce066003d3554d345L36-R44), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-aa603356267e7fdaa699c49f047552a020509f6da4df2d15535f9f32ddfa3959L17-R17), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-aa603356267e7fdaa699c49f047552a020509f6da4df2d15535f9f32ddfa3959L45-R45), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-7d1a7a0695fa52d84eedcbfc5ace07b029ba6f83dbde3f11d4f05dcdbf381de8L114-R114), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-7d1a7a0695fa52d84eedcbfc5ace07b029ba6f83dbde3f11d4f05dcdbf381de8L149-R150), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-4286127167daee528835bdda7d7548370358aedd4be9925feb38e887a372477eL32-R33), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-ccb0d8751745f8295be5d2981238b136044c0c451e0e01044fc6692781eec3ceL13-R14), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-ccb0d8751745f8295be5d2981238b136044c0c451e0e01044fc6692781eec3ceL36-R37), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-fb476f29de832fca91da97cc9d9f278b83db39959969543c1793a9e875340131L10-R10), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-78d9180ebcddc96e6f39707a33c3cdb260c7ea67a8263673aeb5f452bf2d4abaL22-R22), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-78d9180ebcddc96e6f39707a33c3cdb260c7ea67a8263673aeb5f452bf2d4abaL33-R33), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-78d9180ebcddc96e6f39707a33c3cdb260c7ea67a8263673aeb5f452bf2d4abaL53-R53))
*  Define `any` type alias as `interface{}` in `src/engine/config.go` ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-25963a790b4b92626029512213de64d81d974f422e9789c33bbe890eadfccb6aL37-R56))
*  Replace `interFaceToInt` and `interfaceToFloat64` functions with `toIntOrZero` and `toFloat64` functions in `src/template/compare.go` to avoid code duplication and use consistent functions ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-37ca761b0b699ea711fc1e940225cd16d9af95808222826422dcf1e79371a7d1L3-R33), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-37ca761b0b699ea711fc1e940225cd16d9af95808222826422dcf1e79371a7d1L29-R59))
*  Move `toIntOrZero` and `toInt` functions from `src/engine/config.go` to `src/template/compare.go` ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-25963a790b4b92626029512213de64d81d974f422e9789c33bbe890eadfccb6aL37-R56), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-37ca761b0b699ea711fc1e940225cd16d9af95808222826422dcf1e79371a7d1L3-R33))
*  Remove unused imports from `src/template/round.go` ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-96f3684b092ce608c25d8aaa19f02289d4702d0f671c1f6caefe0d8f2b129729L4-R7))
*  Fix typo in `ExpectedPercentage` field type in `src/platform/battery/battery_openbsd_test.go` ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-c71bc8bc6d3b6af71dd71539d3d9d2c3871af7f6fd700d809a9fdd7ebac510d1L11-R15))
*  Fix indentation of `StatusOutput` fields in `src/platform/battery/battery_openbsd_test.go` ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-c71bc8bc6d3b6af71dd71539d3d9d2c3871af7f6fd700d809a9fdd7ebac510d1L21-R21), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-c71bc8bc6d3b6af71dd71539d3d9d2c3871af7f6fd700d809a9fdd7ebac510d1L28-R28), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-c71bc8bc6d3b6af71dd71539d3d9d2c3871af7f6fd700d809a9fdd7ebac510d1L35-R35), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-c71bc8bc6d3b6af71dd71539d3d9d2c3871af7f6fd700d809a9fdd7ebac510d1L42-R42), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-c71bc8bc6d3b6af71dd71539d3d9d2c3871af7f6fd700d809a9fdd7ebac510d1L49-R49))
*  Remove trailing whitespace in `src/platform/battery/battery_openbsd.go` ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4269/files?diff=unified&w=0#diff-f1bdd468a11e20b2be6e03c039411406d021103b9736ad55d3bcd34dd4e000c1L53-R55))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
