### PR TITLE
docs(color): use proper spelling

### DIFF
--- a/src/color/colors_test.go
+++ b/src/color/colors_test.go
@@ -25,11 +25,11 @@ func TestGetAnsiFromColorString(t *testing.T) {
 		{Case: "Invalid background", Expected: emptyColor, Color: "invalid", Background: true},
 		{Case: "Invalid background", Expected: emptyColor, Color: "invalid", Background: false},
 		{Case: "Hex foreground", Expected: Ansi("38;2;170;187;204"), Color: "#AABBCC", Background: false},
-		{Case: "Hex backgrond", Expected: Ansi("48;2;170;187;204"), Color: "#AABBCC", Background: true},
+		{Case: "Hex background", Expected: Ansi("48;2;170;187;204"), Color: "#AABBCC", Background: true},
 		{Case: "Base 8 foreground", Expected: Ansi("31"), Color: "red", Background: false},
 		{Case: "Base 8 background", Expected: Ansi("41"), Color: "red", Background: true},
 		{Case: "Base 16 foreground", Expected: Ansi("91"), Color: "lightRed", Background: false},
-		{Case: "Base 16 backround", Expected: Ansi("101"), Color: "lightRed", Background: true},
+		{Case: "Base 16 background", Expected: Ansi("101"), Color: "lightRed", Background: true},
 		{Case: "Non true color TERM", Expected: Ansi("38;5;146"), Color: "#AABBCC", Color256: true},
 	}
 	for _, tc := range cases {

--- a/src/color/palette.go
+++ b/src/color/palette.go
@@ -11,7 +11,7 @@ type Palette map[Ansi]Ansi
 const (
 	paletteKeyPrefix         = "p:"
 	paletteKeyError          = "palette: requested color %s does not exist in palette of colors %s"
-	paletteMaxRecursionDepth = 3 // allows 3 or less recusive resolutions
+	paletteMaxRecursionDepth = 3 // allows 3 or less recursive resolutions
 	paletteRecursiveKeyError = "palette: recursive resolution of color %s returned palette reference %s and reached recursion depth %d"
 )
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] ~Tests for the changes have been added (for bug fixes / features).~ (not relevant)
- [x] Docs have been added/updated (for bug fixes / features).

### Description

This PR fixes some typos in [`./src/color`](https://github.com/JanDeDobbeleer/oh-my-posh/tree/main/src/color), i.e.:
- `backgrond` and `backround` were replaced by `background`,
- `recusive` was replaced by `recursive`

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
