### PR TITLE
fix(build): reintroduce 386 builds

### DIFF
--- a/src/.goreleaser.yml
+++ b/src/.goreleaser.yml
@@ -5,7 +5,7 @@ before:
   hooks:
     - go mod tidy
     - go install github.com/tc-hib/go-winres@latest
-    - go-winres make --product-version=git-tag --file-version=git-tag --arch="amd64,arm64"
+    - go-winres make --product-version=git-tag --file-version=git-tag --arch="amd64,386,arm64"
 builds:
   -
     binary: "posh-{{ .Os }}-{{ .Arch }}"
@@ -33,7 +33,10 @@ builds:
       - amd64
       - arm64
       - arm
+      - "386"
     ignore:
+      - goos: darwin
+        goarch: "386"
       - goos: darwin
         goarch: arm
       - goos: windows


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

it turns out this was an issue with goreleaser,
not with the 386 builds themselves.

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
