### PR TITLE
fix: update all themes to Nerd Font 3.0+ unicode icon locations

### DIFF
--- a/themes/devious-diamonds.omp.yaml
+++ b/themes/devious-diamonds.omp.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json
+final_space: true
 blocks:
   - type: prompt
     alignment: left
@@ -27,7 +27,7 @@ blocks:
           opensuse: 
           raspbian: 
           ubuntu: 
-          windows: 
+          windows: 󰍲
           wsl: 
           wsl_separator: 
         template: " {{ if .WSL }}{{ end }}{{.Icon}}═"
@@ -42,7 +42,7 @@ blocks:
         powerline_symbol: 
         background: magenta
         foreground: black
-        template: " {{ if .SSHSession }} {{ end }}{{ .UserName }}@{{ .HostName }} "
+        template: " {{ if .SSHSession }}󰌘 {{ end }}{{ .UserName }}@{{ .HostName }} "
       - type: angular
         style: powerline
         powerline_symbol: 
@@ -50,7 +50,7 @@ blocks:
         foreground: black
         properties:
           fetch_version: true
-        template: " ﮰ {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
+        template: " 󰚲 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
       - type: aws
         style: powerline
         powerline_symbol: 
@@ -83,7 +83,7 @@ blocks:
         foreground: black
         properties:
           fetch_version: true
-        template: " ﳑ {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
+        template: " 󰟓 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} "
       - type: java
         style: powerline
         powerline_symbol: 
@@ -103,7 +103,7 @@ blocks:
         powerline_symbol: 
         background: lightYellow
         foreground: black
-        template: " ﴱ {{.Context}}{{if .Namespace}} :: {{.Namespace}}{{end}} "
+        template: " 󰠳 {{.Context}}{{if .Namespace}} :: {{.Namespace}}{{end}} "
       - type: node
         style: powerline
         powerline_symbol: 
@@ -111,7 +111,7 @@ blocks:
         foreground: black
         properties:
           fetch_version: true
-        template: "  {{ if .PackageManagerIcon }}{{ .PackageManagerIcon }} {{ end }}{{ .Full }} "
+        template: " 󰎙 {{ if .PackageManagerIcon }}{{ .PackageManagerIcon }} {{ end }}{{ .Full }} "
       - type: php
         style: powerline
         powerline_symbol: 
@@ -192,7 +192,7 @@ blocks:
           fetch_status: true
           fetch_upstream_icon: true
           fetch_worktree_count: true
-        template: "{{ .UpstreamIcon }}{{ .HEAD }}{{if .BranchStatus }} {{ .BranchStatus }}{{ end }}{{ if .Working.Changed }}  {{ .Working.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }}  {{ .Staging.String }}{{ end }}{{ if gt .StashCount 0 }}  {{ .StashCount }}{{ end }}"
+        template: "{{ .UpstreamIcon }}{{ .HEAD }}{{if .BranchStatus }} {{ .BranchStatus }}{{ end }}{{ if .Working.Changed }}  {{ .Working.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }}  {{ .Staging.String }}{{ end }}{{ if gt .StashCount 0 }} 󰆓 {{ .StashCount }}{{ end }}"
   - type: prompt
     alignment: left
     newline: true
@@ -210,7 +210,7 @@ blocks:
         foreground: black
         properties:
           always_enabled: true
-        template: " {{ if gt .Code 0 }}{{ else }}{{ end }}{{ if eq ( gt .Code 0 ) .Segments.Path.Writable}} {{ end }}"
+        template: " {{ if gt .Code 0 }}󰋔 {{ else }} {{ end }}{{ if eq ( gt .Code 0 ) .Segments.Path.Writable}} {{ end }}"
       - type: path
         style: powerline
         powerline_symbol: 
@@ -221,10 +221,10 @@ blocks:
         properties:
           style: agnoster_short
           folder_icon: 
-          folder_separator_icon: "  "
-          home_icon: 
+          folder_separator_icon: " 󰁕 "
+          home_icon: 󰋜
           max_depth: 3
-        template: "{{ if eq ( gt .Code 0 ) .Writable }} {{ end }} {{ .Path }}{{ if not .Writable  }} {{ end }}{{ if and .Writable .Root }} {{end}}"
+        template: "{{ if eq ( gt .Code 0 ) .Writable }} {{ end }} {{ .Path }}{{ if not .Writable  }} 󰍁 {{ end }}{{ if and .Writable .Root }} {{end}} "
       - type: text
         style: diamond
         trailing_diamond: 

--- a/themes/glowsticks.omp.yaml
+++ b/themes/glowsticks.omp.yaml
@@ -52,7 +52,7 @@ blocks:
           always_enabled: true
           style: round
         style: powerline
-        template: " 羽{{ .FormattedMs }} "
+        template: " 󰔟{{ .FormattedMs }} "
         type: executiontime
 
       # Exit code
@@ -84,14 +84,14 @@ blocks:
         foreground: p:white
         leading_diamond: 
         properties:
-          charged_icon: 
-          charging_icon: 
-          discharging_icon: " "
+          charged_icon: 󰂄
+          charging_icon: 󰂄
+          discharging_icon: "󰁹 "
         style: diamond
-        template: " {{.Templates }}{{ .Percentage}} <transparent></>"
+        template: " {{.Templates }}{{ .Percentage}}󰏰 <transparent></>"
         templates:
-          - '{{if eq "Discharging" .State.String}}{{if lt .Percentage 11}}{{else if lt .Percentage 21}}{{else if lt .Percentage 31}}{{else if lt .Percentage 41}}{{else if lt .Percentage 51}}{{else if lt .Percentage 61}}{{else if lt .Percentage 71}}{{else if lt .Percentage 81}}{{else if lt .Percentage 91}}{{else}}{{end}}{{end}}'
-          - '{{if eq "Charging" .State.String}}{{ if lt .Percentage 21}}{{else if lt .Percentage 31}}{{else if lt .Percentage 41}}{{else if lt .Percentage 61}}{{else if lt .Percentage 81}}{{else if lt .Percentage 91}}{{else}}{{end}}{{end}}'
+          - '{{if eq "Discharging" .State.String}}{{if lt .Percentage 11}}󰁺{{else if lt .Percentage 21}}󰁻{{else if lt .Percentage 31}}󰁼{{else if lt .Percentage 41}}󰁽{{else if lt .Percentage 51}}󰁾{{else if lt .Percentage 61}}󰁾{{else if lt .Percentage 71}}󰂀{{else if lt .Percentage 81}}󰂁{{else if lt .Percentage 91}}󰂂{{else}}󰁹{{end}}{{end}}'
+          - '{{if eq "Charging" .State.String}}{{ if lt .Percentage 21}}󰂆{{else if lt .Percentage 31}}󰂇{{else if lt .Percentage 41}}󰂈{{else if lt .Percentage 61}}󰂉{{else if lt .Percentage 81}}󰂊{{else if lt .Percentage 91}}󰂋{{else}}󰂄{{end}}{{end}}'
         templates_logic: first_match
         type: battery
 
@@ -117,7 +117,7 @@ blocks:
             if ! res=$(curl -s wttr.in -Gsm2 --data-urlencode "format=j1"); then
               echo "$now"
               date +'%s' >/tmp/last_update.w
-              echo 睊 >/tmp/weather.w
+              echo 󰖪 >/tmp/weather.w
               rm /tmp/w_lock.w
               exit 0
             fi
@@ -125,7 +125,7 @@ blocks:
             temp=$(jq -r .temp_C <<<"$res")
             feels_like=$(jq -r .FeelsLikeC <<<"$res")
             [[ $(bc -l <<<"$feels_like!=$temp") -eq 1 ]] && feels_string=" feels $feels_like°C"
-            WWC_MAP='{"113":"Sunny","116":"PartlyCloudy","119":"Cloudy","122":"VeryCloudy","143":"Fog","176":"LightShowers","179":"LightSleetShowers","182":"LightSleet","185":"LightSleet","200":"ThunderyShowers","227":"LightSnow","230":"HeavySnow","248":"Fog","260":"Fog","263":"LightShowers","266":"LightRain","281":"LightSleet","284":"LightSleet","293":"LightRain","296":"LightRain","299":"HeavyShowers","302":"HeavyRain","305":"HeavyShowers","308":"HeavyRain","311":"LightSleet","314":"LightSleet","317":"LightSleet","320":"LightSnow","323":"LightSnowShowers","326":"LightSnowShowers","329":"HeavySnow","332":"HeavySnow","335":"HeavySnowShowers","338":"HeavySnow","350":"LightSleet","353":"LightShowers","356":"HeavyShowers","359":"HeavyRain","362":"LightSleetShowers","365":"LightSleetShowers","368":"LightSnowShowers","371":"HeavySnowShowers","374":"LightSleetShowers","377":"LightSleet","386":"ThunderyShowers","389":"ThunderyHeavyRain","392":"ThunderySnowShowers","395":"HeavySnowShowers"}';NF_DAY_MAP='{"Unknown":"ﮊ","Cloudy":"","Fog":"","HeavyRain":"","HeavyShowers":"","HeavySnow":"","HeavySnowShowers":"","LightRain":"","LightShowers":"","LightSleet":"","LightSleetShowers":"","LightSnow":"","LightSnowShowers":"","PartlyCloudy":"","Sunny":"","ThunderyHeavyRain":"","ThunderyShowers":"","ThunderySnowShowers":"","VeryCloudy":""}';NF_NIGHT_MAP='{"Unknown":"ﮊ","Cloudy":"","Fog":"","HeavyRain":"","HeavyShowers":"","HeavySnow":"","HeavySnowShowers":"","LightRain":"","LightShowers":"","LightSleet":"","LightSleetShowers":"","LightSnow":"","LightSnowShowers":"","PartlyCloudy":"","Sunny":"","ThunderyHeavyRain":"","ThunderyShowers":"","ThunderySnowShowers":"","VeryCloudy":""}'
+            WWC_MAP='{"113":"Sunny","116":"PartlyCloudy","119":"Cloudy","122":"VeryCloudy","143":"Fog","176":"LightShowers","179":"LightSleetShowers","182":"LightSleet","185":"LightSleet","200":"ThunderyShowers","227":"LightSnow","230":"HeavySnow","248":"Fog","260":"Fog","263":"LightShowers","266":"LightRain","281":"LightSleet","284":"LightSleet","293":"LightRain","296":"LightRain","299":"HeavyShowers","302":"HeavyRain","305":"HeavyShowers","308":"HeavyRain","311":"LightSleet","314":"LightSleet","317":"LightSleet","320":"LightSnow","323":"LightSnowShowers","326":"LightSnowShowers","329":"HeavySnow","332":"HeavySnow","335":"HeavySnowShowers","338":"HeavySnow","350":"LightSleet","353":"LightShowers","356":"HeavyShowers","359":"HeavyRain","362":"LightSleetShowers","365":"LightSleetShowers","368":"LightSnowShowers","371":"HeavySnowShowers","374":"LightSleetShowers","377":"LightSleet","386":"ThunderyShowers","389":"ThunderyHeavyRain","392":"ThunderySnowShowers","395":"HeavySnowShowers"}';NF_DAY_MAP='{"Unknown":"󰚌","Cloudy":"","Fog":"","HeavyRain":"","HeavyShowers":"","HeavySnow":"","HeavySnowShowers":"","LightRain":"","LightShowers":"","LightSleet":"","LightSleetShowers":"","LightSnow":"","LightSnowShowers":"","PartlyCloudy":"","Sunny":"","ThunderyHeavyRain":"","ThunderyShowers":"","ThunderySnowShowers":"","VeryCloudy":""}';NF_NIGHT_MAP='{"Unknown":"󰚌","Cloudy":"","Fog":"","HeavyRain":"","HeavyShowers":"","HeavySnow":"","HeavySnowShowers":"","LightRain":"","LightShowers":"","LightSleet":"","LightSleetShowers":"","LightSnow":"","LightSnowShowers":"","PartlyCloudy":"","Sunny":"","ThunderyHeavyRain":"","ThunderyShowers":"","ThunderySnowShowers":"","VeryCloudy":""}'
             cur_h="$(date +'%H')" ;wwc="$(jq '.weatherCode' <<<"$res")"
             if [[ $cur_h -gt 18 || $cur_h -lt 6 ]]; then icon=$(jq -r ".$(echo "$WWC_MAP" | jq -r ".$wwc")" <<<"$NF_DAY_MAP")
             else icon=$(jq -r ".$(echo "$WWC_MAP" | jq -r ".$wwc")" <<<"$NF_NIGHT_MAP"); fi

--- a/themes/mojada.omp.json
+++ b/themes/mojada.omp.json
@@ -93,7 +93,7 @@
             "always_enabled": true
           },
           "style": "plain",
-          "template": " {{ if gt .Code 0 }}\uf52f{{ else }}\uf4a7{{ end }} ",
+          "template": " {{ if gt .Code 0 }}\udb80\udc30{{ else }}\uf4a7{{ end }} ",
           "type": "status"
         },
         {


### PR DESCRIPTION
### Prerequisites

- ✔ I have read and understood the [contributing guide][CONTRIBUTING.md].
- ✔ The commit message follows the [conventional commits][cc] guidelines.
- [n.a] Tests for the changes have been added (for bug fixes / features).
- [n.a] Docs have been added/updated (for bug fixes / features).

### Description

In the 3.0.0 release of Nerd Fonts (published April 30, 2023), many icons were moved to new Unicode codepoints.
In this fix I've updated all the themes to point to the new icon locations based on the table published here: https://github.com/ryanoasis/nerd-fonts/issues/1059#issuecomment-1404891287

I did an initial programmatic pass with this script: https://gist.github.com/Bondrake/b7ceb021f70172b65a551ecc42a78c98
I then manually verified and tested the changes.

It only effected these three themes:
* devious-diamonds
* glowsticks
* mojada