### PR TITLE
fix(shell): prioritize `$?` for consistent status in Bash/Zsh

### DIFF
--- a/src/shell/scripts/omp.bash
+++ b/src/shell/scripts/omp.bash
@@ -35,7 +35,7 @@ function _omp_start_timer() {
 }
 
 function _omp_ftcs_command_start() {
-    if [ "::FTCS_MARKS::" == "true" ]; then
+    if [[ "::FTCS_MARKS::" == "true" ]]; then
         printf "\e]133;C\a"
     fi
 }
@@ -55,11 +55,14 @@ function _omp_hook() {
     local omp_elapsed=-1
     local no_exit_code="true"
 
-    if [[ -n "$omp_start_time" ]]; then
+    if [[ "$omp_start_time" ]]; then
         local omp_now=$(::OMP:: get millis --shell=bash)
-        omp_elapsed=$((omp_now-omp_start_time))
+        omp_elapsed=$((omp_now - omp_start_time))
         omp_start_time=""
         no_exit_code="false"
+    fi
+    if [[ "${pipeStatus[-1]}" != "$ret" ]]; then
+        pipeStatus=("$ret")
     fi
 
     set_poshcontext
@@ -69,11 +72,11 @@ function _omp_hook() {
     return $ret
 }
 
-if [ "$TERM" != "linux" ] && [ -x "$(command -v ::OMP::)" ] && ! [[ "$PROMPT_COMMAND" =~ "_omp_hook" ]]; then
+if [[ "$TERM" != "linux" ]] && [[ -x "$(command -v ::OMP::)" ]] && ! [[ "$PROMPT_COMMAND" =~ "_omp_hook" ]]; then
     PROMPT_COMMAND="_omp_hook; $PROMPT_COMMAND"
 fi
 
-if [ "::UPGRADE::" == "true" ]; then
+if [[ "::UPGRADE::" == "true" ]]; then
     echo "::UPGRADENOTICE::"
 fi
 

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -13,7 +13,7 @@ function _set_posh_cursor_position() {
   # not supported in Midnight Commander
   # see https://github.com/JanDeDobbeleer/oh-my-posh/issues/3415
   if [[ "::CURSOR::" != "true" ]] || [[ -v MC_SID ]]; then
-      return
+    return
   fi
 
   local oldstty=$(stty -g)
@@ -44,7 +44,8 @@ function prompt_ohmyposh_preexec() {
 }
 
 function prompt_ohmyposh_precmd() {
-  omp_last_error=$? pipeStatus=(${pipestatus[@]})
+  omp_last_error=$?
+  local pipeStatus=(${pipestatus[@]})
   omp_stack_count=${#dirstack[@]}
   omp_elapsed=-1
   no_exit_code="true"
@@ -52,6 +53,9 @@ function prompt_ohmyposh_precmd() {
     local omp_now=$(::OMP:: get millis --shell=zsh)
     omp_elapsed=$(($omp_now-$omp_start_time))
     no_exit_code="false"
+  fi
+  if [[ "${pipeStatus[-1]}" != "$omp_last_error" ]]; then
+    pipeStatus=("$omp_last_error")
   fi
   count=$((POSH_PROMPT_COUNT+1))
   export POSH_PROMPT_COUNT=$count
@@ -67,8 +71,8 @@ add-zsh-hook precmd prompt_ohmyposh_precmd
 add-zsh-hook preexec prompt_ohmyposh_preexec
 
 # perform cleanup so a new initialization in current session works
-if [[ "$(zle -lL self-insert)" = *"_posh-tooltip"* ]]; then
-  zle -N self-insert
+if [[ "$(bindkey " ")" = *"_posh-tooltip"* ]]; then
+  bindkey " " self-insert
 fi
 if [[ "$(zle -lL zle-line-init)" = *"_posh-zle-line-init"* ]]; then
   zle -N zle-line-init
@@ -76,7 +80,7 @@ fi
 
 function _posh-tooltip() {
   # https://github.com/zsh-users/zsh-autosuggestions - clear suggestion to avoid keeping it after the newly inserted space
-  if [[ -n "$(zle -lL autosuggest-clear)" ]]; then
+  if [[ "$(zle -lL autosuggest-clear)" ]]; then
     # only if suggestions not disabled (variable not set)
     if ! [[ -v _ZSH_AUTOSUGGEST_DISABLED ]]; then
       zle autosuggest-clear
@@ -84,7 +88,7 @@ function _posh-tooltip() {
   fi
   zle .self-insert
   # https://github.com/zsh-users/zsh-autosuggestions - fetch new suggestion after the space
-  if [[ -n "$(zle -lL autosuggest-fetch)" ]]; then
+  if [[ "$(zle -lL autosuggest-fetch)" ]]; then
     # only if suggestions not disabled (variable not set)
     if ! [[ -v _ZSH_AUTOSUGGEST_DISABLED ]]; then
       zle autosuggest-fetch
@@ -107,30 +111,30 @@ function _posh-tooltip() {
 }
 
 function _posh-zle-line-init() {
-    [[ $CONTEXT == start ]] || return 0
+  [[ $CONTEXT == start ]] || return 0
 
-    # Start regular line editor
-    (( $+zle_bracketed_paste )) && print -r -n - $zle_bracketed_paste[1]
-    zle .recursive-edit
-    local -i ret=$?
-    (( $+zle_bracketed_paste )) && print -r -n - $zle_bracketed_paste[2]
+  # Start regular line editor.
+  (( $+zle_bracketed_paste )) && print -r -n - $zle_bracketed_paste[1]
+  zle .recursive-edit
+  local -i ret=$?
+  (( $+zle_bracketed_paste )) && print -r -n - $zle_bracketed_paste[2]
 
-    eval "$(::OMP:: print transient --status="$omp_last_error" --execution-time="$omp_elapsed" --stack-count="$omp_stack_count" --config="$POSH_THEME" --eval --shell=zsh --shell-version="$ZSH_VERSION" --no-status="$no_exit_code")"
-    zle .reset-prompt
+  eval "$(::OMP:: print transient --status="$omp_last_error" --execution-time="$omp_elapsed" --stack-count="$omp_stack_count" --config="$POSH_THEME" --eval --shell=zsh --shell-version="$ZSH_VERSION" --no-status="$no_exit_code")"
+  zle .reset-prompt
 
-    # If we received EOT, we exit the shell
-    if [[ $ret == 0 && $KEYS == $'\4' ]]; then
-        exit
-    fi
+  # Exit the shell if we receive EOT.
+  if [[ $ret == 0 && $KEYS == $'\4' ]]; then
+    exit
+  fi
 
-    # Ctrl-C
-    if (( ret )); then
-        zle .send-break
-    else
-        # Enter
-        zle .accept-line
-    fi
-    return ret
+  if ((ret)); then
+    # TODO (fix): this is not equal to sending a SIGINT, since the status code ($?) is set to 1 instead of 130.
+    zle .send-break
+  else
+    # Enter
+    zle .accept-line
+  fi
+  return ret
 }
 
 function enable_poshtooltips() {
@@ -146,10 +150,10 @@ function enable_poshtransientprompt() {
   bindkey '^[[F' end-of-line
   bindkey '^[[H' beginning-of-line
   _widgets=$(zle -la)
-  if [[ -n "${_widgets[(r)down-line-or-beginning-search]}" ]]; then
+  if [[ "${_widgets[(r)down-line-or-beginning-search]}" ]]; then
     bindkey '^[[B' down-line-or-beginning-search
   fi
-  if [[ -n "${_widgets[(r)up-line-or-beginning-search]}" ]]; then
+  if [[ "${_widgets[(r)up-line-or-beginning-search]}" ]]; then
     bindkey '^[[A' up-line-or-beginning-search
   fi
 }
@@ -163,9 +167,9 @@ if [[ "::TRANSIENT::" = "true" ]]; then
 fi
 
 if [[ "::UPGRADE::" = "true" ]]; then
-    echo "::UPGRADENOTICE::"
+  echo "::UPGRADENOTICE::"
 fi
 
 if [[ "::AUTOUPGRADE::" = "true" ]]; then
-    ::OMP:: upgrade
+  ::OMP:: upgrade
 fi


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

In Bash (before v5.1) or Zsh, the last error code (`$?`) might not be consistent with the pipeline status. For example, a SIGINT (typically sent by a <kbd>Ctrl</kbd> + <kbd>C</kbd> input) sets `$?` to `130` which means a death by SIGINT, while the previous value of `$PIPESTATUS` (in Bash) or `$pipestatus` (in Zsh) persists. In Bash, this is [a bug which was fixed in v5.1][bash-changelog]. In Zsh, this still happens in the latest version (v5.9).

We can handle such cases consistently. When `$?` is not consistent with the last pipeline status code, we should use the value of `$?` as the argument for both `--status` and `--pipestatus` in an CLI call.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[bash-changelog]: https://git.savannah.gnu.org/cgit/bash.git/tree/CHANGES#n836
