### PR TITLE
chore: adjust help text towards user writable folder

### DIFF
--- a/website/static/install.sh
+++ b/website/static/install.sh
@@ -81,7 +81,7 @@ validate_install_directory() {
 
     # check if we can write to the install directory
     if [ ! -w $install_dir ]; then
-        error "Cannot write to ${install_dir}. Please run the script with sudo and try again:\n  curl -s https://ohmyposh.dev/install.sh | sudo bash -s\n\nAlternatively, you can set a different directory and try again: \n  curl -s https://ohmyposh.dev/install.sh | bash -s -- -d {directory}"
+        error "Cannot write to ${install_dir}. Please set a different directory and try again: \n  curl -s https://ohmyposh.dev/install.sh | bash -s -- -d {directory}"
     fi
 
     # check if the directory is in the PATH


### PR DESCRIPTION
resolves #4479

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 165991f</samp>

Improve error handling in `install.sh` script. Remove sudo suggestion and link to relevant pull request for more information.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 165991f</samp>

*  Simplify error message for unwritable install directory ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4481/files?diff=unified&w=0#diff-72cd6af69c1a958194793b5b6e3c2e799830084925263fd71b3bb84808ea978dL84-R84))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
