### PR TITLE
refactor: replace `golang.org/x/exp/slices` with stdlib

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -39,7 +39,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.2.3
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
-	golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67
 	golang.org/x/mod v0.22.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -86,6 +85,7 @@ require (
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	github.com/zclconf/go-cty v1.15.1 // indirect
+	golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67 // indirect
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/tools v0.28.0 // indirect
 )

--- a/src/segments/project.go
+++ b/src/segments/project.go
@@ -5,12 +5,12 @@ import (
 	"encoding/xml"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/log"
 	"github.com/jandedobbeleer/oh-my-posh/src/properties"
 	"github.com/jandedobbeleer/oh-my-posh/src/regex"
-	"golang.org/x/exp/slices"
 
 	yaml "github.com/goccy/go-yaml"
 	toml "github.com/pelletier/go-toml/v2"


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

The experimental functions in `golang.org/x/exp/slices` are now available in the standard library in Go 1.21.

Reference: https://go.dev/doc/go1.21#slices

The only affected line:

https://github.com/JanDeDobbeleer/oh-my-posh/blob/3d2d8ef850298cc88720f2c40317368d73beafab/src/segments/project.go#L242

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
