### PR TITLE
fix(bash): respect `PROMPT_COMMAND` as an array

### DIFF
--- a/src/shell/scripts/omp.bash
+++ b/src/shell/scripts/omp.bash
@@ -35,7 +35,7 @@ function _omp_set_cursor_position() {
 
     local COL
     local ROW
-    IFS=';' read -sdR -p $'\E[6n' ROW COL
+    IFS=';' read -rsdR -p $'\E[6n' ROW COL
 
     stty "$oldstty"
 
@@ -60,10 +60,10 @@ function set_poshcontext() {
 
 # regular prompt
 function _omp_hook() {
-    _omp_status_cache=$? _omp_pipestatus_cache=(${PIPESTATUS[@]})
+    _omp_status_cache=$? _omp_pipestatus_cache=("${PIPESTATUS[@]}")
 
     if [[ ${#BP_PIPESTATUS[@]} -ge ${#_omp_pipestatus_cache[@]} ]]; then
-        _omp_pipestatus_cache=(${BP_PIPESTATUS[@]})
+        _omp_pipestatus_cache=("${BP_PIPESTATUS[@]}")
     fi
 
     _omp_stack_count=$((${#DIRSTACK[@]} - 1))
@@ -87,6 +87,14 @@ function _omp_hook() {
     return $_omp_status_cache
 }
 
-if [[ $TERM != linux ]] && ! [[ $PROMPT_COMMAND =~ _omp_hook ]]; then
-    PROMPT_COMMAND="_omp_hook; $PROMPT_COMMAND"
-fi
+function _omp_install_hook() {
+    local cmd
+    for cmd in "${PROMPT_COMMAND[@]}"; do
+        if [[ $cmd = "_omp_hook" ]]; then
+            return
+        fi
+    done
+    PROMPT_COMMAND=(_omp_hook "${PROMPT_COMMAND[@]}")
+}
+
+[[ $TERM != linux ]] && _omp_install_hook


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

According to [descriptions about the `PROMPT_COMMAND` variable][bash-manual-prompt-command] in *Bash Reference Manual*:

> If this variable is set, and is an array, the value of each set element is interpreted as a command to execute before printing the primary prompt (`$PS1`). If this is set but not an array variable, its value is used as a command to execute instead.

the variable can be an array, so we should always respect `PROMPT_COMMAND` as an array when installing the OMP hook.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[bash-manual-prompt-command]: https://www.gnu.org/software/bash/manual/bash.html#index-PROMPT_005fCOMMAND