### PR TITLE
chore(winget): update manifest version to 1.6.0

### DIFF
--- a/packages/winget/JanDeDobbeleer.OhMyPosh.installer.yaml
+++ b/packages/winget/JanDeDobbeleer.OhMyPosh.installer.yaml
@@ -47,4 +47,4 @@ Installers:
   InstallerSwitches:
      Custom: /INSTALLER=winget /CURRENTUSER
 ManifestType: installer
-ManifestVersion: 1.4.0
+ManifestVersion: 1.5.0

--- a/packages/winget/JanDeDobbeleer.OhMyPosh.installer.yaml
+++ b/packages/winget/JanDeDobbeleer.OhMyPosh.installer.yaml
@@ -47,4 +47,4 @@ Installers:
   InstallerSwitches:
      Custom: /INSTALLER=winget /CURRENTUSER
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/packages/winget/JanDeDobbeleer.OhMyPosh.locale.en-US.yaml
+++ b/packages/winget/JanDeDobbeleer.OhMyPosh.locale.en-US.yaml
@@ -26,5 +26,5 @@ Tags:
 - "terminal"
 - "oh-my-posh"
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0
 ReleaseNotesUrl: https://github.com/JanDeDobbeleer/oh-my-posh/releases/tag/v<VERSION>

--- a/packages/winget/JanDeDobbeleer.OhMyPosh.locale.en-US.yaml
+++ b/packages/winget/JanDeDobbeleer.OhMyPosh.locale.en-US.yaml
@@ -26,6 +26,5 @@ Tags:
 - "terminal"
 - "oh-my-posh"
 ManifestType: defaultLocale
-ManifestVersion: 1.4.0
+ManifestVersion: 1.5.0
 ReleaseNotesUrl: https://github.com/JanDeDobbeleer/oh-my-posh/releases/tag/v<VERSION>
-

--- a/packages/winget/JanDeDobbeleer.OhMyPosh.yaml
+++ b/packages/winget/JanDeDobbeleer.OhMyPosh.yaml
@@ -2,4 +2,4 @@ PackageIdentifier: JanDeDobbeleer.OhMyPosh
 PackageVersion: <VERSION>
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/packages/winget/JanDeDobbeleer.OhMyPosh.yaml
+++ b/packages/winget/JanDeDobbeleer.OhMyPosh.yaml
@@ -2,4 +2,4 @@ PackageIdentifier: JanDeDobbeleer.OhMyPosh
 PackageVersion: <VERSION>
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.4.0
+ManifestVersion: 1.5.0


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

Manifest version 1.4.0 and lower have been deprecated.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
