### PR TITLE
fix: Firebase Subpaths Check

### DIFF
--- a/.github/workflows/build_code.yml
+++ b/.github/workflows/build_code.yml
@@ -28,7 +28,7 @@ jobs:
         args: build --clean --snapshot --skip=post-hooks --skip=before
         workdir: src
     - name: Archive production artifacts
-      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3
+      uses: actions/upload-artifact@1746f4ab65b179e0ea60a494b83293b640dd5bba
       with:
         name: builds
         retention-days: 1

--- a/src/segments/firebase.go
+++ b/src/segments/firebase.go
@@ -54,7 +54,7 @@ func (f *Firebase) Enabled() bool {
 	// Test if the current directory is a project path
 	// and if it is, return the project name
 	for key, value := range data.ActiveProject {
-		if key == f.env.Pwd() || strings.HasPrefix(f.env.Pwd(), key) {
+		if strings.HasPrefix(f.env.Pwd(), key) {
 			f.Project = value
 			return true
 		}

--- a/src/segments/firebase.go
+++ b/src/segments/firebase.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"path/filepath"
+	"strings"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/platform"
 	"github.com/jandedobbeleer/oh-my-posh/src/properties"
@@ -53,7 +54,7 @@ func (f *Firebase) Enabled() bool {
 	// Test if the current directory is a project path
 	// and if it is, return the project name
 	for key, value := range data.ActiveProject {
-		if key == f.env.Pwd() {
+		if key == f.env.Pwd() || strings.HasPrefix(f.env.Pwd(), key) {
 			f.Project = value
 			return true
 		}

--- a/src/segments/firebase_test.go
+++ b/src/segments/firebase_test.go
@@ -10,22 +10,31 @@ import (
 )
 
 func TestFirebaseSegment(t *testing.T) {
+	config := `{
+		"activeProjects": {
+			"path": "project-name"
+		}
+	}`
 	cases := []struct {
 		Case            string
-		CfgData         string
 		ActiveConfig    string
+		ActivePath      string
 		ExpectedEnabled bool
 		ExpectedString  string
 	}{
 		{
 			Case:            "happy path",
 			ExpectedEnabled: true,
-			ActiveConfig: `{
-				"activeProjects": {
-					"path": "project-name"
-				}
-			}`,
-			ExpectedString: "project-name",
+			ActiveConfig:    config,
+			ActivePath:      "path",
+			ExpectedString:  "project-name",
+		},
+		{
+			Case:            "happy subpath",
+			ExpectedEnabled: true,
+			ActiveConfig:    config,
+			ActivePath:      "path/subpath",
+			ExpectedString:  "project-name",
 		},
 		{
 			Case:            "no active config",
@@ -46,7 +55,7 @@ func TestFirebaseSegment(t *testing.T) {
 	for _, tc := range cases {
 		env := new(mock.MockedEnvironment)
 		env.On("Home").Return("home")
-		env.On("Pwd").Return("path")
+		env.On("Pwd").Return(tc.ActivePath)
 		fcPath := filepath.Join("home", ".config", "configstore", "firebase-tools.json")
 		env.On("FileContent", fcPath).Return(tc.ActiveConfig)
 		env.On("Error", mock2.Anything).Return()


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

As per issue https://github.com/JanDeDobbeleer/oh-my-posh/issues/4850 raised, subpaths were not returning the Firebase project name when they should. 

### Work

Since Active Projects are stored as the "root", then subpaths can be checked with `strings.HasPrefix()`, which resolved this issue.
A test case has been added and a mental note will be kept at the back of my mind forever. 

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
