### PR TITLE
fix: Clean-Detailed Theme Shows Wrong Memory Usage Values

### DIFF
--- a/themes/clean-detailed.omp.json
+++ b/themes/clean-detailed.omp.json
@@ -33,7 +33,7 @@
           "foreground": "#ffffff",
           "leading_diamond": "\ue0b2",
           "style": "diamond",
-          "template": "\ue266 MEM: {{ round .PhysicalPercentUsed .Precision }}% | {{ (div ((sub .PhysicalTotalMemory .PhysicalFreeMemory)|float64) 1000000000.0) }}/{{ (div .PhysicalTotalMemory 1000000000.0) }}GB \ue266 ",
+          "template": "\ue266 MEM: {{ round .PhysicalPercentUsed .Precision }}% | {{ (div ((sub .PhysicalTotalMemory .PhysicalAvailableMemory)|float64) 1073741824.0) }}/{{ (div .PhysicalTotalMemory 1073741824.0) }}GB \ue266 ",
           "trailing_diamond": "<transparent,#516BEB>\ue0b2</>",
           "type": "sysinfo"
         },


### PR DESCRIPTION


### Prerequisites

- [ Yes ] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [ Yes ] The commit message follows the [conventional commits][cc] guidelines.
- [ Yes ] Tests for the changes have been added (for bug fixes / features).
- [ No ] Docs have been added/updated (for bug fixes / features).

### Description

Withing the Clean-Detailed theme the following changes were made:
- Replace PhysicalFreeMemory with PhysicalAvaliableMemory in calculation of total memory in use.
- Change the Division denominator to 1073741824.0 from 10^9 [As 1GByte is not necessarily 10^9 bytes but 1073741824 bytes.]

The Memory In Use/Total Memory Values in the Clean-Detailed default theme are now showing correctly.

Refs: #4497


<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
