### PR TITLE
docs: fix prism theme

### DIFF
--- a/website/src/css/prism-rose-pine-moon.css
+++ b/website/src/css/prism-rose-pine-moon.css
@@ -5,197 +5,197 @@
  * Ported for PrismJS by fvrests [@fvrests]
  */
 
- code[class*="language-"],
- pre[class*="language-"] {
-     color: #e0def4;
-     background: #232136;
-     font-family: "Cartograph CF", ui-monospace, SFMono-Regular, Menlo, Monaco,
-         Consolas, "Liberation Mono", "Courier New", monospace;
-     text-align: left;
-     white-space: pre;
-     word-spacing: normal;
-     word-break: normal;
-     word-wrap: normal;
-     line-height: 1.5;
+code[class*="language-"],
+pre[class*="language-"] {
+  color: #e0def4;
+  background: #232136;
+  font-family: "Cartograph CF", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
+    monospace;
+  text-align: left;
+  white-space: pre;
+  word-spacing: normal;
+  word-break: normal;
+  word-wrap: normal;
+  line-height: 1.5;
 
-     -moz-tab-size: 4;
-     -o-tab-size: 4;
-     tab-size: 4;
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  tab-size: 4;
 
-     -webkit-hyphens: none;
-     -moz-hyphens: none;
-     -ms-hyphens: none;
-     hyphens: none;
+  -webkit-hyphens: none;
+  -moz-hyphens: none;
+  -ms-hyphens: none;
+  hyphens: none;
 
-     @media print {
-         text-shadow: none;
-     }
- }
+  @media print {
+    text-shadow: none;
+  }
+}
 
- /* Selection */
- code[class*="language-"]::-moz-selection,
- pre[class*="language-"]::-moz-selection,
- code[class*="language-"] ::-moz-selection,
- pre[class*="language-"] ::-moz-selection {
-     background: #312f44;
- }
+/* Selection */
+code[class*="language-"]::-moz-selection,
+pre[class*="language-"]::-moz-selection,
+code[class*="language-"] ::-moz-selection,
+pre[class*="language-"] ::-moz-selection {
+  background: #44415a;
+}
 
- code[class*="language-"]::selection,
- pre[class*="language-"]::selection,
- code[class*="language-"] ::selection,
- pre[class*="language-"] ::selection {
-     background: #312f44;
- }
+code[class*="language-"]::selection,
+pre[class*="language-"]::selection,
+code[class*="language-"] ::selection,
+pre[class*="language-"] ::selection {
+  background: #44415a;
+}
 
- /* Code (block & inline) */
- :not(pre) > code[class*="language-"],
- pre[class*="language-"] {
-     color: #e0def4;
-     background: #232136;
- }
+/* Code (block & inline) */
+:not(pre) > code[class*="language-"],
+pre[class*="language-"] {
+  color: #e0def4;
+  background: #232136;
+}
 
- /* Code blocks */
- pre[class*="language-"] {
-     padding: 1em;
-     margin: 0.5em 0;
-     overflow: auto;
- }
+/* Code blocks */
+pre[class*="language-"] {
+  padding: 1em;
+  margin: 0.5em 0;
+  overflow: auto;
+}
 
- /* Inline code */
- :not(pre) > code[class*="language-"] {
-     padding: 0.1em;
-     border-radius: 0.3em;
-     white-space: normal;
-     color: #e0def4;
-     background: #232136;
- }
+/* Inline code */
+:not(pre) > code[class*="language-"] {
+  padding: 0.1em;
+  border-radius: 0.3em;
+  white-space: normal;
+  color: #e0def4;
+  background: #232136;
+}
 
- /* Text style & opacity */
- .token.entity {
-     cursor: help;
- }
+/* Text style & opacity */
+.token.entity {
+  cursor: help;
+}
 
- .token.important,
- .token.bold {
-     font-weight: bold;
- }
+.token.important,
+.token.bold {
+  font-weight: bold;
+}
 
- .token.italic,
- .token.selector,
- .token.doctype,
- .token.attr-name,
- .token.inserted,
- .token.deleted,
- .token.comment,
- .token.prolog,
- .token.cdata,
- .token.constant,
- .token.parameter,
- .token.url {
-     font-style: italic;
- }
+.token.italic,
+.token.selector,
+.token.doctype,
+.token.attr-name,
+.token.inserted,
+.token.deleted,
+.token.comment,
+.token.prolog,
+.token.cdata,
+.token.constant,
+.token.parameter,
+.token.url {
+  font-style: italic;
+}
 
- .token.url {
-     text-decoration: underline;
- }
+.token.url {
+  text-decoration: underline;
+}
 
- .namespace {
-     opacity: 0.7;
- }
+.namespace {
+  opacity: 0.7;
+}
 
- /* Syntax highlighting */
- .token.constant {
-     color: #e0def4;
- }
+/* Syntax highlighting */
+.token.constant {
+  color: #e0def4;
+}
 
- .token.comment,
- .token.prolog,
- .token.cdata,
- .token.punctuation {
-     color: #59546d;
- }
+.token.comment,
+.token.prolog,
+.token.cdata,
+.token.punctuation {
+  color: #908caa;
+}
 
- .token.delimiter,
- .token.important,
- .token.atrule,
- .token.operator,
- .token.keyword {
-     color: #3e8fb0;
- }
+.token.delimiter,
+.token.important,
+.token.atrule,
+.token.operator,
+.token.keyword {
+  color: #3e8fb0;
+}
 
- .token.tag,
- .token.tag .punctuation,
- .token.doctype,
- .token.variable,
- .token.regex,
- .token.class-name,
- .token.selector,
- .token.inserted {
-     color: #9ccfd8;
- }
+.token.tag,
+.token.tag .punctuation,
+.token.doctype,
+.token.variable,
+.token.regex,
+.token.class-name,
+.token.selector,
+.token.inserted {
+  color: #9ccfd8;
+}
 
- .token.boolean,
- .token.entity,
- .token.number,
- .token.symbol,
- .token.function {
-     color: #ea9a97;
- }
+.token.boolean,
+.token.entity,
+.token.number,
+.token.symbol,
+.token.function {
+  color: #ea9a97;
+}
 
- .token.string,
- .token.char,
- .token.property,
- .token.attr-value,
- .token.attr-value .punctuation {
-     color: #f6c177;
- }
+.token.string,
+.token.char,
+.token.property,
+.token.attr-value,
+.token.attr-value .punctuation {
+  color: #f6c177;
+}
 
- .token.parameter,
- .token.url,
- .token.name,
- .token.attr-name,
- .token.builtin {
-     color: #c4a7e7;
- }
+.token.parameter,
+.token.url,
+.token.name,
+.token.attr-name,
+.token.builtin {
+  color: #c4a7e7;
+}
 
- .token.deleted {
-     color: #eb6f92;
- }
+.token.deleted {
+  color: #eb6f92;
+}
 
- /* Insertions & deletions */
- .token.inserted {
-     background: rgba(156 207 216 0.12);
- }
+/* Insertions & deletions */
+.token.inserted {
+  background: rgba(156 207 216 0.12);
+}
 
- .token.deleted {
-     background: rgba(235 111 146 0.12);
- }
+.token.deleted {
+  background: rgba(235 111 146 0.12);
+}
 
- /* Line highlighting */
- pre[data-line] {
-     position: relative;
- }
+/* Line highlighting */
+pre[data-line] {
+  position: relative;
+}
 
- pre[class*="language-"] > code[class*="language-"] {
-     position: relative;
-     z-index: 1;
- }
+pre[class*="language-"] > code[class*="language-"] {
+  position: relative;
+  z-index: 1;
+}
 
- .line-highlight,
- .highlight-lines .highlighted {
-     position: absolute;
-     left: 0;
-     right: 0;
-     padding: inherit 0;
-     margin-top: 1em;
+.line-highlight,
+.highlight-lines .highlighted {
+  position: absolute;
+  left: 0;
+  right: 0;
+  padding: inherit 0;
+  margin-top: 1em;
 
-     background: #312f44;
-     box-shadow: inset 5px 0 0 #e0def4;
+  background: #44415a;
+  box-shadow: inset 5px 0 0 #e0def4;
 
-     z-index: 0;
+  z-index: 0;
 
-     pointer-events: none;
+  pointer-events: none;
 
-     line-height: inherit;
-     white-space: pre;
- }
+  line-height: inherit;
+  white-space: pre;
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

This fixes the prism theme to be the [up to date rose-pine theme](https://github.com/rose-pine/prism/blob/main/dist/prism-rose-pine-moon.css). It literally just copies over the linked theme on top of the current one.

## Before

![image](https://github.com/JanDeDobbeleer/oh-my-posh/assets/109556932/3ca82c2c-de4a-4452-8a92-51fe6bca656b)

## After

![image](https://github.com/JanDeDobbeleer/oh-my-posh/assets/109556932/64dfa314-9c1e-4834-88f2-8c27312303b3)


## Additional Information

A side effect was fixing the highlight colors, but most of the other things just don't work due to how Docusaurus handles prism themes with its built in theme engine.

For future work on the prism theme, you will likely have to figure out how to disable the built-in docusaurus theme as it is applying the styles as inline on the elements themselves. Otherwise, you could potentially just slap a `!important` on most of the declarations in the CSS, though that feels a bit wrong.

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
