### PR TITLE
feat(runtime/http): Use standard library proxy resolution in HTTP client

### DIFF
--- a/src/runtime/http/http.go
+++ b/src/runtime/http/http.go
@@ -3,8 +3,6 @@ package http
 import (
 	"net"
 	"net/http"
-	"net/url"
-	"os"
 	"time"
 )
 
@@ -14,17 +12,9 @@ type httpClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
-func Proxy(_ *http.Request) (*url.URL, error) {
-	proxyURL := os.Getenv("HTTPS_PROXY")
-	if len(proxyURL) == 0 {
-		return nil, nil
-	}
-	return url.Parse(proxyURL)
-}
-
 var (
 	defaultTransport http.RoundTripper = &http.Transport{
-		Proxy: Proxy,
+		Proxy: http.ProxyFromEnvironment,
 		Dial: (&net.Dialer{
 			Timeout: 10 * time.Second,
 		}).Dial,


### PR DESCRIPTION
Replace custom proxy resolution logic with the built-in http.ProxyFromEnvironment. This leverages the standard library to handle proxy configuration, simplifying our codebase and ensuring compatibility with environment variable-based proxy configurations.

The original code did not include test cases for the proxy functionality, and there is no related content in the documentation either. Therefore, the documentation regarding proxy features may need to be updated primarily by the main contributors.