### PR TITLE
feat(block): added FillerTemplate to block

### DIFF
--- a/website/docs/configuration/block.mdx
+++ b/website/docs/configuration/block.mdx
@@ -71,6 +71,27 @@ to be repeated to this property. Add this property to the _right_ aligned block.
   }}
 />
 
+Filler allows you to specify a template to tweak the text used as filler. This template behaves the same as
+Segment templates, however, fewer properties are available.
+
+| Name        | Type   | Description                                                           |
+| ----------- | ------ | --------------------------------------------------------------------- |
+| `.Overflow` | `text` | if no overflow was needed, this is empty. Otherwise `hide` or `break` |
+| `.Padding`  | `int`  | the computed length of the padding between left and right blocks      |
+
+This can be very useful if you wish to use a filler text when there is no overflow and use
+empty space when the right block is hidden or drawn on a newline due to overflow.
+
+<Config
+  data={{
+    block: {
+      alignment: "right",
+      overflow: "hide",
+      filler: "{{ if .Overflow }} {{ else }}-{{ end }}",
+    },
+  }}
+/>
+
 ### Overflow
 
 - `break`


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

This change introduces a new block configuration called "FillerTemplate". This allows the user to specify a template for filler so that different behavior can be configured when the block is handling an overflow.

An example configuration might be:

```yaml
- type: prompt
  alignment: right
  filler_template: "{{ if .Overflow }} {{ else }}<#3d59a1,transparent>━</>{{ end }}"
  overflow: break
```

This would draw filler text ("-") when there is no overflow and empty space when there is an overflow.

