### PR TITLE
fix(pwsh): use correct path variable

### DIFF
--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -305,7 +305,7 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
             $Path = Read-Host 'Please enter the themes path'
         }
 
-        $Path = (Resolve-Path -Path $temp).ProviderPath
+        $Path = (Resolve-Path -Path $Path).ProviderPath
 
         $logo = @'
    __  _____ _      ___  ___       ______         _      __


### PR DESCRIPTION
resolves #4385

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at af9df68</samp>

Fix a bug in `omp.ps1` that overwrites the `$Path` variable and prevents resolving the oh-my-posh executable. This is part of a pull request to improve the installation and update process of oh-my-posh on Windows PowerShell.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at af9df68</samp>

* Fix bug where `$Path` variable was overwritten by `$temp` variable in `omp.ps1` ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4395/files?diff=unified&w=0#diff-878b46f4ae6c1a83e8ee23b152cb60b8d8292218d8c268485633454ac42580c8L308-R308))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
