### PR TITLE
fix(shell): network config cache fallback

### DIFF
--- a/src/platform/shell.go
+++ b/src/platform/shell.go
@@ -351,6 +351,12 @@ func (env *Shell) downloadConfig(location string) error {
 	configPath := filepath.Join(env.CachePath(), filename)
 	cfg, err := env.HTTPRequest(location, nil, 5000)
 	if err != nil {
+		if _, osErr := os.Stat(configPath); !os.IsNotExist(osErr) {
+			// use the already cached config
+			env.CmdFlags.Config = configPath
+			return nil
+		}
+
 		return err
 	}
 	out, err := os.Create(configPath)


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

When running `oh-my-posh init SHELL http://example.com/config.yml` and the user does 
not have network connection, the default config is used, even though the config is cached locally.

This change fixes this and loads the cached config if it exists.

### How

If the network call fails and the config is already cached, this config is loaded.

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
