### PR TITLE
ci: do not use deprecated params for goreleaser

### DIFF
--- a/.github/workflows/build_code.yml
+++ b/.github/workflows/build_code.yml
@@ -25,7 +25,7 @@ jobs:
       with:
         distribution: goreleaser
         version: latest
-        args: build --rm-dist --snapshot --skip-post-hooks --skip-before
+        args: build --clean --snapshot --skip=post-hooks --skip=before
         workdir: src
     - name: Archive production artifacts
       uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: build --rm-dist
+          args: build --clean
           workdir: src
         env:
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

![image](https://github.com/JanDeDobbeleer/oh-my-posh/assets/83997633/71fbc67c-2dad-4600-a5e1-8df7fec4d1cb)

References:
- https://goreleaser.com/deprecations/#-skip
- https://goreleaser.com/deprecations/#__tabbed_9_2