### PR TITLE
theme(tiwahu): better contrast for git segment in vs code terminal

### DIFF
--- a/themes/tiwahu.omp.json
+++ b/themes/tiwahu.omp.json
@@ -55,8 +55,8 @@
           "type": "path"
         },
         {
-          "background": "#f14e32",
-          "foreground": "#f0efe7",
+          "background": "#cf432B",
+          "foreground": "#f1f0e9",
           "properties": {
             "branch_icon": "\ue725 ",
             "cherry_pick_icon": "\ue29b ",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.

### Description

The existing contrast, which matched the [git logo](https://git-scm.com/images/logo@2x.png), worked well in *Windows Terminal*, et al.; however, some places, like *Visual Studio Code*'s terminal, ignored the settings and used dark foreground text instead.  This update provides a better contrast that doesn't trip the threshold while maintaining the original intent of the theme.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
