### PR TITLE
feat(nu): transient prompt

### DIFF
--- a/src/shell/scripts/omp.nu
+++ b/src/shell/scripts/omp.nu
@@ -6,31 +6,36 @@ $env.PROMPT_INDICATOR = ""
 $env.POSH_PID = (random uuid)
 $env.POSH_SHELL_VERSION = (version | get version)
 
+def posh_cmd_duration [] {
+    # We have to do this because the initial value of `$env.CMD_DURATION_MS` is always `0823`,
+    # which is an official setting.
+    # See https://github.com/nushell/nushell/discussions/6402#discussioncomment-3466687.
+    if $env.CMD_DURATION_MS == "0823" { 0 } else { $env.CMD_DURATION_MS }
+}
+
+def posh_width [] {
+    (term size).columns | into string
+}
+
 # PROMPTS
 $env.PROMPT_MULTILINE_INDICATOR = (^::OMP:: print secondary $"--config=($env.POSH_THEME)" --shell=nu $"--shell-version=($env.POSH_SHELL_VERSION)")
 
 $env.PROMPT_COMMAND = { ||
-    # We have to do this because the initial value of `$env.CMD_DURATION_MS` is always `0823`,
-    # which is an official setting.
-    # See https://github.com/nushell/nushell/discussions/6402#discussioncomment-3466687.
-    let cmd_duration = if $env.CMD_DURATION_MS == "0823" { 0 } else { $env.CMD_DURATION_MS }
-
     # hack to set the cursor line to 1 when the user clears the screen
     # this obviously isn't bulletproof, but it's a start
     let clear = (history | last 1 | get 0.command) == "clear"
 
-    let width = ((term size).columns | into string)
-    ^::OMP:: print primary $"--config=($env.POSH_THEME)" --shell=nu $"--shell-version=($env.POSH_SHELL_VERSION)" $"--execution-time=($cmd_duration)" $"--status=($env.LAST_EXIT_CODE)" $"--terminal-width=($width)" $"--cleared=($clear)"
+    ^::OMP:: print primary $"--config=($env.POSH_THEME)" --shell=nu $"--shell-version=($env.POSH_SHELL_VERSION)" $"--execution-time=(posh_cmd_duration)" $"--status=($env.LAST_EXIT_CODE)" $"--terminal-width=(posh_width)" $"--cleared=($clear)"
 }
 
-$env.PROMPT_COMMAND_RIGHT = { ||
-    # We have to do this because the initial value of `$env.CMD_DURATION_MS` is always `0823`,
-    # which is an official setting.
-    # See https://github.com/nushell/nushell/discussions/6402#discussioncomment-3466687.
-    let cmd_duration = if $env.CMD_DURATION_MS == "0823" { 0 } else { $env.CMD_DURATION_MS }
+$env.PROMPT_COMMAND_RIGHT = { ||    
+    ^::OMP:: print right $"--config=($env.POSH_THEME)" --shell=nu $"--shell-version=($env.POSH_SHELL_VERSION)" $"--execution-time=(posh_cmd_duration)" $"--status=($env.LAST_EXIT_CODE)" $"--terminal-width=(posh_width)"
+}
 
-    let width = ((term size).columns | into string)
-    ^::OMP:: print right $"--config=($env.POSH_THEME)" --shell=nu $"--shell-version=($env.POSH_SHELL_VERSION)" $"--execution-time=($cmd_duration)" $"--status=($env.LAST_EXIT_CODE)" $"--terminal-width=($width)"
+if "::TRANSIENT::" == "true" {
+    $env.TRANSIENT_PROMPT_COMMAND = { ||
+        ^::OMP:: print transient $"--config=($env.POSH_THEME)" --shell=nu $"--shell-version=($env.POSH_SHELL_VERSION)" $"--execution-time=(posh_cmd_duration)" $"--status=($env.LAST_EXIT_CODE)" $"--terminal-width=(posh_width)"
+    }
 }
 
 if "::UPGRADE::" == "true" {

--- a/website/docs/configuration/transient.mdx
+++ b/website/docs/configuration/transient.mdx
@@ -8,7 +8,7 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
 :::info
-This feature only works in `fish`, `zsh`, `powershell` (`ConstrainedLanguage` mode unsupported) and `cmd` for the time being.
+This feature only works in `nu`, `fish`, `zsh`, `powershell` (`ConstrainedLanguage` mode unsupported) and `cmd` for the time being.
 :::
 
 Transient prompt, when enabled, replaces the prompt with a simpler one to allow more screen real estate.

--- a/website/docs/installation/customize.mdx
+++ b/website/docs/installation/customize.mdx
@@ -158,7 +158,7 @@ Once altered, reload your config for the changes to take effect.
 <TabItem value="nu">
 
 :::caution
-Oh My Posh requires Nushell v0.84.0 or higher.
+Oh My Posh requires Nushell v0.86.0 or higher.
 :::
 
 Adjust the Oh My Posh init line in the Nushell env file (`$nu.env-path`) by adding the `--config` flag

--- a/website/docs/installation/prompt.mdx
+++ b/website/docs/installation/prompt.mdx
@@ -104,7 +104,7 @@ exec fish
 <TabItem value="nu">
 
 :::caution
-Oh My Posh requires Nushell v0.84.0 or higher.
+Oh My Posh requires Nushell v0.86.0 or higher.
 :::
 
 Add the following line to the Nushell env file (`$nu.env-path`):


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b007609</samp>

Refactor and update the `omp.nu` script to enable the transient prompt feature for Nushell. Update the documentation to reflect the new feature and the minimum version requirement of Nushell v0.86.0.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b007609</samp>

*  Refactor `omp.nu` script to define helper functions and enable transient prompt feature for Nushell ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4363/files?diff=unified&w=0#diff-b4e6f5d564c90b8bcff9623c6cae46e5a6fe4379bd352f7e188c3c09d1289c02L9-R38))
* Update documentation to include Nushell as a supported shell for the transient prompt feature and require Nushell v0.86.0 or higher for Oh My Posh ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4363/files?diff=unified&w=0#diff-e1e570bbebcbc328f3e48f813f67ea67130c514b02bd02a3f592f8678a348014L11-R11), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4363/files?diff=unified&w=0#diff-bc801131a5c62b2aad904a0908d5b3702547be0d5fa0fc7337085e7c5dc56759L161-R161), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4363/files?diff=unified&w=0#diff-bfb275d8f295325f4e636f8ffe143c735c0f0c17e1bde1ed2ec51ff2933683edL107-R107))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
