### PR TITLE
Revert "chore: bump softprops/action-gh-release from 2.1.0 to 2.2.0"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
     target-branch: "main"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "softprops/action-gh-release"
+        # https://github.com/softprops/action-gh-release/issues/556
+        versions: ["2.2.0"]
 
   # Maintain dependencies for Go modules
   - package-ecosystem: "gomod"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
           az storage blob upload-batch --destination v${{ needs.changelog.outputs.version }} --source .
           az storage blob upload-batch --destination latest --overwrite true --source .
       - name: Release 🎓
-        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048
+        uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974
         with:
           tag_name: ${{ needs.changelog.outputs.tag }}
           body: ${{ needs.changelog.outputs.body }}


### PR DESCRIPTION
Close #6018

This reverts commit 85d2be23f529f86eb90382cec4be0ff90babb725.

The release failed due to the bug of softprops/action-gh-release.

- https://github.com/JanDeDobbeleer/oh-my-posh/releases/tag/v24.13.0
- https://github.com/JanDeDobbeleer/oh-my-posh/actions/runs/12330949675/job/34417136591

```
Run softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048
👩‍🏭 Creating new GitHub release for tag v24.13.0...
⬆️ Uploading version.txt...
⬆️ Uploading themes.zip...
⬆️ Uploading posh-windows-arm64.exe...
⬆️ Uploading posh-windows-amd64.exe...
⬆️ Uploading posh-windows-386.exe...
⬆️ Uploading posh-linux-arm64...
⬆️ Uploading posh-linux-arm...
⬆️ Uploading posh-linux-amd64...
⬆️ Uploading posh-linux-386...
⬆️ Uploading posh-freebsd-arm64...
⬆️ Uploading posh-freebsd-arm...
⬆️ Uploading posh-freebsd-amd64...
⬆️ Uploading posh-freebsd-386...
⬆️ Uploading posh-darwin-arm64...
⬆️ Uploading posh-darwin-amd64...
⬆️ Uploading install-x86.msi.sha256...
⬆️ Uploading install-x86.msi...
⬆️ Uploading install-x64.msi.sha256...
⬆️ Uploading install-x64.msi...
⬆️ Uploading install-arm64.msi.sha256...
⬆️ Uploading install-arm64.msi...
⬆️ Uploading checksums.txt.sig...
⬆️ Uploading checksums.txt...
Error: Request body length does not match content-length header
```

softprops/action-gh-release v2.2.0 has a known issue.

- https://github.com/softprops/action-gh-release/issues/556

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
