### PR TITLE
fix(cache): use UUIDs as session IDs

### DIFF
--- a/src/cache/cache.go
+++ b/src/cache/cache.go
@@ -30,9 +30,9 @@ const (
 var SessionFileName = fmt.Sprintf("%s.%s", FileName, sessionID())
 
 func sessionID() string {
-	pid := os.Getenv("POSH_PID")
+	pid := os.Getenv("POSH_SESSION_ID")
 	if len(pid) == 0 {
-		log.Debug("POSH_PID not set, using process pid")
+		log.Debug("POSH_SESSION_ID not set, using PID")
 		pid = strconv.Itoa(os.Getppid())
 	}
 

--- a/src/go.mod
+++ b/src/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/alecthomas/repr v0.4.0 // indirect
 	github.com/esimov/stackblur-go v1.1.0
 	github.com/fogleman/gg v1.3.0
-	github.com/google/uuid v1.6.0 // indirect
+	github.com/google/uuid v1.6.0
 	github.com/gookit/color v1.5.4
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect

--- a/src/shell/init.go
+++ b/src/shell/init.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jandedobbeleer/oh-my-posh/src/log"
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
 )
@@ -80,6 +81,7 @@ func PrintInit(env runtime.Environment, features Features, startTime *time.Time)
 
 	shell := env.Flags().Shell
 	configFile := env.Flags().Config
+	sessionID := uuid.NewString()
 
 	var script string
 
@@ -87,38 +89,47 @@ func PrintInit(env runtime.Environment, features Features, startTime *time.Time)
 	case PWSH, PWSH5:
 		executable = quotePwshOrElvishStr(executable)
 		configFile = quotePwshOrElvishStr(configFile)
+		sessionID = quotePwshOrElvishStr(sessionID)
 		script = pwshInit
 	case ZSH:
 		executable = QuotePosixStr(executable)
 		configFile = QuotePosixStr(configFile)
+		sessionID = QuotePosixStr(sessionID)
 		script = zshInit
 	case BASH:
 		executable = QuotePosixStr(executable)
 		configFile = QuotePosixStr(configFile)
+		sessionID = QuotePosixStr(sessionID)
 		script = bashInit
 	case FISH:
 		executable = quoteFishStr(executable)
 		configFile = quoteFishStr(configFile)
+		sessionID = quoteFishStr(sessionID)
 		script = fishInit
 	case CMD:
 		executable = escapeLuaStr(executable)
 		configFile = escapeLuaStr(configFile)
+		sessionID = escapeLuaStr(sessionID)
 		script = cmdInit
 	case NU:
 		executable = quoteNuStr(executable)
 		configFile = quoteNuStr(configFile)
+		sessionID = quoteNuStr(sessionID)
 		script = nuInit
 	case TCSH:
 		executable = quoteCshStr(executable)
 		configFile = quoteCshStr(configFile)
+		sessionID = quoteCshStr(sessionID)
 		script = tcshInit
 	case ELVISH:
 		executable = quotePwshOrElvishStr(executable)
 		configFile = quotePwshOrElvishStr(configFile)
+		sessionID = quotePwshOrElvishStr(sessionID)
 		script = elvishInit
 	case XONSH:
 		executable = quotePythonStr(executable)
 		configFile = quotePythonStr(configFile)
+		sessionID = quotePythonStr(sessionID)
 		script = xonshInit
 	default:
 		return fmt.Sprintf("echo \"No initialization script available for %s\"", shell)
@@ -128,6 +139,7 @@ func PrintInit(env runtime.Environment, features Features, startTime *time.Time)
 		"::OMP::", executable,
 		"::CONFIG::", configFile,
 		"::SHELL::", shell,
+		"::SESSION_ID::", sessionID,
 	).Replace(script)
 
 	shellScript := features.Lines(shell).String(init)

--- a/src/shell/scripts/omp.bash
+++ b/src/shell/scripts/omp.bash
@@ -1,13 +1,9 @@
 export POSH_THEME=::CONFIG::
 export POSH_SHELL_VERSION=$BASH_VERSION
 export POWERLINE_COMMAND='oh-my-posh'
-export POSH_PID=$$
+export POSH_SESSION_ID=::SESSION_ID::
 export CONDA_PROMPT_MODIFIER=false
 export OSTYPE=$OSTYPE
-
-if [[ $OSTYPE =~ ^(msys|cygwin) ]]; then
-    export POSH_PID=$(command cat /proc/$$/winpid)
-fi
 
 # global variables
 _omp_start_time=''

--- a/src/shell/scripts/omp.elv
+++ b/src/shell/scripts/omp.elv
@@ -1,4 +1,4 @@
-set-env POSH_PID (to-string (randint 10000000000000 10000000000000000))
+set-env POSH_SESSION_ID ::SESSION_ID::
 set-env POSH_THEME ::CONFIG::
 set-env POSH_SHELL_VERSION $version
 set-env POWERLINE_COMMAND oh-my-posh

--- a/src/shell/scripts/omp.fish
+++ b/src/shell/scripts/omp.fish
@@ -1,16 +1,12 @@
 set --export POSH_THEME ::CONFIG::
 set --export POSH_SHELL_VERSION $FISH_VERSION
 set --export POWERLINE_COMMAND oh-my-posh
-set --export POSH_PID $fish_pid
+set --export POSH_SESSION_ID ::SESSION_ID::
 set --export CONDA_PROMPT_MODIFIER false
+
 set --global _omp_tooltip_command ''
 set --global _omp_current_rprompt ''
 set --global _omp_transient 0
-
-if command uname -s | string match -qr '^(CYGWIN|MSYS|MINGW)'
-    set --export POSH_PID (command cat /proc/$fish_pid/winpid)
-end
-
 set --global _omp_executable ::OMP::
 set --global _omp_ftcs_marks 0
 set --global _omp_transient_prompt 0

--- a/src/shell/scripts/omp.lua
+++ b/src/shell/scripts/omp.lua
@@ -3,7 +3,7 @@
 ---@diagnostic disable: lowercase-global
 
 -- Cache PID
-os.setenv('POSH_PID', os.getpid())
+os.setenv('POSH_SESSION_ID', '::SESSION_ID::')
 
 -- Helper functions
 

--- a/src/shell/scripts/omp.nu
+++ b/src/shell/scripts/omp.nu
@@ -6,7 +6,7 @@ if ($env.config? | is-not-empty) {
 $env.POWERLINE_COMMAND = 'oh-my-posh'
 $env.POSH_THEME = (echo ::CONFIG::)
 $env.PROMPT_INDICATOR = ""
-$env.POSH_PID = (random uuid)
+$env.POSH_SESSION_ID = (echo ::SESSION_ID::)
 $env.POSH_SHELL_VERSION = (version | get version)
 
 let _omp_executable: string = (echo ::OMP::)

--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -40,7 +40,7 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
 
     $env:POWERLINE_COMMAND = "oh-my-posh"
     $env:POSH_SHELL_VERSION = $script:PSVersion
-    $env:POSH_PID = $PID
+    $env:POSH_SESSION_ID = ::SESSION_ID::
     $env:CONDA_PROMPT_MODIFIER = $false
 
     # set the default theme

--- a/src/shell/scripts/omp.tcsh
+++ b/src/shell/scripts/omp.tcsh
@@ -1,10 +1,8 @@
 setenv POWERLINE_COMMAND "oh-my-posh";
 setenv POSH_THEME ::CONFIG::;
 setenv POSH_SHELL_VERSION "$tcsh";
-setenv POSH_PID $$;
+setenv POSH_SESSION_ID ::SESSION_ID::;
 setenv OSTYPE "$OSTYPE";
-
-if ( "$OSTYPE" =~ {msys,cygwin}* ) setenv POSH_PID "`cat /proc/$$/winpid`";
 
 if ( ! $?_omp_enabled ) alias precmd '
   set _omp_status = $status;

--- a/src/shell/scripts/omp.xsh
+++ b/src/shell/scripts/omp.xsh
@@ -1,8 +1,6 @@
-import uuid
-
 $POWERLINE_COMMAND = "oh-my-posh"
 $POSH_THEME = ::CONFIG::
-$POSH_PID = uuid.uuid4().hex
+$POSH_SESSION_ID = ::SESSION_ID::
 $POSH_SHELL_VERSION = $XONSH_VERSION
 
 _omp_executable = ::OMP::

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -1,14 +1,10 @@
 export POSH_THEME=::CONFIG::
 export POSH_SHELL_VERSION=$ZSH_VERSION
-export POSH_PID=$$
+export POSH_SESSION_ID=::SESSION_ID::
 export POWERLINE_COMMAND='oh-my-posh'
 export CONDA_PROMPT_MODIFIER=false
 export ZLE_RPROMPT_INDENT=0
 export OSTYPE=$OSTYPE
-
-if [[ $OSTYPE =~ ^(msys|cygwin) ]]; then
-  export POSH_PID=$(command cat /proc/$$/winpid)
-fi
 
 _omp_executable=::OMP::
 _omp_tooltip_command=''


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes or features).
- [ ] Docs have been added or updated (for bug fixes or features).

### Description

Fix #5656.

Using UUIDs as session IDs is more reliable, which is also what Xonsh does in history saving.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary