### PR TITLE
feat(project): add support for `mojo`

### DIFF
--- a/src/segments/project.go
+++ b/src/segments/project.go
@@ -77,6 +77,11 @@ func (n *Project) Enabled() bool {
 			Fetcher: n.getPythonPackage,
 		},
 		{
+			Name:    "mojo",
+			Files:   []string{"mojoproject.toml"},
+			Fetcher: n.getPythonPackage,
+		},
+		{
 			Name:    "php",
 			Files:   []string{"composer.json"},
 			Fetcher: n.getNodePackage,

--- a/src/segments/project_test.go
+++ b/src/segments/project_test.go
@@ -139,6 +139,22 @@ func TestPackage(t *testing.T) {
 			PackageContents: "[project]\nname=\"test\"\nversion=\"3.2.1\"\n",
 		},
 		{
+			Case:            "1.0.0 mojo",
+			ExpectedEnabled: true,
+			ExpectedString:  "\uf487 1.0.0 test",
+			Name:            "mojo",
+			File:            "mojoproject.toml",
+			PackageContents: "[project]\nname=\"test\"\nversion=\"1.0.0\"\n",
+		},
+		{
+			Case:            "3.2.1 mojo",
+			ExpectedEnabled: true,
+			ExpectedString:  "\uf487 3.2.1 test",
+			Name:            "mojo",
+			File:            "mojoproject.toml",
+			PackageContents: "[project]\nname=\"test\"\nversion=\"3.2.1\"\n",
+		},
+		{
 			Case:            "No version present node.js",
 			ExpectedEnabled: true,
 			ExpectedString:  "test",
@@ -176,6 +192,14 @@ func TestPackage(t *testing.T) {
 			ExpectedString:  "test",
 			Name:            "python",
 			File:            "pyproject.toml",
+			PackageContents: "[project]\nname=\"test\"\n",
+		},
+		{
+			Case:            "No version present mojo",
+			ExpectedEnabled: true,
+			ExpectedString:  "test",
+			Name:            "mojo",
+			File:            "mojoproject.toml",
 			PackageContents: "[project]\nname=\"test\"\n",
 		},
 		{
@@ -219,6 +243,14 @@ func TestPackage(t *testing.T) {
 			PackageContents: "[project]\nversion=\"1.0.0\"\n",
 		},
 		{
+			Case:            "No name present mojo",
+			ExpectedEnabled: true,
+			ExpectedString:  "\uf487 1.0.0",
+			Name:            "mojo",
+			File:            "mojoproject.toml",
+			PackageContents: "[project]\nversion=\"1.0.0\"\n",
+		},
+		{
 			Case:            "Empty project package node.js",
 			ExpectedEnabled: true,
 			Name:            "node",
@@ -244,6 +276,13 @@ func TestPackage(t *testing.T) {
 			ExpectedEnabled: true,
 			Name:            "python",
 			File:            "pyproject.toml",
+			PackageContents: "",
+		},
+		{
+			Case:            "Empty project package mojo",
+			ExpectedEnabled: true,
+			Name:            "mojo",
+			File:            "mojoproject.toml",
 			PackageContents: "",
 		},
 		{

--- a/website/docs/segments/system/project.mdx
+++ b/website/docs/segments/system/project.mdx
@@ -13,6 +13,7 @@ Supports:
 - Node.js project (`package.json`)
 - Cargo project (`Cargo.toml`)
 - Python project (`pyproject.toml`, supports metadata defined according to [PEP 621][pep621-standard] or [Poetry][poetry-standard])
+- Mojo project (`mojoproject.toml`)
 - PHP project (`composer.json`)
 - Dart project (`pubspec.yaml`)
 - Any nuspec based project (`*.nuspec`, first file match info is displayed)
@@ -38,7 +39,7 @@ import Config from "@site/src/components/Config.js";
 
 ## Properties
 
-| Name             | Type      | Default | Description             |
+| Name             |   Type    | Default | Description             |
 | ---------------- | :-------: | :-----: | ----------------------- |
 | `always_enabled` | `boolean` | `false` | always show the segment |
 
@@ -54,13 +55,13 @@ import Config from "@site/src/components/Config.js";
 
 ### Properties
 
-| Name       | Type     | Description                                                                                                                                                        |
-| ---------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `.Type`    | `string` | The type of project:<ul><li>`node`</li><li>`cargo`</li><li>`python`</li><li>`php`</li><li>`dart`</li><li>`nuspec`</li><li>`dotnet`</li><li>`julia`</li><li>`powershell`</li></ul> |
-| `.Version` | `string` | The version of your project                                                                                                                                        |
-| `.Target`  | `string` | The target framework/language version of your project                                                                                                               |
-| `.Name`    | `string` | The name of your project                                                                                                                                           |
-| `.Error`   | `string` | The error context when we can't fetch the project info                                                                                                             |
+| Name       | Type     | Description                                                                                                                                                                                      |
+| ---------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `.Type`    | `string` | The type of project:<ul><li>`node`</li><li>`cargo`</li><li>`python`</li><li>`mojo`</li><li>`php`</li><li>`dart`</li><li>`nuspec`</li><li>`dotnet`</li><li>`julia`</li><li>`powershell`</li></ul> |
+| `.Version` | `string` | The version of your project                                                                                                                                                                      |
+| `.Target`  | `string` | The target framework/language version of your project                                                                                                                                            |
+| `.Name`    | `string` | The name of your project                                                                                                                                                                         |
+| `.Error`   | `string` | The error context when we can't fetch the project info                                                                                                                                           |
 
 [templates]: /docs/configuration/templates
 [pep621-standard]: https://peps.python.org/pep-0621/

--- a/website/docs/segments/system/project.mdx
+++ b/website/docs/segments/system/project.mdx
@@ -58,7 +58,7 @@ import Config from "@site/src/components/Config.js";
 | ---------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `.Type`    | `string` | The type of project:<ul><li>`node`</li><li>`cargo`</li><li>`python`</li><li>`php`</li><li>`dart`</li><li>`nuspec`</li><li>`dotnet`</li><li>`julia`</li><li>`powershell`</li></ul> |
 | `.Version` | `string` | The version of your project                                                                                                                                        |
-| `.Target`  | `string` | The target framwork/language version of your project                                                                                                               |
+| `.Target`  | `string` | The target framework/language version of your project                                                                                                               |
 | `.Name`    | `string` | The name of your project                                                                                                                                           |
 | `.Error`   | `string` | The error context when we can't fetch the project info                                                                                                             |
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Adds support for [`Mojo`](https://www.modular.com/mojo) project files (`mojoproject.toml`) to the [`project`](https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/src/segments/project.go) segment.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
