### PR TITLE
chore: update formula name on installation instructions

### DIFF
--- a/website/docs/installation/homebrew.mdx
+++ b/website/docs/installation/homebrew.mdx
@@ -7,7 +7,7 @@ bash shell profile script, and *[Requirements][requirements]* to build Oh My Pos
 :::
 
 ```bash
-brew install jandedobbeleer/oh-my-posh/oh-my-posh
+brew install oh-my-posh
 ```
 
 This installs two things:


### PR DESCRIPTION
Hello! Found a typo with the formula name on the documentation today. I believe the formula name has changed?

### Prerequisites

- [ ] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [ ] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6a6cfe3</samp>

Simplified Homebrew installation command for oh-my-posh. Updated the documentation to use the official formula instead of the custom tap.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 6a6cfe3</samp>

*  Simplify the installation command for oh-my-posh using the official Homebrew formula ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4484/files?diff=unified&w=0#diff-88c19bf1c46b238f9f676cb5c6ce1b44b091a5d9052e663f7530fe3556f4243aL10-R10))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
