### PR TITLE
fix: owm allow location city name with spaces

### DIFF
--- a/src/segments/owm.go
+++ b/src/segments/owm.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net/url"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/platform"
 	"github.com/jandedobbeleer/oh-my-posh/src/properties"
@@ -89,6 +90,8 @@ func (d *Owm) getResult() (*owmDataResponse, error) {
 
 	location := d.props.GetString(Location, "De Bilt,NL")
 
+	location = url.QueryEscape(location)
+
 	if len(apikey) == 0 || len(location) == 0 {
 		return nil, errors.New("no api key or location found")
 	}
@@ -96,7 +99,7 @@ func (d *Owm) getResult() (*owmDataResponse, error) {
 	units := d.props.GetString(Units, "standard")
 	httpTimeout := d.props.GetInt(properties.HTTPTimeout, properties.DefaultHTTPTimeout)
 
-	d.URL = fmt.Sprintf("http://api.openweathermap.org/data/2.5/weather?q=%s&units=%s&appid=%s", location, units, apikey)
+	d.URL = fmt.Sprintf("https://api.openweathermap.org/data/2.5/weather?q=%s&units=%s&appid=%s", location, units, apikey)
 
 	body, err := d.env.HTTPRequest(d.URL, nil, httpTimeout)
 	if err != nil {

--- a/src/segments/owm_test.go
+++ b/src/segments/owm_test.go
@@ -3,6 +3,7 @@ package segments
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"testing"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/mock"
@@ -13,7 +14,7 @@ import (
 )
 
 const (
-	OWMWEATHERAPIURL = "http://api.openweathermap.org/data/2.5/weather?q=%s&units=metric&appid=key"
+	OWMWEATHERAPIURL = "https://api.openweathermap.org/data/2.5/weather?q=%s&units=metric&appid=key"
 )
 
 func TestOWMSegmentSingle(t *testing.T) {
@@ -79,8 +80,9 @@ func TestOWMSegmentSingle(t *testing.T) {
 			properties.CacheTimeout: 0,
 		}
 
-		url := fmt.Sprintf(OWMWEATHERAPIURL, tc.Location)
-		env.On("HTTPRequest", url).Return([]byte(tc.WeatherJSONResponse), tc.Error)
+		location := url.QueryEscape(tc.Location)
+		testURL := fmt.Sprintf(OWMWEATHERAPIURL, location)
+		env.On("HTTPRequest", testURL).Return([]byte(tc.WeatherJSONResponse), tc.Error)
 		env.On("Error", mock2.Anything)
 
 		o := &Owm{
@@ -200,7 +202,8 @@ func TestOWMSegmentIcons(t *testing.T) {
 		},
 	}
 
-	url := fmt.Sprintf(OWMWEATHERAPIURL, "AMSTERDAM,NL")
+	location := url.QueryEscape("AMSTERDAM,NL")
+	testURL := fmt.Sprintf(OWMWEATHERAPIURL, location)
 
 	for _, tc := range cases {
 		env := &mock.MockedEnvironment{}
@@ -208,7 +211,7 @@ func TestOWMSegmentIcons(t *testing.T) {
 		weatherResponse := fmt.Sprintf(`{"weather":[{"icon":"%s"}],"main":{"temp":20.3}}`, tc.IconID)
 		expectedString := fmt.Sprintf("%s (20°C)", tc.ExpectedIconString)
 
-		env.On("HTTPRequest", url).Return([]byte(weatherResponse), nil)
+		env.On("HTTPRequest", testURL).Return([]byte(weatherResponse), nil)
 
 		o := &Owm{
 			props: properties.Map{
@@ -229,9 +232,9 @@ func TestOWMSegmentIcons(t *testing.T) {
 		env := &mock.MockedEnvironment{}
 
 		weatherResponse := fmt.Sprintf(`{"weather":[{"icon":"%s"}],"main":{"temp":20.3}}`, tc.IconID)
-		expectedString := fmt.Sprintf("«%s (20°C)»(%s)", tc.ExpectedIconString, url)
+		expectedString := fmt.Sprintf("«%s (20°C)»(%s)", tc.ExpectedIconString, testURL)
 
-		env.On("HTTPRequest", url).Return([]byte(weatherResponse), nil)
+		env.On("HTTPRequest", testURL).Return([]byte(weatherResponse), nil)
 
 		o := &Owm{
 			props: properties.Map{


### PR DESCRIPTION
- Escape the location parameter of the owm segment to allow for city names with spaces to function correctly.
- Update the owm api url to use https.

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
