### PR TITLE
feat(segments): add Distrobox segment

### DIFF
--- a/src/config/segment_types.go
+++ b/src/config/segment_types.go
@@ -73,6 +73,8 @@ const (
 	DART SegmentType = "dart"
 	// DENO writes the active deno version
 	DENO SegmentType = "deno"
+	// DISTROBOX writes the active distrobox container name
+	DISTROBOX SegmentType = "distrobox"
 	// DOCKER writes the docker context
 	DOCKER SegmentType = "docker"
 	// DOTNET writes which dotnet version is currently active
@@ -254,6 +256,7 @@ var Segments = map[SegmentType]func() SegmentWriter{
 	CRYSTAL:         func() SegmentWriter { return &segments.Crystal{} },
 	DART:            func() SegmentWriter { return &segments.Dart{} },
 	DENO:            func() SegmentWriter { return &segments.Deno{} },
+	DISTROBOX:       func() SegmentWriter { return &segments.Distrobox{} },
 	DOCKER:          func() SegmentWriter { return &segments.Docker{} },
 	DOTNET:          func() SegmentWriter { return &segments.Dotnet{} },
 	ELIXIR:          func() SegmentWriter { return &segments.Elixir{} },

--- a/src/segments/distrobox.go
+++ b/src/segments/distrobox.go
@@ -1,0 +1,25 @@
+package segments
+
+import "github.com/jandedobbeleer/oh-my-posh/src/properties"
+
+type Distrobox struct {
+	base
+
+    ContainerID string
+    Icon        string
+}
+
+const (
+    DistroboxIcon properties.Property = "icon"
+)
+
+func (d *Distrobox) Enabled() bool {
+    d.ContainerID = d.env.Getenv("CONTAINER_ID")
+    d.Icon = d.props.GetString(DistroboxIcon, "\uED95")
+
+    return d.ContainerID != ""
+}
+
+func (d *Distrobox) Template() string {
+    return "{{ .Icon }} {{ .ContainerID }} "
+}

--- a/src/segments/distrobox_test.go
+++ b/src/segments/distrobox_test.go
@@ -1,0 +1,53 @@
+package segments
+
+import (
+    "testing"
+
+    "github.com/jandedobbeleer/oh-my-posh/src/properties"
+    "github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+    "github.com/stretchr/testify/assert"
+)
+
+func TestDistrobox(t *testing.T) {
+    cases := []struct {
+        Case            string
+        ContainerID     string
+        ExpectedEnabled bool
+        ExpectedString  string
+        Template        string
+    }{
+        {
+            Case:            "in distrobox container",
+            ContainerID:     "fedora-toolbox",
+            ExpectedEnabled: true,
+            ExpectedString:  "fedora-toolbox",
+            Template:        "{{ .ContainerID }}",
+        },
+        {
+            Case:            "not in container",
+            ContainerID:     "",
+            ExpectedEnabled: false,
+        },
+        {
+            Case:            "with icon template",
+            ContainerID:     "ubuntu-dev",
+            ExpectedEnabled: true,
+            ExpectedString:  "\uED95 ubuntu-dev",
+            Template:        "{{ .Icon }} {{ .ContainerID }}",
+        },
+    }
+
+    for _, tc := range cases {
+        distrobox := &Distrobox{}
+        env := new(mock.Environment)
+
+        env.On("Getenv", "CONTAINER_ID").Return(tc.ContainerID)
+
+        distrobox.Init(properties.Map{}, env)
+
+        assert.Equal(t, tc.ExpectedEnabled, distrobox.Enabled(), tc.Case)
+        if tc.ExpectedEnabled {
+            assert.Equal(t, tc.ExpectedString, renderTemplate(env, tc.Template, distrobox), tc.Case)
+        }
+    }
+}

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -331,6 +331,7 @@
             "crystal",
             "dart",
             "deno",
+            "distrobox",
             "docker",
             "dotnet",
             "elixir",
@@ -1070,6 +1071,31 @@
               }
             }
           }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "distrobox"
+              },
+            },
+          },
+          "then": {
+            "title": "Distrobox Segment",
+            "description": "https://ohmyposh.dev/docs/cli/distrobox",
+            "properties": {
+              "properties": {
+                "properties": {
+                  "icon": {
+                    "type": "string",
+                    "title": "Container Icon",
+                    "description": "The icon to display before the container name",
+                    "default": "\uED95"
+                  },
+                },
+              },
+            },
+          },
         },
         {
           "if": {

--- a/website/docs/segments/cli/distrobox.mdx
+++ b/website/docs/segments/cli/distrobox.mdx
@@ -1,0 +1,47 @@
+---
+id: distrobox
+title: Distrobox
+sidebar_label: Distrobox
+---
+
+## What
+
+Displays the [Distrobox] container name when inside a Distrobox container environment.
+
+## Sample Configuration
+
+import Config from "@site/src/components/Config.js";
+
+<Config
+  data={{
+    type: "distrobox",
+    style: "powerline",
+    powerline_symbol: "\uE0B0",
+    foreground: "#ffffff",
+    background: "#f07b3c",
+    template: "{{ .Icon }} {{ .ContainerID }}",
+    properties: {
+      icon: "\uED95"
+    }
+  }}
+/>
+
+## Template ([info][templates])
+
+:::note default template
+
+```template
+ {{ .Icon }} {{ .ContainerID }}
+```
+
+:::
+
+### Properties
+
+| Name           | Type     | Description                                                |
+| -------------- | -------- | ---------------------------------------------------------- |
+| `icon`         | `string` | the icon to display - defaults to `\uED95`                 |
+| `.ContainerID` | `string` | the name of the active distrobox container                 |
+
+[Distrobox]: https://github.com/89luca89/distrobox
+[templates]: /docs/configuration/templates

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -68,6 +68,7 @@ module.exports = {
             "segments/cli/bun",
             "segments/cli/cmake",
             "segments/cli/deno",
+            "segments/cli/distrobox",
             "segments/cli/docker",
             "segments/cli/firebase",
             "segments/cli/flutter",


### PR DESCRIPTION
Introduce a new segment to display the active [Distrobox][distrobox] container name.

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Adds a Distrobox CLI segment to display the container name when inside a Distrobox container.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[distrobox]: https://github.com/89luca89/distrobox
