### PR TITLE
chore: Change night-owl to use the inverse powerline arrow head characters.

### DIFF
--- a/themes/night-owl.omp.json
+++ b/themes/night-owl.omp.json
@@ -28,6 +28,7 @@
           "background": "#82AAFF",
           "foreground": "#011627",
           "powerline_symbol": "\ue0b0",
+          "leading_powerline_symbol": "\ue0d7",
           "properties": {
             "folder_icon": "\uf07c ",
             "folder_separator_icon": "<#011627>\ue0b1</> ",
@@ -62,7 +63,7 @@
         {
           "background": "#575656",
           "foreground": "#d6deeb",
-          "leading_diamond": "<transparent,#575656>\ue0b0</>",
+          "leading_diamond": "\ue0d7",
           "properties": {
             "style": "roundrock",
             "threshold": 0
@@ -85,7 +86,7 @@
           "leading_diamond": "\ue0b6",
           "style": "diamond",
           "template": "\uf489  {{ .Name }} ",
-          "trailing_diamond": "<transparent,#d6deeb>\ue0b2</>",
+          "trailing_diamond": "\ue0d6",
           "type": "shell"
         },
         {
@@ -94,7 +95,7 @@
           "leading_diamond": "\ue0b2",
           "style": "diamond",
           "template": "\ue266 {{ round .PhysicalPercentUsed .Precision }}% ",
-          "trailing_diamond": "<transparent,#8f43f3>\ue0b2</>",
+          "trailing_diamond": "\ue0d6",
           "type": "sysinfo"
         },
         {
@@ -103,7 +104,7 @@
           "leading_diamond": "\ue0b2",
           "style": "diamond",
           "template": "\ue753 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} ",
-          "trailing_diamond": "<transparent,#ffffff>\ue0b2</>",
+          "trailing_diamond": "\ue0d6",
           "type": "angular"
         },
         {
@@ -112,7 +113,7 @@
           "leading_diamond": "\ue0b2",
           "style": "diamond",
           "template": "\u03b1 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} ",
-          "trailing_diamond": "<transparent,#ffffff>\ue0b2</>",
+          "trailing_diamond": "\ue0d6",
           "type": "aurelia"
         },
         {
@@ -121,7 +122,7 @@
           "leading_diamond": "\ue0b2",
           "style": "diamond",
           "template": "\ue7ad {{ .Profile }}{{ if .Region }}@{{ .Region }}{{ end }} ",
-          "trailing_diamond": "<transparent,#565656>\ue0b2</>",
+          "trailing_diamond": "\ue0d6",
           "type": "aws"
         },
         {
@@ -130,7 +131,7 @@
           "leading_diamond": "\ue0b2",
           "style": "diamond",
           "template": "\uebd8 {{ .EnvironmentName }} ",
-          "trailing_diamond": "<transparent,#ffffff>\ue0b2</>",
+          "trailing_diamond": "\ue0d6",
           "type": "az"
         },
         {
@@ -139,7 +140,7 @@
           "leading_diamond": "\ue0b2",
           "style": "diamond",
           "template": "\uf104<#f5bf45>\uf0e7</>\uf105 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} ",
-          "trailing_diamond": "<transparent,#ffffff>\ue0b2</>",
+          "trailing_diamond": "\ue0d6",
           "type": "azfunc"
         },
         {
@@ -148,7 +149,7 @@
           "leading_diamond": "\ue0b2",
           "style": "diamond",
           "template": "\ue311  cds {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} ",
-          "trailing_diamond": "<transparent,#5a7a94>\ue0b2</>",
+          "trailing_diamond": "\ue0d6",
           "type": "cds"
         },
         {
@@ -157,7 +158,7 @@
           "leading_diamond": "\ue0b2",
           "style": "diamond",
           "template": "\uE370 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} ",
-          "trailing_diamond": "<transparent,#000000>\ue0b2</>",
+          "trailing_diamond": "\ue0d6",
           "type": "crystal"
         },
         {
@@ -166,7 +167,7 @@
           "leading_diamond": "\ue0b2",
           "style": "diamond",
           "template": "\uf40a  cf {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} ",
-          "trailing_diamond": "<transparent,#ffffff>\ue0b2</>",
+          "trailing_diamond": "\ue0d6",
           "type": "cf"
         },
         {
@@ -175,7 +176,7 @@
           "leading_diamond": "\ue0b2",
           "style": "diamond",
           "template": "\uf40a {{if .Org }}{{ .Org }}{{ end }}{{ if .Space }}/{{ .Space }}{{ end }} ",
-          "trailing_diamond": "<transparent,#ffffff>\ue0b2</>",
+          "trailing_diamond": "\ue0d6",
           "type": "cftarget"
         },
         {
@@ -184,7 +185,7 @@
           "leading_diamond": "\ue0b2",
           "style": "diamond",
           "template": "<#2829b2>\ue61e</> <#be1818>\ue61d</>  cmake {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} ",
-          "trailing_diamond": "<transparent,#d2d2d2>\ue0b2</>",
+          "trailing_diamond": "\ue0d6",
           "type": "cmake"
         },
         {
@@ -193,7 +194,7 @@
           "leading_diamond": "\ue0b2",
           "style": "diamond",
           "template": "\ue798 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} ",
-          "trailing_diamond": "<transparent,#e1e8e9>\ue0b2</>",
+          "trailing_diamond": "\ue0d6",
           "type": "dart"
         },
         {
@@ -202,7 +203,7 @@
           "leading_diamond": "\ue0b2",
           "style": "diamond",
           "template": "\ue77f  {{ if .Unsupported }}\uf071{{ else }}{{ .Full }}{{ end }} ",
-          "trailing_diamond": "<transparent,#0e0e0e>\ue0b2</>",
+          "trailing_diamond": "\ue0d6",
           "type": "dotnet"
         },
         {
@@ -211,7 +212,7 @@
           "leading_diamond": "\ue0b2",
           "style": "diamond",
           "template": "\ue28e {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} ",
-          "trailing_diamond": "<transparent,#06A4CE>\ue0b2</>",
+          "trailing_diamond": "\ue0d6",
           "type": "flutter"
         },
         {
@@ -220,7 +221,7 @@
           "leading_diamond": "\ue0b2",
           "style": "diamond",
           "template": "\ue626 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} ",
-          "trailing_diamond": "<transparent,#ffffff>\ue0b2</>",
+          "trailing_diamond": "\ue0d6",
           "type": "go"
         },
         {
@@ -229,7 +230,7 @@
           "leading_diamond": "\ue0b2",
           "style": "diamond",
           "template": "\ue61f {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} ",
-          "trailing_diamond": "<transparent,#100e23>\ue0b2</>",
+          "trailing_diamond": "\ue0d6",
           "type": "haskell"
         },
         {
@@ -238,7 +239,7 @@
           "leading_diamond": "\ue0b2",
           "style": "diamond",
           "template": "\ue738 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} ",
-          "trailing_diamond": "<transparent,#ffffff>\ue0b2</>",
+          "trailing_diamond": "\ue0d6",
           "type": "java"
         },
         {
@@ -247,7 +248,7 @@
           "leading_diamond": "\ue0b2",
           "style": "diamond",
           "template": "<#ca3c34>\ue624</> {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} ",
-          "trailing_diamond": "<transparent,#945bb3>\ue0b2</>",
+          "trailing_diamond": "\ue0d6",
           "type": "julia"
         },
         {
@@ -256,7 +257,7 @@
           "leading_diamond": "\ue0b2",
           "style": "diamond",
           "template": "K {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} ",
-          "trailing_diamond": "<transparent,#906cff>\ue0b2</>",
+          "trailing_diamond": "\ue0d6",
           "type": "kotlin"
         },
         {
@@ -265,7 +266,7 @@
           "leading_diamond": "\ue0b2",
           "style": "diamond",
           "template": "\uf308 {{.Context}} :: {{if .Namespace}}{{.Namespace}}{{else}}default{{end}} ",
-          "trailing_diamond": "<transparent,#316ce4>\ue0b2</>",
+          "trailing_diamond": "\ue0d6",
           "type": "kubectl"
         },
         {
@@ -274,7 +275,7 @@
           "leading_diamond": "\ue0b2",
           "style": "diamond",
           "template": "\ue620 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} ",
-          "trailing_diamond": "<transparent,#ffffff>\ue0b2</>",
+          "trailing_diamond": "\ue0d6",
           "type": "lua"
         },
         {
@@ -288,7 +289,7 @@
           },
           "style": "diamond",
           "template": "\ue718 {{ if .PackageManagerIcon }}{{ .PackageManagerIcon }} {{ end }}{{ .Full }} ",
-          "trailing_diamond": "<transparent,#303030>\ue0b2</>",
+          "trailing_diamond": "\ue0d6",
           "type": "node"
         },
         {
@@ -297,7 +298,7 @@
           "leading_diamond": "\ue0b2",
           "style": "diamond",
           "template": "Nx {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} ",
-          "trailing_diamond": "<transparent,#6488c0>\ue0b2</>",
+          "trailing_diamond": "\ue0d6",
           "type": "nx"
         },
         {
@@ -306,7 +307,7 @@
           "leading_diamond": "\ue0b2",
           "style": "diamond",
           "template": "\ue769 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} ",
-          "trailing_diamond": "<transparent,#41436d>\ue0b2</>",
+          "trailing_diamond": "\ue0d6",
           "type": "perl"
         },
         {
@@ -315,7 +316,7 @@
           "leading_diamond": "\ue0b2",
           "style": "diamond",
           "template": "\ue73d {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} ",
-          "trailing_diamond": "<transparent,#787CB5>\ue0b2</>",
+          "trailing_diamond": "\ue0d6",
           "type": "php"
         },
         {
@@ -324,7 +325,7 @@
           "leading_diamond": "\ue0b2",
           "style": "diamond",
           "template": "\ue235  {{ if .Error }}{{ .Error }}{{ else }}{{ if .Venv }}{{ .Venv }} {{ end }}{{ .Full }}{{ end }}",
-          "trailing_diamond": "<transparent,#306998>\ue0b2</>",
+          "trailing_diamond": "\ue0d6",
           "type": "python"
         },
         {
@@ -333,7 +334,7 @@
           "leading_diamond": "\ue0b2",
           "style": "diamond",
           "template": "R {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} ",
-          "trailing_diamond": "<transparent,#b9bbbf>\ue0b2</>",
+          "trailing_diamond": "\ue0d6",
           "type": "r"
         },
         {
@@ -342,7 +343,7 @@
           "leading_diamond": "\ue0b2",
           "style": "diamond",
           "template": "\ue791 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} ",
-          "trailing_diamond": "<transparent,#ffffff>\ue0b2</>",
+          "trailing_diamond": "\ue0d6",
           "type": "ruby"
         },
         {
@@ -351,7 +352,7 @@
           "leading_diamond": "\ue0b2",
           "style": "diamond",
           "template": "\ue7a8 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} ",
-          "trailing_diamond": "<transparent,#ffffff>\ue0b2</>",
+          "trailing_diamond": "\ue0d6",
           "type": "rust"
         },
         {
@@ -360,7 +361,7 @@
           "leading_diamond": "\ue0b2",
           "style": "diamond",
           "template": "\ue755 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} ",
-          "trailing_diamond": "<transparent,#fe562e>\ue0b2</>",
+          "trailing_diamond": "\ue0d6",
           "type": "swift"
         },
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description
Change the `night-owl` theme to use U+E0D6 and U+E0D7 for the powerline arrow heads added in https://github.com/ryanoasis/nerd-fonts/pull/1490

#### Before:
![image](https://github.com/user-attachments/assets/5646fb0d-f70c-41d5-abe7-9de7a9ab017c)
![image](https://github.com/user-attachments/assets/fea0f9cb-21ae-44b5-ad94-270aeb56d004)

#### After:
![image](https://github.com/user-attachments/assets/e30dd110-600f-4396-9f17-4d8cebaff07d)
![image](https://github.com/user-attachments/assets/bcac05e5-0030-49c3-aaec-a21b11d971be)


<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
