### PR TITLE
feat(segment): add bazel segment type

### DIFF
--- a/src/engine/segment.go
+++ b/src/engine/segment.go
@@ -104,6 +104,8 @@ const (
 	AZFUNC SegmentType = "azfunc"
 	// BATTERY writes the battery percentage
 	BATTERY SegmentType = "battery"
+	// BAZEL writes the bazel version
+	BAZEL SegmentType = "bazel"
 	// Brewfather segment
 	BREWFATHER SegmentType = "brewfather"
 	// Buf segment writes the active buf version
@@ -265,6 +267,7 @@ var Segments = map[SegmentType]func() SegmentWriter{
 	AZ:              func() SegmentWriter { return &segments.Az{} },
 	AZFUNC:          func() SegmentWriter { return &segments.AzFunc{} },
 	BATTERY:         func() SegmentWriter { return &segments.Battery{} },
+	BAZEL:           func() SegmentWriter { return &segments.Bazel{} },
 	BREWFATHER:      func() SegmentWriter { return &segments.Brewfather{} },
 	BUF:             func() SegmentWriter { return &segments.Buf{} },
 	CARBONINTENSITY: func() SegmentWriter { return &segments.CarbonIntensity{} },

--- a/src/segments/bazel.go
+++ b/src/segments/bazel.go
@@ -1,0 +1,44 @@
+package segments
+
+import (
+	"github.com/jandedobbeleer/oh-my-posh/src/platform"
+	"github.com/jandedobbeleer/oh-my-posh/src/properties"
+)
+
+type Bazel struct {
+	language
+
+	Icon string
+}
+
+const (
+	// Bazel's icon
+	Icon properties.Property = "icon"
+)
+
+func (c *Bazel) Template() string {
+	return " {{ if .Error }}{{ .Icon }} {{ .Error }}{{ else }}{{ url .Icon .URL }} {{ .Full }}{{ end }} "
+}
+
+func (c *Bazel) Init(props properties.Properties, env platform.Environment) {
+	c.language = language{
+		env:        env,
+		props:      props,
+		extensions: []string{"*.bazel", "*.bzl", "BUILD", "WORKSPACE", ".bazelrc", ".bazelversion"},
+		folders:    []string{"bazel-bin", "bazel-out", "bazel-testlogs"},
+		commands: []*cmd{
+			{
+				executable: "bazel",
+				args:       []string{"--version"},
+				regex:      `bazel (?P<version>((?P<major>[0-9]+).(?P<minor>[0-9]+).(?P<patch>[0-9]+)))`,
+			},
+		},
+		// Use the correct URL for Bazel 6.x. it does not have the docs subdomain.
+		versionURLTemplate: "https://{{ if ne .Major \"6\" }}docs.{{ end }}bazel.build/versions/{{ .Major }}.{{ .Minor }}.{{ .Patch }}",
+	}
+	c.Icon = props.GetString(Icon, "\ue63a")
+}
+
+func (c *Bazel) Enabled() bool {
+	return c.language.Enabled()
+}

--- a/src/segments/bazel_test.go
+++ b/src/segments/bazel_test.go
@@ -7,16 +7,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const icon = "\ue63a"
+
 func TestBazel(t *testing.T) {
 	cases := []struct {
 		Case           string
 		ExpectedString string
 		Version        string
+		Template       string
 	}{
-		{Case: "bazel 6.4.0", ExpectedString: "6.4.0", Version: "bazel 6.4.0"},
-		{Case: "bazel 10.11.12", ExpectedString: "10.11.12", Version: "bazel 10.11.12"},
-		{Case: "bazel error", ExpectedString: "err parsing info from bazel with", Version: ""},
-		{Case: "", ExpectedString: "err parsing info from bazel with", Version: ""},
+		{Case: "bazel 6.4.0", ExpectedString: fmt.Sprintf("«%s»(https://bazel.build/versions/6.4.0) 6.4.0", icon), Version: "bazel 6.4.0", Template: ""},
+		{Case: "bazel 10.11.12", ExpectedString: fmt.Sprintf("«%s»(https://docs.bazel.build/versions/3.7.0) 3.7.0", icon), Version: "bazel 3.7.0"},
+		{Case: "", ExpectedString: fmt.Sprintf("%s err parsing info from bazel with", icon), Version: ""},
 	}
 	for _, tc := range cases {
 		params := &mockedLanguageParams{
@@ -26,6 +28,7 @@ func TestBazel(t *testing.T) {
 			extension:     "*.bazel",
 		}
 		env, props := getMockedLanguageEnv(params)
+		props[Icon] = icon
 		b := &Bazel{}
 		b.Init(props, env)
 		failMsg := fmt.Sprintf("Failed in case: %s", tc.Case)

--- a/src/segments/bazel_test.go
+++ b/src/segments/bazel_test.go
@@ -1,0 +1,35 @@
+package segments
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBazel(t *testing.T) {
+	cases := []struct {
+		Case           string
+		ExpectedString string
+		Version        string
+	}{
+		{Case: "bazel 6.4.0", ExpectedString: "6.4.0", Version: "bazel 6.4.0"},
+		{Case: "bazel 10.11.12", ExpectedString: "10.11.12", Version: "bazel 10.11.12"},
+		{Case: "bazel error", ExpectedString: "err parsing info from bazel with", Version: ""},
+		{Case: "", ExpectedString: "err parsing info from bazel with", Version: ""},
+	}
+	for _, tc := range cases {
+		params := &mockedLanguageParams{
+			cmd:           "bazel",
+			versionParam:  "--version",
+			versionOutput: tc.Version,
+			extension:     "*.bazel",
+		}
+		env, props := getMockedLanguageEnv(params)
+		b := &Bazel{}
+		b.Init(props, env)
+		failMsg := fmt.Sprintf("Failed in case: %s", tc.Case)
+		assert.True(t, b.Enabled(), failMsg)
+		assert.Equal(t, tc.ExpectedString, renderTemplate(env, b.Template(), b), failMsg)
+	}
+}

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -613,6 +613,46 @@
           "if": {
             "properties": {
               "type": {
+                "const": "bazel"
+              }
+            }
+          },
+          "then": {
+            "title": "Bazel Segment",
+            "description": "https://ohmyposh.dev/docs/segments/bazel",
+            "properties": {
+              "properties": {
+                "properties": {
+                  "home_enabled": {
+                    "$ref": "#/definitions/home_enabled"
+                  },
+                  "fetch_version": {
+                    "$ref": "#/definitions/fetch_version"
+                  },
+                  "display_mode": {
+                    "$ref": "#/definitions/display_mode"
+                  },
+                  "missing_command_text": {
+                    "$ref": "#/definitions/missing_command_text"
+                  },
+                  "version_url_template": {
+                    "$ref": "#/definitions/version_url_template"
+                  },
+                  "icon": {
+                    "type": "string",
+                    "title": "Icon",
+                    "description": "The icon representing Bazel's logo",
+                    "default": "\ue63a"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
                 "const": "carbonintensity"
               }
             }

--- a/website/docs/segments/bazel.mdx
+++ b/website/docs/segments/bazel.mdx
@@ -1,0 +1,58 @@
+---
+id: bazel
+title: Bazel
+sidebar_label: Bazel
+---
+
+## What
+
+Display the currently active [Bazel][bazel-github] version.
+
+## Sample Configuration
+
+import Config from "@site/src/components/Config.js";
+
+<Config data={{
+  "type": "bazel",
+  "style": "powerline",
+  "powerline_symbol": "\uE0B0",
+  "foreground": "#ffffff",
+  "background": "#43a047",
+}}/>
+
+## Properties
+
+| Name                   | Type      | Description                                                                                                                                                                                                                                              |
+| ---------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `home_enabled`         | `boolean` | display the segment in the HOME folder or not - defaults to `false`                                                                                                                                                                                      |
+| `fetch_version`        | `boolean` | display the Bazel version - defaults to `true`                                                                                                                                                                                                           |
+| `missing_command_text` | `string`  | text to display when the command is missing - defaults to empty                                                                                                                                                                                          |
+| `display_mode`         | `string`  | <ul><li>`always`: the segment is always displayed</li><li>`files`: the segment is only displayed when `*.bazel`, `*.bzl`, `.bazelrc`, `.bazelversion`, `BUILD` or `WORKSPACE` files or any of Bazel's output folders are present (**default**)</li></ul> |
+| `version_url_template` | `string`  | a go [text/template][go-text-template] [template][templates] that creates the URL of the version info documentation                                                                                                                                      |
+| `icon`                 | `string`  | the icon for the segment - defaults to `"\ue63a"`                                                                                                                                                                                                        |
+
+## Template ([info][templates])
+
+:::note default template
+
+```template
+{{ if .Error }}{{ .Icon }} {{ .Error }}{{ else }}{{ url .Icon .URL }} {{ .Full }}{{ end }}
+```
+
+:::
+
+### Properties
+
+| Name     | Type     | Description                                        |
+| -------- | -------- | -------------------------------------------------- |
+| `.Full`  | `string` | the full version                                   |
+| `.Major` | `string` | major number                                       |
+| `.Minor` | `string` | minor number                                       |
+| `.Patch` | `string` | patch number                                       |
+| `.URL`   | `string` | URL of the version info / release notes            |
+| `.Error` | `string` | error encountered when fetching the version string |
+| `.Icon`  | `string` | the icon representing Bazel's logo                 |
+
+[bazel-github]: https://github.com/bazelbuild/bazel
+[go-text-template]: https://golang.org/pkg/text/template/
+[templates]: /docs/configuration/templates

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -57,6 +57,7 @@ module.exports = {
         "segments/az",
         "segments/azfunc",
         "segments/battery",
+        "segments/bazel",
         "segments/brewfather",
         "segments/buf",
         "segments/carbonintensity",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Added a new segment that shows the user the current version of Bazel they are using if any of Bazel's files or folders are in the current path and provides a link for the documentation for that software version.

### How

I have added a segment by following the [guide](https://ohmyposh.dev/docs/contributing/segment) and taking inspiration from the other similar segments that are already present.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
