### PR TITLE
feat(build): embed timezone database

### DIFF
--- a/src/.goreleaser.yml
+++ b/src/.goreleaser.yml
@@ -18,6 +18,7 @@ builds:
       - netgo
       - osusergo
       - static_build
+      - timetzdata
     env:
       - CGO_ENABLED=0
     goos:


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [Contributing Guide][contributing-guide].
- [x] The commit message follows the [Conventional Commits][conventional-commits].
- [ ] Tests for the changes have been added (for bug fixes or features).
- [ ] The documentation has been added or updated (for bug fixes or features).

### Description

Build with the `timetzdata` tag so the package [time/tzdata][go-time-tzdata] is automatically imported and an embedded copy of the timezone database is provided as the fallback. On Windows, this ensures that IANA Time Zones work with a template function like `dateInZone`.

[contributing-guide]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[go-time-tzdata]: https://pkg.go.dev/time/tzdata