### PR TITLE
CLI improvement

### DIFF
--- a/src/cli/cache.go
+++ b/src/cli/cache.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -50,32 +49,13 @@ You can do the following:
 			clear(env.CachePath())
 		case "edit":
 			cacheFilePath := filepath.Join(env.CachePath(), cache.FileName)
-			editFileWithEditor(cacheFilePath)
+			os.Exit(editFileWithEditor(cacheFilePath))
 		}
 	},
 }
 
 func init() {
 	RootCmd.AddCommand(getCache)
-}
-
-func editFileWithEditor(file string) {
-	editor := os.Getenv("EDITOR")
-
-	var args []string
-	if strings.Contains(editor, " ") {
-		splitted := strings.Split(editor, " ")
-		editor = splitted[0]
-		args = splitted[1:]
-	}
-
-	args = append(args, file)
-	cmd := exec.Command(editor, args...)
-
-	err := cmd.Run()
-	if err != nil {
-		fmt.Println(err.Error())
-	}
 }
 
 func clear(cachePath string) {

--- a/src/cli/config.go
+++ b/src/cli/config.go
@@ -5,16 +5,18 @@ import (
 	"os"
 	"time"
 
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
+
 	"github.com/spf13/cobra"
 )
 
 // configCmd represents the config command
 var configCmd = &cobra.Command{
-	Use:   "config [export|migrate|edit]",
+	Use:   "config edit",
 	Short: "Interact with the config",
 	Long: `Interact with the config.
 
-You can export, migrate or edit the config.`,
+You can export, migrate or edit the config (via the editor specified in the environment variable "EDITOR").`,
 	ValidArgs: []string{
 		"export",
 		"migrate",
@@ -29,7 +31,13 @@ You can export, migrate or edit the config.`,
 		}
 		switch args[0] {
 		case "edit":
-			editFileWithEditor(os.Getenv("POSH_THEME"))
+			env := &runtime.Terminal{
+				CmdFlags: &runtime.Flags{
+					Config: configFlag,
+				},
+			}
+			env.ResolveConfigPath()
+			os.Exit(editFileWithEditor(env.CmdFlags.Config))
 		case "get":
 			// only here for backwards compatibility
 			fmt.Print(time.Now().UnixNano() / 1000000)

--- a/src/cli/edit.go
+++ b/src/cli/edit.go
@@ -1,0 +1,34 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func editFileWithEditor(file string) int {
+	editor := strings.TrimSpace(os.Getenv("EDITOR"))
+	if len(editor) == 0 {
+		fmt.Println(`no editor specified in the environment variable "EDITOR"`)
+		return 1
+	}
+
+	var args []string
+	if strings.Contains(editor, " ") {
+		strs := strings.Split(editor, " ")
+		editor = strs[0]
+		args = strs[1:]
+	}
+
+	args = append(args, file)
+	cmd := exec.Command(editor, args...)
+
+	err := cmd.Run()
+	if err != nil {
+		fmt.Println(err.Error())
+		return 1
+	}
+
+	return cmd.ProcessState.ExitCode()
+}

--- a/src/cli/print.go
+++ b/src/cli/print.go
@@ -66,7 +66,6 @@ var printCmd = &cobra.Command{
 			Plain:         plain,
 			Primary:       args[0] == "primary",
 			Cleared:       cleared,
-			Cached:        cached,
 			NoExitCode:    noStatus,
 			Column:        column,
 			JobCount:      jobCount,

--- a/src/config/segment.go
+++ b/src/config/segment.go
@@ -53,13 +53,13 @@ type Segment struct {
 	MaxWidth               int            `json:"max_width,omitempty" toml:"max_width,omitempty"`
 	MinWidth               int            `json:"min_width,omitempty" toml:"min_width,omitempty"`
 	Filler                 string         `json:"filler,omitempty" toml:"filler,omitempty"`
-	Background             color.Ansi     `json:"background" toml:"background"`
-	Foreground             color.Ansi     `json:"foreground" toml:"foreground"`
+	Background             color.Ansi     `json:"background,omitempty" toml:"background,omitempty"`
+	Foreground             color.Ansi     `json:"foreground,omitempty" toml:"foreground,omitempty"`
 	Newline                bool           `json:"newline,omitempty" toml:"newline,omitempty"`
 
 	Enabled bool `json:"-" toml:"-"`
 
-	Text string
+	Text string `json:"-" toml:"-"`
 
 	env        runtime.Environment
 	writer     SegmentWriter
@@ -67,8 +67,8 @@ type Segment struct {
 	name       string
 
 	// debug info
-	Duration   time.Duration
-	NameLength int
+	Duration   time.Duration `json:"-" toml:"-"`
+	NameLength int           `json:"-" toml:"-"`
 }
 
 func (segment *Segment) Name() string {

--- a/src/runtime/environment.go
+++ b/src/runtime/environment.go
@@ -98,7 +98,6 @@ type Flags struct {
 	HasTransient  bool
 	PromptCount   int
 	Cleared       bool
-	Cached        bool
 	NoExitCode    bool
 	Column        int
 	JobCount      int

--- a/website/docs/configuration/segment.mdx
+++ b/website/docs/configuration/segment.mdx
@@ -132,7 +132,7 @@ will not be rendered when in one of the excluded locations.
 ```
 
 The strings specified in these properties are evaluated as [regular expressions][regex]. You
-can use any valid regular expression construct, but the regular expression must match the entire directory
+can use any valid regular expression construct, but the regular expression must match the **ENTIRE** directory
 name. The following will match `/Users/posh/Projects/Foo` but not `/home/Users/posh/Projects/Foo`.
 
 ```json
@@ -156,8 +156,8 @@ You can also combine these properties:
 
 - Oh My Posh will accept both `/` and `\` as path separators for a folder and will match regardless of which
   is used by the current operating system.
-- Because the strings are evaluated as regular expressions, if you want to use a `\` in a Windows
-  directory name, you need to specify it as `\\\\`.
+- Because the strings are evaluated as regular expressions, if you want to use a backslash (`\`) in a Windows
+  directory name, you need to specify it as double backslashes, and if using JSON format you should escape it as `\\\\`.
 - The character `~` at the start of a specified folder will match the user's home directory.
 - The comparison is case-insensitive on Windows and macOS, but case-sensitive on other operating systems.
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Tweak CLI help text, add error messages and fix some execution logic (e.g., the tilde prefix expansion during path resolution) for `config` and `cache` commands.

Closes #5481.

Closes #5482.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary