### PR TITLE
Allow nushell to have set_poshcontext like other shells

### DIFF
--- a/src/shell/scripts/omp.nu
+++ b/src/shell/scripts/omp.nu
@@ -28,6 +28,10 @@ $env.PROMPT_COMMAND = { ||
         $clear = (history | is-empty) or ((history | last 1 | get 0.command) == "clear")
     }
 
+    if ($env.SET_POSHCONTEXT? | is-not-empty) {
+        do --env $env.SET_POSHCONTEXT
+    }
+
     ^::OMP:: print primary $"--config=($env.POSH_THEME)" --shell=nu $"--shell-version=($env.POSH_SHELL_VERSION)" $"--execution-time=(posh_cmd_duration)" $"--status=($env.LAST_EXIT_CODE)" $"--terminal-width=(posh_width)" $"--cleared=($clear)"
 }
 

--- a/website/docs/configuration/templates.mdx
+++ b/website/docs/configuration/templates.mdx
@@ -91,6 +91,15 @@ end
 ```
 
 </TabItem>
+<TabItem value="nu">
+
+```bash
+$env.SET_POSHCONTEXT = {
+	$env.POSH = ( date now );
+}
+```
+
+</TabItem>
 </Tabs>
 
 :::


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

This change allows nushell to execute `set_poshcontext` like other shells do.

Following the same example on the docs for nushell would be:

```nu
def --env set_poshcontext [] {
	$env.POSH = ( date now );
}
```

I don't know how to update the doc