### PR TITLE
theme: Updated java version foreground color to white from red in atomic.omp.json

### DIFF
--- a/themes/atomic.omp.json
+++ b/themes/atomic.omp.json
@@ -94,7 +94,7 @@
         },
         {
           "background": "#0e8ac8",
-          "foreground": "#ec2729",
+          "foreground": "#ffffff",
           "leading_diamond": "\ue0b6",
           "style": "diamond",
           "template": "\ue738 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }}",


### PR DESCRIPTION
Red foreground is difficult to read on a blue background that's why changed it to white which looks good and is easier to read.

Before:
![image](https://github.com/JanDeDobbeleer/oh-my-posh/assets/25565506/77bedad8-5ea8-4df2-ac47-2fc42adf9320)

After: 
![image](https://github.com/JanDeDobbeleer/oh-my-posh/assets/25565506/4151d6cc-221a-4d9b-877a-ddfd18fe5ac6)

