### PR TITLE
Fix: home icon for sonicboom themes

### DIFF
--- a/themes/sonicboom_dark.omp.json
+++ b/themes/sonicboom_dark.omp.json
@@ -42,7 +42,7 @@
           "properties": {
             "folder_icon": "\ue5fe",
             "folder_separator_icon": " <#000000>\ue0bd </>",
-            "home_icon": "\ueb06",
+            "home_icon": "\uf7db",
             "style": "agnoster_short"
           },
           "style": "plain",

--- a/themes/sonicboom_light.omp.json
+++ b/themes/sonicboom_light.omp.json
@@ -42,7 +42,7 @@
           "properties": {
             "folder_icon": "\ue5fe",
             "folder_separator_icon": "<transparent> \ue0bd </>",
-            "home_icon": "\ueb06",
+            "home_icon": "\uf7db",
             "style": "agnoster_short"
           },
           "style": "plain",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description
The home icon does not render in PWSH or terminal on windows using the font MesloLGM Nerd Font Mono. The updated icon in the commit for these two themes resolves that issue.

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
