### PR TITLE
theme(atomic): add a space between the gear icon and formatted time

### DIFF
--- a/themes/atomic.omp.json
+++ b/themes/atomic.omp.json
@@ -59,7 +59,7 @@
             "threshold": 0
           },
           "style": "diamond",
-          "template": " \ueba2{{ .FormattedMs }}\u2800",
+          "template": " \ueba2 {{ .FormattedMs }}\u2800",
           "trailing_diamond": "\ue0b4",
           "type": "executiontime"
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary

The command execution duration and the gear icon overlapped on my system (Windows Terminal, CaskaydiaCove Nerd Font), as shown in the image.

![](https://private-user-images.githubusercontent.com/69118069/309849745-395d383d-47da-42da-9d30-5fc3c705786e.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MDk1NzQ2NjgsIm5iZiI6MTcwOTU3NDM2OCwicGF0aCI6Ii82OTExODA2OS8zMDk4NDk3NDUtMzk1ZDM4M2QtNDdkYS00MmRhLTlkMzAtNWZjM2M3MDU3ODZlLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDAzMDQlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwMzA0VDE3NDYwOFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWE1ZWY0ZGE0OGVmM2I4YzUwZjdkZWFiNWEzMDhlOTMxNDIyYTg5ODI3OGQ3ZTljZDEwZTc5MDkzZGYwMDk3NmEmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.AT_a8jfYsQlNv_CelsxMUBITTvbSxkytlrdLcqES0bc)

After adding a space between the symbol and the formatted time, it no longer overlaps and is perfectly visible.

![](https://private-user-images.githubusercontent.com/69118069/309850182-c5623d75-7ada-4c3f-9ea2-0a1f6b76e6ec.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MDk1NzQ2NjgsIm5iZiI6MTcwOTU3NDM2OCwicGF0aCI6Ii82OTExODA2OS8zMDk4NTAxODItYzU2MjNkNzUtN2FkYS00YzNmLTllYTItMGExZjZiNzZlNmVjLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDAzMDQlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwMzA0VDE3NDYwOFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWQ1ZTA2YTA5NTU2ZjgzMzJlZjYyNDA4MzU0OTljOTE1MjdlZmJlOWFiOGQwYmRlNTFiOTc3YTA2NGE4ZTk5NjkmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.8OmMLN57oWW_wMRyJYiwL4DUKJcueGr2NfeL5KgiTeQ)

Not sure if this is just the case for me, I tried fixing it locally but every update reverts the change.