### PR TITLE
fix(zsh): correctly align right block

### DIFF
--- a/src/engine/block.go
+++ b/src/engine/block.go
@@ -129,14 +129,18 @@ func (b *Block) RenderSegments() (string, int) {
 		if !segment.Enabled && segment.style() != Accordion {
 			continue
 		}
+
 		if colors, newCycle := cycle.Loop(); colors != nil {
 			cycle = &newCycle
 			segment.colors = colors
 		}
+
 		b.setActiveSegment(segment)
 		b.renderActiveSegment()
 	}
+
 	b.writeSeparator(true)
+
 	return b.writer.String()
 }
 

--- a/src/engine/engine.go
+++ b/src/engine/engine.go
@@ -222,6 +222,14 @@ func (e *Engine) renderBlock(block *Block, cancelNewline bool) bool {
 			return false
 		}
 
+		// in ZSH, RPROMPT is printed with a trailing space
+		// to ensure alignment, we need to print a space here
+		// see https://github.com/JanDeDobbeleer/oh-my-posh/issues/4327
+		if e.Env.Shell() == shell.ZSH {
+			text += " "
+			length++
+		}
+
 		space, OK := e.canWriteRightBlock(false)
 		// we can't print the right block as there's not enough room available
 		if !OK {


### PR DESCRIPTION
resolves #4327

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 18dfc68</samp>

This pull request improves the readability of the `block.go` code and fixes a ZSH alignment bug in `engine.go`. It addresses the issue reported in #4327.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 18dfc68</samp>

* Fix ZSH RPROMPT alignment by appending a space to the block text and length if the shell is ZSH ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4431/files?diff=unified&w=0#diff-2621eae7a3bca7157aca7db673f968d3bd065529cd80f6b32e348807463ff78bR225-R232))
* Improve readability of block rendering by adding blank lines between different logic sections ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4431/files?diff=unified&w=0#diff-88a08b290b6321ea570d290d5ef5524c1d57feac559c1f9de7598ea22581d001L132-R143))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
