### PR TITLE
feat(spotify): add cache

### DIFF
--- a/src/segments/spotify_darwin.go
+++ b/src/segments/spotify_darwin.go
@@ -2,7 +2,20 @@
 
 package segments
 
+import (
+	"encoding/json"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/properties"
+)
+
+const spotifyCacheKey = "spotify_music_player"
+
 func (s *Spotify) Enabled() bool {
+	cacheTimeout := s.props.GetInt(properties.CacheTimeout, 0)
+	if cacheTimeout > 0 && s.getFromCache() {
+		return true
+	}
+
 	// Check if running
 	running := s.runAppleScriptCommand("application \"Spotify\" is running")
 	if running == "false" || running == "" {
@@ -23,7 +36,12 @@ func (s *Spotify) Enabled() bool {
 
 	s.Artist = s.runAppleScriptCommand("tell application \"Spotify\" to artist of current track as string")
 	s.Track = s.runAppleScriptCommand("tell application \"Spotify\" to name of current track as string")
+
 	s.resolveIcon()
+
+	if cacheTimeout > 0 {
+		s.setCache(cacheTimeout)
+	}
 
 	return true
 }
@@ -31,4 +49,29 @@ func (s *Spotify) Enabled() bool {
 func (s *Spotify) runAppleScriptCommand(command string) string {
 	val, _ := s.env.RunCommand("osascript", "-e", command)
 	return val
+}
+
+func (s *Spotify) getFromCache() bool {
+	str, found := s.env.Cache().Get(spotifyCacheKey)
+	if !found {
+		return false
+	}
+
+	var cachedMusicPlayer MusicPlayer
+	err := json.Unmarshal([]byte(str), &cachedMusicPlayer)
+	if err != nil {
+		return false
+	}
+
+	s.MusicPlayer = cachedMusicPlayer
+	return true
+}
+
+func (s *Spotify) setCache(cacheTimeout int) {
+	cache, err := json.Marshal(s.MusicPlayer)
+	if err != nil {
+		return
+	}
+
+	s.env.Cache().Set(spotifyCacheKey, string(cache), cacheTimeout)
 }

--- a/website/docs/segments/music/spotify.mdx
+++ b/website/docs/segments/music/spotify.mdx
@@ -19,28 +19,31 @@ fetching information from the native Spotify application and Edge PWA.
 
 ## Sample Configuration
 
-import Config from '@site/src/components/Config.js';
+import Config from "@site/src/components/Config.js";
 
-<Config data={{
-  "type": "spotify",
-  "style": "powerline",
-  "powerline_symbol": "\uE0B0",
-  "foreground": "#ffffff",
-  "background": "#1BD760",
-  "properties": {
-    "playing_icon": "\uE602 ",
-    "paused_icon": "\uF8E3 ",
-    "stopped_icon": "\uF04D "
-  }
-}}/>
+<Config
+  data={{
+    type: "spotify",
+    style: "powerline",
+    powerline_symbol: "\uE0B0",
+    foreground: "#ffffff",
+    background: "#1BD760",
+    properties: {
+      playing_icon: "\uE602 ",
+      paused_icon: "\uF8E3 ",
+      stopped_icon: "\uF04D ",
+    },
+  }}
+/>
 
 ## Properties
 
-| Name           | Type     | Default   | Description                    |
-| -------------- | :------: | :-------: | ------------------------------ |
-| `playing_icon` | `string` | `\uE602 ` | text/icon to show when playing |
-| `paused_icon`  | `string` | `\uF8E3 ` | text/icon to show when paused  |
-| `stopped_icon` | `string` | `\uF04D`  | text/icon to show when stopped |
+| Name            |   Type   |  Default  | Description                                                                  |
+| --------------- | :------: | :-------: | ---------------------------------------------------------------------------- |
+| `playing_icon`  | `string` | `\uE602 ` | text/icon to show when playing                                               |
+| `paused_icon`   | `string` | `\uF8E3 ` | text/icon to show when paused                                                |
+| `stopped_icon`  | `string` | `\uF04D`  | text/icon to show when stopped                                               |
+| `cache_timeout` |  `int`   |    `0`    | **macOS only** in minutes - How long to wait before fetching new information |
 
 ## Template ([info][templates])
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines 
- [ ] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features) **(I will after the community agrees to add this functionality)** .

### Description

This is a WIP PR, used as a POC only for MacOS. Of course I plan to implement it for Windows and WSL as well, I just wanted to check if it's even something the community would like to have and get some feedback. 

Since adding the spotify segment slows down the shell I decided to implement a caching mechanism.
Acknowledging that most songs are longer than 2-3 minutes, a 1 minute cache can greatly improve the UX.
If someone is using spotify with podcasts then the benefit is even greater.

I tried to make as few changes as possible in the platform-specific implementation.

example config:

```yaml
      - type: spotify
        style: powerline
        powerline_symbol: ...
        foreground: "#000000"
        background: "#1DB954"
        template: "{{ .Icon }}{{ if ne .Status \"stopped\" }}{{ .Artist }} - {{ .Track }}{{ end }}"
        properties:
          cache_timeout: 1
```

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
