### PR TITLE
fix(path): improve path cleaning, normalization and parsing

### DIFF
--- a/src/terminal/writer.go
+++ b/src/terminal/writer.go
@@ -86,6 +86,8 @@ const (
 	hyperLinkText    = "<TEXT>"
 	hyperLinkTextEnd = "</TEXT>"
 
+	empty = "<>"
+
 	startProgress = "\x1b]9;4;3;0\x07"
 	endProgress   = "\x1b]9;4;0;0\x07"
 
@@ -158,10 +160,6 @@ func ChangeLine(numberOfLines int) string {
 func Pwd(pwdType, userName, hostName, pwd string) string {
 	if Plain {
 		return ""
-	}
-
-	if strings.HasSuffix(pwd, ":") {
-		pwd += `/`
 	}
 
 	switch pwdType {
@@ -345,6 +343,9 @@ func Write(background, foreground color.Ansi, text string) {
 			case hyperLinkEnd:
 				i += len([]rune(match[ANCHOR])) - 1
 				builder.WriteString(formats.HyperlinkEnd)
+				continue
+			case empty:
+				i += len([]rune(match[ANCHOR])) - 1
 				continue
 			}
 

--- a/website/docs/segments/system/path.mdx
+++ b/website/docs/segments/system/path.mdx
@@ -77,7 +77,9 @@ For example, to swap out `C:\Users\Leet\GitHub` with a GitHub icon, you can do t
 - To make mapped locations work cross-platform, use `/` as the path separator, Oh My Posh will
   automatically match effective separators based on the running operating system.
 - If you want to match all child directories, you can use `*` as a wildcard, for example:
-  `"C:/Users/Bill/*": "$"` will turn `C:/Users/Bill/Downloads` into `$/Downloads`.
+  `"C:/Users/Bill/*": "$"` will turn `C:/Users/Bill/Downloads` into `$/Downloads` but leave `C:/Users/Bill` unchanged.
+- To prevent mangling path elements, if you use any text style tags (e.g., `<lightGreen>...</>`) in replacement values,
+  you should avoid using a chevron character (`<`/`>`) in the `folder_separator_icon` property, and vice versa.
 - The character `~` at the start of a mapped location will match the user's home directory.
 - The match is case-insensitive on Windows and macOS, but case-sensitive on other operating systems. This means that for
   user Bill, who has a user account `Bill` on Windows and `bill` on Linux, `~/Foo` might match


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

This PR has made the following improvements of path cleaning, normalization and parsing to fix some bugs in a `path` segment (especially use cases of UNC paths on Windows):

- Always respect and carefully handle a UNC path on Windows (even in a Cygwin environment).
- Convert a Cygwin path to lowercase during the path normalization (`(*Path).normalize`).
- Calculate the path length correctly to determine whether the Powerlevel style should be used.
- Escape chevron characters (`<`/`>`) to avoid applying unexpected text styles.
- Ensure correct output of `.Parent` property in the template.
- Ensure correct behavior of colorizing a path.
- Ensure working cases of `gitdir_format` with `mapped_locations` applied.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary