### PR TITLE
fix(schema): remove nonexistent targets from URLs

### DIFF
--- a/themes/schema.json
+++ b/themes/schema.json
@@ -286,7 +286,7 @@
         "type": {
           "type": "string",
           "title": "Segment Type",
-          "description": "https://ohmyposh.dev/docs/configuration/segment#type",
+          "description": "https://ohmyposh.dev/docs/configuration/segment",
           "enum": [
             "az",
             "aws",
@@ -414,12 +414,12 @@
         },
         "templates": {
           "$ref": "#/definitions/templates",
-          "description": "https://ohmyposh.dev/docs/configuration/segment#templates"
+          "description": "https://ohmyposh.dev/docs/configuration/segment"
         },
         "templates_logic": {
           "type": "string",
           "title": "Templates Logic",
-          "description": "https://ohmyposh.dev/docs/configuration/segment#templates",
+          "description": "https://ohmyposh.dev/docs/configuration/segment",
           "enum": [
             "first_match",
             "join"
@@ -476,13 +476,13 @@
         "interactive": {
           "type": "boolean",
           "title": "Allow the use of interactive prompt escape sequences",
-          "description": "https://ohmyposh.dev/docs/configuration/segment#interactive",
+          "description": "https://ohmyposh.dev/docs/configuration/segment",
           "default": false
         },
         "alias": {
           "type": "string",
           "title": "Give the segment an alias for use in templates",
-          "description": "https://ohmyposh.dev/docs/configuration/segment#alias",
+          "description": "https://ohmyposh.dev/docs/configuration/segment",
           "default": ""
         }
       },

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -425,16 +425,16 @@
             "join"
           ]
         },
-        "max_cols": {
+        "max_width": {
           "type": "integer",
           "title": "if the terminal width exceeds this value, the segment will be hidden",
-          "description": "https://ohmyposh.dev/docs/configuration/segment#max_cols",
+          "description": "https://ohmyposh.dev/docs/configuration/segment",
           "default": 0
         },
-        "min_cols": {
+        "min_width": {
           "type": "integer",
           "title": "if the terminal width is inferior than this value, the segment will be hidden",
-          "description": "https://ohmyposh.dev/docs/configuration/segment#min_cols",
+          "description": "https://ohmyposh.dev/docs/configuration/segment",
           "default": 0
         },
         "properties": {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

More JSON schema fixes.
Primarily addressing https://github.com/JanDeDobbeleer/oh-my-posh/issues/4878, the JSON schema had `min_cols` and `max_cols` when the documentation and code references `min_width` and `max_width`.

I also noticed some outdates URLs that pointed to targets that didn't exist on their pages, so I removed the targets.

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
