### PR TITLE
fix Go symbol in golang.mdx

### DIFF
--- a/website/docs/segments/languages/golang.mdx
+++ b/website/docs/segments/languages/golang.mdx
@@ -19,7 +19,7 @@ import Config from "@site/src/components/Config.js";
     powerline_symbol: "\uE0B0",
     foreground: "#ffffff",
     background: "#7FD5EA",
-    template: " \u202D\uFCD1 {{ .Full }} ",
+    template: " \ue627 {{ .Full }} ",
   }}
 />
 


### PR DESCRIPTION


### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

According to https://www.nerdfonts.com/cheat-sheet `\ufdc1` symbol is removed. It's not displayed correctly on newest fonts anymore. Replace it with new Go symbol. Fixes #4625