### PR TITLE
fix(zsh): work around bugs when used with zsh-syntax-highlighting

### DIFF
--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -90,9 +90,9 @@ function _omp_cleanup() {
   )
   local widget
   for widget in "${omp_widgets[@]}"; do
-    if [[ ${widgets[_omp_original::$widget]} ]]; then
+    if [[ ${widgets[._omp_original::$widget]} ]]; then
       # Restore the original widget.
-      zle -A _omp_original::$widget $widget
+      zle -A ._omp_original::$widget $widget
     elif [[ ${widgets[$widget]} = user:_omp_* ]]; then
       # Delete the OMP-defined widget.
       zle -D $widget
@@ -182,9 +182,9 @@ function _omp_create_widget() {
 
   # User-defined or builtin: backup and decorate it.
   *)
-    # Back up the original widget.
-    zle -A $widget _omp_original::$widget
-    eval "_omp_decorated_${(q)widget}() { _omp_call_widget ${(q)omp_func} _omp_original::${(q)widget} -- \"\$@\" }"
+    # Back up the original widget. The leading dot in widget name is to work around bugs when used with zsh-syntax-highlighting in Zsh v5.8 or lower.
+    zle -A $widget ._omp_original::$widget
+    eval "_omp_decorated_${(q)widget}() { _omp_call_widget ${(q)omp_func} ._omp_original::${(q)widget} -- \"\$@\" }"
     zle -N $widget _omp_decorated_$widget
     ;;
   esac


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

Related to #5288. See my [comment]. The fix originated from [powerlevel10k][powerlevel10k-code].

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[comment]: https://github.com/JanDeDobbeleer/oh-my-posh/issues/5288#issuecomment-2254099973
[powerlevel10k-code]: https://github.com/romkatv/powerlevel10k/blob/2b7da93df04acd04d84f5de827e5b14077839a4b/internal/p10k.zsh#L8082-L8083
