### PR TITLE
feat: adds zig segment

### DIFF
--- a/src/config/segment_types.go
+++ b/src/config/segment_types.go
@@ -217,6 +217,8 @@ const (
 	YARN SegmentType = "yarn"
 	// YTM writes YouTube Music information and status
 	YTM SegmentType = "ytm"
+	// ZIG writes the active zig version
+	ZIG SegmentType = "zig"
 )
 
 // Segments contains all available prompt segment writers.
@@ -316,6 +318,7 @@ var Segments = map[SegmentType]func() SegmentWriter{
 	XMAKE:           func() SegmentWriter { return &segments.XMake{} },
 	YARN:            func() SegmentWriter { return &segments.Yarn{} },
 	YTM:             func() SegmentWriter { return &segments.Ytm{} },
+	ZIG:             func() SegmentWriter { return &segments.Zig{} },
 }
 
 func (segment *Segment) MapSegmentWithWriter(env runtime.Environment) error {

--- a/src/segments/zig.go
+++ b/src/segments/zig.go
@@ -1,0 +1,29 @@
+package segments
+
+type Zig struct {
+	language
+}
+
+func (zig *Zig) Template() string {
+	return languageTemplate
+}
+
+func (zig *Zig) Enabled() bool {
+	zig.extensions = []string{"*.zig", "*.zon"}
+	zig.projectFiles = []string{"build.zig"}
+	zig.commands = []*cmd{
+		{
+			executable: "zig",
+			args:       []string{"version"},
+			regex:      `(?P<version>(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)`, //nolint:lll
+		},
+	}
+
+	zig.versionURLTemplate = "https://ziglang.org/download/{{ .Major }}.{{ .Minor }}.{{ .Patch }}/release-notes.html"
+
+	return zig.language.Enabled()
+}
+
+func (zig *Zig) InProjectDir() bool {
+	return zig.projectRoot != nil
+}

--- a/src/segments/zig_test.go
+++ b/src/segments/zig_test.go
@@ -1,0 +1,74 @@
+package segments
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestZig(t *testing.T) {
+	cases := []struct {
+		Case           string
+		Version        string
+		ExpectedString string
+		ExpectedURL    string
+		InProjectDir   bool
+	}{
+		{
+			Case:           "zig 0.13.0 - not in project dir",
+			Version:        "0.13.0",
+			InProjectDir:   false,
+			ExpectedString: "0.13.0",
+			ExpectedURL:    "https://ziglang.org/download/0.13.0/release-notes.html",
+		},
+		{
+			Case:           "zig 0.12.0-dev.2063+804cee3b9 - not in project dir",
+			Version:        "0.12.0-dev.2063+804cee3b9",
+			InProjectDir:   false,
+			ExpectedString: "0.12.0-dev.2063+804cee3b9",
+			ExpectedURL:    "https://ziglang.org/download/0.12.0/release-notes.html",
+		},
+		{
+			Case:           "zig 0.13.0 - in project dir",
+			Version:        "0.13.0",
+			InProjectDir:   true,
+			ExpectedString: "0.13.0",
+			ExpectedURL:    "https://ziglang.org/download/0.13.0/release-notes.html",
+		},
+		{
+			Case:           "zig 0.12.0-dev.2063+804cee3b9 - in project dir",
+			Version:        "0.12.0-dev.2063+804cee3b9",
+			InProjectDir:   true,
+			ExpectedString: "0.12.0-dev.2063+804cee3b9",
+			ExpectedURL:    "https://ziglang.org/download/0.12.0/release-notes.html",
+		},
+	}
+	for _, tc := range cases {
+		params := &mockedLanguageParams{
+			cmd:           "zig",
+			versionParam:  "version",
+			versionOutput: tc.Version,
+			extension:     "*.zig",
+		}
+
+		env, props := getMockedLanguageEnv(params)
+
+		dummyDir := &runtime.FileInfo{}
+
+		if tc.InProjectDir {
+			env.On("HasParentFilePath", "build.zig", false).Return(dummyDir, nil)
+		} else {
+			env.On("HasParentFilePath", "build.zig", false).Return(dummyDir, errors.New("build.zig not found"))
+		}
+
+		zig := &Zig{}
+		zig.Init(props, env)
+
+		assert.True(t, zig.Enabled(), tc.Case)
+		assert.Equal(t, tc.ExpectedString, renderTemplate(env, zig.Template(), zig), tc.Case)
+		assert.Equal(t, tc.ExpectedURL, renderTemplate(env, zig.URL, zig), tc.Case)
+		assert.Equal(t, tc.InProjectDir, zig.InProjectDir(), tc.Case)
+	}
+}

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -4642,6 +4642,55 @@
             "title": "Nix Shell",
             "description": "https://ohmyposh.dev/docs/segments/cli/nix-shell"
           }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "zig"
+              }
+            }
+          },
+          "then": {
+            "title": "Zig Segment",
+            "description": "https://ohmyposh.dev/docs/segments/languages/zig",
+            "properties": {
+              "properties": {
+                "properties": {
+                  "home_enabled": {
+                    "$ref": "#/definitions/home_enabled"
+                  },
+                  "fetch_version": {
+                    "$ref": "#/definitions/fetch_version"
+                  },
+                  "display_mode": {
+                    "$ref": "#/definitions/display_mode"
+                  },
+                  "missing_command_text": {
+                    "$ref": "#/definitions/missing_command_text"
+                  },
+                  "version_url_template": {
+                    "$ref": "#/definitions/version_url_template"
+                  },
+                  "extensions": {
+                    "type": "array",
+                    "title": "Extensions",
+                    "description": "The extensions to look for when determining if the current directory is an zig project",
+                    "default": [
+                      "*.zig",
+                      "*.zon"
+                    ],
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "folders": {
+                    "$ref": "#/definitions/folders"
+                  }
+                }
+              }
+            }
+          }
         }
       ]
     }

--- a/website/docs/segments/languages/zig.mdx
+++ b/website/docs/segments/languages/zig.mdx
@@ -1,0 +1,64 @@
+---
+id: zig
+title: Zig
+sidebar_label: Zig
+---
+
+## What
+
+Display the currently active [zig][zig] version.
+
+## Sample Configuration
+
+import Config from "@site/src/components/Config.js";
+
+<Config
+  data={{
+    type: "zig",
+    style: "powerline",
+    powerline_symbol: "\ue0b0",
+    foreground: "#342311",
+    background: "#ffad55",
+    template: " \ue6a9 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} ",
+  }}
+/>
+
+## Properties
+
+| Name                   |    Type    |    Default     | Description                                                                                                                                                                                                                          |
+| ---------------------- | :--------: | :------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `home_enabled`         | `boolean`  |    `false`     | display the segment in the HOME folder or not                                                                                                                                                                                        |
+| `fetch_version`        | `boolean`  |     `true`     | fetch the zig version (`zig version`)                                                                                                                                                                                                |
+| `missing_command_text` |  `string`  |                | text to display when the command is missing                                                                                                                                                                                          |
+| `display_mode`         |  `string`  |   `context`    | <ul><li>`always`: the segment is always displayed</li><li>`files`: the segment is only displayed when file `extensions` listed are present</li><li>`context`: displays the segment when the environment or files is active</li></ul> |
+| `version_url_template` |  `string`  |                | a go [text/template][go-text-template] [template][templates] that creates the URL of the version info / release notes                                                                                                                |
+| `extensions`           | `[]string` | `*.zig, *.zon` | allows to override the default list of file extensions to validate                                                                                                                                                                   |
+| `folders`              | `[]string` |                | allows to override the list of folder names to validate                                                                                                                                                                              |
+
+## Template ([info][templates])
+
+:::note default template
+
+```template
+{{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }}
+```
+
+:::
+
+### Properties
+
+| Name             | Type     | Description                                           |
+| ---------------- | -------- | ----------------------------------------------------- |
+| `.Full`          | `string` | the full version                                      |
+| `.Major`         | `string` | major number                                          |
+| `.Minor`         | `string` | minor number                                          |
+| `.Patch`         | `string` | patch number                                          |
+| `.Prerelease`    | `string` | prerelease identifier                                 |
+| `.BuildMetadata` | `string` | build identifier                                      |
+| `.URL`           | `string` | URL of the version info / release notes               |
+| `.InProjectDir`  | `bool`   | whether the working directory is within a Zig project |
+| `.Error`         | `string` | error encountered when fetching the version string    |
+
+[go-text-template]: https://golang.org/pkg/text/template/
+[templates]: /docs/configuration/templates
+[zig]: https://ziglang.org/

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -143,6 +143,7 @@ module.exports = {
             "segments/languages/rust",
             "segments/languages/swift",
             "segments/languages/vala",
+            "segments/languages/zig",
           ]
         },
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Adds a zig language segment to display the zig version when there is a zig file in the current directory or when inside a zig project.

![20241106110824](https://github.com/user-attachments/assets/4bc4785c-7b00-4d80-8b66-ceaa69f5ac44)

I’m not very familiar with golang, hope I didn’t mess things up. 😋

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
