### PR TITLE
Add missing `auto_upgrade` setting to documentation and config schema

### DIFF
--- a/themes/schema.json
+++ b/themes/schema.json
@@ -4676,6 +4676,12 @@
       "description": "https://ohmyposh.dev/docs/configuration/title#general-settings",
       "default": false
     },
+    "auto_upgrade": {
+      "type": "boolean",
+      "title": "Enable automatic upgrades for Oh My Posh (supports Windows/macOS only)",
+      "description": "https://ohmyposh.dev/docs/configuration/title#general-settings",
+      "default": false
+    },
     "patch_pwsh_bleed": {
       "type": "boolean",
       "title": "Patch PowerShell Color Bleed",

--- a/website/docs/configuration/general.mdx
+++ b/website/docs/configuration/general.mdx
@@ -137,6 +137,7 @@ For example, the following is a valid `--config` flag:
 | `disable_cursor_positioning` | `boolean`        | disable fetching the cursor position in bash and zsh in case of unwanted side-effects                                                                                                                                                                                        |
 | `patch_pwsh_bleed`           | `boolean`        | patch a PowerShell bug where the background colors bleed into the next line at the end of the buffer (can be removed when [this][pwsh-bleed] is merged)                                                                                                                      |
 | `disable_notice`             | `boolean`        | disable the upgrade notice                                                                                                                                                                                                                                                   |
+| `auto_upgrade`               | `boolean`        | enable automatic upgrades for Oh My Posh (supports Windows/macOS only)                                                                                                                                                                                                       |
 | `iterm_features`             | `[]string`       | enable iTerm2 specific features:<ul><li>`prompt_mark`: add the `iterm2_prompt_mark` [function][iterm2-si] for supported shells</li><li>`current_dir`: expose the current directory for iTerm2</li><li>`remote_host`: expose the current remote and user for iTerm2</li></ul> |
 
 ### JSON Schema Validation
@@ -160,7 +161,7 @@ For example, given the following code:
 ```
 
 Warnings will be raised for type, since `an_invalid_entry` is not in the list of acceptable values, as well as
-for the entire segment item (enclosed in {}), since it lacks the required `style` key. Take advantage of these
+for the entire segment item (enclosed in `{}`), since it lacks the required `style` key. Take advantage of these
 warnings, and ignore them at your peril.
 
 ### Accepted Formats


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

The `auto_upgrade` setting was introduced in #5080. The config schema (`schema.json`) is also updated.

Related: #5120.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
