### PR TITLE
refactor(migrate): delete redundant type conversion

### DIFF
--- a/src/engine/migrate.go
+++ b/src/engine/migrate.go
@@ -65,7 +65,7 @@ func (segment *Segment) migrationOne(env platform.Environment) {
 		segment.migrateIconOverride("stash_count_icon", " \uF692 ")
 		segment.migrateIconOverride("worktree_count_icon", " \uf1bb ")
 		segment.migrateIconOverride("status_separator_icon", " |")
-		if segment.Properties.GetBool(properties.Property("status_colors_enabled"), false) {
+		if segment.Properties.GetBool("status_colors_enabled", false) {
 			background := segment.Properties.GetBool(colorBackground, true)
 			segment.migrateColorOverride("local_changes_color", "{{ if or (.Working.Changed) (.Staging.Changed) }}%s{{ end }}", background)
 			segment.migrateColorOverride("ahead_and_behind_color", "{{ if and (gt .Ahead 0) (gt .Behind 0) }}%s{{ end }}", background)
@@ -87,10 +87,10 @@ func (segment *Segment) migrationOne(env platform.Environment) {
 		segment.migrateColorOverride("charging_color", `{{ if eq "Charging" .State.String }}%s{{ end }}`, background)
 		segment.migrateColorOverride("discharging_color", `{{ if eq "Discharging" .State.String }}%s{{ end }}`, background)
 		stateList := []string{`"Discharging"`}
-		if segment.Properties.GetBool(properties.Property("display_charging"), true) {
+		if segment.Properties.GetBool("display_charging", true) {
 			stateList = append(stateList, `"Charging"`)
 		}
-		if segment.Properties.GetBool(properties.Property("display_charged"), true) {
+		if segment.Properties.GetBool("display_charged", true) {
 			stateList = append(stateList, `"Full"`)
 		}
 		if len(stateList) < 3 {
@@ -112,10 +112,10 @@ func (segment *Segment) migrationOne(env platform.Environment) {
 		segment.migrateIconOverride("ssh_icon", "\ueba9 ")
 		template := segment.Properties.GetString(segmentTemplate, segment.writer.Template())
 		template = strings.ReplaceAll(template, ".ComputerName", ".HostName")
-		if !segment.Properties.GetBool(properties.Property("display_host"), true) {
+		if !segment.Properties.GetBool("display_host", true) {
 			template = strings.ReplaceAll(template, "@{{ .HostName }}", "")
 		}
-		if !segment.Properties.GetBool(properties.Property("display_user"), true) {
+		if !segment.Properties.GetBool("display_user", true) {
 			template = strings.ReplaceAll(template, "@", "")
 			template = strings.ReplaceAll(template, "{{ .UserName }}", "")
 		}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- ~~[ ] Tests for the changes have been added (for bug fixes / features).~~
- ~~[ ] Docs have been added/updated (for bug fixes / features).~~

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 478c228</samp>

Refactored and simplified segment properties handling in `migrate.go`. Used a map and string keys instead of a custom type and enum values.

`Property` is a defined type [^3] with underlying type of `string` [^1].

https://github.com/JanDeDobbeleer/oh-my-posh/blob/0706a5b14481e2ec145d2ac4ef87a981f9d5eee8/src/properties/map.go#L20-L21

From the Go specification [^2]:

> "two types are identical if their underlying type literals are structurally equivalent".

Therefore, we don't need to explicitly convert the string values to `Property`.

[^1]: https://go.dev/ref/spec#Underlying_types
[^2]: https://go.dev/ref/spec#Type_identity
[^3]: https://go.dev/ref/spec#Type_definitions

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 478c228</samp>

*  Simplify the `segment.Properties.GetBool` method to use a string argument instead of a `properties.Property` argument ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4410/files?diff=unified&w=0#diff-4dc8564adef53b078cb7db85f7695adaf782a08080a802afe00e883523a9a19eL68-R68), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4410/files?diff=unified&w=0#diff-4dc8564adef53b078cb7db85f7695adaf782a08080a802afe00e883523a9a19eL90-R93), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4410/files?diff=unified&w=0#diff-4dc8564adef53b078cb7db85f7695adaf782a08080a802afe00e883523a9a19eL115-R118))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
