### PR TITLE
Update-folder-icon-insonicboom_dark.omp.json

### DIFF
--- a/themes/sonicboom_dark.omp.json
+++ b/themes/sonicboom_dark.omp.json
@@ -41,7 +41,7 @@
           "foreground": "#43CCEA",
           "properties": {
             "folder_icon": "\ue5fe",
-            "folder_separator_icon": "<transparent> \ue0bd </>",
+            "folder_separator_icon": " <#000000>\ue0bd </>",
             "home_icon": "\ueb06",
             "style": "agnoster_short"
           },


### PR DESCRIPTION
Adjust the separate folder icon to not cut the home icon in path

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bcf7e1d</samp>

Changed the color of the folder separator icon in the `sonicboom_dark` theme to fix a visibility issue. This theme is a JSON file for the oh-my-posh prompt customization tool.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bcf7e1d</samp>

* Change the folder separator icon color to black for better contrast ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4369/files?diff=unified&w=0#diff-482bc099f7e8f67390b807acf6cac1fefae7c5204f8b1aacb9373c7abc77cc69L44-R44))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
