### PR TITLE
fix: use `.PhysicalAvailableMemory` instead of `PhysicalFreeMemory` to show memory usage

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2982,6 +2982,15 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "BoscoDomingo",
+      "name": "Bosco Domingo",
+      "avatar_url": "https://avatars.githubusercontent.com/u/46006784?v=4",
+      "profile": "https://dub.sh/boscodomingo",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2964,6 +2964,15 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "spg-iwilson",
+      "name": "Ivan Wilson",
+      "avatar_url": "https://avatars.githubusercontent.com/u/25376734?v=4",
+      "profile": "https://sharepointgurus.net",
+      "contributions": [
+        "design"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -2973,6 +2973,15 @@
       "contributions": [
         "design"
       ]
+    },
+    {
+      "login": "mdanish-kh",
+      "name": "Muhammad Danish",
+      "avatar_url": "https://avatars.githubusercontent.com/u/88161975?v=4",
+      "profile": "https://github.com/mdanish-kh",
+      "contributions": [
+        "doc"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/themes/1_shell.omp.json
+++ b/themes/1_shell.omp.json
@@ -69,7 +69,7 @@
         {
           "foreground": "#94ffa2",
           "style": "diamond",
-          "template": " <#ffffff>MEM:</> {{ round .PhysicalPercentUsed .Precision }}% ({{ (div ((sub .PhysicalTotalMemory .PhysicalFreeMemory)|float64) 1073741824.0) }}/{{ (div .PhysicalTotalMemory 1073741824.0) }}GB)",
+          "template": " <#ffffff>MEM:</> {{ round .PhysicalPercentUsed .Precision }}% ({{ (div ((sub .PhysicalTotalMemory .PhysicalAvailableMemory)|float64) 1073741824.0) }}/{{ (div .PhysicalTotalMemory 1073741824.0) }}GB)",
           "type": "sysinfo"
         }
       ],

--- a/themes/di4am0nd.omp.json
+++ b/themes/di4am0nd.omp.json
@@ -46,7 +46,7 @@
         {
           "foreground": "#85C980",
           "style": "diamond",
-          "template": "RAM:{{ (div ((sub .PhysicalTotalMemory .PhysicalFreeMemory)|float64) 1073741824.0) }}/{{ (div .PhysicalTotalMemory 1073741824.0) }}GB ",
+          "template": "RAM:{{ (div ((sub .PhysicalTotalMemory .PhysicalAvailableMemory)|float64) 1073741824.0) }}/{{ (div .PhysicalTotalMemory 1073741824.0) }}GB ",
           "trailing_diamond": " ",
           "type": "sysinfo"
         },

--- a/themes/easy-term.omp.json
+++ b/themes/easy-term.omp.json
@@ -79,7 +79,7 @@
         {
           "foreground": "#81ff91",
           "style": "diamond",
-          "template": "<#cc7eda> \u007C </><#7eb8da>RAM:</> {{ (div ((sub .PhysicalTotalMemory .PhysicalFreeMemory)|float64) 1073741824.0) }}/{{ (div .PhysicalTotalMemory 1073741824.0) }}GB",
+          "template": "<#cc7eda> \u007C </><#7eb8da>RAM:</> {{ (div ((sub .PhysicalTotalMemory .PhysicalAvailableMemory)|float64) 1073741824.0) }}/{{ (div .PhysicalTotalMemory 1073741824.0) }}GB",
           "type": "sysinfo"
         },
         {

--- a/themes/if_tea.omp.json
+++ b/themes/if_tea.omp.json
@@ -44,7 +44,7 @@
           "background": "#00c7fc",
           "foreground": "#000000",
           "style": "diamond",
-          "template": "RAM: {{ (div ((sub .PhysicalTotalMemory .PhysicalFreeMemory)|float64) 1073741824.0) }}/{{ (div .PhysicalTotalMemory 1073741824.0) }}GB \ue266 ",
+          "template": "RAM: {{ (div ((sub .PhysicalTotalMemory .PhysicalAvailableMemory)|float64) 1073741824.0) }}/{{ (div .PhysicalTotalMemory 1073741824.0) }}GB \ue266 ",
           "trailing_diamond": "<transparent,#00c7fc>\ue0b2</>",
           "type": "sysinfo"
         },

--- a/themes/illusi0n.omp.json
+++ b/themes/illusi0n.omp.json
@@ -12,7 +12,7 @@
         {
           "foreground": "#ff8800",
           "style": "diamond",
-          "template": "{{ (div ((sub .PhysicalTotalMemory .PhysicalFreeMemory)|float64) 1073741824.0) }}/{{ (div .PhysicalTotalMemory 1073741824.0) }}GB ",
+          "template": "{{ (div ((sub .PhysicalTotalMemory .PhysicalAvailableMemory)|float64) 1073741824.0) }}/{{ (div .PhysicalTotalMemory 1073741824.0) }}GB ",
           "type": "sysinfo"
         }
       ],

--- a/themes/tokyo.omp.json
+++ b/themes/tokyo.omp.json
@@ -31,7 +31,7 @@
         {
           "foreground": "#be9ddf",
           "style": "diamond",
-          "template": "[<#ffffff>\ue266</> RAM: {{ (div ((sub .PhysicalTotalMemory .PhysicalFreeMemory)|float64) 1073741824.0) }}/{{ (div .PhysicalTotalMemory 1073741824.0) }}GB]",
+          "template": "[<#ffffff>\ue266</> RAM: {{ (div ((sub .PhysicalTotalMemory .PhysicalAvailableMemory)|float64) 1073741824.0) }}/{{ (div .PhysicalTotalMemory 1073741824.0) }}GB]",
           "type": "sysinfo"
         },
         {

--- a/themes/wholespace.omp.json
+++ b/themes/wholespace.omp.json
@@ -42,7 +42,7 @@
           "background": "#516BEB",
           "foreground": "#ffffff",
           "style": "diamond",
-          "template": "RAM: {{ (div ((sub .PhysicalTotalMemory .PhysicalFreeMemory)|float64) 1073741824.0) }}/{{ (div .PhysicalTotalMemory 1073741824.0) }}GB \ue266 ",
+          "template": "RAM: {{ (div ((sub .PhysicalTotalMemory .PhysicalAvailableMemory)|float64) 1073741824.0) }}/{{ (div .PhysicalTotalMemory 1073741824.0) }}GB \ue266 ",
           "trailing_diamond": "<transparent,#516BEB>\ue0b2</>",
           "type": "sysinfo"
         },

--- a/website/docs/contributors.md
+++ b/website/docs/contributors.md
@@ -418,6 +418,7 @@ Thanks goes to these wonderful people ([emoji key][acek]):
     </tr>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://sharepointgurus.net"><img src="https://avatars.githubusercontent.com/u/25376734?v=4?s=100" width="100px;" alt="Ivan Wilson"/><br /><sub><b>Ivan Wilson</b></sub></a><br /><a href="#design-spg-iwilson" title="Design">🎨</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/mdanish-kh"><img src="https://avatars.githubusercontent.com/u/88161975?v=4?s=100" width="100px;" alt="Muhammad Danish"/><br /><sub><b>Muhammad Danish</b></sub></a><br /><a href="https://github.com/JanDeDobbeleer/oh-my-posh/commits?author=mdanish-kh" title="Documentation">📖</a></td>
     </tr>
   </tbody>
 </table>

--- a/website/docs/contributors.md
+++ b/website/docs/contributors.md
@@ -419,6 +419,7 @@ Thanks goes to these wonderful people ([emoji key][acek]):
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://sharepointgurus.net"><img src="https://avatars.githubusercontent.com/u/25376734?v=4?s=100" width="100px;" alt="Ivan Wilson"/><br /><sub><b>Ivan Wilson</b></sub></a><br /><a href="#design-spg-iwilson" title="Design">🎨</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/mdanish-kh"><img src="https://avatars.githubusercontent.com/u/88161975?v=4?s=100" width="100px;" alt="Muhammad Danish"/><br /><sub><b>Muhammad Danish</b></sub></a><br /><a href="https://github.com/JanDeDobbeleer/oh-my-posh/commits?author=mdanish-kh" title="Documentation">📖</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://dub.sh/boscodomingo"><img src="https://avatars.githubusercontent.com/u/46006784?v=4?s=100" width="100px;" alt="Bosco Domingo"/><br /><sub><b>Bosco Domingo</b></sub></a><br /><a href="https://github.com/JanDeDobbeleer/oh-my-posh/commits?author=BoscoDomingo" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>

--- a/website/docs/contributors.md
+++ b/website/docs/contributors.md
@@ -416,6 +416,9 @@ Thanks goes to these wonderful people ([emoji key][acek]):
       <td align="center" valign="top" width="14.28%"><a href="https://wiyco.dev"><img src="https://avatars.githubusercontent.com/u/72733890?v=4?s=100" width="100px;" alt="wiyco"/><br /><sub><b>wiyco</b></sub></a><br /><a href="https://github.com/JanDeDobbeleer/oh-my-posh/commits?author=wiyco" title="Code">💻</a> <a href="#design-wiyco" title="Design">🎨</a> <a href="https://github.com/JanDeDobbeleer/oh-my-posh/commits?author=wiyco" title="Documentation">📖</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/abhro"><img src="https://avatars.githubusercontent.com/u/5664668?v=4?s=100" width="100px;" alt="abhro"/><br /><sub><b>abhro</b></sub></a><br /><a href="https://github.com/JanDeDobbeleer/oh-my-posh/commits?author=abhro" title="Documentation">📖</a></td>
     </tr>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://sharepointgurus.net"><img src="https://avatars.githubusercontent.com/u/25376734?v=4?s=100" width="100px;" alt="Ivan Wilson"/><br /><sub><b>Ivan Wilson</b></sub></a><br /><a href="#design-spg-iwilson" title="Design">🎨</a></td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

When showing memory usage, what you want to know is the really **used** memory, which doesn't include cached memory; cache memory can be claimed by the kernel under memory pressure.

The Linux kernel will try to use as much cache as possible by default, but that doesn't mean that the RAM is not available. This PR fixes that and shows only the real used memory.

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
