### PR TITLE
feat(zsh): remove rprompt space natively

### DIFF
--- a/src/engine/engine.go
+++ b/src/engine/engine.go
@@ -222,14 +222,6 @@ func (e *Engine) renderBlock(block *Block, cancelNewline bool) bool {
 			return false
 		}
 
-		// in ZSH, RPROMPT is printed with a trailing space
-		// to ensure alignment, we need to print a space here
-		// see https://github.com/JanDeDobbeleer/oh-my-posh/issues/4327
-		if e.Env.Shell() == shell.ZSH {
-			text += " "
-			length++
-		}
-
 		space, OK := e.canWriteRightBlock(false)
 		// we can't print the right block as there's not enough room available
 		if !OK {

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -4,6 +4,7 @@ export POSH_PID=$$
 export POWERLINE_COMMAND="oh-my-posh"
 export CONDA_PROMPT_MODIFIER=false
 export POSH_PROMPT_COUNT=0
+export ZLE_RPROMPT_INDENT=0
 
 # set secondary prompt
 PS2="$(::OMP:: print secondary --config="$POSH_THEME" --shell=zsh)"


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

relates to #4938

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
