### PR TITLE
update glowsticks' battery and time symbols to non mdi- symbols which were removed

### DIFF
--- a/themes/glowsticks.omp.yaml
+++ b/themes/glowsticks.omp.yaml
@@ -52,7 +52,7 @@ blocks:
           always_enabled: true
           style: round
         style: powerline
-        template: " 羽{{ .FormattedMs }} "
+        template: " 󰔟 {{ .FormattedMs }} "
         type: executiontime
 
       # Exit code
@@ -88,10 +88,10 @@ blocks:
           charging_icon: 
           discharging_icon: " "
         style: diamond
-        template: " {{.Templates }}{{ .Percentage}} <transparent></>"
+        template: " {{.Templates }} {{ .Percentage}}<transparent> </>"
         templates:
-          - '{{if eq "Discharging" .State.String}}{{if lt .Percentage 11}}{{else if lt .Percentage 21}}{{else if lt .Percentage 31}}{{else if lt .Percentage 41}}{{else if lt .Percentage 51}}{{else if lt .Percentage 61}}{{else if lt .Percentage 71}}{{else if lt .Percentage 81}}{{else if lt .Percentage 91}}{{else}}{{end}}{{end}}'
-          - '{{if eq "Charging" .State.String}}{{ if lt .Percentage 21}}{{else if lt .Percentage 31}}{{else if lt .Percentage 41}}{{else if lt .Percentage 61}}{{else if lt .Percentage 81}}{{else if lt .Percentage 91}}{{else}}{{end}}{{end}}'
+          - '{{if eq "Discharging" .State.String}}{{if lt .Percentage 11}}󰁺{{else if lt .Percentage 21}}󰁻{{else if lt .Percentage 31}}󰁼{{else if lt .Percentage 41}}󰁽{{else if lt .Percentage 51}}󰁾{{else if lt .Percentage 61}}󰁿{{else if lt .Percentage 71}}󰂀{{else if lt .Percentage 81}}󰂁{{else if lt .Percentage 91}}󰂂{{else}}󰁹{{end}}{{end}}'
+          - '{{if eq "Charging"    .State.String}}{{if lt .Percentage 11}}󰢜{{else if lt .Percentage 21}}󰂆{{else if lt .Percentage 31}}󰂇{{else if lt .Percentage 41}}󰂈{{else if lt .Percentage 51}}󰢝{{else if lt .Percentage 61}}󰂉{{else if lt .Percentage 71}}󰢞{{else if lt .Percentage 81}}󰂊{{else if lt .Percentage 91}}󰂋{{else}}󰂄{{end}}{{end}}'
         templates_logic: first_match
         type: battery
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.

### Description

![image](https://github.com/JanDeDobbeleer/oh-my-posh/assets/70787919/daab4a56-f7e8-4891-95bd-32fe8ab888a3)

also lets me add more increments for the charging characters.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
