### PR TITLE
docs: fix command suggestion for enabling autoupgrade in notice

### DIFF
--- a/src/upgrade/notice.go
+++ b/src/upgrade/notice.go
@@ -39,7 +39,7 @@ const (
 A new release of Oh My Posh is available: %s → %s
 To upgrade, run: 'oh-my-posh upgrade%s'
 
-To enable automated upgrades, run: 'oh-my-posh enable autoupgrade'.
+To enable automated upgrades, run: 'oh-my-posh enable upgrade'.
 `
 )
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

`oh-my-posh enable autoupgrade` has been changed to `oh-my-posh enable upgrade`. This PR updates the command suggested by `oh-my-posh notice` to reflect that. 

Resolves https://github.com/JanDeDobbeleer/oh-my-posh/issues/5885

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
