### PR TITLE
fix(git): initialize status prior to bare repo check

### DIFF
--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -167,6 +167,9 @@ func (g *Git) Enabled() bool {
 
 	g.RepoName = platform.Base(g.env, g.convertToLinuxPath(g.realDir))
 
+	g.Working = &GitStatus{}
+	g.Staging = &GitStatus{}
+
 	if g.IsBare {
 		g.getBareRepoInfo()
 		return true
@@ -186,8 +189,6 @@ func (g *Git) Enabled() bool {
 		g.setBranchStatus()
 	} else {
 		g.setPrettyHEADName()
-		g.Working = &GitStatus{}
-		g.Staging = &GitStatus{}
 	}
 	if g.props.GetBool(FetchUpstreamIcon, false) {
 		g.UpstreamIcon = g.getUpstreamIcon()


### PR DESCRIPTION
resolves #4330

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c682fe7</samp>

Fix panic in `git` segment for bare repositories and remove redundant code. Simplify the `Git` struct and its usage in `src/segments/git.go`.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c682fe7</samp>

* Fix panic in git segment with bare repository by initializing `Working` and `Staging` fields of `g` ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4334/files?diff=unified&w=0#diff-5ca08bba45ba772ce1cbd182429db15292b228ac7c5dc0cf370dcbe55611fd92R170-R172))
* Remove redundant initialization of `Working` and `Staging` fields of `g` for code cleanup and optimization ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4334/files?diff=unified&w=0#diff-5ca08bba45ba772ce1cbd182429db15292b228ac7c5dc0cf370dcbe55611fd92L189-L190))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
