### PR TITLE
docs(code): change jsonc code blocks language identifier

### DIFF
--- a/website/docs/configuration/templates.mdx
+++ b/website/docs/configuration/templates.mdx
@@ -114,7 +114,7 @@ $env.SET_POSHCONTEXT = {
 
 ### Example
 
-```json
+```jsonc
 {
   "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
   "version": 2,
@@ -206,7 +206,7 @@ your config does not contain a git segment as Oh My Posh only populates the prop
 If you have two identical segments for a different purpose, you can make use of the `alias` property on the segment
 to distinct between both. For example:
 
-```json
+```jsonc
 {
   "type": "command",
   // highlight-next-line

--- a/website/docs/configuration/title.mdx
+++ b/website/docs/configuration/title.mdx
@@ -21,7 +21,7 @@ the current working directory is `/usr/home/omp` and the shell is `zsh`.
 
 To learn more about templates and their possibilities, have a look at the [template][templates] section.
 
-```json
+```jsonc
 {
     "console_title_template": "{{.Folder}}{{if .Root}} :: root{{end}} :: {{.Shell}}",
     // outputs:

--- a/website/docs/faq.mdx
+++ b/website/docs/faq.mdx
@@ -118,7 +118,7 @@ the steps [here][export] to export it to a local file so you can adjust the [seg
 
 In the example below, it's assumed that the execution segment's icon `\ueba2` has an unexpected space after it in Windows Terminal.
 
-```json
+```jsonc
 {
   "type": "executiontime",
   "template": "\ueba2" // unexpected space
@@ -127,7 +127,7 @@ In the example below, it's assumed that the execution segment's icon `\ueba2` ha
 
 Adjust it by adding `\u2800` immediately after the icon.
 
-```json
+```jsonc
 {
   "type": "executiontime",
   "template": "\ueba2\u2800" // solved

--- a/website/docs/introduction.md
+++ b/website/docs/introduction.md
@@ -28,7 +28,7 @@ The basic layout of the config file is as follows.
 
 A [block][block] has properties that indicate its position and the [segments][segment] it will render.
 
-```json
+```jsonc
 {
     "blocks": [
         {

--- a/website/docs/segments/web/brewfather.mdx
+++ b/website/docs/segments/web/brewfather.mdx
@@ -137,7 +137,7 @@ If there are no readings available, `.Reading` will be null.
 
 Hyperlink formatting example
 
-```json
+```jsonc
 {
   // General format: «text»(link)
   "template": "«{{.StatusIcon}} {{if .DaysBottledOrFermented}}{{.DaysBottledOrFermented}}d{{end}} {{.Recipe.Name}}»({{.URL}})"

--- a/website/docs/segments/web/wakatime.mdx
+++ b/website/docs/segments/web/wakatime.mdx
@@ -42,7 +42,7 @@ import Config from '@site/src/components/Config.js';
 
 If you don't want to include the API key into your configuration, the following modification can be done.
 
-```json
+```jsonc
 "properties": {
   // highlight-next-line
   "url": "https://wakatime.com/api/v1/users/current/summaries?start=today&end=today&api_key={{ .Env.WAKATIME_API_KEY }}",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Changed language identifiers for JSONC code blocks in documentation from `json` to `jsonc` to reflect the file format change and ensure correct syntax highlighting.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
