### PR TITLE
Add Git Branch Pattern property

### DIFF
--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -121,6 +121,8 @@ const (
 	IgnoreSubmodules properties.Property = "ignore_submodules"
 	// MappedBranches allows overriding certain branches with an icon/text
 	MappedBranches properties.Property = "mapped_branches"
+	// BranchPatterns allows for a custom regexes to be used to extract parts of the branch name
+	BranchPatterns properties.Property = "branch_patterns"
 
 	DETACHED     = "(detached)"
 	BRANCHPREFIX = "ref: refs/heads/"

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -141,6 +141,15 @@
       "description": "Custom glyph/text for specific branches",
       "default": {}
     },
+    "branch_patterns": {
+      "type": "array",
+      "title": "Branch Patterns",
+      "description": "Regular expressions and match index (in the format \"pattern:matchIdx\") to match against the branch name. The match index 0 (default, when omitted) is the full match, 1 is the first capture group, etc.",
+      "default": [],
+      "items": {
+        "type": "string"
+      }
+    },
     "cache_duration": {
       "type": "string",
       "title": "Cache duration",

--- a/website/docs/segments/scm/git.mdx
+++ b/website/docs/segments/scm/git.mdx
@@ -39,6 +39,9 @@ import Config from "@site/src/components/Config.js";
         "feat/*": "🚀 ",
         "bug/*": "🐛 ",
       },
+      branch_patterns: [
+        ".* [A-Z0-9]+-[0-9]+"
+      ],
     },
   }}
 />
@@ -63,6 +66,7 @@ You can set the following properties to `true` to enable fetching additional inf
 | `status_formats`      | `map[string]string` |         | a key, value map allowing to override how individual status items are displayed. For example, `"status_formats": { "Added": "Added: %d" }` will display the added count as `Added: 1` instead of `+1`. See the [Status](#status) section for available overrides.                                                                     |
 | `source`              |      `string`       |  `cli`  | <ul><li>`cli`: fetch the information using the git CLI</li><li>`pwsh`: fetch the information from the [posh-git][poshgit] PowerShell Module</li></ul>                                                                                                                                                                                 |
 | `mapped_branches`     |      `object`       |         | custom glyph/text for specific branches. You can use `*` at the end as a wildcard character for matching                                                                                                                                                                                                                              |
+| `branch_patterns`     |      `array`        |         | regular expressions and match index (that must be positive) in the format `"pattern:matchIdx"` to match against the branch name. The match index `0` (default, when omitted) is the full match, 1 is the first capture group, etc.<ul><li>Applied after `mapped_branches`</li><li>Pattern order matters</li></ul> |
 | `full_branch_path`    |       `bool`        | `true`  | display the full branch path instead of only the last part (e.g. `feature/branch` instead of `branch`)                                                                                                                                                                                                                                |
 
 ### Icons


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

This proposal aims to give control over the branch name that is extracted, with regular expressions.

I am not familiar with `Go`, but tried my best.

In my workflow, I usually have long branch name (such as `feature/PROJECT-12345-scope-of-ticket`), and while interacting in the terminal, I don't really care about the scope. This feature allows me to extract only the issue part, and can still be combined with the `mapping_branches`.

Can't wait to have feedback, and hopefully see something like this in the project, which is great btw, good job !

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary

> Also, I have to say that the setup was pretty easy, thanks to the `devcontainer`. :+1:

### Question

Is the documentation/schema aimed to be edited by hand ? Or is there anything I missed to handle this automatically ?
I felt it hard to write this part, mainly due to alignment.
