### PR TITLE
fix(pulumi): improve reliability of filepath hash calculation

### DIFF
--- a/src/segments/pulumi.go
+++ b/src/segments/pulumi.go
@@ -154,7 +154,7 @@ func (p *Pulumi) getProjectName() error {
 		return hex.EncodeToString(h.Sum(nil))
 	}
 
-	p.workspaceSHA1 = sha1HexString(p.env.Pwd() + "/" + fileName)
+	p.workspaceSHA1 = sha1HexString(p.env.Pwd() + p.env.PathSeparator() + fileName)
 
 	return nil
 }

--- a/src/segments/pulumi_test.go
+++ b/src/segments/pulumi_test.go
@@ -203,6 +203,8 @@ description: A Console App
 		env.On("HasFiles", pulumiJSON).Return(len(tc.JSONConfig) > 0)
 		env.On("FileContent", pulumiJSON).Return(tc.JSONConfig, nil)
 
+		env.On("PathSeparator").Return("/")
+
 		env.On("HasFolder", filepath.Clean("/home/foobar/.pulumi/workspaces")).Return(tc.HasWorkspaceFolder)
 		workspaceFile := "oh-my-posh-c62b7b6786c5c5a85896576e46a25d7c9f888e92-workspace.json"
 		env.On("HasFilesInDir", filepath.Clean("/home/foobar/.pulumi/workspaces"), workspaceFile).Return(len(tc.WorkSpaceFile) > 0)


### PR DESCRIPTION
Changing this line of code to use filepath.Join rather than relying on concatenation with a "/" symbol. Windows uses "\" in its file paths. So the use of "/" leads to an incorrect hash calculation and prevents this segment from working in Windows. The filepath.Join() function is already used in the getPulumiStackName() function, so this change is only needed in the getProjectName() function.

I'm not certain where docs would be added, so I'm leaving that unchecked.

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
