### PR TITLE
fix(terminal): calculate length correctly

### DIFF
--- a/src/terminal/writer.go
+++ b/src/terminal/writer.go
@@ -344,7 +344,6 @@ func Write(background, foreground color.Ansi, text string) {
 			continue
 		}
 
-		length += runewidth.RuneWidth(s)
 		write(s)
 	}
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

Fix an almost imperceptible bug that the length calculation for `<` characters is incorrect.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
