### PR TITLE
feat(kubectl): add cache to kubectl

### DIFF
--- a/website/docs/segments/cli/kubectl.mdx
+++ b/website/docs/segments/cli/kubectl.mdx
@@ -8,6 +8,10 @@ sidebar_label: Kubectl
 
 Display the currently active Kubernetes context name and namespace name.
 
+:::caution
+The Kubernetes context is cached for 1 minute by default. To avoid caching, set `cache_timeout` to 0.
+:::
+
 ## Sample Configuration
 
 import Config from "@site/src/components/Config.js";
@@ -35,6 +39,7 @@ import Config from "@site/src/components/Config.js";
 | `display_error`    | `boolean` | `false` | show the error context when failing to retrieve the kubectl information         |
 | `parse_kubeconfig` | `boolean` | `false` | parse kubeconfig files instead of calling out to kubectl to improve performance |
 | `context_aliases`  | `object`  |         | custom context namespace                                                        |
+| `cache_timeout`    | `int`     |   `1`   | in minutes - how long is the context cached                                     |
 
 ## Template ([info][templates])
 

--- a/website/docs/segments/cli/kubectl.mdx
+++ b/website/docs/segments/cli/kubectl.mdx
@@ -1,7 +1,7 @@
 ---
 id: kubectl
-title: Kubectl Context
-sidebar_label: Kubectl
+title: Kubernetes
+sidebar_label: Kubernetes
 ---
 
 ## What


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description
Hey 👋 
The `kubectl` segment is a bit slow - both in command and file parsing mode. With a `kubeconfig` file consisting of 50+ clusters, each operation takes ~400ms (according to `oh-my-posh debug`).

Under the assumption that usually, you are making a few operations under the same Kube context before moving to a different one, I thought it would be nice to leverage the caching.
This PR will add a default cache of 1 minute, before checking/parsing the context again.

Users can disable it using `cache_timeout` - same as other segments.

Thank you for all the hard work! 💪 

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
