### PR TITLE
fix: update segment title

### DIFF
--- a/themes/schema.json
+++ b/themes/schema.json
@@ -284,7 +284,7 @@
     },
     "segment": {
       "type": "object",
-      "title": "A segment",
+      "title": "Segment",
       "description": "https://ohmyposh.dev/docs/configuration/segment",
       "default": {},
       "required": [


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

This is simply an update to the title for `segment` in `schema.json`. 

In a project I'm working on that uses the omp schema for code generation, I found that the `title` property is being used (when present, otherwise the key name is used from what I can tell) to infer class/interface/type names which causes `ASegment` to be generated for `segment`. 

>[!NOTE] 
> Alternatively, the title could be removed here (as is the case for `block`), but I am unsure if this is being used for anything programmatic. If this is preferable, please let me know and I will update the code / PR. 

I will share more about the aforementioned project at a later time. I believe it benefit the community.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
