### PR TITLE
feature(devcontainer): prebuild oh my posh

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -38,11 +38,6 @@ RUN echo 'deb http://download.opensuse.org/repositories/shells:/fish:/release:/3
 
 ARG USERNAME=vscode
 
-# Download the oh-my-posh binary
-RUN mkdir /home/${USERNAME}/bin; \
-    wget https://github.com/JanDeDobbeleer/oh-my-posh/releases/latest/download/posh-linux-$(dpkg --print-architecture) -O /home/${USERNAME}/bin/oh-my-posh; \
-    chmod +x /home/${USERNAME}/bin/oh-my-posh; \
-    chown ${USERNAME}: /home/${USERNAME}/bin;
 
 # NOTE: devcontainers are Linux-only at this time but when
 # Windows or Darwin is supported someone will need to improve

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -73,5 +73,9 @@
     }
   },
   // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-  "remoteUser": "vscode"
+  "remoteUser": "vscode",
+  // This is running the same command as the VSCode Task 'devcontainer: rebuild oh-my-posh'
+  // It Compiles *oh-my-posh* from this repo while **overwriting** your preinstalled stable release.'
+  // Ideal for getting straight into developing & testing whilst using a devcontainer
+  "updateContentCommand": "cd src && go build -v -buildvcs=false -o /home/vscode/bin/oh-my-posh -ldflags \"-s -w -X 'github.com/jandedobbeleer/oh-my-posh/src/build.Version=development-$(git --no-pager log -1 --pretty=%h-%s)' -extldflags '-static'\""
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Test Notes
This uses the devcontainer.json property `updateContentCommand` to run the same command that is the VSCode task named `devcontainer: rebuild oh-my-posh`
https://containers.dev/implementors/json_reference/#lifecycle-scripts

![image](https://github.com/JanDeDobbeleer/oh-my-posh/assets/1389894/7fa252ba-9d56-43fd-af3f-c879db1f4f3c)

This means we can get straight stuck into development when working inside a GitHub Codespace or locally run Docker DevContainer and not forget why our changes are not working because we forgot to run the task 🙈 

* Spin up a new GitHub Codespace or DevContainer
* Once CodeSpace is run & open the same command for building it locally is run
* Go straight to the terminal and run `oh-my-posh version`

### Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cc5c4f7</samp>

Add a `updateContentCommand` to `devcontainer.json` to compile `oh-my-posh` from source in the devcontainer. This enables testing and debugging the latest changes in the prompt theme engine.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cc5c4f7</samp>

*  Add a `updateContentCommand` property to the `devcontainer.json` file to automatically compile the `oh-my-posh` executable from the source code in the devcontainer ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4322/files?diff=unified&w=0#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L76-R80))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
