### PR TITLE
feat: Added in Helm segment support for helmfiles

### DIFF
--- a/src/segments/helm.go
+++ b/src/segments/helm.go
@@ -19,7 +19,7 @@ func (h *Helm) Enabled() bool {
 	}
 
 	inChart := false
-	files := []string{"Chart.yml", "Chart.yaml"}
+	files := []string{"Chart.yml", "Chart.yaml", "helmfile.yaml", "helmfile.yml"}
 	for _, file := range files {
 		if _, err := h.env.HasParentFilePath(file); err == nil {
 			inChart = true

--- a/src/segments/helm_test.go
+++ b/src/segments/helm_test.go
@@ -58,6 +58,22 @@ func TestHelmSegment(t *testing.T) {
 			ChartFile:       "Chart.yaml",
 		},
 		{
+			Case:            "DisplayMode always inside chart. Chart file helmfile.yaml",
+			HelmExists:      true,
+			ExpectedEnabled: true,
+			ExpectedString:  "Helm 3.12.3",
+			DisplayMode:     "files",
+			ChartFile:       "helmfile.yaml",
+		},
+		{
+			Case:            "DisplayMode always inside chart. Chart file helmfile.yml",
+			HelmExists:      true,
+			ExpectedEnabled: true,
+			ExpectedString:  "Helm 3.12.3",
+			DisplayMode:     "files",
+			ChartFile:       "helmfile.yml",
+		},
+		{
 			Case:            "DisplayMode always outside chart",
 			HelmExists:      true,
 			ExpectedEnabled: false,

--- a/website/docs/segments/helm.mdx
+++ b/website/docs/segments/helm.mdx
@@ -25,7 +25,7 @@ import Config from '@site/src/components/Config.js';
 
 | Name           | Type     | Default  | Description                                                                                                                                                      |
 | -------------- | :------: | :------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `display_mode` | `string` | `always` | <ul><li>`always`: the segment is always displayed</li><li>`files`: the segment is only displayed when a `Chart.yaml` (or `Chart.yml`) file is present </li></ul> |
+| `display_mode` | `string` | `always` | <ul><li>`always`: the segment is always displayed</li><li>`files`: the segment is only displayed when a chart source file `Chart.yaml` (or `Chart.yml`) or helmfile `helmfile.yaml` (or `helmfile.yml`) is present </li></ul> |
 
 ## Template ([info][templates])
 


### PR DESCRIPTION
[Helmfile](https://github.com/helmfile/helmfile) is a useful utility to deploy multiple helm charts with a simple yaml syntax. When run, `helm` is invoked from your local machine. It'd be quite useful to know your current helm version before you run `helmfile apply` and potentially clobber something with your old helm version.

### Prerequisites

- [X] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [X] The commit message follows the [conventional commits][cc] guidelines.
- [X] Tests for the changes have been added (for bug fixes / features).
- [X] Docs have been added/updated (for bug fixes / features).

### Description

Simply adds in `helmfile.yaml` and `helmfile.yml` to file checks for display_mode. 


### Disclaimer

First time contributor, I probably screwed something up.