### PR TITLE
docs: Update share-theme.md to clarify output filename

### DIFF
--- a/src/cli/config_export.go
+++ b/src/cli/config_export.go
@@ -88,11 +88,13 @@ func cleanOutputPath(path string, env runtime.Environment) string {
 		path = strings.TrimPrefix(path, "~")
 		path = filepath.Join(env.Home(), path)
 	}
+
 	if !filepath.IsAbs(path) {
 		if absPath, err := filepath.Abs(path); err == nil {
 			path = absPath
 		}
 	}
+
 	return filepath.Clean(path)
 }
 

--- a/src/image/image.go
+++ b/src/image/image.go
@@ -150,10 +150,7 @@ type Renderer struct {
 func (ir *Renderer) Init(env runtime.Environment) error {
 	ir.env = env
 
-	if ir.Path == "" {
-		match := regex.FindNamedRegexMatch(`.*(\/|\\)(?P<STR>.+)\.(json|yaml|yml|toml)`, env.Flags().Config)
-		ir.Path = fmt.Sprintf("%s.png", strings.TrimSuffix(match[str], ".omp"))
-	}
+	ir.setOutputPath(env.Flags().Config)
 
 	ir.cleanContent()
 
@@ -204,6 +201,28 @@ func (ir *Renderer) Init(env runtime.Environment) error {
 	}
 
 	return nil
+}
+
+func (ir *Renderer) setOutputPath(config string) {
+	if len(ir.Path) != 0 {
+		return
+	}
+
+	if len(config) == 0 {
+		ir.Path = "prompt.png"
+		return
+	}
+
+	config = filepath.Base(config)
+
+	match := regex.FindNamedRegexMatch(`(\.?)(?P<STR>.*)\.(json|yaml|yml|toml|jsonc)`, config)
+	path := strings.TrimRight(match[str], ".omp")
+
+	if len(path) == 0 {
+		path = "prompt"
+	}
+
+	ir.Path = fmt.Sprintf("%s.png", path)
 }
 
 func (ir *Renderer) loadFonts() error {

--- a/website/docs/share-theme.md
+++ b/website/docs/share-theme.md
@@ -13,7 +13,7 @@ Depending on your config, you might have to tweak the output a little bit.
 :::
 
 The oh-my-posh executable has the `config export image` command to export your current theme configuration
-to an image file (.png).
+to a PNG image file (if no other options are specified this will be the name of the config file, or `prompt.png`).
 
 ```powershell
 oh-my-posh config export image
@@ -23,6 +23,6 @@ There are a couple of additional flags you can use to tweak the image rendering:
 
 - `--author`: the name of the creator, added after `ohmyposh.dev`
 - `--background-color`: the hex background color to use (e.g. `#222222`)
-- `--output`: the file to export to (e.g. `theme.png`)
+- `--output`: the file to export to (e.g. `mytheme.png`)
 
 For all options, and additional examples, use `oh-my-posh config export image --help`


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Docs have been added/updated (for bug fixes / features).

### Description
Added clarification that the output file will literally be `.png` - when I first ran the command I couldn't see an export then realised it was called this and hidden by default as it's a dotfile.

Not sure if it might be worth changing it so that if no export filename is specified a default (e.g., `omptheme.png` or similar) is used to stop it ended up being a hidden file?  For just now I've just updated the docs though.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
