### PR TITLE
chore:Devcontainer compatibility with podman

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -64,10 +64,10 @@ RUN chmod 777 -R /home/${USERNAME}/.config
 
 # Override vscode's own Bash prompt with oh-my-posh:
 RUN sed -i 's/^__bash_prompt$/#&/' /home/${USERNAME}/.bashrc && \
-    echo "eval \"\$(oh-my-posh init bash --config $POSH_THEME)\"" >> /home/${USERNAME}/.bashrc
+    echo "eval \"\$(oh-my-posh init bash)\"" >> /home/${USERNAME}/.bashrc
 
 # Override vscode's own ZSH prompt with oh-my-posh:
-RUN echo "eval \"\$(oh-my-posh init zsh --config $POSH_THEME)\"" >> /home/${USERNAME}/.zshrc
+RUN echo "eval \"\$(oh-my-posh init zsh)\"" >> /home/${USERNAME}/.zshrc
 
 # Set container timezone:
 ARG TZ="UTC"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,7 +20,16 @@
       "PS_VERSION": "7.2.7"
     }
   },
-  "runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
+  "runArgs": [
+    "--cap-add=SYS_PTRACE",
+    "--security-opt",
+    "seccomp=unconfined",
+    "--security-opt",
+    "label=disable"
+  ],
+  "containerEnv": {
+    "HOME": "/home/vscode"
+  },
 
   "customizations": {
     "vscode": {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description
Podman is stricter than Docker.
Modify devcontainer.json so that it is possible to start the devcontainer with podman. Also make sure that SELinux label are dropped within the container otherwise the worksapce is unusable. These changes remain compatible with Docker.

Note: podman needs the option --userns=keep-id. However this would make Docker break as it is an unsupported user mode. The solution is to add this option to /etc/containers/container.conf.