### PR TITLE
refactor: remove io/ioutil

### DIFF
--- a/src/engine/image_test.go
+++ b/src/engine/image_test.go
@@ -1,7 +1,6 @@
 package engine
 
 import (
-	"io/ioutil" //nolint:staticcheck,nolintlint
 	"os"
 	"path/filepath"
 	"testing"
@@ -29,7 +28,7 @@ var cases = []struct {
 
 func runImageTest(config, content string) (string, error) {
 	poshImagePath := "jandedobbeleer.png"
-	file, err := ioutil.TempFile("", poshImagePath)
+	file, err := os.CreateTemp("", poshImagePath)
 	if err != nil {
 		return "", err
 	}

--- a/src/font/install_unix.go
+++ b/src/font/install_unix.go
@@ -5,7 +5,6 @@
 package font
 
 import (
-	"io/ioutil" //nolint:staticcheck,nolintlint
 	"os"
 	"path"
 	"strings"
@@ -27,5 +26,5 @@ func install(font *Font, _ bool) error {
 		return err
 	}
 
-	return ioutil.WriteFile(fullPath, font.Data, 0644)
+	return os.WriteFile(fullPath, font.Data, 0644)
 }

--- a/src/platform/battery/battery_linux.go
+++ b/src/platform/battery/battery_linux.go
@@ -24,7 +24,6 @@ package battery
 import (
 	"errors"
 	"fmt"
-	"io/ioutil" //nolint:staticcheck,nolintlint
 	"os"
 	"path/filepath"
 	"strconv"
@@ -43,7 +42,7 @@ func newState(name string) (State, error) {
 }
 
 func readFloat(path, filename string) (float64, error) {
-	str, err := ioutil.ReadFile(filepath.Join(path, filename))
+	str, err := os.ReadFile(filepath.Join(path, filename))
 	if err != nil {
 		return 0, err
 	}
@@ -66,12 +65,12 @@ func readAmp(path, filename string, volts float64) (float64, error) {
 }
 
 func isBattery(path string) bool {
-	t, err := ioutil.ReadFile(filepath.Join(path, "type"))
+	t, err := os.ReadFile(filepath.Join(path, "type"))
 	return err == nil && string(t) == "Battery\n"
 }
 
 func getBatteryFiles() ([]string, error) {
-	files, err := ioutil.ReadDir(sysfs)
+	files, err := os.ReadDir(sysfs)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +118,7 @@ func getByPath(path string) (*battery, error) {
 		}
 	}
 
-	state, err := ioutil.ReadFile(filepath.Join(path, "status"))
+	state, err := os.ReadFile(filepath.Join(path, "status"))
 	if err != nil || len(state) == 0 {
 		return nil, errors.New("unable to parse or invalid status")
 	}


### PR DESCRIPTION


### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [n/a] Tests for the changes have been added (for bug fixes / features).
- [n/a] Docs have been added/updated (for bug fixes / features).

### Description

io/ioutil has been deprected since go 1.16
https://pkg.go.dev/io/ioutil


### How


<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
