### PR TITLE
feat(git): add .LatestTag template property

### DIFF
--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -832,3 +832,7 @@ func (g *Git) getSwitchMode(property properties.Property, gitSwitch, mode string
 	}
 	return fmt.Sprintf("%s%s", gitSwitch, mode)
 }
+
+func (g *Git) LatestTag() string {
+	return g.getGitCommandOutput("describe", "--tags", "--abbrev=0")
+}

--- a/website/docs/segments/git.mdx
+++ b/website/docs/segments/git.mdx
@@ -158,6 +158,7 @@ You can set the following properties to `true` to enable fetching additional inf
 | `.Rebase`        | `boolean` | true when in a rebase                                                                                                            |
 | `.CherryPick`    | `boolean` | true when in a cherry pick                                                                                                       |
 | `.Revert`        | `boolean` | true when in a revert                                                                                                            |
+| `.LatestTag`     | `string`  | the latest tag name                                                                                                       |
 
 ### Status
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 39bff29</samp>

This pull request adds a new option to the `Git` segment to show the latest tag name for the current git repo. It also updates the documentation and the theme schema to reflect the new feature.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 39bff29</samp>

*  Add a new feature to the git segment that allows users to display the latest tag name for the git repo in their prompt ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4422/files?diff=unified&w=0#diff-5ca08bba45ba772ce1cbd182429db15292b228ac7c5dc0cf370dcbe55611fd92R69-R70), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4422/files?diff=unified&w=0#diff-5ca08bba45ba772ce1cbd182429db15292b228ac7c5dc0cf370dcbe55611fd92R145), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4422/files?diff=unified&w=0#diff-5ca08bba45ba772ce1cbd182429db15292b228ac7c5dc0cf370dcbe55611fd92R199-R203), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4422/files?diff=unified&w=0#diff-892c540c9bfebcb3bb8a0be1714201cd17eb6f0d40367c09f80d56e883b7335eR917-R922), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4422/files?diff=unified&w=0#diff-8396c4caea4be2af52706d5b8d5f1ff73062c8b0274d540d6a4cace1ffa277caR83), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4422/files?diff=unified&w=0#diff-8396c4caea4be2af52706d5b8d5f1ff73062c8b0274d540d6a4cace1ffa277caR162))
  *  Add a new boolean property `FetchLatestTag` to the `segments` package and the `themes/schema.json` file, with a default value of false and a title and description for the user interface ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4422/files?diff=unified&w=0#diff-5ca08bba45ba772ce1cbd182429db15292b228ac7c5dc0cf370dcbe55611fd92R69-R70), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4422/files?diff=unified&w=0#diff-892c540c9bfebcb3bb8a0be1714201cd17eb6f0d40367c09f80d56e883b7335eR917-R922))
  *  Add a new string field `LatestTag` to the `Git` type, which stores the latest tag name for the git repo ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4422/files?diff=unified&w=0#diff-5ca08bba45ba772ce1cbd182429db15292b228ac7c5dc0cf370dcbe55611fd92R145))
  *  Add a new block of code to the `Enabled` function of the `Git` type, which checks if the `FetchLatestTag` property is set to true, and if so, runs a git command to get the latest tag name and assigns it to the `LatestTag` field ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4422/files?diff=unified&w=0#diff-5ca08bba45ba772ce1cbd182429db15292b228ac7c5dc0cf370dcbe55611fd92R199-R203))
  *  Add a new row to the table in the `website/docs/segments/git.mdx` file, which documents the `FetchLatestTag` property and its default value and description for the users of the git segment ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4422/files?diff=unified&w=0#diff-8396c4caea4be2af52706d5b8d5f1ff73062c8b0274d540d6a4cace1ffa277caR83))
  *  Add a new row to the table in the `website/docs/segments/git.mdx` file, which documents the `.LatestTag` template variable and its type and description for the users of the git segment ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4422/files?diff=unified&w=0#diff-8396c4caea4be2af52706d5b8d5f1ff73062c8b0274d540d6a4cace1ffa277caR162))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
