### PR TITLE
 feat(svn): Add repository name to segment

### DIFF
--- a/src/segments/svn.go
+++ b/src/segments/svn.go
@@ -1,6 +1,7 @@
 package segments
 
 import (
+	"path"
 	"strconv"
 	"strings"
 
@@ -121,6 +122,18 @@ func (s *Svn) setSvnStatus() {
 		// element is the element from someSlice for where we are
 		s.Working.add(line[0:1])
 	}
+}
+
+func (s *Svn) Repo() string {
+	// Get the repository name as the last path element of the repository root URL
+	repo := s.getSvnCommandOutput("info", "--show-item", "repos-root-url")
+	base := path.Base(repo)
+
+	if base == "." {
+		return ""
+	}
+
+	return base
 }
 
 func (s *Svn) getSvnCommandOutput(command string, args ...string) string {

--- a/src/segments/svn_test.go
+++ b/src/segments/svn_test.go
@@ -262,3 +262,44 @@ R       Moved.File`,
 		assert.Equal(t, tc.ExpectedConflicts, s.Working.HasConflicts(), tc.Case)
 	}
 }
+
+func TestRepo(t *testing.T) {
+	cases := []struct {
+		Case     string
+		Repo     string
+		Expected string
+	}{
+		{
+			Case:     "No repo",
+			Repo:     "",
+			Expected: "",
+		},
+		{
+			Case:     "Repo with trailing slash",
+			Repo:     "http://example.com/",
+			Expected: "example.com",
+		},
+		{
+			Case:     "Repo without trailing slash",
+			Repo:     "http://example.com",
+			Expected: "example.com",
+		},
+		{
+			Case:     "Repo with a path",
+			Repo:     "http://example.com/test/repo",
+			Expected: "repo",
+		},
+	}
+	for _, tc := range cases {
+		env := new(mock.MockedEnvironment)
+		env.On("RunCommand", "svn", []string{"info", "", "--show-item", "repos-root-url"}).Return(tc.Repo, nil)
+		s := &Svn{
+			scm: scm{
+				env:     env,
+				command: SVNCOMMAND,
+			},
+		}
+
+		assert.Equal(t, tc.Expected, s.Repo(), tc.Case)
+	}
+}

--- a/website/docs/segments/svn.mdx
+++ b/website/docs/segments/svn.mdx
@@ -39,6 +39,10 @@ You can set the following properties to `true` to enable fetching additional inf
 | `native_fallback`   | `boolean`           | `false` | when set to `true` and `svn.exe` is not available when inside a WSL2 shared Windows drive, we will fallback to the native svn executable to fetch data. Not all information can be displayed in this case                                                        |
 | `status_formats`    | `map[string]string` |         | a key, value map allowing to override how individual status items are displayed. For example, `"status_formats": { "Added": "Added: %d" }` will display the added count as `Added: 1` instead of `+1`. See the [Status](#status) section for available overrides |
 
+:::info
+The fields `Repo`, `Branch` and `BaseRev` will still work with `fetch_status` set to `false`.
+:::
+
 ## Template ([info][templates])
 
 :::note default template
@@ -51,11 +55,12 @@ You can set the following properties to `true` to enable fetching additional inf
 
 ### Properties
 
-| Name       | Type     | Description                                           |
-| ---------- | -------- | ----------------------------------------------------- |
-| `.Working` | `Status` | changes in the worktree (see below)                   |
-| `.Branch`  | `string` | current branch (releative URL reported by `svn info`) |
-| `.BaseRev` | `int`    | the currently checked out revision number             |
+| Name       | Type     | Description                                                |
+| ---------- | -------- | ---------------------------------------------------------- |
+| `.Working` | `Status` | changes in the worktree (see below)                        |
+| `.Branch`  | `string` | current branch (relative URL reported by `svn info`)       |
+| `.BaseRev` | `int`    | the currently checked out revision number                  |
+| `.Repo`    | `string` | current repository (repos root URL reported by `svn info`) |
 
 ### Status
 
@@ -83,5 +88,4 @@ Local changes use the following syntax:
 | `!`  | Conflicted  |
 
 [svn]: https://subversion.apache.org
-[templates]: /docs/config-templates
-[hyperlinks]: /docs/config-templates#custom
+[templates]: /configuration/templates.mdx


### PR DESCRIPTION
Add the name of the current svn repository to the svn segment.

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

This feature allows to add and display the SVN repository name as a segment property.
It works similar to the already existing 'Branch' property, but resolves the root repository name based on the `svn info` command.