### PR TITLE
docs: fix themes page

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,12 +7,6 @@
 
 ### Description
 
-copilot:summary
-
-### How
-
-copilot:walkthrough
-
 <!---
 
 Tips:

--- a/src/engine/image.go
+++ b/src/engine/image.go
@@ -216,7 +216,7 @@ func (ir *ImageRenderer) loadFonts() error {
 
 	// Download font if not cached
 	if data == nil {
-		url := "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.0.0/Hack.zip"
+		url := "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.1.0/Hack.zip"
 		var err error
 
 		data, err = fontCLI.Download(url)

--- a/website/export_themes.js
+++ b/website/export_themes.js
@@ -116,6 +116,8 @@ themeConfigOverrrides.set('catppuccin_mocha.omp.json', newThemeConfig(40, 40, 'I
     links.push(`[${themeName}]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/themes/${theme} '${themeName}'\n`);
   }
 
+  await fs.promises.appendFile('./docs/themes.md', '\n');
+
   for (const link of links) {
     await fs.promises.appendFile('./docs/themes.md', link);
   }


### PR DESCRIPTION
- chore: update Nerd Font to v3.1.0
- docs: add space after last theme block

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e235a56</samp>

Updated Hack font in `image.go` and fixed website formatting in `export_themes.js`. These changes enhance the appearance and functionality of the oh-my-posh themes.

### How

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at e235a56</samp>

*  Update Hack font to latest version for better rendering ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4492/files?diff=unified&w=0#diff-4ad23c6dbe12603450e5bf41725eb341b55fa79a66d0941b57b88effd77be3e3L219-R219))
*  Fix formatting issue for last theme on website by adding new line to `themes.md` ([link](https://github.com/JanDeDobbeleer/oh-my-posh/pull/4492/files?diff=unified&w=0#diff-7470b21e3b8f8e3e7cea770222b576c0caec45c3be6dfc693980cc0f94a5dd5eR119-R120))

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
