### PR TITLE
fix(prompt): write real newlines for Elvish on non-Windows systems

### DIFF
--- a/src/prompt/engine.go
+++ b/src/prompt/engine.go
@@ -113,8 +113,8 @@ func (e *Engine) getNewline() string {
 	}
 
 	// Warp terminal will remove a newline character ('\n') from the prompt, so we hack it in.
-	// For Elvish, we do this to prevent cutting off a right-aligned block.
-	if e.isWarp() || e.Env.Shell() == shell.ELVISH {
+	// For Elvish on Windows, we do this to prevent cutting off a right-aligned block.
+	if e.isWarp() || (e.Env.Shell() == shell.ELVISH && e.Env.GOOS() == runtime.WINDOWS) {
 		return terminal.LineBreak()
 	}
 
@@ -545,16 +545,17 @@ func New(flags *runtime.Flags) *Engine {
 	}
 
 	switch env.Shell() {
-	case shell.TCSH:
-		// In Tcsh, newlines in a prompt are badly translated.
-		// No silver bullet here. We have to reduce the terminal width by 1 so a right-aligned block will not be broken.
-		eng.rectifyTerminalWidth(-1)
-	case shell.ELVISH, shell.XONSH:
-		// In these shells, the behavior of wrapping at the end of a prompt line is inconsistent across platforms.
+	case shell.XONSH:
+		// In Xonsh, the behavior of wrapping at the end of a prompt line is inconsistent across platforms.
 		// On Windows, it wraps before the rightmost cell on the terminal screen, that is, the rightmost cell is never available for a prompt line.
 		if eng.Env.GOOS() == runtime.WINDOWS {
 			eng.rectifyTerminalWidth(-1)
 		}
+	case shell.TCSH, shell.ELVISH:
+		// In Tcsh, newlines in a prompt are badly translated.
+		// No silver bullet here. We have to reduce the terminal width by 1 so a right-aligned block will not be broken.
+		// In Elvish, the behavior is similar to that in Xonsh, but we do this for all platforms.
+		eng.rectifyTerminalWidth(-1)
 	case shell.PWSH, shell.PWSH5:
 		// when in PowerShell, and force patching the bleed bug
 		// we need to reduce the terminal width by 1 so the last

--- a/src/prompt/rprompt.go
+++ b/src/prompt/rprompt.go
@@ -2,6 +2,8 @@ package prompt
 
 import (
 	"github.com/jandedobbeleer/oh-my-posh/src/config"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
+	"github.com/jandedobbeleer/oh-my-posh/src/shell"
 )
 
 func (e *Engine) RPrompt() string {
@@ -28,6 +30,11 @@ func (e *Engine) RPrompt() string {
 
 	text, length := e.renderBlockSegments(rprompt)
 	e.rpromptLength = length
+
+	if e.Env.Shell() == shell.ELVISH && e.Env.GOOS() != runtime.WINDOWS {
+		// Workaround to align with a right-aligned block on non-Windows systems.
+		text += " "
+	}
 
 	return text
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes or features).
- [ ] Docs have been added or updated (for bug fixes or features).

### Description

Follow-up to #5614, providing a fix to render newlines correctly in a prompt for Elvish on non-Windows systems.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary