### PR TITLE
feat(pwsh): pass original last execution status to Set-PoshContext

### DIFF
--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -113,7 +113,7 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
         $stdoutTask.Result
     }
 
-    function Set-PoshContext {}
+    function Set-PoshContext([bool]$originalStatus) {}
 
     function Get-CleanPSWD {
         $pswd = $PWD.ToString()
@@ -388,7 +388,7 @@ Example:
             catch {}
         }
 
-        Set-PoshContext
+        Set-PoshContext $script:ErrorCode
     }
 
     function Update-PoshErrorCode {

--- a/website/docs/configuration/templates.mdx
+++ b/website/docs/configuration/templates.mdx
@@ -58,7 +58,7 @@ This can be used to for example populate an environment variable with a specific
 <TabItem value="powershell">
 
 ```powershell
-function Set-EnvVar {
+function Set-EnvVar([bool]$originalStatus) {
     $env:POSH=$(Get-Date)
 }
 New-Alias -Name 'Set-PoshContext' -Value 'Set-EnvVar' -Scope Global -Force


### PR DESCRIPTION
…r use in pwsh alias.

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

Updates the `Set-PoshContext` in `src/shell/scripts/omp.ps1` to include a parameter: `[bool]$originalStatus`. This allows for the original execution status to be passed into the `Set-PoshContext` function so it can be used during the execution of a configured alias (if applicable). The parameter is needed because `$?` will not show the proper output and `$script:` variables can't be accessed from the alias. Therefore, if a user wanted to do logic based on the execution status they need a different method of accessing the correct status value, which the parameter provides.

Notes:
- I don't know if any tests are needed - from what I could tell, the existing powershell tests cover this but I may be mistaken.
- This should not cause any problems with existing installs. Having an alias without the parameter present will not cause any errors.
- Rebased and fixed errors with the commit messages.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
