### PR TITLE
fix(os): icon not showing up on almalinux. added 'almalinux' to the icon map

### DIFF
--- a/src/segments/os.go
+++ b/src/segments/os.go
@@ -51,6 +51,7 @@ func (oi *Os) Enabled() bool {
 func (oi *Os) getDistroIcon(distro string) string {
 	iconMap := map[string]string{
 		"alma":                "\uF31D",
+		"almalinux":           "\uF31D",
 		"almalinux9":          "\uF31D",
 		"alpine":              "\uF300",
 		"aosc":                "\uF301",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [] Tests for the changes have been added (for bug fixes / features).
- [] Docs have been added/updated (for bug fixes / features).

### Description
on almalinux 9.2 (Turquoise Kodkod) icons don't seem to be working.
it seems that its detected as 'almalinux' instead of 'almalinux9' or 'alma'

### how
 adding 'almalinux' to the icon map seems to fix it