### PR TITLE
fix: image export of extended Nerd Font glyphs

### DIFF
--- a/src/engine/image.go
+++ b/src/engine/image.go
@@ -42,8 +42,8 @@ import (
 
 	"github.com/esimov/stackblur-go"
 	"github.com/fogleman/gg"
-	"github.com/golang/freetype/truetype"
 	"golang.org/x/image/font"
+	"golang.org/x/image/font/opentype"
 )
 
 type ConnectionError struct {
@@ -217,7 +217,7 @@ func (ir *ImageRenderer) loadFonts() error {
 
 	// Download font if not cached
 	if data == nil {
-		url := "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.1.0/Hack.zip"
+		url := "https://github.com/ryanoasis/nerd-fonts/releases/download/v3.2.1/Hack.zip"
 		var err error
 
 		data, err = fontCLI.Download(url)
@@ -237,7 +237,7 @@ func (ir *ImageRenderer) loadFonts() error {
 		return err
 	}
 
-	fontFaceOptions := &truetype.Options{Size: 2.0 * 12, DPI: 144}
+	fontFaceOptions := &opentype.FaceOptions{Size: 2.0 * 12, DPI: 144}
 
 	parseFont := func(file *zip.File) (font.Face, error) {
 		rc, err := file.Open()
@@ -252,12 +252,16 @@ func (ir *ImageRenderer) loadFonts() error {
 			return nil, err
 		}
 
-		font, err := truetype.Parse(data)
+		font, err := opentype.Parse(data)
 		if err != nil {
 			return nil, err
 		}
 
-		return truetype.NewFace(font, fontFaceOptions), nil
+		fontFace, err := opentype.NewFace(font, fontFaceOptions)
+		if err != nil {
+			return nil, err
+		}
+		return fontFace, nil
 	}
 
 	for _, file := range zipReader.File {

--- a/src/go.mod
+++ b/src/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/alecthomas/repr v0.4.0 // indirect
 	github.com/esimov/stackblur-go v1.1.0
 	github.com/fogleman/gg v1.3.0
-	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gookit/color v1.5.4
 	github.com/huandu/xstrings v1.4.0 // indirect
@@ -70,6 +69,7 @@ require (
 	github.com/containerd/console v1.0.4 // indirect
 	github.com/dsnet/compress v0.0.1 // indirect
 	github.com/fatih/color v1.16.0 // indirect
+	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect


### PR DESCRIPTION
### Prerequisites

✔ I have read and understood the [contributing guide][CONTRIBUTING.md].
✔ The commit message follows the [conventional commits][cc] guidelines.
ⁿ/ₐ Tests for the changes have been added (for bug fixes / features).
ⁿ/ₐ Docs have been added/updated (for bug fixes / features).

### Description
Since Nerd Font release 3.0.0 about a year ago, many icons are in Unicode codepoints beyond the Basic Multilingual Plane. The `golang/freetype/truetype` font rasterizer does not currently handle these properly. Fortunately, [golang.org/x/image/font/opentype](https://pkg.go.dev/golang.org/x/image/font/opentype) will work basically as a drop-in replacement without this limitation.

Fixes #4480

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
