### PR TITLE
Add kdracula theme

### DIFF
--- a/themes/kdracula.omp.json
+++ b/themes/kdracula.omp.json
@@ -1,0 +1,141 @@
+{
+    "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
+    "version": 2,
+    "final_space": true,
+    "blocks": [
+      {
+        "type": "prompt",
+        "alignment": "left",
+        "segments": [
+          {
+            "type": "os",
+            "style": "diamond",
+            "foreground": "#ffffff",
+            "background": "#0c7bbb",
+            "leading_diamond": "\u256d\u2500\ue0b2",
+            "template": " {{ if .WSL }}\ue712 on {{ end }}{{ .Icon }}  ",
+            "properties": {
+              "alpine": "\uf300",
+              "arch": "\uf303",
+              "centos": "\uf304",
+              "debian": "\uf306",
+              "elementary": "\uf309",
+              "fedora": "\uf30a",
+              "gentoo": "\uf30d",
+              "linux": "\ue712",
+              "macos": "\ue711",
+              "manjaro": "\uf312",
+              "mint": "\uf30f",
+              "opensuse": "\uf314",
+              "raspbian": "\uf315",
+              "ubuntu": "\uf31c",
+              "windows": "\ue70f"
+            }
+          },
+          {
+            "type": "text",
+            "style": "diamond",
+            "powerline_symbol": "\ue0b0",
+            "foreground": "#ffffff",
+            "background": "#DA627D",
+            "template": " 🏠  "
+          },
+          {
+            "type": "path",
+            "style": "powerline",
+            "powerline_symbol": "\ue0b0",
+            "foreground": "#ffffff",
+            "background": "#8a62da",
+            "template": " {{ .Path }} ",
+            "properties": {
+              "style": "folder"
+            }
+          },
+          {
+            "type": "git",
+            "style": "powerline",
+            "powerline_symbol": "\ue0b0",
+            "foreground": "#43CCEA",
+            "foreground_templates": [
+              "{{ if or (.Working.Changed) (.Staging.Changed) }}#FF9248{{ end }}",
+              "{{ if and (gt .Ahead 0) (gt .Behind 0) }}#ff4500{{ end }}",
+              "{{ if gt .Ahead 0 }}#B388FF{{ end }}",
+              "{{ if gt .Behind 0 }}#B388FF{{ end }}"
+            ],
+            "background": "#191f48",
+            "trailing_diamond": "\ue0b4",
+            "template": " {{ .UpstreamIcon }}{{ .HEAD }}{{if .BranchStatus }} {{ .BranchStatus }}{{ end }}{{ if .Working.Changed }} \uf044 {{ .Working.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }} \uf046 {{ .Staging.String }}{{ end }}{{ if gt .StashCount 0 }} \ueb4b {{ .StashCount }}{{ end }} ",
+            "properties": {
+              "branch_max_length": 25,
+              "fetch_stash_count": true,
+              "fetch_status": true,
+              "fetch_upstream_icon": true
+            }
+          }
+        ],
+        "newline": true
+      },
+      {
+        "type": "prompt",
+        "alignment": "right",
+        "segments": [
+          {
+            "type": "sysinfo",
+            "style": "diamond",
+            "foreground": "#81ff91",
+            "template": "<#cc7eda> | </><#7eb8da>RAM:</> {{ (div ((sub .PhysicalTotalMemory .PhysicalFreeMemory)|float64) 1000000000.0) }}/{{ (div .PhysicalTotalMemory 1000000000.0) }}GB"
+          },
+          {
+            "type": "ruby",
+            "style": "powerline",
+            "foreground": "#E0115F",
+            "template": " <#cc7eda> | </><#7eb8da>\ue739</> {{ .Full }}",
+            "properties": {
+              "fetch_version": true
+            }
+          },
+          {
+            "type": "node",
+            "style": "powerline",
+            "foreground": "#81ff91",
+            "template": "<#cc7eda> | </><#7eb8da>\ue718</> {{ if .PackageManagerIcon }}{{ .PackageManagerIcon }} {{ end }}{{ .Full }}",
+            "properties": {
+              "fetch_version": true
+            }
+          },
+          {
+            "type": "php",
+            "style": "powerline",
+            "foreground": "#81ff91",
+            "template": "<#cc7eda> | </><#7eb8da>\ue73d</> {{ .Full }}"
+          },
+          {
+            "type": "npm",
+            "style": "powerline",
+            "foreground": "#81ff91",
+            "template": "<#cc7eda> | </><#7eb8da>\ue71e </> {{ .Full }}"
+          },
+          {
+            "type": "sysinfo",
+            "style": "powerline",
+            "foreground": "#81ff91",
+            "template": "<> </>"
+          }
+        ]
+      },
+      {
+        "type": "prompt",
+        "alignment": "left",
+        "segments": [
+          {
+            "type": "text",
+            "style": "plain",
+            "foreground": "#0c7bbb",
+            "template": "\u2570\u2500"
+          }
+        ],
+        "newline": true
+      }
+    ]
+  }
+  


### PR DESCRIPTION
### Prerequisites

- [X] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [X] The commit message follows the [conventional commits][cc] guidelines.
- [X] Tests for the changes have been added (for bug fixes / features).
- [X] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ae40d05</samp>

Add a new theme file `kdracula.omp.json` for oh-my-posh that uses the Dracula color scheme and various symbols to create a custom prompt. The theme file is compatible with the version 2 format of the tool and is part of a pull request that introduces new themes.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ae40d05</samp>

*  Add a new theme file `themes/kdracula.omp.json` for oh-my-posh based on the Dracula color scheme and using icons, powerline symbols, and diamonds ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4377/files?diff=unified&w=0#diff-2d157ccbc9844334fbfd654d947851baf908d79e241a1716139ba1f513ba9436R1-R141))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
