### PR TITLE
chore: lock issues after 6 months

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,29 @@
+name: 'Lock Threads'
+
+on:
+  schedule:
+    - cron: '0 0 * * 1'
+
+permissions:
+  issues: write
+
+concurrency:
+  group: lock
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@be8aa5be94131386884a6da4189effda9b14aa21
+        with:
+          issue-inactive-days: '182'
+          issue-comment: >
+            This issue has been automatically locked since there
+            has not been any recent activity (i.e. last half year) after it was closed.
+            It helps our maintainers focus on the active issues.
+
+            If you have found a problem that seems similar, please open a
+            [discussion](https://github.com/JanDeDobbeleer/oh-my-posh/discussions/new?category=troubleshoot)
+            first, complete the body with all the details necessary to reproduce,
+            and mention this issue as reference.
+          process-only: 'issues'


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 683f3c0</samp>

Add a GitHub action to lock closed issues after 182 days. This helps to keep the issue tracker clean and avoid confusion.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 683f3c0</samp>

* Add a new workflow file `lock.yml` to automatically lock closed issues after 182 days of inactivity ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4436/files?diff=unified&w=0#diff-d53fada4c18b028e40fe65252d480fbc1fe2220c0f3f1c6e39a802cbe2c3fc61R1-R29))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
