### PR TITLE
Fix valid and error lines clearing command

### DIFF
--- a/src/prompt/extra.go
+++ b/src/prompt/extra.go
@@ -110,10 +110,14 @@ func (e *Engine) ExtraPrompt(promptType ExtraPromptType) string {
 		}
 		return str
 	case shell.PWSH, shell.PWSH5:
-		// Return the string and empty our buffer
-		// clear the line afterwards to prevent text from being written on the same line
-		// see https://github.com/JanDeDobbeleer/oh-my-posh/issues/3628
-		return str + terminal.ClearAfter()
+		if promptType == Transient {
+			// Return the string and empty our buffer
+			// clear the line afterwards to prevent text from being written on the same line
+			// see https://github.com/JanDeDobbeleer/oh-my-posh/issues/3628
+			return str + terminal.ClearAfter()
+		}
+
+		return str
 	case shell.CMD, shell.BASH, shell.FISH, shell.NU, shell.GENERIC:
 		// Return the string and empty our buffer
 		return str


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

When using the `valid_line`/`error_line` config, everything after the primary prompt is cleared except for the current line of input as the validity changes

https://github.com/user-attachments/assets/b07923aa-c3e5-4470-acb8-9b3288a41213

This is due to a `ClearAfter`, introduced in #3630/#3628, is written after the `valid_line`/`error_line` template. This PR limits that `ClearAfter` to transient prompts.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
