### PR TITLE
feat(git): add icon for Codeberg upstream

### DIFF
--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -101,6 +101,8 @@ const (
 	AzureDevOpsIcon properties.Property = "azure_devops_icon"
 	// CodeCommit shows  when upstream is aws codecommit
 	CodeCommit properties.Property = "codecommit_icon"
+	// CodebergIcon shows when upstream is codeberg
+	CodebergIcon properties.Property = "codeberg_icon"
 	// GitlabIcon shows when upstream is gitlab
 	GitlabIcon properties.Property = "gitlab_icon"
 	// GitIcon shows when the upstream can't be identified
@@ -498,6 +500,7 @@ func (g *Git) getUpstreamIcon() string {
 		"dev.azure.com":    {AzureDevOpsIcon, "\uEBE8 "},
 		"visualstudio.com": {AzureDevOpsIcon, "\uEBE8 "},
 		"codecommit":       {CodeCommit, "\uF270 "},
+		"codeberg":         {CodebergIcon, "\uF330 "},
 	}
 	for key, value := range defaults {
 		if strings.Contains(g.UpstreamURL, key) {

--- a/src/segments/git_test.go
+++ b/src/segments/git_test.go
@@ -672,6 +672,7 @@ func TestGitUpstream(t *testing.T) {
 		{Case: "Azure DevOps", Expected: "AD", Upstream: "dev.azure.com/test"},
 		{Case: "Azure DevOps Dos", Expected: "AD", Upstream: "test.visualstudio.com"},
 		{Case: "CodeCommit", Expected: "AC", Upstream: "codecommit::eu-west-1://test-repository"},
+		{Case: "Codeberg", Expected: "CB", Upstream: "codeberg.org:user/repo.git"},
 		{Case: "Gitstash", Expected: "G", Upstream: "gitstash.com/test"},
 		{Case: "My custom server", Expected: "CU", Upstream: "mycustom.server/test"},
 	}
@@ -687,6 +688,7 @@ func TestGitUpstream(t *testing.T) {
 			BitbucketIcon:   "BB",
 			AzureDevOpsIcon: "AD",
 			CodeCommit:      "AC",
+			CodebergIcon:    "CB",
 			GitIcon:         "G",
 			UpstreamIcons: map[string]string{
 				"mycustom.server": "CU",

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -1328,6 +1328,12 @@
                     "description": "Icon/text to display when the upstream is CodeCommit",
                     "default": "\uF270"
                   },
+                  "codeberg_icon": {
+                    "type": "string",
+                    "title": "Codeberg Icon",
+                    "description": "Icon/text to display when the upstream is Codeberg",
+                    "default": "\uF330"
+                  },
                   "git_icon": {
                     "type": "string",
                     "title": "Git Icon",

--- a/website/docs/segments/git.mdx
+++ b/website/docs/segments/git.mdx
@@ -116,6 +116,7 @@ You can set the following properties to `true` to enable fetching additional inf
 | `bitbucket_icon`    | `string`            | `\uF171` | icon/text to display when the upstream is Bitbucket                                                                                                                          |
 | `azure_devops_icon` | `string`            | `\uEBE8` | icon/text to display when the upstream is Azure DevOps                                                                                                                       |
 | `codecommit_icon`   | `string`            | `\uF270` | icon/text to display when the upstream is AWS CodeCommit                                                                                                                     |
+| `codeberg_icon`     | `string`            | `\uF330` | icon/text to display when the upstream is Codeberg                                                                                                                           |
 | `git_icon`          | `string`            | `\uE5FB` | icon/text to display when the upstream is not known/mapped                                                                                                                   |
 | `upstream_icons`    | `map[string]string` |          | a key, value map representing the remote URL (or a part of that URL) and icon to use in case the upstream URL contains the key. These get precedence over the standard icons |
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description
Add an icon for Codeberg git remotes.
<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
