### PR TITLE
fix velvet

### DIFF
--- a/src/engine/image.go
+++ b/src/engine/image.go
@@ -299,7 +299,7 @@ var doubleWidthRunes = []RuneRange{
 	// Font Awesome Extension
 	{Start: '\ue200', End: '\ue2a9'},
 	// Material Design Icons
-	{Start: '\U000f0001', End: '\U000f0848'},
+	{Start: '\U000f0001', End: '\U000f1af0'},
 	// Weather
 	{Start: '\ue300', End: '\ue3eb'},
 	// Octicons

--- a/themes/velvet.omp.json
+++ b/themes/velvet.omp.json
@@ -72,7 +72,7 @@
             "always_enabled": true
           },
           "style": "diamond",
-          "template": " \ueb05{{ if gt .Code 0 }} {{.Code}}{{ end }} ",
+          "template": " \uf08a{{ if gt .Code 0 }} {{.Code}}{{ end }} ",
           "trailing_diamond": "\ue0b4",
           "type": "status"
         }


### PR DESCRIPTION
- themes(velvet): adjust heart icon
- fix(image): adjust material icons range

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5b539be</samp>

This pull request updates the Material Design Icons range in `image.go` and changes the git status icon in the velvet theme. These changes improve the compatibility and usability of oh-my-posh.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5b539be</samp>

*  Update Material Design Icons range to include latest icons ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4437/files?diff=unified&w=0#diff-4ad23c6dbe12603450e5bf41725eb341b55fa79a66d0941b57b88effd77be3e3L302-R302))
* Change git status icon in velvet theme from branch to fork ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4437/files?diff=unified&w=0#diff-4cca8b8536fe6b83e8e869229dbecced11673b7b58cffc14963f75ebb025deb2L75-R75))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
