### PR TITLE
Update atomic.omp.json

### DIFF
--- a/themes/atomic.omp.json
+++ b/themes/atomic.omp.json
@@ -210,7 +210,7 @@
             "windows": "\ue70f"
           },
           "style": "diamond",
-          "template": " {{ if .WSL }}WSL at {{ end }}{{.Icon}}<#262626> \ue0b2</>",
+          "template": " {{ if .WSL }}WSL at {{ end }}{{.Icon}}<#222222> \ue0b2</>",
           "type": "os"
         },
         {


### PR DESCRIPTION
there was a minor bug in the color of diamond connecting OS logo and battery
<this is my first PR to a big project like this>

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2bc4de2</samp>

Changed the os segment background color in the `atomic.omp.json` theme file to improve the visual consistency of the atomic theme.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2bc4de2</samp>

* Changed the background color of the os segment to match the rest of the theme ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4289/files?diff=unified&w=0#diff-3fde3ea20945c5b898727a3366729171f7995d9e2f3d20821edb5d1b3eafbf1fL213-R213))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
