### PR TITLE
feat(segment): add `mojo`

### DIFF
--- a/src/config/segment_types.go
+++ b/src/config/segment_types.go
@@ -115,6 +115,8 @@ const (
 	LUA SegmentType = "lua"
 	// MERCURIAL writes the Mercurial source control information
 	MERCURIAL SegmentType = "mercurial"
+	// MOJO writes the active version of Mojo and the name of the Magic virtual env
+	MOJO SegmentType = "mojo"
 	// MVN writes the active maven version
 	MVN SegmentType = "mvn"
 	// NBA writes NBA game data
@@ -263,6 +265,7 @@ var Segments = map[SegmentType]func() SegmentWriter{
 	LASTFM:          func() SegmentWriter { return &segments.LastFM{} },
 	LUA:             func() SegmentWriter { return &segments.Lua{} },
 	MERCURIAL:       func() SegmentWriter { return &segments.Mercurial{} },
+	MOJO:            func() SegmentWriter { return &segments.Mojo{} },
 	MVN:             func() SegmentWriter { return &segments.Mvn{} },
 	NBA:             func() SegmentWriter { return &segments.Nba{} },
 	NBGV:            func() SegmentWriter { return &segments.Nbgv{} },

--- a/src/segments/mojo.go
+++ b/src/segments/mojo.go
@@ -1,0 +1,57 @@
+package segments
+
+import (
+	"slices"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/properties"
+)
+
+type Mojo struct {
+	Venv string
+	language
+}
+
+func (m *Mojo) Template() string {
+	return " {{ if .Error }}{{ .Error }}{{ else }}{{ if .Venv }}{{ .Venv }} {{ end }}{{ .Full }}{{ end }} "
+}
+
+func (m *Mojo) Enabled() bool {
+	m.extensions = []string{"*.🔥", "*.mojo", "mojoproject.toml"}
+	m.commands = []*cmd{
+		{
+			executable: "mojo",
+			args:       []string{"--version"},
+			regex:      `(?:mojo (?P<version>((?P<major>[0-9]+).(?P<minor>[0-9]+).(?P<patch>[0-9]+))))`,
+		},
+	}
+	m.displayMode = m.props.GetString(DisplayMode, DisplayModeEnvironment)
+	m.language.loadContext = m.loadContext
+	m.language.inContext = m.inContext
+
+	return m.language.Enabled()
+}
+
+func (m *Mojo) loadContext() {
+	if !m.language.props.GetBool(FetchVirtualEnv, true) {
+		return
+	}
+	// Magic, the official package manager and virtual env manager,
+	// is built on top of pixi: https://github.com/prefix-dev/pixi
+	venv := m.language.env.Getenv("PIXI_ENVIRONMENT_NAME")
+	if len(venv) > 0 && m.canUseVenvName(venv) {
+		m.Venv = venv
+	}
+}
+
+func (m *Mojo) inContext() bool {
+	return m.Venv != ""
+}
+
+func (m *Mojo) canUseVenvName(name string) bool {
+	defaultNames := []string{"default"}
+	if m.language.props.GetBool(properties.DisplayDefault, true) ||
+		!slices.Contains(defaultNames, name) {
+		return true
+	}
+	return false
+}

--- a/src/segments/mojo_test.go
+++ b/src/segments/mojo_test.go
@@ -1,0 +1,89 @@
+package segments
+
+import (
+	"testing"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/properties"
+
+	"github.com/alecthomas/assert"
+)
+
+func TestMojoTemplate(t *testing.T) {
+	cases := []struct {
+		Case            string
+		Expected        string
+		VirtualEnvName  string
+		FetchVirtualEnv bool
+		DisplayDefault  bool
+		FetchVersion    bool
+	}{
+		{
+			Case:            "Virtual environment is present",
+			Expected:        "foo 24.5.0",
+			VirtualEnvName:  "foo",
+			FetchVirtualEnv: true,
+			DisplayDefault:  true,
+			FetchVersion:    true,
+		},
+		{
+			Case:            "No virtual environment present",
+			Expected:        "24.5.0",
+			VirtualEnvName:  "",
+			FetchVirtualEnv: true,
+			DisplayDefault:  true,
+			FetchVersion:    true,
+		},
+		{
+			Case:            "Hide the virtual environment, but show the version",
+			Expected:        "24.5.0",
+			VirtualEnvName:  "foo",
+			FetchVirtualEnv: false,
+			DisplayDefault:  true,
+			FetchVersion:    true,
+		},
+		{
+			Case:            "Show the virtual environment, but hide the version",
+			Expected:        "foo",
+			VirtualEnvName:  "foo",
+			FetchVirtualEnv: true,
+			DisplayDefault:  true,
+			FetchVersion:    false,
+		},
+		{
+			Case:            "Show the default virtual environment",
+			Expected:        "default 24.5.0",
+			VirtualEnvName:  "default",
+			FetchVirtualEnv: true,
+			DisplayDefault:  true,
+			FetchVersion:    true,
+		},
+		{
+			Case:            "Hide the default virtual environment",
+			Expected:        "24.5.0",
+			VirtualEnvName:  "default",
+			FetchVirtualEnv: true,
+			DisplayDefault:  false,
+			FetchVersion:    true,
+		},
+	}
+
+	for _, tc := range cases {
+		params := &mockedLanguageParams{
+			cmd:           "mojo",
+			versionParam:  "--version",
+			versionOutput: "mojo 24.5.0 (e8aacb95)",
+			extension:     "*.mojo",
+		}
+		env, props := getMockedLanguageEnv(params)
+		env.On("Getenv", "PIXI_ENVIRONMENT_NAME").Return(tc.VirtualEnvName)
+		props[properties.DisplayDefault] = tc.DisplayDefault
+		props[properties.FetchVersion] = tc.FetchVersion
+		props[FetchVirtualEnv] = tc.FetchVirtualEnv
+		props[DisplayMode] = DisplayModeAlways
+
+		mojo := &Mojo{}
+		mojo.Init(props, env)
+		assert.True(t, mojo.Enabled())
+		assert.Equal(t, tc.Expected, renderTemplate(env, mojo.Template(), mojo), tc.Case)
+	}
+}

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -342,6 +342,7 @@
             "lastfm",
             "lua",
             "mercurial",
+            "mojo",
             "mvn",
             "nbgv",
             "nightscout",
@@ -4514,6 +4515,68 @@
                   },
                   "status_formats": {
                     "$ref": "#/definitions/status_formats"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "mojo"
+              }
+            }
+          },
+          "then": {
+            "title": "Mojo Segment",
+            "description": "https://ohmyposh.dev/docs/segments/languages/mojo",
+            "properties": {
+              "properties": {
+                "properties": {
+                  "home_enabled": {
+                    "$ref": "#/definitions/home_enabled"
+                  },
+                  "fetch_virtual_env": {
+                    "type": "boolean",
+                    "title": "Fetch Virtual Env",
+                    "description": "Fetch the name of the virtualenv or not",
+                    "default": true
+                  },
+                  "display_default": {
+                    "type": "boolean",
+                    "title": "Display Default",
+                    "description": "Show the name of the virtualenv when it's default",
+                    "default": true
+                  },
+                  "fetch_version": {
+                    "$ref": "#/definitions/fetch_version"
+                  },
+                  "display_mode": {
+                    "$ref": "#/definitions/display_mode"
+                  },
+                  "missing_command_text": {
+                    "$ref": "#/definitions/missing_command_text"
+                  },
+                  "version_url_template": {
+                    "$ref": "#/definitions/version_url_template"
+                  },
+                  "extensions": {
+                    "type": "array",
+                    "title": "Extensions",
+                    "description": "The extensions to look for when determining if a folder is a Mojo workspace",
+                    "default": [
+                      "*.🔥",
+                      "*.mojo",
+                      "mojoproject.toml"
+                    ],
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "folders": {
+                    "$ref": "#/definitions/folders"
                   }
                 }
               }

--- a/website/docs/segments/languages/mojo.mdx
+++ b/website/docs/segments/languages/mojo.mdx
@@ -1,0 +1,64 @@
+---
+id: mojo
+title: Mojo
+sidebar_label: Mojo
+---
+
+## What
+
+Display the currently active version of [Mojo][mojo] and the name of the [Magic][magic] virtual environment.
+
+## Sample Configuration
+
+import Config from "@site/src/components/Config.js";
+
+<Config
+  data={{
+    type: "mojo",
+    style: "powerline",
+    powerline_symbol: "\uE0B0",
+    foreground: "#100e23",
+    background: "#906cff",
+    template: " 🔥 {{ .Full }} ",
+  }}
+/>
+
+## Properties
+
+| Name                   | Type       | Default                                   | Description                                                                                                                                                                                                                          |
+| ---------------------- | :--------: | :---------------------------------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `home_enabled`         | `boolean`  | `false`                                   | display the segment in the HOME folder or not                                                                                                                                                                                        |
+| `fetch_virtual_env`    | `boolean`  | `true`                                    | fetch the name of the virtualenv or not                                                                                                                                                                                              |
+| `display_default`      | `boolean`  | `true`                                    | show the name of the virtualenv when it's equal to `default` or not                                                                                                                                                          |
+| `fetch_version`        | `boolean`  | `true`                                    | fetch the Mojo version or not                                                                                                                                                                                                             |
+| `missing_command_text` | `string`   |                                           | text to display when the command is missing                                                                                                                                                                                          |
+| `display_mode`         | `string`   | `environment`                             | <ul><li>`always`: the segment is always displayed</li><li>`files`: the segment is only displayed when file `extensions` listed are present</li><li>`environment`: the segment is only displayed when in a virtual environment</li><li>`context`: displays the segment when the environment or files is active</li></ul> |
+| `version_url_template` | `string`   |                                           | a go [text/template][go-text-template] [template][templates] that creates the URL of the version info / release notes                                                                                                                |
+| `extensions`           | `[]string` | `*.🔥, *.mojo, mojoproject.toml` | allows to override the default list of file extensions to validate                                                                                                                                                                   |
+| `folders`              | `[]string` |                                           | allows to override the list of folder names to validate                                                                                                                                                                              |
+
+## Template ([info][templates])
+
+:::note default template
+
+```template
+{{ if .Error }}{{ .Error }}{{ else }}{{ if .Venv }}{{ .Venv }} {{ end }}{{ .Full }}{{ end }}
+```
+
+:::
+
+### Properties
+
+| Name     | Type     | Description                                        |
+| -------- | -------- | -------------------------------------------------- |
+| `.Venv`  | `string` | the virtual environment name (if present)          |
+| `.Full`  | `string` | the full version                                   |
+| `.Major` | `string` | major number                                       |
+| `.Minor` | `string` | minor number                                       |
+| `.Patch` | `string` | patch number                                       |
+| `.Error` | `string` | error encountered when fetching the version string |
+
+[go-text-template]: https://golang.org/pkg/text/template/
+[templates]: /docs/configuration/templates
+[mojo]: https://docs.modular.com/mojo
+[magic]: https://docs.modular.com/magic

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -129,6 +129,7 @@ module.exports = {
             "segments/languages/julia",
             "segments/languages/kotlin",
             "segments/languages/lua",
+            "segments/languages/mojo",
             "segments/languages/node",
             "segments/languages/ocaml",
             "segments/languages/perl",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Adds a segment for [`Mojo`](https://www.modular.com/mojo).

I've made a few minor adjustments compared to the previous pull request. I also removed the information about the support for the `cache_version` property from `mojo.mdx` and my section in `schema.json`, because you said it would become deprecated in the new major update.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
