### PR TITLE
Segment for Azure Developer CLI (azd)

### DIFF
--- a/src/engine/segment.go
+++ b/src/engine/segment.go
@@ -101,6 +101,8 @@ const (
 	AWS SegmentType = "aws"
 	// AZ writes the Azure subscription info we're currently in
 	AZ SegmentType = "az"
+	// AZD writes the Azure Developer CLI environment info we're current in
+	AZD SegmentType = "azd"
 	// AZFUNC writes current AZ func version
 	AZFUNC SegmentType = "azfunc"
 	// BATTERY writes the battery percentage
@@ -278,6 +280,7 @@ var Segments = map[SegmentType]func() SegmentWriter{
 	ARGOCD:          func() SegmentWriter { return &segments.Argocd{} },
 	AWS:             func() SegmentWriter { return &segments.Aws{} },
 	AZ:              func() SegmentWriter { return &segments.Az{} },
+	AZD:             func() SegmentWriter { return &segments.Azd{} },
 	AZFUNC:          func() SegmentWriter { return &segments.AzFunc{} },
 	BATTERY:         func() SegmentWriter { return &segments.Battery{} },
 	BAZEL:           func() SegmentWriter { return &segments.Bazel{} },

--- a/src/segments/azd.go
+++ b/src/segments/azd.go
@@ -1,0 +1,78 @@
+package segments
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/platform"
+	"github.com/jandedobbeleer/oh-my-posh/src/properties"
+)
+
+type Azd struct {
+	props properties.Properties
+	env   platform.Environment
+
+	azdConfig
+}
+
+type azdConfig struct {
+	Version            int    `json:"version"`
+	DefaultEnvironment string `json:"defaultEnvironment"`
+}
+
+func (t *Azd) Template() string {
+	return " \uebd8 {{ .DefaultEnvironment }} "
+}
+
+func (t *Azd) Init(props properties.Properties, env platform.Environment) {
+	t.props = props
+	t.env = env
+}
+
+func (t *Azd) Enabled() bool {
+	var parentFilePath string
+
+	folders := t.props.GetStringArray(LanguageFolders, []string{".azure"})
+	for _, folder := range folders {
+		if file, err := t.env.HasParentFilePath(folder); err == nil {
+			parentFilePath = file.ParentFolder
+			break
+		}
+	}
+
+	if len(parentFilePath) == 0 {
+		t.env.Debug("No .azure folder found in parent directories")
+		return false
+	}
+
+	dotAzureFolder := filepath.Join(parentFilePath, ".azure")
+	files := t.env.LsDir(dotAzureFolder)
+
+	for _, file := range files {
+		if file.IsDir() {
+			continue
+		}
+
+		if strings.EqualFold(file.Name(), "config.json") {
+			return t.TryReadConfigJSON(filepath.Join(dotAzureFolder, file.Name()))
+		}
+	}
+
+	return false
+}
+
+func (t *Azd) TryReadConfigJSON(file string) bool {
+	if len(file) == 0 {
+		return false
+	}
+
+	content := t.env.FileContent(file)
+	var config azdConfig
+	if err := json.Unmarshal([]byte(content), &config); err != nil {
+		return false
+	}
+
+	t.azdConfig = config
+	return true
+}

--- a/src/segments/azd_test.go
+++ b/src/segments/azd_test.go
@@ -1,0 +1,72 @@
+package segments
+
+import (
+	"errors"
+	"io/fs"
+	"path/filepath"
+	"testing"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/mock"
+	"github.com/jandedobbeleer/oh-my-posh/src/platform"
+	"github.com/jandedobbeleer/oh-my-posh/src/properties"
+	"github.com/stretchr/testify/assert"
+	mock2 "github.com/stretchr/testify/mock"
+)
+
+func TestAzdSegment(t *testing.T) {
+	cases := []struct {
+		Case            string
+		ExpectedEnabled bool
+		ExpectedString  string
+		Template        string
+		IsInited        bool
+	}{
+		{
+			Case:            "no .azure directory found",
+			ExpectedEnabled: false,
+		},
+		{
+			Case:            "Environment located",
+			ExpectedEnabled: true,
+			ExpectedString:  "TestEnvironment",
+			Template:        "{{ .DefaultEnvironment }}",
+			IsInited:        true,
+		},
+	}
+
+	for _, tc := range cases {
+		env := new(mock.MockedEnvironment)
+		env.On("Debug", mock2.Anything)
+
+		if tc.IsInited {
+			fileInfo := &platform.FileInfo{
+				Path:         "test/.azure",
+				ParentFolder: "test",
+				IsDir:        true,
+			}
+			env.On("HasParentFilePath", ".azure").Return(fileInfo, nil)
+			dirEntries := []fs.DirEntry{
+				&MockDirEntry{
+					name:  "config.json",
+					isDir: false,
+				}, &MockDirEntry{
+					name:  "TestEnvironment",
+					isDir: true,
+				},
+			}
+			env.On("LsDir", filepath.Join("test", ".azure")).Return(dirEntries, nil)
+
+			env.On("FileContent", filepath.Join("test", ".azure", "config.json")).Return(`{"version": 1, "defaultEnvironment": "TestEnvironment"}`, nil)
+		} else {
+			env.On("HasParentFilePath", ".azure").Return(&platform.FileInfo{}, errors.New("no such file or directory"))
+		}
+
+		azd := Azd{
+			env:   env,
+			props: properties.Map{},
+		}
+
+		assert.Equal(t, tc.ExpectedEnabled, azd.Enabled(), tc.Case)
+		assert.Equal(t, tc.ExpectedString, renderTemplate(env, tc.Template, azd), tc.Case)
+	}
+}

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -289,6 +289,7 @@
           "description": "https://ohmyposh.dev/docs/configuration/segment",
           "enum": [
             "az",
+            "azd",
             "aws",
             "azfunc",
             "argocd",
@@ -647,6 +648,24 @@
                     ]
                   }
                 }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "azd"
+              }
+            }
+          },
+          "then": {
+            "title": "Azure Developer CLI Segment",
+            "description": "https://ohmyposh.dev/docs/segments/azd",
+            "properties": {
+              "properties": {
+                "properties": { }
               }
             }
           }

--- a/website/docs/segments/azd.mdx
+++ b/website/docs/segments/azd.mdx
@@ -1,0 +1,44 @@
+---
+id: azd
+title: Azure Developer CLI
+sidebar_label: azd
+---
+
+## What
+
+Display the currently active environment in the Azure Developer CLI.
+
+## Sample Configuration
+
+import Config from "@site/src/components/Config.js";
+
+<Config
+  data={{
+    type: "azd",
+    style: "powerline",
+    powerline_symbol: "\uE0B0",
+    foreground: "#000000",
+    background: "#9ec3f0",
+    template: " \uebd8 {{ .DefaultEnvironment }} ",
+  }}
+/>
+
+## Template ([info][templates])
+
+:::note default template
+
+```template
+ \uebd8 {{ .DefaultEnvironment }}
+```
+
+:::
+
+### Properties
+
+| Name                  | Type     | Description                          |
+| --------------------- | -------- | ------------------------------------ |
+| `.DefaultEnvironment` | `string` | Azure Developer CLI environment name |
+| `.Version`            | `number` | Config version number                |
+
+[templates]: /docs/configuration/templates
+[azd]: https://aka.ms/azd


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

I wanted to show the current environment as per [`azd`](https://aka.ms/azd), so I've added a segment that will show that.

Here's an example of the prompt with it:

![Prompt sample](https://github.com/JanDeDobbeleer/oh-my-posh/assets/434140/336ca582-6de8-4c84-9c50-9b64672f82ae)

