### PR TITLE
Update broken link in pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
 Tips:
 
 If you're not comfortable with working with Git,
-we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
+we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
 Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.
 
 -->


### PR DESCRIPTION
The pull request template has a link to the contributing docs page on using Git, but the link failed. I found the correct one, needing just a single character change.

### Prerequisites

- [x ] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x ] The commit message follows the [conventional commits][cc] guidelines.
- [x ] Tests for the changes have been added (for bug fixes / features).
- [x ] Docs have been added/updated (for bug fixes / features).

### Description
See above.
<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing_git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
