### PR TITLE
fix(ansi): pop color at the end of the text

### DIFF
--- a/src/ansi/ansi_writer.go
+++ b/src/ansi/ansi_writer.go
@@ -342,7 +342,7 @@ func (w *Writer) Write(background, foreground, text string) {
 	// reset colors
 	w.writeEscapedAnsiString(resetStyle.End)
 
-	// reset current
+	// pop last color from the stack
 	w.current.Pop()
 }
 
@@ -487,6 +487,7 @@ func (w *Writer) endColorOverride(position int) int {
 
 	// do not restore colors at the end of the string, we print it anyways
 	if position == len(w.runes)-1 {
+		w.current.Pop()
 		return position
 	}
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2e81302</samp>

Fixed a color override bug and improved documentation in the `ansi` package. This ensures that segments have the correct colors and that the code is easier to understand.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2e81302</samp>

*  Clarify comment about color stack behavior ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4293/files?diff=unified&w=0#diff-0267d2a06e9c5eab5a04e9625772dd68774a70872a4014630cdb15183ce7dcd9L345-R345))
*  Fix bug with color override not being cleared when ending a segment ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4293/files?diff=unified&w=0#diff-0267d2a06e9c5eab5a04e9625772dd68774a70872a4014630cdb15183ce7dcd9R490))

resolves #4290

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
