### PR TITLE
docs(templates): correct example for `matchP` helper function

### DIFF
--- a/website/docs/configuration/templates.mdx
+++ b/website/docs/configuration/templates.mdx
@@ -171,16 +171,16 @@ use them.
 
 <!-- markdownlint-disable MD013 -->
 
-| Template                                                       | Description                                                                                                                |
-| -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `{{ url .UpstreamIcon .UpstreamURL }}`                         | Create an `OSC8` hyperlink to a website to open your default browser (needs terminal [support][terminal-list-hyperlinks]). |
-| `{{ path .Path .Location }}`                                   | Create an `OSC8` file link to a folder to open your file explorer (needs terminal [support][terminal-list-hyperlinks]).    |
-| `{{ secondsRound 3600 }}`                                      | Round seconds to a time indication. In this case the output is `1h`.                                                       |
-| `{{ if glob "*.go" }}OK{{ else }}NOK{{ end }}`                 | Exposes [filepath.Glob][glob] as a boolean template function.                                                              |
-| `{{ if matchP "*.Repo" .Path }}Repo{{ else }}No Repo{{ end }}` | Exposes [regexp.MatchString][regexpms] as a boolean template function.                                                     |
-| `{{ replaceP "c.t" "cut code cat" "dog" }}`                    | Exposes [regexp.ReplaceAllString][regexpra] as a string template function.                                                 |
-| <code>\{\{ .Code &vert; hresult \}\}</code>                    | Transform a status code to its HRESULT value for easy troubleshooting. For example `-1978335212` becomes `0x8A150014`.     |
-| `{{ readFile ".version.json" }}`                               | Read a file in the current directory. Returns a string.                                                                    |
+| Template                                                           | Description                                                                                                                |
+| ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| `{{ url .UpstreamIcon .UpstreamURL }}`                             | Create an `OSC8` hyperlink to a website to open your default browser (needs terminal [support][terminal-list-hyperlinks]). |
+| `{{ path .Path .Location }}`                                       | Create an `OSC8` file link to a folder to open your file explorer (needs terminal [support][terminal-list-hyperlinks]).    |
+| `{{ secondsRound 3600 }}`                                          | Round seconds to a time indication. In this case the output is `1h`.                                                       |
+| `{{ if glob "*.go" }}OK{{ else }}NOK{{ end }}`                     | Exposes [filepath.Glob][glob] as a boolean template function.                                                              |
+| `{{ if matchP ".*\\.Repo$" .Path }}Repo{{ else }}No Repo{{ end }}` | Exposes [regexp.MatchString][regexpms] as a boolean template function.                                                     |
+| `{{ replaceP "c.t" "cut code cat" "dog" }}`                        | Exposes [regexp.ReplaceAllString][regexpra] as a string template function.                                                 |
+| <code>\{\{ .Code &vert; hresult \}\}</code>                        | Transform a status code to its HRESULT value for easy troubleshooting. For example `-1978335212` becomes `0x8A150014`.     |
+| `{{ readFile ".version.json" }}`                                   | Read a file in the current directory. Returns a string.                                                                    |
 
 <!-- markdownlint-enable MD013 -->
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

Correct the example for the `matchP` helper function in the documentation: a regular expression should be used instead of a globbing pattern.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary