### PR TITLE
docs: fix: list in customize.mdx

### DIFF
--- a/website/docs/installation/customize.mdx
+++ b/website/docs/installation/customize.mdx
@@ -18,15 +18,15 @@ There are two possible values the `--config` flag can handle:
 
 - a path to a local configuration file
 
-```powershell
---config 'C:/Users/Posh/jandedobbeleer.omp.json'
-```
+  ```powershell
+  --config 'C:/Users/Posh/jandedobbeleer.omp.json'
+  ```
 
 - a URL pointing to a remote config
 
-```powershell
---config 'https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/jandedobbeleer.omp.json'
-```
+  ```powershell
+  --config 'https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/jandedobbeleer.omp.json'
+  ```
 
 ### Set the configuration
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Trailing list items/contents must match the initial list indent, otherwise the list gets broken  into many smaller lists.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
