### PR TITLE
fix links to Bazel docs for versions greater than 6

### DIFF
--- a/src/segments/bazel.go
+++ b/src/segments/bazel.go
@@ -33,8 +33,8 @@ func (c *Bazel) Init(props properties.Properties, env platform.Environment) {
 				regex:      `bazel (?P<version>((?P<major>[0-9]+).(?P<minor>[0-9]+).(?P<patch>[0-9]+)))`,
 			},
 		},
-		// Use the correct URL for Bazel 6.x. it does not have the docs subdomain.
-		versionURLTemplate: "https://{{ if ne .Major \"6\" }}docs.{{ end }}bazel.build/versions/{{ .Major }}.{{ .Minor }}.{{ .Patch }}",
+		// Use the correct URL for Bazel >5.4.1, since they do not have the docs subdomain.
+		versionURLTemplate: "https://{{ if lt .Major 6 }}docs.{{ end }}bazel.build/versions/{{ .Major }}.{{ .Minor }}.{{ .Patch }}",
 	}
 	c.Icon = props.GetString(Icon, "\ue63a")
 }

--- a/src/segments/bazel_test.go
+++ b/src/segments/bazel_test.go
@@ -14,9 +14,12 @@ func TestBazel(t *testing.T) {
 		Version        string
 		Template       string
 	}{
+		{Case: "bazel 4.0.0", ExpectedString: "<LINK>https://docs.bazel.build/versions/4.0.0<TEXT>\ue63a</TEXT></LINK> 4.0.0", Version: "bazel 4.0.0", Template: ""},
+		{Case: "bazel 5.4.1", ExpectedString: "<LINK>https://docs.bazel.build/versions/5.4.1<TEXT>\ue63a</TEXT></LINK> 5.4.1", Version: "bazel 5.4.1", Template: ""},
 		{Case: "bazel 6.4.0", ExpectedString: "<LINK>https://bazel.build/versions/6.4.0<TEXT>\ue63a</TEXT></LINK> 6.4.0", Version: "bazel 6.4.0", Template: ""},
-		{Case: "bazel 10.11.12", ExpectedString: "<LINK>https://docs.bazel.build/versions/3.7.0<TEXT>\ue63a</TEXT></LINK> 3.7.0", Version: "bazel 3.7.0"},
-		{Case: "", ExpectedString: "\ue63a err parsing info from bazel with", Version: ""},
+		{Case: "bazel 7.1.1", ExpectedString: "<LINK>https://bazel.build/versions/7.1.1<TEXT>\ue63a</TEXT></LINK> 7.1.1", Version: "bazel 7.1.1", Template: ""},
+		{Case: "bazel 10.11.12", ExpectedString: "<LINK>https://bazel.build/versions/10.11.12<TEXT>\ue63a</TEXT></LINK> 10.11.12", Version: "bazel 10.11.12", Template: ""},
+		{Case: "", ExpectedString: "\ue63a err parsing info from bazel with", Version: "", Template: ""},
 	}
 	for _, tc := range cases {
 		params := &mockedLanguageParams{


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).

### Description

Quick fix to links to bazel > 6.
Added some more tests.