### PR TITLE
docs: Remove "pathname://" prefix from windows store install link

### DIFF
--- a/website/docs/installation/windows.mdx
+++ b/website/docs/installation/windows.mdx
@@ -20,7 +20,7 @@ To display all icons, we recommend the use of a [Nerd Font][fonts].
 When using oh-my-posh inside the WSL, make sure to follow the [Linux][linux] installation guide.
 :::
 
-<a href="pathname://ms-windows-store://pdp/?productid=XP8K0HKJFRXGCK" target="_blank">
+<a href="ms-windows-store://pdp/?productid=XP8K0HKJFRXGCK" target="_blank">
   <img
     src={require('/img/winstore.png').default}
     alt="Windows Store Link"


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
  - I will amend the commit message before publishing this PR for review
- [ ] Tests for the changes have been added (for bug fixes / features). **N/A**
- [x] Docs have been added/updated (for bug fixes / features).

### Description

This change fixes the link in the windows documentation to the windows store to download oh my posh. The existing link was prefixed with "pathname://", which when clicked opens a new empty tab. As far as I can tell this is not a valid protocol name.

Copying and pasting the link without "pathname://" into the address bar will correctly open the windows store for oh my posh. I tested this using the latest stable version of MS Edge and Firefox on Windows 11.

I would include example links in this PR description, but apparently github doesn't allow for non-http links.


<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
