### PR TITLE
fix(pwsh): wrap keyhandlers in try/finally

### DIFF
--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -182,20 +182,27 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
 
     if (("::TRANSIENT::" -eq "true") -and ($ExecutionContext.SessionState.LanguageMode -ne "ConstrainedLanguage")) {
         Set-PSReadLineKeyHandler -Key Enter -BriefDescription 'OhMyPoshEnterKeyHandler' -ScriptBlock {
-            $executingCommand = Set-TransientPrompt
-            [Microsoft.PowerShell.PSConsoleReadLine]::AcceptLine()
-            # Write FTCS_COMMAND_EXECUTED after accepting the input - it should still happen before execution
-            if (("::FTCS_MARKS::" -eq "true") -and $executingCommand) {
-                Write-Host "$([char]0x1b)]133;C`a" -NoNewline
+            try {
+                $executingCommand = Set-TransientPrompt
+                [Microsoft.PowerShell.PSConsoleReadLine]::AcceptLine()
+                # Write FTCS_COMMAND_EXECUTED after accepting the input - it should still happen before execution
+                if (("::FTCS_MARKS::" -eq "true") -and $executingCommand) {
+                    Write-Host "$([char]0x1b)]133;C`a" -NoNewline
+                }
             }
+            finally {}
         }
         Set-PSReadLineKeyHandler -Key Ctrl+c -BriefDescription 'OhMyPoshCtrlCKeyHandler' -ScriptBlock {
-            $start = $null
-            [Microsoft.PowerShell.PSConsoleReadLine]::GetSelectionState([ref]$start, [ref]$null)
-            # only render a transient prompt when no text is selected
-            if ($start -eq -1) {
-                Set-TransientPrompt
+            try {
+                $start = $null
+                [Microsoft.PowerShell.PSConsoleReadLine]::GetSelectionState([ref]$start, [ref]$null)
+                # only render a transient prompt when no text is selected
+                if ($start -eq -1) {
+                    Set-TransientPrompt
+                }
             }
+            finally {}
+
             [Microsoft.PowerShell.PSConsoleReadLine]::CopyOrCancelLine()
         }
     }
@@ -209,7 +216,9 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
                 $executingCommand = $parseErrors.Count -eq 0
             }
             finally {}
+
             [Microsoft.PowerShell.PSConsoleReadLine]::AcceptLine()
+
             # Write FTCS_COMMAND_EXECUTED after accepting the input - it should still happen before execution
             if ($executingCommand) {
                 Write-Host "$([char]0x1b)]133;C`a" -NoNewline


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5a9632f</samp>

Fix transient prompt bug and improve code style in `omp.ps1` script. The script now handles errors and breakpoints more gracefully and is easier to read.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5a9632f</samp>

* Fix a bug where the transient prompt would not be restored after an error or a breakpoint in the debugger by adding a try-finally block around the script blocks for the Enter and Ctrl+c key handlers in `omp.ps1` ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4420/files?diff=unified&w=0#diff-878b46f4ae6c1a83e8ee23b152cb60b8d8292218d8c268485633454ac42580c8L185-R205))
* Improve the readability and consistency of the code in the Enter key handler by adding a blank line before and after the call to `[Microsoft.PowerShell.PSConsoleReadLine]::AcceptLine()` in `omp.ps1` ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4420/files?diff=unified&w=0#diff-878b46f4ae6c1a83e8ee23b152cb60b8d8292218d8c268485633454ac42580c8L212-R221))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
