### PR TITLE
fix(theme) adding space to template to preserve the intended display style without side effects

### DIFF
--- a/themes/montys.omp.json
+++ b/themes/montys.omp.json
@@ -81,7 +81,7 @@
             "always_enabled": true
           },
           "style": "diamond",
-          "template": " {{ if gt .Code 0 }}\uf421{{ else }}\uf469{{ end }}",
+          "template": " {{ if gt .Code 0 }}\uf421{{ else }}\uf469{{ end }} ",
           "trailing_diamond": "\ue0b4",
           "type": "status"
         }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

This pull request addresses an issue observed in [**montys**] theme, where the status character at the end of the rendered content was being truncated, The solution involved adjusting the template to include additional space, thereby allowing ample room for the character to render fully. This adjustment resolves the rendering issue and ensures the complete display of the status character.



**Before change**
![image](https://github.com/JanDeDobbeleer/oh-my-posh/assets/63824041/2ec973e6-e195-4d92-a5e0-6b74eed27c23)

![image](https://github.com/JanDeDobbeleer/oh-my-posh/assets/63824041/e3797327-f860-4cca-a553-2437ee054982)

**After change**
![image](https://github.com/JanDeDobbeleer/oh-my-posh/assets/63824041/7fc7b4bf-a69c-4d1c-9f60-a4f43e6d5e3f)

![image](https://github.com/JanDeDobbeleer/oh-my-posh/assets/63824041/c681dfd1-82a1-409f-9bce-117b1b4cbd0a)


