### PR TITLE
feat(segment): add fortran (through gfortran)

### DIFF
--- a/src/config/segment_types.go
+++ b/src/config/segment_types.go
@@ -85,6 +85,8 @@ const (
 	EXIT SegmentType = "exit"
 	// FLUTTER writes the flutter version
 	FLUTTER SegmentType = "flutter"
+	// FORTRAN writes the gfortran version
+	FORTRAN SegmentType = "fortran"
 	// FOSSIL writes the fossil status
 	FOSSIL SegmentType = "fossil"
 	// GCP writes the active GCP context
@@ -254,6 +256,7 @@ var Segments = map[SegmentType]func() SegmentWriter{
 	ELIXIR:          func() SegmentWriter { return &segments.Elixir{} },
 	EXIT:            func() SegmentWriter { return &segments.Status{} },
 	FLUTTER:         func() SegmentWriter { return &segments.Flutter{} },
+	FORTRAN:         func() SegmentWriter { return &segments.Fortran{} },
 	FOSSIL:          func() SegmentWriter { return &segments.Fossil{} },
 	GCP:             func() SegmentWriter { return &segments.Gcp{} },
 	FIREBASE:        func() SegmentWriter { return &segments.Firebase{} },

--- a/src/segments/fortran.go
+++ b/src/segments/fortran.go
@@ -1,0 +1,30 @@
+package segments
+
+type Fortran struct {
+	language
+}
+
+func (f *Fortran) Template() string {
+	return languageTemplate
+}
+
+func (f *Fortran) Enabled() bool {
+	f.extensions = []string{
+		"*.f", "*.for", "*.fpp",
+		"*.f77", "*.f90", "*.f95",
+		"*.f03", "*.f08",
+		"*.F", "*.FOR", "*.FPP",
+		"*.F77", "*.F90", "*.F95",
+		"*.F03", "*.F08",
+		"fpm.toml",
+	}
+	f.commands = []*cmd{
+		{
+			executable: "gfortran",
+			args:       []string{"--version"},
+			regex:      `GNU Fortran \(.*\) (?P<version>((?P<major>[0-9]+).(?P<minor>[0-9]+).(?P<patch>[0-9]+)))`,
+		},
+	}
+
+	return f.language.Enabled()
+}

--- a/src/segments/fortran_test.go
+++ b/src/segments/fortran_test.go
@@ -1,0 +1,46 @@
+package segments
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFortran(t *testing.T) {
+	cases := []struct {
+		Case           string
+		ExpectedString string
+		Version        string
+	}{
+		{
+			Case:           "GNU Fortran 10.2.1 Debian",
+			ExpectedString: "10.2.1",
+			Version: `GNU Fortran (Debian 10.2.1-6) 10.2.1 20210110
+			Copyright (C) 2020 Free Software Foundation, Inc.
+			This is free software; see the source for copying conditions.  There is NO
+			warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.`,
+		},
+		{
+			Case:           "GNU Fortran 11.4.0 Ubuntu",
+			ExpectedString: "11.4.0",
+			Version: `GNU Fortran (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
+			Copyright (C) 2021 Free Software Foundation, Inc.
+			This is free software; see the source for copying conditions.  There is NO
+			warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.`,
+		},
+	}
+	for _, tc := range cases {
+		params := &mockedLanguageParams{
+			cmd:           "gfortran",
+			versionParam:  "--version",
+			versionOutput: tc.Version,
+			extension:     "*.f",
+		}
+		env, props := getMockedLanguageEnv(params)
+		f := &Fortran{}
+		f.Init(props, env)
+		assert.True(t, f.Enabled(), fmt.Sprintf("Failed in case: %s", tc.Case))
+		assert.Equal(t, tc.ExpectedString, renderTemplate(env, f.Template(), f), fmt.Sprintf("Failed in case: %s", tc.Case))
+	}
+}

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -339,6 +339,7 @@
             "fossil",
             "gcp",
             "firebase",
+            "fortran",
             "git",
             "gitversion",
             "go",
@@ -1233,6 +1234,60 @@
                     "items": {
                       "type": "string"
                     }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "fortran"
+              }
+            }
+          },
+          "then": {
+            "title": "Fortran Segment",
+            "description": "https://ohmyposh.dev/docs/segments/languages/fortran",
+            "properties": {
+              "properties": {
+                "properties": {
+                  "home_enabled": {
+                    "$ref": "#/definitions/home_enabled"
+                  },
+                  "fetch_version": {
+                    "$ref": "#/definitions/fetch_version"
+                  },
+                  "cache_duration": {
+                    "$ref": "#/definitions/cache_duration",
+                    "default": "none"
+                  },
+                  "display_mode": {
+                    "$ref": "#/definitions/display_mode"
+                  },
+                  "missing_command_text": {
+                    "$ref": "#/definitions/missing_command_text"
+                  },
+                  "version_url_template": {
+                    "$ref": "#/definitions/version_url_template"
+                  },
+                  "extensions": {
+                    "type": "array",
+                    "title": "Extensions",
+                    "description": "The extensions to look for when determining if a folder is a Fortran workspace",
+                    "default": [
+                      "fpm.toml",
+                      "*.f", "*.for", "*.fpp", "*.f77", "*.f90", "*.f95", "*.f03", "*.f08",
+                      "*.F", "*.FOR", "*.FPP", "*.F77", "*.F90", "*.F95", "*.F03", "*.F08"
+                    ],
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "folders": {
+                    "$ref": "#/definitions/folders"
                   }
                 }
               }

--- a/website/docs/segments/languages/fortran.mdx
+++ b/website/docs/segments/languages/fortran.mdx
@@ -1,0 +1,69 @@
+---
+id: fortran
+title: Fortran
+sidebar_label: Fortran
+---
+
+## What
+
+Display the currently active [fortran] compiler version.
+
+:::warning Compiler support
+
+This only works with the [gfortran] compiler.
+
+:::
+
+## Sample Configuration
+
+import Config from "@site/src/components/Config.js";
+
+<Config
+  data={{
+    type: "fortran",
+    style: "powerline",
+    powerline_symbol: "\uE0B0",
+    foreground: "#ffffff",
+    background: "#422251",
+    template: " \udb84\ude1a {{ .Full }} ",
+  }}
+/>
+
+## Properties
+
+| Name                   |    Type    |                                                 Default                                                 | Description                                                                                                                                                                                                                          |
+| ---------------------- | :--------: | :-----------------------------------------------------------------------------------------------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `home_enabled`         | `boolean`  |                                                 `false`                                                 | display the segment in the HOME folder or not                                                                                                                                                                                        |
+| `fetch_version`        | `boolean`  |                                                 `true`                                                  | fetch the gfortran version                                                                                                                                                                                                           |
+| `cache_duration`       |  `string`  |                                                 `none`                                                  | the duration for which the version will be cached. The duration is a string in the format `1h2m3s` and is parsed using the [time.ParseDuration] function from the Go standard library. To disable the cache, use `none`              |
+| `missing_command_text` |  `string`  |                                                                                                         | text to display when the command is missing                                                                                                                                                                                          |
+| `display_mode`         |  `string`  |                                                `context`                                                | <ul><li>`always`: the segment is always displayed</li><li>`files`: the segment is only displayed when file `extensions` listed are present</li><li>`context`: displays the segment when the environment or files is active</li></ul> |
+| `version_url_template` |  `string`  |                                                                                                         | a go [text/template][go-text-template] [template][templates] that creates the URL of the version info / release notes                                                                                                                |
+| `extensions`           | `[]string` | `fpm.toml, *.f, *.for, *.fpp, *.f77, *.f90, *.f95, *.f03, *.f08` + uppercase equivalents (`*.F` etc...) | allows to override the default list of file extensions to validate                                                                                                                                                                   |
+| `folders`              | `[]string` |                                                                                                         | allows to override the list of folder names to validate                                                                                                                                                                              |
+
+## Template ([info][templates])
+
+:::note default template
+
+```template
+{{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }}
+```
+
+:::
+
+### Properties
+
+| Name     | Type     | Description                                        |
+| -------- | -------- | -------------------------------------------------- |
+| `.Full`  | `string` | the full version                                   |
+| `.Major` | `string` | major number                                       |
+| `.Minor` | `string` | minor number                                       |
+| `.URL`   | `string` | URL of the version info / release notes            |
+| `.Error` | `string` | error encountered when fetching the version string |
+
+[go-text-template]: https://golang.org/pkg/text/template/
+[templates]: /docs/configuration/templates
+[fortran]: https://fortran-lang.org/
+[gfortran]: https://fortranwiki.org/fortran/show/GFortran
+[time.ParseDuration]: https://golang.org/pkg/time/#ParseDuration

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -127,6 +127,7 @@ module.exports = {
             "segments/languages/dart",
             "segments/languages/dotnet",
             "segments/languages/elixir",
+            "segments/languages/fortran",
             "segments/languages/golang",
             "segments/languages/haskell",
             "segments/languages/java",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

Add Fortran support. Only works with the gfortran compiler (the most standard open-source one as far as I know, included in the gcc). I have to say I am not very comfortable with contributing to open source projects, so there might be things done wrong. I mostly recycled the Rust and Elixir segments to make this one.