### PR TITLE
Handle non-filesystem paths in PowerShell

### DIFF
--- a/src/cache/template.go
+++ b/src/cache/template.go
@@ -10,6 +10,7 @@ type Template struct {
 	Root          bool
 	PWD           string
 	AbsolutePWD   string
+	PSWD          string
 	Folder        string
 	Shell         string
 	ShellVersion  string

--- a/src/runtime/terminal.go
+++ b/src/runtime/terminal.go
@@ -62,7 +62,7 @@ func (term *Terminal) Init() {
 
 	if term.CmdFlags.Plain {
 		log.Plain()
-		log.Debug("dlain mode enabled")
+		log.Debug("plain mode enabled")
 	}
 
 	initCache := func(fileName string) *cache.File {
@@ -673,6 +673,8 @@ func (term *Terminal) TemplateCache() *cache.Template {
 	if term.IsWsl() {
 		tmplCache.AbsolutePWD, _ = term.RunCommand("wslpath", "-m", pwd)
 	}
+
+	tmplCache.PSWD = term.CmdFlags.PSWD
 
 	tmplCache.Folder = Base(term, pwd)
 	if term.GOOS() == WINDOWS && strings.HasSuffix(tmplCache.Folder, ":") {

--- a/src/segments/path.go
+++ b/src/segments/path.go
@@ -109,7 +109,11 @@ func (pt *Path) Enabled() bool {
 	pt.setStyle()
 	pwd := pt.env.Pwd()
 
-	pt.Location = strings.ReplaceAll(pt.env.TemplateCache().AbsolutePWD, `\`, `/`)
+	pt.Location = pt.env.TemplateCache().AbsolutePWD
+	if pt.env.GOOS() == runtime.WINDOWS {
+		pt.Location = strings.ReplaceAll(pt.Location, `\`, `/`)
+	}
+
 	pt.StackCount = pt.env.StackCount()
 	pt.Writable = pt.env.DirIsWritable(pwd)
 	return true
@@ -609,7 +613,7 @@ func (pt *Path) normalizePath(path string) string {
 			lastChar = clean[len(clean)-1:][0]
 		}
 
-		if char == '/' && lastChar != 60 { // 60 == <, this is done to ovoid replacing color codes
+		if char == '/' && lastChar != 60 { // 60 == <, this is done to avoid replacing color codes
 			clean = append(clean, 92) // 92 == \
 			continue
 		}

--- a/src/template/text.go
+++ b/src/template/text.go
@@ -28,6 +28,7 @@ var (
 		"Root",
 		"PWD",
 		"AbsolutePWD",
+		"PSWD",
 		"Folder",
 		"Shell",
 		"ShellVersion",

--- a/website/docs/configuration/templates.mdx
+++ b/website/docs/configuration/templates.mdx
@@ -22,6 +22,7 @@ it with `.$` to reference it directly.
 | `.Root`         | `boolean` | is the current user root/admin or not                             |
 | `.PWD`          | `string`  | the current working directory (`~` for `$HOME`)                   |
 | `.AbsolutePWD`  | `string`  | the current working directory (unaltered)                         |
+| `.PSWD       `  | `string`  | the current non-filesystem working directory in PowerShell        |
 | `.Folder`       | `string`  | the current working folder                                        |
 | `.Shell`        | `string`  | the current shell name                                            |
 | `.ShellVersion` | `string`  | the current shell version                                         |


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

When generating a prompt for PowerShell, a non-filesystem (e.g., a Windows Registry path `HKLM:\SOFTWARE`, or the environment PSDrive `Env:/`) path can be passed to the `--pswd` flag (working directory in PowerShell). However, in the template of a `path` segment, `.Writable` works only for the actual (filesystem) working directory (typically returned by the `os.Getwd` function). When combined with other template logic, this can lead to inconsistent and confusing cases (e.g., showing a wrong folder icon in a `path` segment). To get rid of unexpected results and avoid breaking other use cases, we should:

- only pass the path whose PSProvider is not `FileSystem`, to the `--pswd` flag;
- add `.PSWD` which keeps the value of the `--pswd` flag, to the template.

That way when `.PSWD` is non-empty, we know clearly that the result reported by `.Writable` in a `path` segment is unrelated to the "displayed" path which is a non-filesystem working directory in PowerShell.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary