### PR TITLE
fix(shell): use Windows PID as `POSH_PID` in a Cygwin environment

### DIFF
--- a/src/shell/scripts/omp.bash
+++ b/src/shell/scripts/omp.bash
@@ -5,6 +5,10 @@ export POSH_PID=$$
 export CONDA_PROMPT_MODIFIER=false
 export OSTYPE=$OSTYPE
 
+if [[ $OSTYPE =~ ^(msys|cygwin) ]]; then
+    export POSH_PID=$(command cat /proc/$$/winpid)
+fi
+
 # global variables
 _omp_start_time=""
 _omp_stack_count=0

--- a/src/shell/scripts/omp.fish
+++ b/src/shell/scripts/omp.fish
@@ -7,6 +7,10 @@ set --global _omp_tooltip_command ''
 set --global _omp_current_rprompt ''
 set --global _omp_transient 0
 
+if command uname -s | string match -qr '^(CYGWIN|MSYS|MINGW)'
+    set --export POSH_PID (command cat /proc/$fish_pid/winpid)
+end
+
 set --global _omp_executable ::OMP::
 set --global _omp_ftcs_marks 0
 set --global _omp_transient_prompt 0
@@ -112,25 +116,25 @@ function _omp_preexec --on-event fish_preexec
 end
 
 # perform cleanup so a new initialization in current session works
-if bind \r --user 2>/dev/null | string match -q -e _omp_enter_key_handler
+if bind \r --user 2>/dev/null | string match -qe _omp_enter_key_handler
     bind -e \r -M default
     bind -e \r -M insert
     bind -e \r -M visual
 end
 
-if bind \n --user 2>/dev/null | string match -q -e _omp_enter_key_handler
+if bind \n --user 2>/dev/null | string match -qe _omp_enter_key_handler
     bind -e \n -M default
     bind -e \n -M insert
     bind -e \n -M visual
 end
 
-if bind \cc --user 2>/dev/null | string match -q -e _omp_ctrl_c_key_handler
+if bind \cc --user 2>/dev/null | string match -qe _omp_ctrl_c_key_handler
     bind -e \cc -M default
     bind -e \cc -M insert
     bind -e \cc -M visual
 end
 
-if bind \x20 --user 2>/dev/null | string match -q -e _omp_space_key_handler
+if bind \x20 --user 2>/dev/null | string match -qe _omp_space_key_handler
     bind -e \x20 -M default
     bind -e \x20 -M insert
 end

--- a/src/shell/scripts/omp.tcsh
+++ b/src/shell/scripts/omp.tcsh
@@ -2,6 +2,11 @@ setenv POWERLINE_COMMAND "oh-my-posh";
 setenv POSH_THEME ::CONFIG::;
 setenv POSH_SHELL_VERSION "";
 setenv POSH_PID $$;
+setenv OSTYPE "$OSTYPE";
+
+if ("$OSTYPE" =~ {msys,cygwin}*) then
+  setenv POSH_PID "`cat /proc/$$/winpid`";
+endif
 
 set POSH_COMMAND = ::OMP::;
 set USER_PRECMD = "`alias precmd`";

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -5,6 +5,11 @@ export POWERLINE_COMMAND="oh-my-posh"
 export CONDA_PROMPT_MODIFIER=false
 export POSH_PROMPT_COUNT=0
 export ZLE_RPROMPT_INDENT=0
+export OSTYPE=$OSTYPE
+
+if [[ $OSTYPE =~ ^(msys|cygwin) ]]; then
+  export POSH_PID=$(command cat /proc/$$/winpid)
+fi
 
 _omp_executable=::OMP::
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

When we're in a Cygwin (MinGW/MSYS) environment, for example, Git Bash, the PID reported by `$$` is actually a Cygwin PID, while the OMP cache file should be named after a real (Windows) PID for consistency and uniqueness. To address this, we can retrieve the Windows PID (WINPID) from `/proc/<PID>/winpid` for a shell session.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary