### PR TITLE
feat: update to go1.21.4

### DIFF
--- a/.github/workflows/composite/bootstrap-go/action.yml
+++ b/.github/workflows/composite/bootstrap-go/action.yml
@@ -9,7 +9,7 @@ runs:
   steps:
     - name: Install Go 🚀
       env:
-        VERSION: "1.21.3"
+        VERSION: "1.21.4"
       shell: pwsh
       run: |
         # Delete conflicting go versions first


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7c1a547</samp>

Updated the Go version used by the bootstrap-go action to `1.21.4`. This improves the reliability and compatibility of the oh-my-posh build and test process.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 7c1a547</samp>

* Update the Go version to 1.21.4 for installing the Go toolchain ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4470/files?diff=unified&w=0#diff-9277619c7b532713f181cfd3095bb6a504d85c715b155d569a75d1e736e8a52bL12-R12))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
