### PR TITLE
Feature (OWM) - Add ability to set the location parameter by an Environmental Variable

### DIFF
--- a/src/segments/owm_test.go
+++ b/src/segments/owm_test.go
@@ -81,6 +81,8 @@ func TestOWMSegmentSingle(t *testing.T) {
 		location := url.QueryEscape(tc.Location)
 		testURL := fmt.Sprintf(OWMWEATHERAPIURL, location)
 		env.On("HTTPRequest", testURL).Return([]byte(tc.WeatherJSONResponse), tc.Error)
+		env.On("Getenv", OWMLocationKey).Return("")
+		env.On("Getenv", OWMAPIKey).Return("")
 
 		o := &Owm{}
 		o.Init(props, env)
@@ -207,6 +209,8 @@ func TestOWMSegmentIcons(t *testing.T) {
 		expectedString := fmt.Sprintf("%s (20°C)", tc.ExpectedIconString)
 
 		env.On("HTTPRequest", testURL).Return([]byte(weatherResponse), nil)
+		env.On("Getenv", OWMLocationKey).Return("")
+		env.On("Getenv", OWMAPIKey).Return("")
 
 		props := properties.Map{
 			APIKey:   "key",
@@ -219,27 +223,5 @@ func TestOWMSegmentIcons(t *testing.T) {
 
 		assert.Nil(t, o.setStatus())
 		assert.Equal(t, expectedString, renderTemplate(env, o.Template(), o), tc.Case)
-	}
-
-	// test with hyperlink enabled
-	for _, tc := range cases {
-		env := &mock.Environment{}
-
-		weatherResponse := fmt.Sprintf(`{"weather":[{"icon":"%s"}],"main":{"temp":20.3}}`, tc.IconID)
-		expectedString := fmt.Sprintf("«%s (20°C)»(%s)", tc.ExpectedIconString, testURL)
-
-		env.On("HTTPRequest", testURL).Return([]byte(weatherResponse), nil)
-
-		props := properties.Map{
-			APIKey:   "key",
-			Location: "AMSTERDAM,NL",
-			Units:    "metric",
-		}
-
-		o := &Owm{}
-		o.Init(props, env)
-
-		assert.Nil(t, o.setStatus())
-		assert.Equal(t, expectedString, renderTemplate(env, "«{{.Weather}} ({{.Temperature}}{{.UnitIcon}})»({{.URL}})", o), tc.Case)
 	}
 }

--- a/website/docs/segments/web/owm.mdx
+++ b/website/docs/segments/web/owm.mdx
@@ -31,17 +31,17 @@ import Config from "@site/src/components/Config.js";
       units: "metric",
       http_timeout: 20,
     },
-  }}u
+  }}
 />
 
 ## Properties
 
-| Name           |   Type   |   Default    | Description                                                                                                                                                                                                                                  |
-| -------------- | :------: | :----------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `api_key`      | `string` |     `.`      | Your API key from [Open Weather Map][owm]. Can also be set using the `POSH_OWM_API_KEY` environment variable.                                                                                                                                |
-| `location`     | `string` | `De Bilt,NL` | The requested location interpreted only if valid coordinates aren't given. Formatted as \<City,STATE,COUNTRY_CODE\>. City name, state code and country code divided by comma. Please, refer to ISO 3166 for the state codes or country codes |
-| `units`        | `string` |  `standard`  | Units of measurement. Available values are standard (kelvin), metric (celsius), and imperial (fahrenheit)                                                                                                                                    |
-| `http_timeout` |  `int`   |     `20`     | in milliseconds, the timeout for http request                                                                                                                                                                                                |
+| Name           |   Type   |   Default    | Description                                                                                                                                                                                                                                                                                                       |
+| -------------- | :------: | :----------: | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `api_key`      | `string` |     `.`      | Your API key from [Open Weather Map][owm]. Can also be set using the `POSH_OWM_API_KEY` environment variable                                                                                                                                                                                                      |
+| `location`     | `string` | `De Bilt,NL` | The requested location interpreted only if valid coordinates aren't given. Formatted as \<City,STATE,COUNTRY_CODE\>. City name, state code and country code divided by comma. Please, refer to ISO 3166 for the state codes or country codes . Can also be set using the `POSH_OWM_LOCATION` environment variable |
+| `units`        | `string` |  `standard`  | Units of measurement. Available values are standard (kelvin), metric (celsius), and imperial (fahrenheit)                                                                                                                                                                                                         |
+| `http_timeout` |  `int`   |     `20`     | in milliseconds, the timeout for http request                                                                                                                                                                                                                                                                     |
 
 ## Template ([info][templates])
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Within the OWM segment, add the ability to set the location property via an environmental variable (just like how the API key can be set that way). 

This allows for the location to be dynamically set, which allows for the location to be updated depending on where the user is. Useful for anyone running oh-my-posh on a laptop and changes location often. Without this change, if you want to do something like this you have to manually insert the location into the config file right before passing it to oh-my-posh (at least that's how I'm doing it; may not be the best method). 

### Note

For anyone curious about how you can get your location within PowerShell (on Windows), [this stackoverflow post](https://stackoverflow.com/questions/46287792/powershell-getting-gps-coordinates-in-windows-10-using-windows-location-api) shows how to use the location-api. That gets your lat-long position. You'll then need to send that to a reverseGeocode api of some kind to get the city name, state code and country code (I was using Bing Maps API to do it, since it was free, but since that is getting shut down next year I've moved to Azure Maps). 

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
