### PR TITLE
fix: added python venv support for the clean-detailed.omp theme

### DIFF
--- a/themes/clean-detailed.omp.json
+++ b/themes/clean-detailed.omp.json
@@ -69,8 +69,23 @@
           },
           "style": "diamond",
           "template": " {{ .UpstreamIcon }}{{ .HEAD }}{{if .BranchStatus }} {{ .BranchStatus }}{{ end }}{{ if .Working.Changed }} \uf044 {{ .Working.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }} \uf046 {{ .Staging.String }}{{ end }}{{ if gt .StashCount 0 }} \ueb4b {{ .StashCount }}{{ end }} ",
-          "trailing_diamond": "\ue0b0",
+          "trailing_diamond": "<transparent,#17D7A0>\ue0b2</>",
           "type": "git"
+        },
+        {
+          "background": "#FFDE57",
+          "foreground": "#111111",
+          "leading_diamond": "\ue0b2",
+          "powerline_symbol": "\ue0b0",
+          "properties": {
+              "display_mode": "environment",
+              "fetch_virtual_env": true,
+              "home_enabled": true
+          },
+          "style": "diamond",
+          "template": " \ue235 {{ if .Venv }}({{ .Venv }}){{ end }} ",
+          "trailing_diamond": "\ue0b0",
+          "type": "python"
         }
       ],
       "type": "prompt"


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Support for the python virtual environment for the clean-detailed.omp theme has been added.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
