### PR TITLE
feat(tooltips): allow multiple tooltips for tip

### DIFF
--- a/website/docs/configuration/tooltips.mdx
+++ b/website/docs/configuration/tooltips.mdx
@@ -47,4 +47,28 @@ This configuration will render a right-aligned git segment when you type `git` o
 A tip should not include any spaces. Keep in mind that this is a blocking call, meaning that if the segment renders slow,
 you can't type until it's visible. Optimizations in this space are being explored.
 
+Note that you can also define multiple tooltips for the same tip to compose tooltips for individual commands. For example,
+this configuration will render the AWS profile as well as the Azure subscription information when you type `terraform`
+followed by a space.
+
+<Config data={{
+  "blocks": [],
+  "tooltips": [
+    {
+      "type": "aws",
+      "tips": ["aws", "terraform"],
+      "style": "plain",
+      "foreground": "#e0af68",
+      "template": "\uf0e0f {{.Profile}}{{if .Region}}@{{.Region}}{{end}}"
+    },
+    {
+      "type": "az",
+      "tips": ["az", "terraform"],
+      "style": "plain",
+      "foreground": "#b4f9f8",
+      "template": "\uebd8 {{ .Name }}"
+    }
+  ]
+}}/>
+
 [clink]: https://chrisant996.github.io/clink/


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description
Instead of rendering only the last tooltip that matches a given tip it will now render all tooltips that trigger for that tip. This is helpful for commands like `terraform` that might operate on multiple cloud providers at once.

<img width="649" alt="image" src="https://github.com/JanDeDobbeleer/oh-my-posh/assets/4354632/eea0ba22-b258-4107-985a-1cf5a05f29ce">

```toml
[[tooltips]]
type = 'aws'
tips = ['aws', 'terraform']
style = 'plain'
foreground = 'p:terminal-yellow'
template = '󰸏 {{.Profile}}{{if .Region}}@{{.Region}}{{end}}'

[[tooltips]]
type = "az"
tips = ['az', 'terraform']
style = 'plain'
foreground = 'p:celeste-blue'
template = '  {{ .Name }}'
```


[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
