### PR TITLE
fix(ansi): reset transparent on override end

### DIFF
--- a/src/ansi/ansi_writer_test.go
+++ b/src/ansi/ansi_writer_test.go
@@ -200,6 +200,12 @@ func TestWriteANSIColors(t *testing.T) {
 			Expected: "\x1b[47m\x1b[30mhello, \x1b[31mworld, \x1b[37mrabbit\x1b[31m hello\x1b[0m",
 			Colors:   &Colors{Foreground: "black", Background: "white"},
 		},
+		{
+			Case:     "Transparent override",
+			Input:    "home<transparent> / </>code<transparent> / </>src ",
+			Expected: "\x1b[47m\x1b[30mhome\x1b[0m\x1b[37;49m\x1b[7m / \x1b[27m\x1b[47m\x1b[30mcode\x1b[0m\x1b[37;49m\x1b[7m / \x1b[27m\x1b[47m\x1b[30msrc \x1b[0m",
+			Colors:   &Colors{Foreground: "black", Background: "white"},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9bce6c0</samp>

This pull request enhances the `ansi_writer` module to handle transparent backgrounds for color overrides, and adds a test case for this feature. It also fixes a bug and refactors a defer statement in the same module.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9bce6c0</samp>

*  Add support for transparent background tag in ANSI writer ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4281/files?diff=unified&w=0#diff-0267d2a06e9c5eab5a04e9625772dd68774a70872a4014630cdb15183ce7dcd9L505-R522), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4281/files?diff=unified&w=0#diff-7214a6ffb60e6b167949f626066440b0deabc9698c4e7923aa23478ab773476aR203-R208))
* Fix logical error in endColorOverride function ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4281/files?diff=unified&w=0#diff-0267d2a06e9c5eab5a04e9625772dd68774a70872a4014630cdb15183ce7dcd9L496-R496))
* Move defer statement to pop colors from stack to endColorOverride function ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4281/files?diff=unified&w=0#diff-0267d2a06e9c5eab5a04e9625772dd68774a70872a4014630cdb15183ce7dcd9L485-L487))

resolves #4280

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
