### PR TITLE
fix(schema): add zig to `$.definitions.segment.properties.type.enum`

### DIFF
--- a/themes/schema.json
+++ b/themes/schema.json
@@ -401,7 +401,8 @@
             "withings",
             "xmake",
             "yarn",
-            "ytm"
+            "ytm",
+            "zig"
           ]
         },
         "style": {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

I just realized I forgot to add zig to the `$.definitions.segment.properties.type.enum` within schema.json. 

This update fixes that oversight by including zig in the allowed property types.

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
