### PR TITLE
docs: add FAQ entry for accessing the fish bind mode

### DIFF
--- a/website/docs/faq.mdx
+++ b/website/docs/faq.mdx
@@ -279,6 +279,26 @@ This is most likely caused by two Oh My Posh init lines in your `.zshrc`, remove
 
 You should update fish to v3.4.0 or higher. Fish supports `$(...)` and `"$(...)"` since v3.4.0, as described in its [changelog][fish-changelog].
 
+### Fish: Display current bind (Vim) mode
+
+Use the `set_poshcontext` function to export the current mode. Note that scope shadowing must be disabled in order to
+access the `$fish_bind_mode` variable.
+
+```fish
+function set_poshcontext --no-scope-shadowing
+  set --export FISH__BIND_MODE $fish_bind_mode
+end
+```
+
+You can then use this in a template, for example this replicates the [example in the Fish documentation][fish-mode-prompt]:
+
+```json
+{
+  "type": "text",
+  "template": "{{ if eq .Env.FISH__BIND_MODE \"default\" }}<red>[N]</>{{ else if eq .Env.FISH__BIND_MODE \"insert\" }}<green>[I]</>{{ else if eq .Env.FISH__BIND_MODE \"replace_one\" }}<green>[R]</>{{ else if eq .Env.FISH__BIND_MODE \"visual\"}}<brmagenta>[V]</>{{ else }}<red>[?]</>{{ end }}"
+}
+```
+
 ### After updating my Nerd Font to a newer version, the prompt displays unknown characters
 
 Nerd Fonts moved the icons to a different location in the font for v3.
@@ -319,3 +339,4 @@ This is a known problem with Xonsh. The issue is tracked [here][xonsh-issue].
 [fish-changelog]: https://fishshell.com/docs/current/relnotes.html#id1
 [xonsh-issue]: https://github.com/xonsh/xonsh/issues/3810
 [zsh-init]: https://github.com/JanDeDobbeleer/oh-my-posh/discussions/3462#discussioncomment-5155790
+[fish-mode-prompt]: https://fishshell.com/docs/current/cmds/fish_mode_prompt.html#example


### PR DESCRIPTION
### Prerequisites

- [X] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [X] The commit message follows the [conventional commits][cc] guidelines.
- [X] Tests for the changes have been added (for bug fixes / features).
- [X] Docs have been added/updated (for bug fixes / features).

### Description

Adds a FAQ entry demonstrating how to access the fish bind mode using `set_poshcontext`.

### Remarks

This was somewhat nontrivial as the `$fish_bind_mode` variable was inaccessible from `set_poshcontext` by default. I have tested the example.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
