### PR TITLE
feat: add support for fish mode

### DIFF
--- a/src/cache/template.go
+++ b/src/cache/template.go
@@ -18,6 +18,7 @@ type Template struct {
 	Code          int
 	Env           map[string]string
 	Var           maps.Simple
+	ShellVar      maps.Simple
 	OS            string
 	WSL           bool
 	PromptCount   int

--- a/src/prompt/new.go
+++ b/src/prompt/new.go
@@ -23,6 +23,7 @@ func New(flags *runtime.Flags) *Engine {
 	}
 
 	env.Var = cfg.Var
+	env.ShellVar = flags.ShellVars
 	flags.HasTransient = cfg.TransientPrompt != nil
 
 	terminal.Init(env.Shell())

--- a/src/runtime/os.go
+++ b/src/runtime/os.go
@@ -62,6 +62,7 @@ type Flags struct {
 	Cleared       bool
 	NoExitCode    bool
 	Column        int
+	ShellVars     maps.Simple
 }
 
 type CommandError struct {
@@ -197,6 +198,7 @@ type Environment interface {
 type Terminal struct {
 	CmdFlags *Flags
 	Var      maps.Simple
+	ShellVar maps.Simple
 
 	cwd       string
 	host      string
@@ -769,9 +771,14 @@ func (term *Terminal) TemplateCache() *cache.Template {
 	tmplCache.PromptCount = term.CmdFlags.PromptCount
 	tmplCache.Env = make(map[string]string)
 	tmplCache.Var = make(map[string]any)
+	tmplCache.ShellVar = make(map[string]any)
 
 	if term.Var != nil {
 		tmplCache.Var = term.Var
+	}
+
+	if term.ShellVar != nil {
+		tmplCache.ShellVar = term.ShellVar
 	}
 
 	const separator = "="

--- a/src/shell/scripts/omp.fish
+++ b/src/shell/scripts/omp.fish
@@ -29,6 +29,7 @@ function fish_prompt
     set --global omp_stack_count (count $dirstack)
     set --global omp_duration "$CMD_DURATION$cmd_duration"
     set --global omp_no_exit_code false
+    set --global omp_fish_mode $fish_bind_mode
 
     # check if variable set, < 3.2 case
     if set --query omp_lastcommand; and test "$omp_lastcommand" = ""
@@ -61,7 +62,7 @@ function fish_prompt
 
     ::PROMPT_MARK::
 
-    ::OMP:: print primary --config $POSH_THEME --shell fish --status $omp_status_cache --pipestatus="$omp_pipestatus_cache" --execution-time $omp_duration --stack-count $omp_stack_count --shell-version $FISH_VERSION --cleared=$omp_cleared --no-status=$omp_no_exit_code
+    ::OMP:: print primary --config $POSH_THEME --shell fish --status $omp_status_cache --pipestatus="$omp_pipestatus_cache" --execution-time $omp_duration --stack-count $omp_stack_count --shell-version $FISH_VERSION --cleared=$omp_cleared --no-status=$omp_no_exit_code --var FISH__MODE=$omp_fish_mode
 end
 
 function fish_right_prompt
@@ -78,7 +79,8 @@ function fish_right_prompt
       return
     end
     set has_omp_tooltip false
-    ::OMP:: print right --config $POSH_THEME --shell fish --status $omp_status_cache --execution-time $omp_duration --stack-count $omp_stack_count --shell-version $FISH_VERSION
+    set omp_fish_mode $fish_bind_mode
+    ::OMP:: print right --config $POSH_THEME --shell fish --status $omp_status_cache --execution-time $omp_duration --stack-count $omp_stack_count --shell-version $FISH_VERSION --var FISH__MODE=$omp_fish_mode
 end
 
 function postexec_omp --on-event fish_postexec

--- a/src/template/text.go
+++ b/src/template/text.go
@@ -39,6 +39,7 @@ var (
 		"SHLVL",
 		"Templates",
 		"Var",
+		"ShellVar",
 		"Data",
 	}
 )

--- a/website/docs/configuration/templates.mdx
+++ b/website/docs/configuration/templates.mdx
@@ -141,6 +141,42 @@ $env.SET_POSHCONTEXT = {
 }
 ```
 
+## Shell variables
+
+| Name                | Type  | Description                            |
+| ------------------- | ----- | -------------------------------------- |
+| `.ShellVar.VarName` | `any` | Variables passed from the active shell |
+
+### Fish supported variables
+
+| Name                   | Type     | Description                                                                          |
+| ---------------------- | -------- | ------------------------------------------------------------------------------------ |
+| `.ShellVar.FISH__MODE` | `string` | The current [VI mode](https://fishshell.com/docs/current/cmds/fish_mode_prompt.html) |
+
+### Example
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
+  "version": 2,
+  "blocks": [
+    {
+      "type": "prompt",
+      "alignment": "left",
+      "segments": [
+        {
+          "type": "text",
+          "style": "plain",
+          "foreground": "p:white",
+          // highlight-next-line
+          "template": "{{ if eq .TermVar.FISH__MODE \"insert\" }} [I] {{ else }} [?] {{ end }}"
+        }
+      ]
+    }
+  ]
+}
+```
+
 ## Template logic
 
 <!--  markdownlint-disable MD013 -->


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Adds a new mechanism for shells to pass variables to omp through a `--var key=value` argument. An attempt is made to parse these as an integer, a boolean, and falling back to string. The result is added to `ShellVar` for use in templates.

This is then used to create the `ShellVar.FISH__MODE` variable, which is set to the value of `$fish_bind_mode`.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
