### PR TITLE
docs: fix broken links after rename(overview->general)

### DIFF
--- a/themes/schema.json
+++ b/themes/schema.json
@@ -3,7 +3,7 @@
   "$id": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
   "type": "object",
   "title": "The Oh My Posh theme definition",
-  "description": "https://ohmyposh.dev/docs/configuration/overview",
+  "description": "https://ohmyposh.dev/docs/configuration/general",
   "definitions": {
     "color": {
       "anyOf": [
@@ -3295,13 +3295,13 @@
     "final_space": {
       "type": "boolean",
       "title": "Final Space",
-      "description": "https://ohmyposh.dev/docs/configuration/overview#general-settings",
+      "description": "https://ohmyposh.dev/docs/configuration/general#general-settings",
       "default": true
     },
     "disable_cursor_positioning": {
       "type": "boolean",
       "title": "Disable Cursor Positioning",
-      "description": "https://ohmyposh.dev/docs/configuration/overview#general-settings",
+      "description": "https://ohmyposh.dev/docs/configuration/general#general-settings",
       "default": false
     },
     "shell_integration": {
@@ -3312,7 +3312,7 @@
     "pwd": {
       "type": "string",
       "title": "Enable OSC99/7/51",
-      "description": "https://ohmyposh.dev/docs/configuration/overview#general-settings",
+      "description": "https://ohmyposh.dev/docs/configuration/general#general-settings",
       "default": ""
     },
     "console_title_template": {
@@ -3328,7 +3328,7 @@
       "type": "array",
       "title": "Block array",
       "default": [],
-      "description": "https://ohmyposh.dev/docs/configuration/overview#blocks",
+      "description": "https://ohmyposh.dev/docs/configuration/general#blocks",
       "items": {
         "$ref": "#/definitions/block"
       }

--- a/website/docs/installation/customize.mdx
+++ b/website/docs/installation/customize.mdx
@@ -275,11 +275,10 @@ Inside the WSL, you can find your Windows user's home folder here: `/mnt/c/Users
 
 Maybe there's a theme you like, but you don't fancy the colors. Or, maybe there's a segment you
 want to tweak/add, or replace some of the icons with a different one. Whatever the case, **read through
-available options first**, by starting with the [configuration guide][configuration].
+available options first**, by starting with the [configuration][configuration].
 
 You can export the current theme (default, or set via `--config`) to the format you like (`json`, `yaml`, or `toml`)
 which can be used to tweak and store as your own custom theme.
-
 
 ```bash
 oh-my-posh config export --output ~/.mytheme.omp.json
@@ -298,7 +297,7 @@ The [configuration][configuration] section covers the basic building blocks and 
 segments section covers how to configure each available segment.
 
 [themes]: themes.md
-[configuration]: configuration/overview.mdx
+[configuration]: configuration/general.mdx
 [prompt]: prompt.mdx
 [jandedobbeleer]: /docs/themes#jandedobbeleer
 [json-schema]: https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json

--- a/website/docs/installation/fonts.mdx
+++ b/website/docs/installation/fonts.mdx
@@ -114,6 +114,5 @@ The `minimal` themes do not make use of Nerd Font icons.
 [nerdfonts]: https://www.nerdfonts.com/
 [meslo]: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.0.2/Meslo.zip
 [themes]: https://github.com/JanDeDobbeleer/oh-my-posh/tree/main/themes
-[font-thread]: https://github.com/JanDeDobbeleer/oh-my-posh/issues/145#issuecomment-730162622
-[configuration]: /docs/configuration/overview
+[configuration]: /docs/installation/customize
 [wt-issue-8993]: https://github.com/microsoft/terminal/issues/8993

--- a/website/docs/installation/linux.mdx
+++ b/website/docs/installation/linux.mdx
@@ -59,9 +59,3 @@ curl -s https://ohmyposh.dev/install.sh | bash -s -- -d ~/bin
 <Next />
 
 [fonts]: /docs/installation/fonts
-[scoop]: https://scoop.sh/
-[wt]: https://github.com/microsoft/terminal
-[iterm2]: https://www.iterm2.com/
-[powershell]: https://www.powershellgallery.com/packages/oh-my-posh
-[configuration]: /docs/configuration/overview
-[themes]: /docs/themes

--- a/website/docs/installation/macos.mdx
+++ b/website/docs/installation/macos.mdx
@@ -26,8 +26,3 @@ To display all icons, we recommend the use of a [Nerd Font][fonts].
 
 [256-colors]: /docs/configuration/colors#standard-colors
 [fonts]: /docs/installation/fonts
-[scoop]: https://scoop.sh/
-[wt]: https://github.com/microsoft/terminal
-[iterm2]: https://www.iterm2.com/
-[powershell]: https://www.powershellgallery.com/packages/oh-my-posh
-[configuration]: /docs/configuration/overview


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

https://github.com/JanDeDobbeleer/oh-my-posh/issues/4338

overview->general links fixed + unneeded hyperlinks removed installation section

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 316a5fc</samp>

Updated and removed links in the website docs and the schema file to match the new documentation structure and avoid irrelevant or broken references. This improves the clarity and consistency of the documentation for users and developers of `oh-my-posh`.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 316a5fc</samp>

*  Update description URLs of schema properties to point to the new general configuration page ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4348/files?diff=unified&w=0#diff-892c540c9bfebcb3bb8a0be1714201cd17eb6f0d40367c09f80d56e883b7335eL6-R6), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4348/files?diff=unified&w=0#diff-892c540c9bfebcb3bb8a0be1714201cd17eb6f0d40367c09f80d56e883b7335eL3298-R3298), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4348/files?diff=unified&w=0#diff-892c540c9bfebcb3bb8a0be1714201cd17eb6f0d40367c09f80d56e883b7335eL3304-R3304), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4348/files?diff=unified&w=0#diff-892c540c9bfebcb3bb8a0be1714201cd17eb6f0d40367c09f80d56e883b7335eL3315-R3315), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4348/files?diff=unified&w=0#diff-892c540c9bfebcb3bb8a0be1714201cd17eb6f0d40367c09f80d56e883b7335eL3331-R3331))
*  Update links to the configuration guide and page in the `customize.mdx` file to point to the new general configuration page ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4348/files?diff=unified&w=0#diff-bc801131a5c62b2aad904a0908d5b3702547be0d5fa0fc7337085e7c5dc56759L278-R282), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4348/files?diff=unified&w=0#diff-bc801131a5c62b2aad904a0908d5b3702547be0d5fa0fc7337085e7c5dc56759L301-R300))
*  Remove link to the font-thread and update link to the customize page in the `fonts.mdx` file ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4348/files?diff=unified&w=0#diff-5c8e0ab19afeeaa35e6eb2a66123d403b41ab9a2414f2007836aa008edd46a16L117-R117))
*  Remove irrelevant links for linux users in the `linux.mdx` file ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4348/files?diff=unified&w=0#diff-d779dbc7df5991d5fd62eae99c6ba1f2dc11686d4f8b7ac9ff6b5b6ef1be3a30L61-L66))
*  Remove irrelevant links for macos users in the `macos.mdx` file ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4348/files?diff=unified&w=0#diff-5318aa49951fe4475354c530eaa6c8f4c792a73cf7e36fd3d42e96529f1ea63dL28-L32))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
