### PR TITLE
Update capr4n.omp.json

### DIFF
--- a/themes/capr4n.omp.json
+++ b/themes/capr4n.omp.json
@@ -18,7 +18,7 @@
             "always_enabled": true
           },
           "style": "plain",
-          "template": " \ueba2{{ .FormattedMs }} ",
+          "template": " \ueba2 {{ .FormattedMs }} ",
           "type": "executiontime"
         }
       ],


### PR DESCRIPTION
Added Whitespace between Icon and Time

### Prerequisites

- [X] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [X] The commit message follows the [conventional commits][cc] guidelines.
- [X] Tests for the changes have been added (for bug fixes / features).
- [X] Docs have been added/updated (for bug fixes / features).

### Description

Found a Missing Whitespace in this theme and added it. ;) 

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
