### PR TITLE
Fix and refactoring on initialization scripts for Bash, Zsh and Fish

### DIFF
--- a/src/shell/scripts/omp.bash
+++ b/src/shell/scripts/omp.bash
@@ -4,19 +4,19 @@ export POWERLINE_COMMAND="oh-my-posh"
 export POSH_PID=$$
 export CONDA_PROMPT_MODIFIER=false
 
-omp_start_time=""
-omp_stack_count=0
-omp_elapsed=-1
-omp_no_exit_code="true"
-omp_ret=0
-omp_pipe_status=0
+_omp_start_time=""
+_omp_stack_count=0
+_omp_elapsed=-1
+_omp_no_exit_code="true"
+_omp_status_cache=0
+_omp_pipestatus_cache=0
 
 # start timer on command start
-PS0='${omp_start_time:0:$((omp_start_time="$(_omp_start_timer)",0))}$(_omp_ftcs_command_start)'
+PS0='${_omp_start_time:0:$((_omp_start_time="$(_omp_start_timer)",0))}$(_omp_ftcs_command_start)'
 # set secondary prompt
 PS2="$(::OMP:: print secondary --config="$POSH_THEME" --shell=bash --shell-version="$BASH_VERSION")"
 
-function _set_posh_cursor_position() {
+function _omp_set_cursor_position() {
     # not supported in Midnight Commander
     # see https://github.com/JanDeDobbeleer/oh-my-posh/issues/3415
     if [[ "::CURSOR::" != "true" ]] || [[ -v MC_SID ]]; then
@@ -53,35 +53,35 @@ function set_poshcontext() {
 
 # regular prompt
 function _omp_hook() {
-    omp_ret=$? omp_pipe_status=(${PIPESTATUS[@]})
+    _omp_status_cache=$? _omp_pipestatus_cache=(${PIPESTATUS[@]})
 
-    if [[ "${#BP_PIPESTATUS[@]}" -ge "${#omp_pipe_status[@]}" ]]; then
-        omp_pipe_status=(${BP_PIPESTATUS[@]})
+    if [[ "${#BP_PIPESTATUS[@]}" -ge "${#_omp_pipestatus_cache[@]}" ]]; then
+        _omp_pipestatus_cache=(${BP_PIPESTATUS[@]})
     fi
 
-    omp_stack_count=$((${#DIRSTACK[@]} - 1))
+    _omp_stack_count=$((${#DIRSTACK[@]} - 1))
 
-    if [[ "$omp_start_time" ]]; then
+    if [[ "$_omp_start_time" ]]; then
         local omp_now=$(::OMP:: get millis --shell=bash)
-        omp_elapsed=$((omp_now - omp_start_time))
-        omp_start_time=""
-        omp_no_exit_code="false"
+        _omp_elapsed=$((omp_now - _omp_start_time))
+        _omp_start_time=""
+        _omp_no_exit_code="false"
     fi
 
-    if [[ "${omp_pipe_status[-1]}" != "$omp_ret" ]]; then
-        omp_pipe_status=("$omp_ret")
+    if [[ "${_omp_pipestatus_cache[-1]}" != "$_omp_status_cache" ]]; then
+        _omp_pipestatus_cache=("$_omp_status_cache")
     fi
 
     set_poshcontext
-    _set_posh_cursor_position
+    _omp_set_cursor_position
 
-    PS1="$(::OMP:: print primary --config="$POSH_THEME" --shell=bash --shell-version="$BASH_VERSION" --status="$omp_ret" --pipestatus="${omp_pipe_status[*]}" --execution-time="$omp_elapsed" --stack-count="$omp_stack_count" --no-status="$omp_no_exit_code" --terminal-width="${COLUMNS-0}" | tr -d '\0')"
+    PS1="$(::OMP:: print primary --config="$POSH_THEME" --shell=bash --shell-version="$BASH_VERSION" --status="$_omp_status_cache" --pipestatus="${_omp_pipestatus_cache[*]}" --execution-time="$_omp_elapsed" --stack-count="$_omp_stack_count" --no-status="$_omp_no_exit_code" --terminal-width="${COLUMNS-0}" | tr -d '\0')"
 }
 
 # rprompt
-_omp_rprompt() {
-    ::OMP:: print right --config="$POSH_THEME" --shell=bash --shell-version="$BASH_VERSION" --status="$omp_ret" --pipestatus="${omp_pipe_status[*]}" --execution-time="$omp_elapsed" --stack-count="$omp_stack_count" --no-status="$omp_no_exit_code" --terminal-width="${COLUMNS-0}" | tr -d '\0'
-    return $omp_ret
+function _omp_rprompt() {
+    ::OMP:: print right --config="$POSH_THEME" --shell=bash --shell-version="$BASH_VERSION" --status="$_omp_status_cache" --pipestatus="${_omp_pipestatus_cache[*]}" --execution-time="$_omp_elapsed" --stack-count="$_omp_stack_count" --no-status="$_omp_no_exit_code" --terminal-width="${COLUMNS-0}" | tr -d '\0'
+    return $_omp_status_cache
 }
 
 if [[ "$TERM" != "linux" ]] && [[ -x "$(command -v ::OMP::)" ]] && ! [[ "$PROMPT_COMMAND" =~ "_omp_hook" ]]; then

--- a/src/shell/scripts/omp.fish
+++ b/src/shell/scripts/omp.fish
@@ -3,12 +3,12 @@ set --export POSH_SHELL_VERSION $FISH_VERSION
 set --global POWERLINE_COMMAND oh-my-posh
 set --global POSH_PID $fish_pid
 set --global CONDA_PROMPT_MODIFIER false
-set --global omp_tooltip_command ''
-set --global omp_current_rprompt ''
-set --global omp_transient false
+set --global _omp_tooltip_command ''
+set --global _omp_current_rprompt ''
+set --global _omp_transient false
 
 # We use this to avoid unnecessary CLI calls for prompt repaint.
-set --global omp_new_prompt true
+set --global _omp_new_prompt true
 
 # template function for context loading
 function set_poshcontext
@@ -24,37 +24,37 @@ function fish_prompt
     # commandline --function repaint does not do this
     # see https://github.com/fish-shell/fish-shell/issues/8418
     printf \e\[0J
-    if test "$omp_transient" = true
-        ::OMP:: print transient --config $POSH_THEME --shell fish --status $omp_status_cache --pipestatus="$omp_pipestatus_cache" --execution-time $omp_duration --stack-count $omp_stack_count --shell-version $FISH_VERSION --no-status=$omp_no_exit_code
+    if test "$_omp_transient" = true
+        ::OMP:: print transient --config $POSH_THEME --shell fish --status $_omp_status_cache --pipestatus="$_omp_pipestatus_cache" --execution-time $_omp_duration --stack-count $_omp_stack_count --shell-version $FISH_VERSION --no-status=$_omp_no_exit_code
         return
     end
-    if test "$omp_new_prompt" = false
-        echo -n "$omp_current_prompt"
+    if test "$_omp_new_prompt" = false
+        echo -n "$_omp_current_prompt"
         return
     end
-    set --global omp_status_cache $omp_status_cache_temp
-    set --global omp_pipestatus_cache $omp_pipestatus_cache_temp
-    set --global omp_stack_count (count $dirstack)
-    set --global omp_duration "$CMD_DURATION$cmd_duration"
-    set --global omp_no_exit_code false
+    set --global _omp_status_cache $omp_status_cache_temp
+    set --global _omp_pipestatus_cache $omp_pipestatus_cache_temp
+    set --global _omp_stack_count (count $dirstack)
+    set --global _omp_duration "$CMD_DURATION$cmd_duration"
+    set --global _omp_no_exit_code false
 
     # check if variable set, < 3.2 case
-    if set --query omp_lastcommand; and test -z "$omp_lastcommand"
-        set omp_duration 0
-        set omp_no_exit_code true
+    if set --query _omp_last_command; and test -z "$_omp_last_command"
+        set _omp_duration 0
+        set _omp_no_exit_code true
     end
 
     # works with fish >=3.2
-    if set --query omp_last_status_generation; and test "$omp_last_status_generation" = "$status_generation"
-        set omp_duration 0
-        set omp_no_exit_code true
-    else if test -z "$omp_last_status_generation"
-        # first execution - $status_generation is 0, $omp_last_status_generation is empty
-        set omp_no_exit_code true
+    if set --query _omp_last_status_generation; and test "$_omp_last_status_generation" = "$status_generation"
+        set _omp_duration 0
+        set _omp_no_exit_code true
+    else if test -z "$_omp_last_status_generation"
+        # first execution - $status_generation is 0, $_omp_last_status_generation is empty
+        set _omp_no_exit_code true
     end
 
     if set --query status_generation
-        set --global omp_last_status_generation $status_generation
+        set --global _omp_last_status_generation $status_generation
     end
 
     set_poshcontext
@@ -70,32 +70,32 @@ function fish_prompt
     ::PROMPT_MARK::
 
     # The prompt is saved for possible reuse, typically a repaint after clearing the screen buffer.
-    set --global omp_current_prompt (::OMP:: print primary --config $POSH_THEME --shell fish --status $omp_status_cache --pipestatus="$omp_pipestatus_cache" --execution-time $omp_duration --stack-count $omp_stack_count --shell-version $FISH_VERSION --cleared=$omp_cleared --no-status=$omp_no_exit_code | string collect)
-    echo -n "$omp_current_prompt"
+    set --global _omp_current_prompt (::OMP:: print primary --config $POSH_THEME --shell fish --status $_omp_status_cache --pipestatus="$_omp_pipestatus_cache" --execution-time $_omp_duration --stack-count $_omp_stack_count --shell-version $FISH_VERSION --cleared=$omp_cleared --no-status=$_omp_no_exit_code | string collect)
+    echo -n "$_omp_current_prompt"
 end
 
 function fish_right_prompt
-    if test "$omp_transient" = true
-        set omp_transient false
+    if test "$_omp_transient" = true
+        set _omp_transient false
         return
     end
     # Repaint an existing right prompt.
-    if test "$omp_new_prompt" = false
-        echo -n "$omp_current_rprompt"
+    if test "$_omp_new_prompt" = false
+        echo -n "$_omp_current_rprompt"
         return
     end
-    set omp_new_prompt false
-    set --global omp_current_rprompt (::OMP:: print right --config $POSH_THEME --shell fish --status $omp_status_cache --pipestatus="$omp_pipestatus_cache" --execution-time $omp_duration --stack-count $omp_stack_count --shell-version $FISH_VERSION --no-status=$omp_no_exit_code | string join '')
-    echo -n "$omp_current_rprompt"
+    set _omp_new_prompt false
+    set --global _omp_current_rprompt (::OMP:: print right --config $POSH_THEME --shell fish --status $_omp_status_cache --pipestatus="$_omp_pipestatus_cache" --execution-time $_omp_duration --stack-count $_omp_stack_count --shell-version $FISH_VERSION --no-status=$_omp_no_exit_code | string join '')
+    echo -n "$_omp_current_rprompt"
 end
 
-function postexec_omp --on-event fish_postexec
+function _omp_postexec --on-event fish_postexec
     # works with fish <3.2
     # pre and postexec not fired for empty command in fish >=3.2
-    set --global omp_lastcommand $argv
+    set --global _omp_last_command $argv
 end
 
-function preexec_omp --on-event fish_preexec
+function _omp_preexec --on-event fish_preexec
     if test "::FTCS_MARKS::" = true
         echo -ne "\e]133;C\a"
     end
@@ -130,16 +130,16 @@ function _omp_space_key_handler
     # Get the first word of command line as tip.
     set --local tooltip_command (commandline --current-buffer | string trim -l | string split --allow-empty -f1 ' ' | string collect)
     # Ignore an empty/repeated tooltip command.
-    if test -z "$tooltip_command" || test "$tooltip_command" = "$omp_tooltip_command"
+    if test -z "$tooltip_command" || test "$tooltip_command" = "$_omp_tooltip_command"
         return
     end
-    set omp_tooltip_command $tooltip_command
-    set --local tooltip_prompt (::OMP:: print tooltip --config $POSH_THEME --shell fish --status $omp_status_cache --pipestatus="$omp_pipestatus_cache" --execution-time $omp_duration --stack-count $omp_stack_count --shell-version $FISH_VERSION --command $omp_tooltip_command --no-status=$omp_no_exit_code | string join '')
+    set _omp_tooltip_command $tooltip_command
+    set --local tooltip_prompt (::OMP:: print tooltip --config $POSH_THEME --shell fish --status $_omp_status_cache --pipestatus="$_omp_pipestatus_cache" --execution-time $_omp_duration --stack-count $_omp_stack_count --shell-version $FISH_VERSION --command $_omp_tooltip_command --no-status=$_omp_no_exit_code | string join '')
     if test -z "$tooltip_prompt"
         return
     end
     # Save the tooltip prompt to avoid unnecessary CLI calls.
-    set omp_current_rprompt $tooltip_prompt
+    set _omp_current_rprompt $tooltip_prompt
     commandline --function repaint
 end
 
@@ -156,10 +156,10 @@ function _omp_enter_key_handler
         return
     end
     if commandline --is-valid || test -z (commandline --current-buffer | string trim -l | string collect)
-        set omp_new_prompt true
-        set omp_tooltip_command ''
+        set _omp_new_prompt true
+        set _omp_tooltip_command ''
         if test "::TRANSIENT::" = true
-            set omp_transient true
+            set _omp_transient true
             commandline --function repaint
         end
     end
@@ -171,10 +171,10 @@ function _omp_ctrl_c_key_handler
         return
     end
     # Render a transient prompt on Ctrl-C with non-empty command line buffer.
-    set omp_new_prompt true
-    set omp_tooltip_command ''
+    set _omp_new_prompt true
+    set _omp_tooltip_command ''
     if test "::TRANSIENT::" = true
-        set omp_transient true
+        set _omp_transient true
         commandline --function repaint
     end
     commandline --function cancel-commandline

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -9,7 +9,7 @@ export ZLE_RPROMPT_INDENT=0
 # set secondary prompt
 PS2="$(::OMP:: print secondary --config="$POSH_THEME" --shell=zsh)"
 
-function _set_posh_cursor_position() {
+function _omp_set_cursor_position() {
   # not supported in Midnight Commander
   # see https://github.com/JanDeDobbeleer/oh-my-posh/issues/3415
   if [[ "::CURSOR::" != "true" ]] || [[ -v MC_SID ]]; then
@@ -36,45 +36,45 @@ function set_poshcontext() {
   return
 }
 
-function prompt_ohmyposh_preexec() {
+function _omp_preexec() {
   if [[ "::FTCS_MARKS::" = "true" ]]; then
     printf "\033]133;C\007"
   fi
 
-  omp_start_time=$(::OMP:: get millis)
+  _omp_start_time=$(::OMP:: get millis)
 }
 
-function prompt_ohmyposh_precmd() {
-  omp_status_cache=$?
-  omp_pipestatus_cache=(${pipestatus[@]})
-  omp_stack_count=${#dirstack[@]}
-  omp_elapsed=-1
-  omp_no_exit_code="true"
+function _omp_precmd() {
+  _omp_status_cache=$?
+  _omp_pipestatus_cache=(${pipestatus[@]})
+  _omp_stack_count=${#dirstack[@]}
+  _omp_elapsed=-1
+  _omp_no_exit_code="true"
 
-  if [ $omp_start_time ]; then
+  if [ $_omp_start_time ]; then
     local omp_now=$(::OMP:: get millis --shell=zsh)
-    omp_elapsed=$(($omp_now - $omp_start_time))
-    omp_no_exit_code="false"
+    _omp_elapsed=$(($omp_now - $_omp_start_time))
+    _omp_no_exit_code="false"
   fi
 
-  if [[ "${omp_pipestatus_cache[-1]}" != "$omp_status_cache" ]]; then
-    omp_pipestatus_cache=("$omp_status_cache")
+  if [[ "${_omp_pipestatus_cache[-1]}" != "$_omp_status_cache" ]]; then
+    _omp_pipestatus_cache=("$_omp_status_cache")
   fi
 
   count=$((POSH_PROMPT_COUNT + 1))
   export POSH_PROMPT_COUNT=$count
 
   set_poshcontext
-  _set_posh_cursor_position
+  _omp_set_cursor_position
 
-  eval "$(::OMP:: print primary --config="$POSH_THEME" --status="$omp_status_cache" --pipestatus="${omp_pipestatus_cache[*]}" --execution-time="$omp_elapsed" --stack-count="$omp_stack_count" --eval --shell=zsh --shell-version="$ZSH_VERSION" --no-status="$omp_no_exit_code")"
-  unset omp_start_time
+  eval "$(::OMP:: print primary --config="$POSH_THEME" --status="$_omp_status_cache" --pipestatus="${_omp_pipestatus_cache[*]}" --execution-time="$_omp_elapsed" --stack-count="$_omp_stack_count" --eval --shell=zsh --shell-version="$ZSH_VERSION" --no-status="$_omp_no_exit_code")"
+  unset _omp_start_time
 }
 
 # add hook functions
 autoload -Uz add-zsh-hook
-add-zsh-hook precmd prompt_ohmyposh_precmd
-add-zsh-hook preexec prompt_ohmyposh_preexec
+add-zsh-hook precmd _omp_precmd
+add-zsh-hook preexec _omp_preexec
 
 # Prevent incorrect behaviors when the initialization is executed twice in current session.
 function _omp_cleanup() {
@@ -105,12 +105,12 @@ function _omp_render_tooltip() {
   local tooltip_command=${${(MS)BUFFER##[[:graph:]]*}%%[[:space:]]*}
 
   # Ignore an empty/repeated tooltip command.
-  if [[ -z "$tooltip_command" ]] || [[ "$tooltip_command" = "$omp_tooltip_command" ]]; then
+  if [[ -z "$tooltip_command" ]] || [[ "$tooltip_command" = "$_omp_tooltip_command" ]]; then
     return
   fi
 
-  omp_tooltip_command="$tooltip_command"
-  local tooltip=$(::OMP:: print tooltip --config="$POSH_THEME" --status="$omp_status_cache" --pipestatus="${omp_pipestatus_cache[*]}" --execution-time="$omp_elapsed" --stack-count="$omp_stack_count" --command="$tooltip_command" --shell=zsh --shell-version="$ZSH_VERSION" --no-status="$omp_no_exit_code")
+  _omp_tooltip_command="$tooltip_command"
+  local tooltip=$(::OMP:: print tooltip --config="$POSH_THEME" --status="$_omp_status_cache" --pipestatus="${_omp_pipestatus_cache[*]}" --execution-time="$_omp_elapsed" --stack-count="$_omp_stack_count" --command="$tooltip_command" --shell=zsh --shell-version="$ZSH_VERSION" --no-status="$_omp_no_exit_code")
   if [[ -z "$tooltip" ]]; then
     return
   fi
@@ -128,8 +128,8 @@ function _omp_zle-line-init() {
   local -i ret=$?
   (( $+zle_bracketed_paste )) && print -r -n - $zle_bracketed_paste[2]
 
-  omp_tooltip_command=''
-  eval "$(::OMP:: print transient --config="$POSH_THEME" --status="$omp_status_cache" --pipestatus="${omp_pipestatus_cache[*]}" --execution-time="$omp_elapsed" --stack-count="$omp_stack_count" --eval --shell=zsh --shell-version="$ZSH_VERSION" --no-status="$omp_no_exit_code")"
+  _omp_tooltip_command=''
+  eval "$(::OMP:: print transient --config="$POSH_THEME" --status="$_omp_status_cache" --pipestatus="${_omp_pipestatus_cache[*]}" --execution-time="$_omp_elapsed" --stack-count="$_omp_stack_count" --eval --shell=zsh --shell-version="$ZSH_VERSION" --no-status="$_omp_no_exit_code")"
   zle .reset-prompt
 
   # Exit the shell if we receive EOT.


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

This PR includes the following changes:

- Use a decorated `self-insert` widget for rendering tooltips in Zsh instead of modifying the keybinding of the space bar, which avoids the bug mentioned in #5079. (Special THANKS to @po1o for the core idea.)
- Prevent incorrect behaviors when the OMP initialization (`eval "$(oh-my-posh init zsh)"`) is unexpectedly executed twice in a Zsh session.
- Normalize the names of internally used global variables/functions in Bash, Zsh and Fish with the unified `_omp_` prefix, for easier future maintenance.

Fix #5079.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
