### PR TITLE
chore: build linux 386

### DIFF
--- a/src/.goreleaser.yml
+++ b/src/.goreleaser.yml
@@ -31,8 +31,6 @@ builds:
     ignore:
       - goos: darwin
         goarch: "386"
-      - goos: linux
-        goarch: "386"
       - goos: darwin
         goarch: arm
       - goos: windows

--- a/website/static/install.sh
+++ b/website/static/install.sh
@@ -39,7 +39,7 @@ while getopts ":hd:" option; do
    esac
 done
 
-SUPPORTED_TARGETS="linux-amd64 linux-arm linux-arm64 darwin-amd64 darwin-arm64"
+SUPPORTED_TARGETS="linux-386 linux-amd64 linux-arm linux-arm64 darwin-amd64 darwin-arm64"
 
 validate_dependency() {
     if ! command -v $1 >/dev/null; then
@@ -171,6 +171,7 @@ detect_arch() {
     armv*) arch="arm" ;;
     arm64) arch="arm64" ;;
     aarch64) arch="arm64" ;;
+    i686) arch="386" ;;
   esac
 
   if [ "${arch}" = "arm64" ] && [ "$(getconf LONG_BIT)" -eq 32 ]; then


### PR DESCRIPTION
relates to #4397

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4db85cc</samp>

This pull request adds support for installing oh-my-posh on 32-bit Linux systems, by modifying the `install.sh` script and removing the linux-386 build from the `.goreleaser.yml` file.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4db85cc</samp>

* Remove linux-386 build from goreleaser configuration, as it is not supported by the binary ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4401/files?diff=unified&w=0#diff-107f8a530a936d499769641b3bab12988441052d939e7f7a8bcf7765cdb1d254L34-L35))
* Add linux-386 option to supported targets in install script, to allow manual installation on that platform ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4401/files?diff=unified&w=0#diff-72cd6af69c1a958194793b5b6e3c2e799830084925263fd71b3bb84808ea978dL42-R42))
* Handle i686 architecture in install script, by mapping it to 386 arch ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4401/files?diff=unified&w=0#diff-72cd6af69c1a958194793b5b6e3c2e799830084925263fd71b3bb84808ea978dR174))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
