### PR TITLE
feat(cache): make cache location logic cross platform

### DIFF
--- a/src/runtime/terminal_unix.go
+++ b/src/runtime/terminal_unix.go
@@ -113,27 +113,6 @@ func (term *Terminal) Platform() string {
 	return platform
 }
 
-func (term *Terminal) CachePath() string {
-	defer term.Trace(time.Now())
-
-	// allow the user to set the cache path using OMP_CACHE_DIR
-	if cachePath := returnOrBuildCachePath(term.Getenv("OMP_CACHE_DIR")); len(cachePath) != 0 {
-		return cachePath
-	}
-
-	// get XDG_CACHE_HOME if present
-	if cachePath := returnOrBuildCachePath(term.Getenv("XDG_CACHE_HOME")); len(cachePath) != 0 {
-		return cachePath
-	}
-
-	// HOME cache folder
-	if cachePath := returnOrBuildCachePath(term.Home() + "/.cache"); len(cachePath) != 0 {
-		return cachePath
-	}
-
-	return term.Home()
-}
-
 func (term *Terminal) WindowsRegistryKeyValue(_ string) (*WindowsRegistryValue, error) {
 	return nil, &NotImplemented{}
 }

--- a/src/runtime/terminal_windows.go
+++ b/src/runtime/terminal_windows.go
@@ -121,17 +121,6 @@ func (term *Terminal) Platform() string {
 	return WINDOWS
 }
 
-func (term *Terminal) CachePath() string {
-	defer term.Trace(time.Now())
-
-	// get LOCALAPPDATA if present
-	if cachePath := returnOrBuildCachePath(term.Getenv("LOCALAPPDATA")); len(cachePath) != 0 {
-		return cachePath
-	}
-
-	return term.Home()
-}
-
 // Takes a registry path to a key like
 //
 //	"HKLM\Software\Microsoft\Windows NT\CurrentVersion\EditionID"


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

we will loop the existance of the following environment variables and validate
if the location exists, get or create the `oh-my-posh` folder in there to use
as a cache location. As `LOCALAPPDATA` only exists on Windows, we will check
for that one first, then follow with all known other cache locations.

- `LOCALAPPDATA`
- `OMP_CACHE_DIR`
- `XDG_CACHE_HOME`
- `HOME/.cache`

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
