### PR TITLE
fix: update node LTS version numbers

### DIFF
--- a/src/segments/node.go
+++ b/src/segments/node.go
@@ -88,11 +88,11 @@ func (n *Node) matchesVersionFile() (string, bool) {
 		case "fermium":
 			fileVersion = "14.21.3"
 		case "gallium":
-			fileVersion = "16.20.1"
+			fileVersion = "16.20.2"
 		case "hydrogen":
-			fileVersion = "18.19.0"
+			fileVersion = "18.19.1"
 		case "iron":
-			fileVersion = "20.10.0"
+			fileVersion = "20.11.1"
 		}
 	}
 

--- a/src/segments/node_test.go
+++ b/src/segments/node_test.go
@@ -11,10 +11,10 @@ import (
 
 func TestNodeMatchesVersionFile(t *testing.T) {
 	nodeVersion := version{
-		Full:  "20.10.0",
+		Full:  "20.11.1",
 		Major: "20",
-		Minor: "10",
-		Patch: "0",
+		Minor: "11",
+		Patch: "1",
 	}
 	cases := []struct {
 		Case            string
@@ -23,16 +23,16 @@ func TestNodeMatchesVersionFile(t *testing.T) {
 		RCVersion       string
 	}{
 		{Case: "no file context", Expected: true, RCVersion: ""},
-		{Case: "version match", Expected: true, ExpectedVersion: "20.10.0", RCVersion: "20.10.0"},
-		{Case: "version match with newline", Expected: true, ExpectedVersion: "20.10.0", RCVersion: "20.10.0\n"},
+		{Case: "version match", Expected: true, ExpectedVersion: "20.11.1", RCVersion: "20.11.1"},
+		{Case: "version match with newline", Expected: true, ExpectedVersion: "20.11.1", RCVersion: "20.11.1\n"},
 		{Case: "version mismatch", Expected: false, ExpectedVersion: "3.2.1", RCVersion: "3.2.1"},
-		{Case: "version match in other format", Expected: true, ExpectedVersion: "20.10.0", RCVersion: "v20.10.0"},
-		{Case: "version match without patch", Expected: true, ExpectedVersion: "20.10", RCVersion: "20.10"},
-		{Case: "version match without patch in other format", Expected: true, ExpectedVersion: "20.10", RCVersion: "v20.10"},
+		{Case: "version match in other format", Expected: true, ExpectedVersion: "20.11.1", RCVersion: "v20.11.1"},
+		{Case: "version match without patch", Expected: true, ExpectedVersion: "20.11", RCVersion: "20.11"},
+		{Case: "version match without patch in other format", Expected: true, ExpectedVersion: "20.11", RCVersion: "v20.11"},
 		{Case: "version match without minor", Expected: true, ExpectedVersion: "20", RCVersion: "20"},
 		{Case: "version match without minor in other format", Expected: true, ExpectedVersion: "20", RCVersion: "v20"},
-		{Case: "lts match", Expected: true, ExpectedVersion: "20.10.0", RCVersion: "lts/iron"},
-		{Case: "lts match upper case", Expected: true, ExpectedVersion: "20.10.0", RCVersion: "lts/Iron"},
+		{Case: "lts match", Expected: true, ExpectedVersion: "20.11.1", RCVersion: "lts/iron"},
+		{Case: "lts match upper case", Expected: true, ExpectedVersion: "20.11.1", RCVersion: "lts/Iron"},
 		{Case: "lts mismatch", Expected: false, ExpectedVersion: "8.17.0", RCVersion: "lts/carbon"},
 	}
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [NA] Docs have been added/updated (for bug fixes / features).

### Description

Node LTS versions have been updated. This PR updates the oh-my-posh node segement's LTS version numbers for the respective LTS names. (perhaps there's a way to automate this in the future?).

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
