### PR TITLE
feat(font): implement cyclic shifting for item rotation

### DIFF
--- a/src/font/cli.go
+++ b/src/font/cli.go
@@ -214,6 +214,26 @@ func (m *main) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}()
 			m.spinner.Spinner = spinner.Globe
 			return m, m.spinner.Tick
+
+		case "up", "k":
+			if m.list != nil {
+				if m.list.Index() == 0 {
+					m.list.Select(len(m.list.Items()) - 1)
+				} else {
+					m.list.Select(m.list.Index() - 1)
+				}
+			}
+			return m, nil
+
+		case "down", "j":
+			if m.list != nil {
+				if m.list.Index() == len(m.list.Items())-1 {
+					m.list.Select(0)
+				} else {
+					m.list.Select(m.list.Index() + 1)
+				}
+			}
+			return m, nil
 		}
 
 	case zipMsg:


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description
**Summary:**
This pull request introduces a circular (or cyclic) shifting mechanism for handling the rotation of options/items in [fonts installation](https://ohmyposh.dev/docs/installation/fonts). This feature allows for smooth transitions between the first and last items in the list, providing a seamless experience when navigating through options.

**Key Changes:**
- Implemented circular shifting functionality to rotate items in a list.
- Updated the algorithm to handle cases where the last item moves to the first position, and vice versa.

**Benefits:**
- Enhances user experience by enabling continuous rotation of options/items.
- Simplifies navigation when dealing with lists where looping behavior is desired.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
