### PR TITLE
feat(mvn): Add maven segment

### DIFF
--- a/src/config/segment_types.go
+++ b/src/config/segment_types.go
@@ -114,6 +114,8 @@ const (
 	LUA SegmentType = "lua"
 	// MERCURIAL writes the Mercurial source control information
 	MERCURIAL SegmentType = "mercurial"
+	// MVN writes the active maven version
+	MVN SegmentType = "mvn"
 	// NBA writes NBA game data
 	NBA SegmentType = "nba"
 	// NBGV writes the nbgv version information
@@ -258,6 +260,7 @@ var Segments = map[SegmentType]func() SegmentWriter{
 	LASTFM:          func() SegmentWriter { return &segments.LastFM{} },
 	LUA:             func() SegmentWriter { return &segments.Lua{} },
 	MERCURIAL:       func() SegmentWriter { return &segments.Mercurial{} },
+	MVN:             func() SegmentWriter { return &segments.Mvn{} },
 	NBA:             func() SegmentWriter { return &segments.Nba{} },
 	NBGV:            func() SegmentWriter { return &segments.Nbgv{} },
 	NIGHTSCOUT:      func() SegmentWriter { return &segments.Nightscout{} },

--- a/src/segments/mvn.go
+++ b/src/segments/mvn.go
@@ -1,0 +1,39 @@
+package segments
+
+import (
+	"github.com/jandedobbeleer/oh-my-posh/src/properties"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
+)
+
+type Mvn struct {
+	language
+}
+
+func (m *Mvn) Enabled() bool {
+	return m.language.Enabled()
+}
+
+func (m *Mvn) Template() string {
+	return languageTemplate
+}
+
+func (m *Mvn) Init(props properties.Properties, env runtime.Environment) {
+	m.language = language{
+		env:        env,
+		props:      props,
+		extensions: []string{"pom.xml"},
+		commands: []*cmd{
+			{
+				executable: "mvn",
+				args:       []string{"--version"},
+				regex:      `(?P<version>((?P<major>[0-9]+).(?P<minor>[0-9]+).(?P<patch>[0-9]+)(?:-(?P<prerelease>[a-z]+-[0-9]+))?))`,
+			},
+		},
+		versionURLTemplate: "https://github.com/apache/maven/releases/tag/maven-{{ .Full }}",
+	}
+
+	mvnw, err := m.language.env.HasParentFilePath("mvnw", false)
+	if err == nil {
+		m.language.commands[0].executable = mvnw.Path
+	}
+}

--- a/src/segments/mvn_test.go
+++ b/src/segments/mvn_test.go
@@ -1,0 +1,61 @@
+package segments
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
+
+	"github.com/alecthomas/assert"
+)
+
+func TestMvn(t *testing.T) {
+	cases := []struct {
+		Case           string
+		ExpectedString string
+		MvnVersion     string
+		HasMvnw        bool
+		MvnwVersion    string
+	}{
+		{
+			Case:           "Maven version",
+			ExpectedString: "1.0.0",
+			MvnVersion:     "Apache Maven 1.0.0",
+			HasMvnw:        false,
+			MvnwVersion:    ""},
+		{
+			Case:           "Local Maven version from wrapper",
+			ExpectedString: "1.1.0-beta-9",
+			MvnVersion:     "Apache Maven 1.0.0",
+			HasMvnw:        true,
+			MvnwVersion:    "Apache Maven 1.1.0-beta-9"},
+	}
+	for _, tc := range cases {
+		params := &mockedLanguageParams{
+			cmd:           "mvn",
+			versionParam:  "--version",
+			versionOutput: tc.MvnVersion,
+			extension:     "pom.xml",
+		}
+		env, props := getMockedLanguageEnv(params)
+
+		fileInfo := &runtime.FileInfo{
+			Path:         "../mvnw",
+			ParentFolder: "./",
+			IsDir:        false,
+		}
+		var err error
+		if !tc.HasMvnw {
+			err = errors.New("no match")
+		}
+		env.On("HasParentFilePath", "mvnw", false).Return(fileInfo, err)
+		env.On("HasCommand", fileInfo.Path).Return(tc.HasMvnw)
+		env.On("RunCommand", fileInfo.Path, []string{"--version"}).Return(tc.MvnwVersion, nil)
+
+		m := &Mvn{}
+		m.Init(props, env)
+		assert.True(t, m.Enabled(), fmt.Sprintf("Failed in case: %s", tc.Case))
+		assert.Equal(t, tc.ExpectedString, renderTemplate(env, m.Template(), m), fmt.Sprintf("Failed in case: %s", tc.Case))
+	}
+}

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -342,6 +342,7 @@
             "lastfm",
             "lua",
             "mercurial",
+            "mvn",
             "nbgv",
             "nightscout",
             "node",

--- a/website/docs/segments/cli/mvn.mdx
+++ b/website/docs/segments/cli/mvn.mdx
@@ -1,0 +1,62 @@
+---
+id: mvn
+title: Maven
+sidebar_label: Maven
+---
+
+## What
+
+Display the currently active [Maven][maven-docs] version.
+
+## Sample Configuration
+
+import Config from "@site/src/components/Config.js";
+
+<Config
+  data={{
+    type: "mvn",
+    style: "powerline",
+    powerline_symbol: "\uE0B0",
+    foreground: "#FFFFFF",
+    background: "#2E2A65",
+    template: " Maven {{ .Full }} ",
+  }}
+/>
+
+## Properties
+
+| Name                   |    Type    |  Default  | Description                                                                                                                                                                                                                          |
+|------------------------|:----------:|:---------:|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `home_enabled`         | `boolean`  |  `false`  | display the segment in the HOME folder or not                                                                                                                                                                                        |
+| `fetch_version`        | `boolean`  |  `true`   | fetch the Maven version                                                                                                                                                                                                              |
+| `missing_command_text` |  `string`  |           | text to display when the command is missing                                                                                                                                                                                          |
+| `display_mode`         |  `string`  | `context` | <ul><li>`always`: the segment is always displayed</li><li>`files`: the segment is only displayed when file `extensions` listed are present</li><li>`context`: displays the segment when the environment or files is active</li></ul> |
+| `version_url_template` |  `string`  |           | a go [text/template][go-text-template] [template][templates] that creates the URL of the version info / release notes                                                                                                                |
+| `extensions`           | `[]string` | `pom.xml` | allows to override the default list of file extensions to validate                                                                                                                                                                   |
+| `folders`              | `[]string` |           | allows to override the list of folder names to validate                                                                                                                                                                              |
+| `cache_version`        | `boolean`  |  `false`  | cache the executable's version or not                                                                                                                                                                                                |
+
+## Template ([info][templates])
+
+:::note default template
+
+```template
+{{.Full}}
+```
+
+:::
+
+### Properties
+
+| Name     | Type     | Description                                        |
+|----------|----------|----------------------------------------------------|
+| `.Full`  | `string` | the full version                                   |
+| `.Major` | `string` | major number                                       |
+| `.Minor` | `string` | minor number                                       |
+| `.Patch` | `string` | patch number                                       |
+| `.URL`   | `string` | URL of the version info / release notes            |
+| `.Error` | `string` | error encountered when fetching the version string |
+
+[go-text-template]: https://golang.org/pkg/text/template/
+[templates]: /docs/configuration/templates
+[maven-docs]: https://maven.apache.org

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -69,6 +69,7 @@ module.exports = {
             "segments/cli/gitversion",
             "segments/cli/helm",
             "segments/cli/kubectl",
+            "segments/cli/mvn",
             "segments/cli/nbgv",
             "segments/cli/npm",
             "segments/cli/nx",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Hi,

This PR adds the "mvn" segment to display the current [Maven](https://maven.apache.org/) version. When the project includes a [Maven wrapper](https://maven.apache.org/wrapper/), this segment uses the `mvnw` command to determine the active Maven version.

<img width="299" alt="image" src="https://github.com/user-attachments/assets/4ef2ee96-4ec6-4cff-9726-c8d799869a90">

This change resolves #5299.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
