### PR TITLE
fix(pwsh): prevent a command from eating tail of a transient prompt

### DIFF
--- a/src/prompt/engine.go
+++ b/src/prompt/engine.go
@@ -157,7 +157,9 @@ func (e *Engine) shouldFill(filler string, padLength int) (string, bool) {
 	}
 
 	repeat := padLength / lenFiller
-	return strings.Repeat(filler, repeat), true
+	unfilled := padLength % lenFiller
+	text := strings.Repeat(filler, repeat) + strings.Repeat(" ", unfilled)
+	return text, true
 }
 
 func (e *Engine) getTitleTemplateText() string {
@@ -531,7 +533,7 @@ func New(flags *runtime.Flags) *Engine {
 
 	switch env.Shell() {
 	case shell.ELVISH:
-		// In Elvish, continuous text is always cut off before the right-most cell on the terminal screen.
+		// In Elvish, a prompt line will always wrap when the cursor reaches the rightmost cell on the terminal screen.
 		// We have to reduce the terminal width by 1 so a right-aligned block will not be broken.
 		eng.rectifyTerminalWidth(-1)
 	case shell.PWSH, shell.PWSH5:

--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -458,7 +458,18 @@ Example:
         Set-PSReadLineOption -ExtraPromptLineCount (($standardOut | Measure-Object -Line).Lines - 1)
 
         # The output can be multi-line, joining them ensures proper rendering.
-        $standardOut -join "`n"
+        $output = $standardOut -join "`n"
+
+        if ($script:PromptType -eq 'transient') {
+            # Workaround to prevent a command from eating the tail of a transient prompt, when we're at the end of the line.
+            $command = ''
+            [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$command, [ref]$null)
+            if ($command) {
+                $output += "  `b`b"
+            }
+        }
+
+        $output
 
         # remove any posh-git status
         $env:POSH_GIT_STATUS = $null


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

Resolves #5601.

This is a workaround using spaces and backspaces, simple and reliable. It's needed only when we know the input buffer is non-empty, so we have to put it in shell code.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary