### PR TITLE
docs: imrove home page

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -34,7 +34,7 @@
 }
 
 .hero--image {
-  margin-top: 10px;
+  margin-top: 4rem;
 }
 
 .header-github-link:hover {

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -63,12 +63,21 @@ function Home() {
           <div className={styles.buttons}>
             <Link
               className={classnames(
-                "button button--outline button--lg",
+                "button button--primary button--lg",
                 styles.getStarted
               )}
               to={useBaseUrl("docs/")}
             >
-              Get Started
+              Get Started &rarr;
+            </Link>
+            <Link
+              className={classnames(
+                "button button--outline button--lg",
+                styles.getStarted
+              )}
+              to={useBaseUrl("docs/themes")}
+            >
+              See themes &rarr;
             </Link>
           </div>
           <img class="hero--image" src="/img/hero.png" alt="Oh My Posh prompt"></img>

--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -21,6 +21,7 @@
 
 .buttons {
   display: flex;
+  flex-wrap: wrap;
   gap: 1rem 1.5rem;
   align-items: center;
   justify-content: center;

--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -21,7 +21,7 @@
 
 .buttons {
   display: flex;
-  gap: 2rem;
+  gap: 1rem 1.5rem;
   align-items: center;
   justify-content: center;
 }

--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -15,7 +15,7 @@
 
 @media screen and (max-width: 966px) {
   .heroBanner {
-    padding: 2rem;
+    padding: 2rem 0;
   }
 }
 

--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -7,6 +7,7 @@
 
 .heroBanner {
   padding: 4rem 0;
+  min-height: 60vh;
   text-align: center;
   position: relative;
   overflow: hidden;
@@ -20,6 +21,7 @@
 
 .buttons {
   display: flex;
+  gap: 2rem;
   align-items: center;
   justify-content: center;
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Changes the home page hero section to have more spacing and improves the buttons.

- The hero section was changed to match 60% of the screen's height so it acts more like a hero section.
- The existing "Get Started" button now has a &rarr; character and is full color. Along side it is a button to view the themes.
- Additional space has been added between the buttons and the example image
- Fixes the mobile view side padding on the hero (it included the sides accidentally)

These changes were inspired by the [Pico CSS](https://picocss.com) and [Starship](https://starship.rs) websites.

## Before

| Desktop | Mobile |
|--------|--------|
| ![image](https://github.com/JanDeDobbeleer/oh-my-posh/assets/109556932/9719ecd3-8c52-4591-9930-ef9ec7c49aef) | ![image](https://github.com/JanDeDobbeleer/oh-my-posh/assets/109556932/15616a86-d986-49c3-9ebf-6c11ab5fbda9) |

## After

| Desktop | Mobile |
|--------|--------|
| ![image](https://github.com/JanDeDobbeleer/oh-my-posh/assets/109556932/df8ca3f4-cdd8-45ad-9cb6-962efc88e5c3) | ![image](https://github.com/JanDeDobbeleer/oh-my-posh/assets/109556932/306df9bc-f914-41d9-a907-2b958a0b4168) | 

## Additional Info

The two buttons' gap might look better as 1rem, since there isn't that much flavor text on the second line. This causes the page to feel like a triangle more than the diamond of most hero sections.

With 1rem spacing:

![image](https://github.com/JanDeDobbeleer/oh-my-posh/assets/109556932/52d22cc7-9202-416b-a749-3c7d33dfb5dd)

The button styles were changed a little using the [Infima presets](https://infima.dev/docs/components/button/) to stay consistent. The main button was changed from an outline to the primary version.

Other styles could be used, such as the `success` or `info` colors, but semantically the primary makes more sense even if it doesn't contrast the hero section as much.

![image](https://github.com/JanDeDobbeleer/oh-my-posh/assets/109556932/12aa5920-c7d7-4bdf-8e21-1f17bf443177)


If any of the above changes look better than the current version, please comment and I can easily apply them.

As one final note, the example image kind of gets really tiny on mobile. I know that the intended audience would probably view the website from a desktop, but it still is a bit silly looking on the phone.

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
