### PR TITLE
feat(python): make folder fallback env names customizable

### DIFF
--- a/src/segments/python.go
+++ b/src/segments/python.go
@@ -22,6 +22,7 @@ const (
 	FetchVirtualEnv      properties.Property = "fetch_virtual_env"
 	UsePythonVersionFile properties.Property = "use_python_version_file"
 	FolderNameFallback   properties.Property = "folder_name_fallback"
+	FallbackNames        properties.Property = "fallback_names"
 )
 
 func (p *Python) Template() string {
@@ -81,10 +82,10 @@ func (p *Python) loadContext() {
 	}
 
 	folderNameFallback := p.language.props.GetBool(FolderNameFallback, true)
-	defaultVenvNames := []string{
+	defaultVenvNames := p.language.props.GetStringArray(FallbackNames, []string{
 		".venv",
 		"venv",
-	}
+	})
 
 	var venv string
 	for _, venvVar := range venvVars {

--- a/src/segments/python.go
+++ b/src/segments/python.go
@@ -22,7 +22,7 @@ const (
 	FetchVirtualEnv      properties.Property = "fetch_virtual_env"
 	UsePythonVersionFile properties.Property = "use_python_version_file"
 	FolderNameFallback   properties.Property = "folder_name_fallback"
-	FallbackNames        properties.Property = "fallback_names"
+	DefaultVenvNames     properties.Property = "default_venv_names"
 )
 
 func (p *Python) Template() string {
@@ -82,7 +82,7 @@ func (p *Python) loadContext() {
 	}
 
 	folderNameFallback := p.language.props.GetBool(FolderNameFallback, true)
-	defaultVenvNames := p.language.props.GetStringArray(FallbackNames, []string{
+	defaultVenvNames := p.language.props.GetStringArray(DefaultVenvNames, []string{
 		".venv",
 		"venv",
 	})

--- a/src/segments/python_test.go
+++ b/src/segments/python_test.go
@@ -203,19 +203,19 @@ func TestPythonVirtualEnvIgnoreCustomVenvNames(t *testing.T) {
 	cases := []struct {
 		Expected           string
 		FolderNameFallback bool
-		FallbackNames      []string
+		DefaultVenvNames   []string
 		VirtualEnvName     string
 	}{
 		{
 			Expected:           "folder",
 			FolderNameFallback: true,
-			FallbackNames:      []string{"env"},
+			DefaultVenvNames:   []string{"env"},
 			VirtualEnvName:     "/path/to/folder/env",
 		},
 		{
 			Expected:           "venv",
 			FolderNameFallback: true,
-			FallbackNames:      []string{"env"},
+			DefaultVenvNames:   []string{"env"},
 			VirtualEnvName:     "/path/to/folder/venv",
 		},
 	}
@@ -235,7 +235,7 @@ func TestPythonVirtualEnvIgnoreCustomVenvNames(t *testing.T) {
 		env.On("HasParentFilePath", ".python-version", false).Return(&runtime.FileInfo{}, errors.New("no match at root level"))
 
 		props[FolderNameFallback] = tc.FolderNameFallback
-		props[FallbackNames] = tc.FallbackNames
+		props[DefaultVenvNames] = tc.DefaultVenvNames
 
 		python := &Python{}
 		python.Init(props, env)

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -2653,6 +2653,24 @@
                     "items": {
                       "type": "string"
                     }
+                  },
+                  "folder_name_fallback": {
+                    "type": "boolean",
+                    "title": "Folder Name Fallback",
+                    "description": "Replace virtual environment names in fallback_names list with parent folder name",
+                    "default": "true"
+                  },
+                  "fallback_names": {
+                    "type": "array",
+                    "title": "Fallback Names",
+                    "description": "Names to replace when folder_name_fallback is true",
+                    "default": [
+                      ".venv",
+                      "venv"
+                    ],
+                    "items": {
+                      "type": "string"
+                    }
                   }
                 }
               }

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -2657,12 +2657,12 @@
                   "folder_name_fallback": {
                     "type": "boolean",
                     "title": "Folder Name Fallback",
-                    "description": "Replace virtual environment names in fallback_names list with parent folder name",
+                    "description": "Replace virtual environment names in default_venv_names list with parent folder name",
                     "default": "true"
                   },
-                  "fallback_names": {
+                  "default_venv_names": {
                     "type": "array",
-                    "title": "Fallback Names",
+                    "title": "Default Venv Names",
                     "description": "Names to replace when folder_name_fallback is true",
                     "default": [
                       ".venv",

--- a/website/docs/segments/languages/python.mdx
+++ b/website/docs/segments/languages/python.mdx
@@ -38,7 +38,8 @@ import Config from "@site/src/components/Config.js";
 | `extensions`           | `[]string` | `*.py, *.ipynb, pyproject.toml, venv.bak` | allows to override the default list of file extensions to validate                                                                                                                                                                   |
 | `folders`              | `[]string` |                                           | allows to override the list of folder names to validate                                                                                                                                                                              |
 | `cache_version`        | `boolean`  | `false`                                   | cache the executable's version or not                                                                                                                                                                                                |
-| `folder_name_fallback` | `boolean`  | `true`                                    | instead of `venv` or `.venv` (case sensitive), use the parent folder name as the virtual environment's name or not                                                                                                                   |
+| `folder_name_fallback` | `boolean`  | `true`                                    | instead of `fallback_names` (case sensitive), use the parent folder name as the virtual environment's name or not                                                                                                                   |
+| `fallback_names`       | `[]string` | `.venv, venv` | allows to override the list of environment's name replaced when `folder_name_fallback` is `true` |
 
 ## Template ([info][templates])
 

--- a/website/docs/segments/languages/python.mdx
+++ b/website/docs/segments/languages/python.mdx
@@ -38,8 +38,8 @@ import Config from "@site/src/components/Config.js";
 | `extensions`           | `[]string` | `*.py, *.ipynb, pyproject.toml, venv.bak` | allows to override the default list of file extensions to validate                                                                                                                                                                   |
 | `folders`              | `[]string` |                                           | allows to override the list of folder names to validate                                                                                                                                                                              |
 | `cache_version`        | `boolean`  | `false`                                   | cache the executable's version or not                                                                                                                                                                                                |
-| `folder_name_fallback` | `boolean`  | `true`                                    | instead of `fallback_names` (case sensitive), use the parent folder name as the virtual environment's name or not                                                                                                                   |
-| `fallback_names`       | `[]string` | `.venv, venv` | allows to override the list of environment's name replaced when `folder_name_fallback` is `true` |
+| `folder_name_fallback` | `boolean`  | `true`                                    | instead of `default_venv_names` (case sensitive), use the parent folder name as the virtual environment's name or not                                                                                                                   |
+| `default_venv_names`       | `[]string` | `.venv, venv` | allows to override the list of environment's name replaced when `folder_name_fallback` is `true` |
 
 ## Template ([info][templates])
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Add the possibilty to customize python virtualenvs name replaced by the parent folder name