### PR TITLE
fix(docs): correct syntax issue

### DIFF
--- a/website/docs/configuration/segment.mdx
+++ b/website/docs/configuration/segment.mdx
@@ -22,7 +22,7 @@ understand how to configure a segment.
           "powerline_symbol": "\uE0B0",
           "foreground": "#ffffff",
           "background": "#61AFEF",
-          "template": " {{ .Path }}} ",
+          "template": " {{ .Path }} ",
           "properties": {
             ...
           }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Related issue: Fixes #5513 

There is a syntax issue for configuring example of segments in https://ohmyposh.dev/docs/configuration/segment, located in: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/website/docs/configuration/segment.mdx

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
