### PR TITLE
Adjusts white space between words and icons on json theme

### DIFF
--- a/themes/json.omp.json
+++ b/themes/json.omp.json
@@ -10,7 +10,7 @@
             "style": "folder"
           },
           "style": "diamond",
-          "template": "<#42E66C>\u2B22 </> <b>{{ .Path }}</b> ",
+          "template": "<#42E66C>\u2B22 </><b>{{ .Path }}</b>",
           "type": "path"
         },
         {
@@ -19,13 +19,13 @@
             "branch_icon": ""
           },
           "style": "diamond",
-          "template": "<#ffffff>\u26A1</><b> {{ .HEAD }}</b>",
+          "template": "<#ffffff> \u26A1 </><b>{{ .HEAD }}</b>",
           "type": "git"
         },
         {
           "foreground": "#ff0000",
           "style": "diamond",
-          "template": "<#ff0000> \u25C9 </>",
+          "template": "<#ff0000> \u25C9</>",
           "type": "text"
         }
       ],


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b3f79e0</samp>

Fixed spacing issues in `json.omp.json` theme. Made segment templates more consistent and tidy.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b3f79e0</samp>

* Remove extra spaces in segment templates to make output more consistent and compact ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4439/files?diff=unified&w=0#diff-143306f18d504f7c05784564daae1cc6274bcd489a8460569f4ff6bae2d07866L13-R13), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4439/files?diff=unified&w=0#diff-143306f18d504f7c05784564daae1cc6274bcd489a8460569f4ff6bae2d07866L22-R22), [link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4439/files?diff=unified&w=0#diff-143306f18d504f7c05784564daae1cc6274bcd489a8460569f4ff6bae2d07866L28-R28)) in `json.omp.json`

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
