### PR TITLE
fix: prompt termination in devious-diamonds theme

### DIFF
--- a/themes/devious-diamonds.omp.yaml
+++ b/themes/devious-diamonds.omp.yaml
@@ -234,7 +234,7 @@ blocks:
         foreground: white
         properties:
           root_icon: 
-        template: "{{ if and .Root ( not .Segments.Path.Writable ) }} {{ end }}{{ if and .Root .Segments.Path.Writable }}  {{ end }} \b"
+        template: "{{ if not .Root }}\u2800{{ end }}{{ if and .Root ( not .Segments.Path.Writable ) }} {{ end }}{{ if and .Root .Segments.Path.Writable }}  {{ end }}"
 console_title_template: "{{ .Folder }}"
 palette:
   black: "#1B1A23"


### PR DESCRIPTION
The " \b" in this template was causing issues with non-deletable characters when you used tab to pop up suggestions in zsh. The approach of inserting an invisible character if not root preserves the trailing diamond without introducing spacing issues.

### Prerequisites

- [✔] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [ ✔] The commit message follows the [conventional commits][cc] guidelines.
- [ n/a] Tests for the changes have been added (for bug fixes / features).
- [ n/a] Docs have been added/updated (for bug fixes / features).

### Description

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
