### PR TITLE
fix(theme): update velvet theme to display Python environment correctly

### DIFF
--- a/themes/velvet.omp.json
+++ b/themes/velvet.omp.json
@@ -79,21 +79,22 @@
       ],
       "type": "prompt"
     },
-    {
+        {
       "alignment": "right",
       "segments": [
         {
-          "background": "#4c1f5e",
-          "foreground": "#E4F34A",
-          "leading_diamond": " \ue0b6",
+          "background": "#170B3B",
+          "foreground": "#efdcf9",
+          "powerline_symbol": "\ue0b0",
           "properties": {
-            "fetch_version": false
+              "display_mode": "environment",
+              "fetch_virtual_env": true,
+              "home_enabled": true
           },
-          "style": "diamond",
-          "template": "\ue235{{ if .Error }}{{ .Error }}{{ else }}{{ if .Venv }}{{ .Venv }} {{ end }}{{ .Full }}{{ end }}",
-          "trailing_diamond": "\ue0b4",
+          "style": "powerline",
+          "template": " \ue235 {{ if .Venv }}({{ .Venv }}){{ end }} ",
           "type": "python"
-        },
+      },
         {
           "background": "#4c1f5e",
           "foreground": "#7FD5EA",


### PR DESCRIPTION
Updated the velvet theme configuration to use a Powerline style and fetch the virtual environment details accurately. Changed colors and adjusted the template for better readability and consistency.

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

The velvet theme in `oh-my-posh` has been updated to:
1. Use a Powerline style for better visual alignment.
2. Fetch and display the Python virtual environment (`Venv`) accurately.
3. Enhance readability by modifying colors and adjusting the template.

This change improves user experience by clearly displaying the active Python environment in the terminal.

Before the change:
![image](https://github.com/user-attachments/assets/6a57f116-6d5e-4833-aff4-d797cdcae109)
The right component for environment doesn't work properly.


**Updated** change looks like this: 
![image](https://github.com/user-attachments/assets/855fae08-f1a4-4db7-af73-a348ebbccdce)

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
