### PR TITLE
feat(project): add support for `dart`

### DIFF
--- a/src/segments/project.go
+++ b/src/segments/project.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jandedobbeleer/oh-my-posh/src/regex"
 	"golang.org/x/exp/slices"
 
+	yaml "github.com/goccy/go-yaml"
 	toml "github.com/pelletier/go-toml/v2"
 )
 
@@ -79,6 +80,11 @@ func (n *Project) Enabled() bool {
 			Name:    "php",
 			Files:   []string{"composer.json"},
 			Fetcher: n.getNodePackage,
+		},
+		{
+			Name:    "dart",
+			Files:   []string{"pubspec.yaml"},
+			Fetcher: n.getDartPackage,
 		},
 		{
 			Name:    "nuspec",
@@ -178,6 +184,18 @@ func (n *Project) getPythonPackage(item ProjectItem) *ProjectData {
 		Version: data.Project.Version,
 		Name:    data.Project.Name,
 	}
+}
+
+func (n *Project) getDartPackage(item ProjectItem) *ProjectData {
+	content := n.env.FileContent(item.Files[0])
+	var data ProjectData
+	err := yaml.Unmarshal([]byte(content), &data)
+	if err != nil {
+		n.Error = err.Error()
+		return nil
+	}
+
+	return &data
 }
 
 func (n *Project) getNuSpecPackage(_ ProjectItem) *ProjectData {

--- a/src/segments/project_test.go
+++ b/src/segments/project_test.go
@@ -75,6 +75,22 @@ func TestPackage(t *testing.T) {
 			PackageContents: "{\"version\":\"3.2.1\",\"name\":\"test\"}",
 		},
 		{
+			Case:            "1.0.0 dart",
+			ExpectedEnabled: true,
+			ExpectedString:  "\uf487 1.0.0 test",
+			Name:            "dart",
+			File:            "pubspec.yaml",
+			PackageContents: "name: test\nversion: 1.0.0",
+		},
+		{
+			Case:            "3.2.1 dart",
+			ExpectedEnabled: true,
+			ExpectedString:  "\uf487 3.2.1 test",
+			Name:            "dart",
+			File:            "pubspec.yaml",
+			PackageContents: "name: test\nversion: 3.2.1",
+		},
+		{
 			Case:            "1.0.0 cargo",
 			ExpectedEnabled: true,
 			ExpectedString:  "\uf487 1.0.0 test",
@@ -131,6 +147,14 @@ func TestPackage(t *testing.T) {
 			PackageContents: "{\"name\":\"test\"}",
 		},
 		{
+			Case:            "No version present dart",
+			ExpectedEnabled: true,
+			ExpectedString:  "test",
+			Name:            "dart",
+			File:            "pubspec.yaml",
+			PackageContents: "name: test",
+		},
+		{
 			Case:            "No version present cargo",
 			ExpectedEnabled: true,
 			ExpectedString:  "test",
@@ -161,6 +185,14 @@ func TestPackage(t *testing.T) {
 			Name:            "node",
 			File:            "package.json",
 			PackageContents: "{\"version\":\"1.0.0\"}",
+		},
+		{
+			Case:            "No name present dart",
+			ExpectedEnabled: true,
+			ExpectedString:  "\uf487 1.0.0",
+			Name:            "dart",
+			File:            "pubspec.yaml",
+			PackageContents: "version: 1.0.0",
 		},
 		{
 			Case:            "No name present cargo",
@@ -194,6 +226,13 @@ func TestPackage(t *testing.T) {
 			PackageContents: "{}",
 		},
 		{
+			Case:            "Empty project package dart",
+			ExpectedEnabled: true,
+			Name:            "dart",
+			File:            "pubspec.yaml",
+			PackageContents: "",
+		},
+		{
 			Case:            "Empty project package cargo",
 			ExpectedEnabled: true,
 			Name:            "cargo",
@@ -219,6 +258,13 @@ func TestPackage(t *testing.T) {
 			ExpectedString:  "toml: line 1: unexpected end of table name (table names cannot be empty)",
 			Name:            "cargo",
 			File:            "Cargo.toml",
+			PackageContents: "[",
+		},
+		{
+			Case:            "Invalid yaml",
+			ExpectedString:  "[1:1] sequence was used where mapping is expected\n>  1 | [\n       ^",
+			Name:            "dart",
+			File:            "pubspec.yaml",
 			PackageContents: "[",
 		},
 		{

--- a/website/docs/segments/system/project.mdx
+++ b/website/docs/segments/system/project.mdx
@@ -14,6 +14,7 @@ Supports:
 - Cargo project (`Cargo.toml`)
 - Python project (`pyproject.toml`, supports metadata defined according to [PEP 621][pep621-standard] or [Poetry][poetry-standard])
 - PHP project (`composer.json`)
+- Dart project (`pubspec.yaml`)
 - Any nuspec based project (`*.nuspec`, first file match info is displayed)
 - .NET project (`*.sln`, `*.slnf`, `*.csproj`, `*.vbproj` or `*.fsproj`, first file match info is displayed)
 - Julia project (`JuliaProject.toml`, `Project.toml`)
@@ -55,7 +56,7 @@ import Config from "@site/src/components/Config.js";
 
 | Name       | Type     | Description                                                                                                                                                        |
 | ---------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `.Type`    | `string` | The type of project:<ul><li>`node`</li><li>`cargo`</li><li>`python`</li><li>`php`</li><li>`nuspec`</li><li>`dotnet`</li><li>`julia`</li><li>`powershell`</li></ul> |
+| `.Type`    | `string` | The type of project:<ul><li>`node`</li><li>`cargo`</li><li>`python`</li><li>`php`</li><li>`dart`</li><li>`nuspec`</li><li>`dotnet`</li><li>`julia`</li><li>`powershell`</li></ul> |
 | `.Version` | `string` | The version of your project                                                                                                                                        |
 | `.Target`  | `string` | The target framwork/language version of your project                                                                                                               |
 | `.Name`    | `string` | The name of your project                                                                                                                                           |


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Adds support for [`Dart`](https://dart.dev/) project files (`pubspec.yaml`) to the [`project`](https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/src/segments/project.go) segment.

Resolves #5717

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
