### PR TITLE
Ignore TFM if not found

### DIFF
--- a/src/segments/project_test.go
+++ b/src/segments/project_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/alecthomas/assert"
 
+	mock2 "github.com/stretchr/testify/mock"
 	testify_mock "github.com/stretchr/testify/mock"
 )
 
@@ -343,8 +344,8 @@ func TestDotnetProject(t *testing.T) {
 			Case:            "invalid or empty contents",
 			FileName:        "Invalid.csproj",
 			HasFiles:        true,
-			ExpectedEnabled: false,
-			ExpectedString:  "cannot extract TFM from Invalid project file",
+			ExpectedEnabled: true,
+			ExpectedString:  "Invalid",
 		},
 		{
 			Case:            "no files",
@@ -370,6 +371,7 @@ func TestDotnetProject(t *testing.T) {
 			},
 		})
 		env.On("FileContent", tc.FileName).Return(tc.ProjectContents)
+		env.On("Error", mock2.Anything)
 		pkg := &Project{}
 		pkg.Init(properties.Map{}, env)
 		assert.Equal(t, tc.ExpectedEnabled, pkg.Enabled(), tc.Case)


### PR DESCRIPTION
### Prerequisites

- [X] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [X] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

Visual Studio solution and solution filter files do not have a TFM (`Target`) and fail because of that.

### How

Defaulted to an empty string for the `Target` when not found.


I can add unit tests for this, but I'm no GO programmer and I haven't found any.

If someone points me at a similar feature, I can add the tests.