### PR TITLE
git worktree reponame

### DIFF
--- a/src/platform/shell_unix.go
+++ b/src/platform/shell_unix.go
@@ -66,6 +66,16 @@ func (env *Shell) TerminalWidth() (int, error) {
 		env.Error(err)
 	}
 
+	// fetch width from the environment variable
+	// in case the terminal width is not available
+	if width == 0 {
+		i, err := strconv.Atoi(env.Getenv("COLUMNS"))
+		if err != nil {
+			env.Error(err)
+		}
+		width = uint(i)
+	}
+
 	env.CmdFlags.TerminalWidth = int(width)
 	env.DebugF("terminal width: %d", env.CmdFlags.TerminalWidth)
 	return env.CmdFlags.TerminalWidth, err

--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -167,7 +167,7 @@ func (g *Git) Enabled() bool {
 		g.setUser()
 	}
 
-	g.RepoName = platform.Base(g.env, g.convertToLinuxPath(g.realDir))
+	g.RepoName = g.repoName()
 
 	g.Working = &GitStatus{}
 	g.Staging = &GitStatus{}
@@ -266,6 +266,10 @@ func (g *Git) Kraken() string {
 		g.Hash = g.getGitCommandOutput("rev-parse", "HEAD")
 	}
 	return fmt.Sprintf("gitkraken://repolink/%s/commit/%s?url=%s", root, g.Hash, url2.QueryEscape(g.RawUpstreamURL))
+}
+
+func (g *Git) LatestTag() string {
+	return g.getGitCommandOutput("describe", "--tags", "--abbrev=0")
 }
 
 func (g *Git) shouldDisplay() bool {
@@ -850,6 +854,15 @@ func (g *Git) getSwitchMode(property properties.Property, gitSwitch, mode string
 	return fmt.Sprintf("%s%s", gitSwitch, mode)
 }
 
-func (g *Git) LatestTag() string {
-	return g.getGitCommandOutput("describe", "--tags", "--abbrev=0")
+func (g *Git) repoName() string {
+	if !g.IsWorkTree {
+		return platform.Base(g.env, g.convertToLinuxPath(g.realDir))
+	}
+
+	ind := strings.LastIndex(g.workingDir, ".git/worktrees")
+	if ind > -1 {
+		return platform.Base(g.env, g.workingDir[:ind])
+	}
+
+	return ""
 }

--- a/src/segments/git_test.go
+++ b/src/segments/git_test.go
@@ -1108,3 +1108,51 @@ func TestGitRemotes(t *testing.T) {
 		assert.Equal(t, tc.Expected, len(got), tc.Case)
 	}
 }
+
+func TestGitRepoName(t *testing.T) {
+	cases := []struct {
+		Case       string
+		Expected   string
+		WorkingDir string
+		RealDir    string
+		IsWorkTree bool
+	}{
+		{
+			Case:       "In worktree",
+			Expected:   "oh-my-posh",
+			IsWorkTree: true,
+			WorkingDir: "/Users/jan/Code/oh-my-posh/.git/worktrees/oh-my-posh2",
+		},
+		{
+			Case:       "Not in worktree",
+			Expected:   "oh-my-posh",
+			IsWorkTree: false,
+			RealDir:    "/Users/jan/Code/oh-my-posh",
+		},
+		{
+			Case:       "In worktree, unexpected dir",
+			Expected:   "",
+			IsWorkTree: true,
+			WorkingDir: "/Users/jan/Code/oh-my-posh2",
+		},
+	}
+
+	for _, tc := range cases {
+		env := new(mock.MockedEnvironment)
+		env.On("PathSeparator").Return("/")
+		env.On("GOOS").Return(platform.LINUX)
+
+		g := &Git{
+			scm: scm{
+				props:      properties.Map{},
+				env:        env,
+				realDir:    tc.RealDir,
+				workingDir: tc.WorkingDir,
+			},
+			IsWorkTree: tc.IsWorkTree,
+		}
+
+		got := g.repoName()
+		assert.Equal(t, tc.Expected, got, tc.Case)
+	}
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

- fix(git): show original worktree as repo name
- fix(unix): fetch COLUMNS when we don't have a terminal width

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
