### PR TITLE
fix(themes): yarn nerdfont 3.x icon codepoint

### DIFF
--- a/src/engine/config_test.go
+++ b/src/engine/config_test.go
@@ -56,6 +56,8 @@ func TestEscapeGlyphs(t *testing.T) {
 		{Input: "\ufd03", Expected: "\\ufd03"},
 		{Input: "}", Expected: "}"},
 		{Input: "🏚", Expected: "🏚"},
+		{Input: "\U000F011B", Expected: "\\udb80\\udd1b"},
+		{Input: "󰄛", Expected: "\\udb80\\udd1b"},
 	}
 	for _, tc := range cases {
 		assert.Equal(t, tc.Expected, escapeGlyphs(tc.Input, false), tc.Input)

--- a/src/segments/node.go
+++ b/src/segments/node.go
@@ -55,7 +55,7 @@ func (n *Node) loadContext() {
 		return
 	}
 	if n.language.env.HasFiles("yarn.lock") {
-		n.PackageManagerIcon = n.language.props.GetString(YarnIcon, "\uF011B")
+		n.PackageManagerIcon = n.language.props.GetString(YarnIcon, "\U000F011B")
 		return
 	}
 	if n.language.env.HasFiles("package-lock.json") || n.language.env.HasFiles("package.json") {

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -1500,7 +1500,7 @@
                     "type": "string",
                     "title": "Yarn Icon",
                     "description": "Icon/text to use for Yarn",
-                    "default": " \uF011B"
+                    "default": " \udb80\udd1b"
                   },
                   "npm_icon": {
                     "type": "string",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 450512d</samp>

This pull request fixes a bug in the Yarn icon display and adds tests and schema updates to ensure consistency. It changes the escape sequence for the Yarn icon from `\u` to `\U` in `node.go`, `config_test.go`, and `themes/schema.json`.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 450512d</samp>

* Fix Yarn icon display bug by using `\U` escape sequence for Unicode code point `\U000F011B` in `node.go` ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4407/files?diff=unified&w=0#diff-8f30f858aba84cb58a520682d09848b527cfce5b9970f6037eea804191953eadL58-R58))
* Update default value of Yarn icon in `themes/schema.json` to match the `\U` escape sequence ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4407/files?diff=unified&w=0#diff-892c540c9bfebcb3bb8a0be1714201cd17eb6f0d40367c09f80d56e883b7335eL1503-R1503))
* Add test cases for escaping Unicode code point `\U000F011B` and glyph `󰄛` in `config_test.go` ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4407/files?diff=unified&w=0#diff-c95d3ec80b3fecf7d41fa28718433e5976d6b4a277011f4c9e4dbeb4f28662aaR59-R60))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
