### PR TITLE
docs: add chocolatey as an install method for windows

### DIFF
--- a/website/docs/installation/windows.mdx
+++ b/website/docs/installation/windows.mdx
@@ -36,6 +36,7 @@ When using oh-my-posh inside the WSL, make sure to follow the [Linux][linux] ins
   values={[
     { label: 'winget', value: 'winget', },
     { label: 'scoop', value: 'scoop', },
+    { label: 'choco', value: 'choco'},
     { label: 'manual', value: 'manual', },
   ]
 }>
@@ -57,6 +58,17 @@ scoop install https://github.com/JanDeDobbeleer/oh-my-posh/releases/latest/downl
 ```
 
 </TabItem>
+
+<TabItem value="choco">
+
+Open a PowerShell prompt and run the following command:
+
+```powershell
+choco install oh-my-posh
+``` 
+
+</TabItem>
+
 <TabItem value="manual">
 
 Open a PowerShell prompt and run the following command:
@@ -104,6 +116,7 @@ Exclusions should be added with the full path to the executable, you can get it 
   values={[
     { label: 'winget', value: 'winget', },
     { label: 'scoop', value: 'scoop', },
+    { label: 'choco', value: 'choco'},
     { label: 'manual', value: 'manual', },
   ]
 }>
@@ -125,6 +138,17 @@ scoop update oh-my-posh
 ```
 
 </TabItem>
+
+<TabItem value="choco">
+
+Open a PowerShell prompt and run the following command:
+
+```powershell
+choco upgrade oh-my-posh
+```
+
+</TabItem>
+
 <TabItem value="manual">
 
 Open a PowerShell prompt and run the following command:

--- a/website/docs/installation/windows.mdx
+++ b/website/docs/installation/windows.mdx
@@ -36,7 +36,7 @@ When using oh-my-posh inside the WSL, make sure to follow the [Linux][linux] ins
   values={[
     { label: 'winget', value: 'winget', },
     { label: 'scoop', value: 'scoop', },
-    { label: 'chocolatey', value: 'choco'},
+    { label: 'chocolatey', value: 'chocolatey'},
     { label: 'manual', value: 'manual', },
   ]
 }>
@@ -59,7 +59,7 @@ scoop install https://github.com/JanDeDobbeleer/oh-my-posh/releases/latest/downl
 
 </TabItem>
 
-<TabItem value="choco">
+<TabItem value="chocolatey">
 
 Open a PowerShell prompt and run the following command:
 
@@ -116,7 +116,7 @@ Exclusions should be added with the full path to the executable, you can get it 
   values={[
     { label: 'winget', value: 'winget', },
     { label: 'scoop', value: 'scoop', },
-    { label: 'choco', value: 'choco'},
+    { label: 'chocolatey', value: 'chocolatey'},
     { label: 'manual', value: 'manual', },
   ]
 }>
@@ -139,7 +139,7 @@ scoop update oh-my-posh
 
 </TabItem>
 
-<TabItem value="choco">
+<TabItem value="chocolatey">
 
 Open a PowerShell prompt and run the following command:
 

--- a/website/docs/installation/windows.mdx
+++ b/website/docs/installation/windows.mdx
@@ -36,7 +36,7 @@ When using oh-my-posh inside the WSL, make sure to follow the [Linux][linux] ins
   values={[
     { label: 'winget', value: 'winget', },
     { label: 'scoop', value: 'scoop', },
-    { label: 'choco', value: 'choco'},
+    { label: 'chocolatey', value: 'choco'},
     { label: 'manual', value: 'manual', },
   ]
 }>


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Docs have been added/updated (for bug fixes / features).
- [ ] Tests for the changes have been added (for bug fixes / features).

### Description

This pull request aims to address #4654 and focuses on improving the documentation by including information about using Chocolatey as an installation and update method for [Oh My Posh](https://ohmyposh.dev/) on Windows.

![image](https://github.com/JanDeDobbeleer/oh-my-posh/assets/72668825/f1313306-8285-4f73-8fc3-c02afabffed8)


<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
