### PR TITLE
multiple fixes

### DIFF
--- a/src/platform/shell_unix.go
+++ b/src/platform/shell_unix.go
@@ -100,14 +100,22 @@ func (env *Shell) Platform() string {
 
 func (env *Shell) CachePath() string {
 	defer env.Trace(time.Now())
+
+	// allow the user to set the cache path using OMP_CACHE_DIR
+	if cachePath := returnOrBuildCachePath(env.Getenv("OMP_CACHE_DIR")); len(cachePath) != 0 {
+		return cachePath
+	}
+
 	// get XDG_CACHE_HOME if present
 	if cachePath := returnOrBuildCachePath(env.Getenv("XDG_CACHE_HOME")); len(cachePath) != 0 {
 		return cachePath
 	}
+
 	// HOME cache folder
 	if cachePath := returnOrBuildCachePath(env.Home() + "/.cache"); len(cachePath) != 0 {
 		return cachePath
 	}
+
 	return env.Home()
 }
 


### PR DESCRIPTION
- fix(git): do not convert path when using native_fallback in WSL
- feat(shell): allow user to specify the cache path with OMP_CACHE_DIR

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0237901</samp>

This pull request enhances the `scm` segment for WSL users and adds a new option to customize the cache path for oh-my-posh. It also improves the code style and documentation of some files.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0237901</samp>

*  Add `OMP_CACHE_DIR` environment variable to set cache path for oh-my-posh ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4358/files?diff=unified&w=0#diff-1f02b7ad2e3778653d9ceeb0b98bb4dda191717162633780a40773a03ffc2d65L103-R118))
*  Add `nativeFallback` field to `scm` type to use native command as fallback when command.exe version is not available or fails ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4358/files?diff=unified&w=0#diff-46c523a7233881c05a54e9ec352285789f795a767894b241c58aa13259a4738cL91-R95))
*  Skip path conversion when `nativeFallback` is true in `convertToWindowsPath` function ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4358/files?diff=unified&w=0#diff-46c523a7233881c05a54e9ec352285789f795a767894b241c58aa13259a4738cL138-R146))
*  Set `nativeFallback` to true when native command is used as fallback in `hasCommand` function ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4358/files?diff=unified&w=0#diff-46c523a7233881c05a54e9ec352285789f795a767894b241c58aa13259a4738cL171-R186))
*  Explain logic of `hasCommand` function with comment and add blank lines for readability ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4358/files?diff=unified&w=0#diff-46c523a7233881c05a54e9ec352285789f795a767894b241c58aa13259a4738cR154), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4358/files?diff=unified&w=0#diff-46c523a7233881c05a54e9ec352285789f795a767894b241c58aa13259a4738cL155-R176))
*  Add blank lines for readability in `branchName` function ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4358/files?diff=unified&w=0#diff-46c523a7233881c05a54e9ec352285789f795a767894b241c58aa13259a4738cL114-R124))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
