### PR TITLE
fix(pwsh): validate theme path existence

### DIFF
--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -301,13 +301,11 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
             $List
         )
 
-        if ($Path -eq "") {
-            do {
-                $temp = Read-Host 'Please enter the themes path'
-            }
-            while (-not (Test-Path -LiteralPath $temp))
-            $Path = (Resolve-Path -Path $temp).ProviderPath
+        while (-not (Test-Path -LiteralPath $Path)) {
+            $Path = Read-Host 'Please enter the themes path'
         }
+
+        $Path = (Resolve-Path -Path $temp).ProviderPath
 
         $logo = @'
    __  _____ _      ___  ___       ______         _      __

--- a/website/static/install.sh
+++ b/website/static/install.sh
@@ -127,8 +127,9 @@ install() {
     info "⬇️  Downloading oh-my-posh from ${url}"
 
     http_response=$(curl -s -f -L $url -o $executable -w "%{http_code}")
-    if [ $http_response != "200" ]; then
-        error "Unable to download executable at ${url}\nPlease validate your connection and/or proxy settings"
+
+    if [ $http_response != "200" ] || [ ! -f $executable ]; then
+        error "Unable to download executable at ${url}\nPlease validate your curl, connection and/or proxy settings"
     fi
 
     chmod +x $executable
@@ -139,15 +140,19 @@ install() {
     info "🎨 Installing oh-my-posh themes in ${cache_dir}/themes\n"
 
     theme_dir="${cache_dir}/themes"
-    url="https://github.com/JanDeDobbeleer/oh-my-posh/releases/latest/download/themes.zip"
     mkdir -p $theme_dir
-    http_response=$(curl -s -f -L $url -o ${cache_dir}/themes.zip -w "%{http_code}")
-    if [ $http_response == "200" ]; then
-        unzip -o -q ${cache_dir}/themes.zip -d $theme_dir
+    zip_file="${cache_dir}/themes.zip"
+
+    url="https://github.com/JanDeDobbeleer/oh-my-posh/releases/latest/download/themes.zip"
+
+    http_response=$(curl -s -f -L $url -o $zip_file -w "%{http_code}")
+
+    if [ $http_response == "200" ] && [ -f $zip_file ]; then
+        unzip -o -q $zip_file -d $theme_dir
         chmod u+rw ${theme_dir}/*.omp.*
-        rm ${cache_dir}/themes.zip
+        rm $zip_file
     else
-        warn "Unable to download themes at ${url}\nPlease validate your connection and/or proxy settings"
+        warn "Unable to download themes at ${url}\nPlease validate your curl, connection and/or proxy settings"
     fi
 
     info "🚀 Installation complete.\n\nYou can follow the instructions at https://ohmyposh.dev/docs/installation/prompt"


### PR DESCRIPTION
resolves #4359

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cb932ac</samp>

Simplified the user input validation logic in `omp.ps1` by using a while loop instead of a do-while loop.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cb932ac</samp>

*  Simplify the user input validation for themes path using a while loop ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4362/files?diff=unified&w=0#diff-878b46f4ae6c1a83e8ee23b152cb60b8d8292218d8c268485633454ac42580c8L304-R309))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
