### PR TITLE
docs: fix a few broken link in themes' json schema

### DIFF
--- a/themes/schema.json
+++ b/themes/schema.json
@@ -4741,19 +4741,19 @@
     "disable_notice": {
       "type": "boolean",
       "title": "Disable Upgrade Notice",
-      "description": "https://ohmyposh.dev/docs/configuration/title#general-settings",
+      "description": "https://ohmyposh.dev/docs/configuration/general#general-settings",
       "default": false
     },
     "auto_upgrade": {
       "type": "boolean",
       "title": "Enable automatic upgrades for Oh My Posh (supports Windows/macOS only)",
-      "description": "https://ohmyposh.dev/docs/configuration/title#general-settings",
+      "description": "https://ohmyposh.dev/docs/configuration/general#general-settings",
       "default": false
     },
     "patch_pwsh_bleed": {
       "type": "boolean",
       "title": "Patch PowerShell Color Bleed",
-      "description": "https://ohmyposh.dev/docs/configuration/title#general-settings",
+      "description": "https://ohmyposh.dev/docs/configuration/general#general-settings",
       "default": false
     },
     "console_title_template": {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

A few of the links in the description field in the theme's json schema were pointing to a wrong URL (about the console title). Those were actually documented under General > General Settings instead.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
