### PR TITLE
docs(faq): clarify Vim mode handling and improve prompt rendering

### DIFF
--- a/website/docs/faq.mdx
+++ b/website/docs/faq.mdx
@@ -278,22 +278,23 @@ This is most likely caused by two Oh My Posh init lines in your `.zshrc`, remove
 ### Fish: Display current bind (Vim) mode
 
 By default, Oh My Posh will not re-render the prompt (i.e., generate a new prompt) until a new command is run, so you should
-call the `omp_repaint_prompt` function to do prompt re-rendering whenever `$fish_bind_mode` changes:
+export `$fish_bind_mode` to `FISH__BIND_MODE` and call the `omp_repaint_prompt` function to do prompt re-rendering when
+`$fish_bind_mode` changes:
 
 ```fish
 function rerender_on_bind_mode_change --on-variable fish_bind_mode
-    if test "$fish_bind_mode" != paste
+    if test "$fish_bind_mode" != paste -a "$fish_bind_mode" != "$FISH__BIND_MODE"
+        set -gx FISH__BIND_MODE $fish_bind_mode
         omp_repaint_prompt
     end
 end
 ```
 
-Then export the current bind mode in the `set_poshcontext` function. Note that scope shadowing must be disabled in order to
-access the `$fish_bind_mode` variable.
+Next, mask the `fish_default_mode_prompt` function to prevent it from echoing the current mode:
 
 ```fish
-function set_poshcontext --no-scope-shadowing
-  set --export FISH__BIND_MODE $fish_bind_mode
+function fish_default_mode_prompt --description "Display vi prompt mode"
+    # This function is masked and does nothing
 end
 ```
 


### PR DESCRIPTION
Updated the Fish section of the FAQ to address issues with Vim mode display:
1. Moved the export of `$fish_bind_mode` to `FISH__BIND_MODE` within the `rerender_on_bind_mode_change` function, as `set_poshcontext` had no effect.
2. Added instructions to mask the `fish_default_mode_prompt` function to prevent it from echoing the mode before Oh My Posh renders the prompt, ensuring a cleaner prompt display.

### Prerequisites

- [y] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [y] The commit message follows the [conventional commits][cc] guidelines.
- [y] Tests for the changes have been added (for bug fixes / features).
- [y] Docs have been added/updated (for bug fixes / features).

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
