### PR TITLE
fix(template): use standard sync.Map for knownFields

### DIFF
--- a/src/template/init.go
+++ b/src/template/init.go
@@ -21,13 +21,13 @@ const (
 var (
 	shell       string
 	env         runtime.Environment
-	knownFields *maps.Concurrent
+	knownFields sync.Map
 )
 
 func Init(environment runtime.Environment, vars maps.Simple) {
 	env = environment
 	shell = env.Shell()
-	knownFields = maps.NewConcurrent()
+	knownFields = sync.Map{}
 
 	renderPool = sync.Pool{
 		New: func() any {

--- a/src/template/text.go
+++ b/src/template/text.go
@@ -136,7 +136,7 @@ func (f *fields) init(data any) {
 		name := val.Name()
 
 		// check if we already know the fields of this struct
-		if kf, OK := knownFields.Get(name); OK {
+		if kf, OK := knownFields.Load(name); OK {
 			for key := range kf.(fields) {
 				(*f)[key] = true
 			}
@@ -169,7 +169,7 @@ func (f *fields) init(data any) {
 			(*f)[ptrType.Method(i).Name] = true
 		}
 
-		knownFields.Set(name, *f)
+		knownFields.Store(name, *f)
 	case reflect.Map:
 		m, ok := data.(map[string]any)
 		if !ok {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Solves the following error:

```
fatal error: concurrent map iteration and map write

goroutine 1 [running]:
internal/runtime/maps.fatal({0x7ff6cebda779?, 0x40000fb0d8?})
        C:/Program Files/Go/src/runtime/panic.go:1058 +0x20
internal/runtime/maps.(*Iter).Next(0x40000fb0d8?)
        C:/Program Files/Go/src/internal/runtime/maps/table.go:683 +0x94
github.com/jandedobbeleer/oh-my-posh/src/template.(*fields).init(0x40000fb5e0, {0x7ff6ceb2e920, 0x40000a6cf0})
        d:/oh-my-posh/src/template/text.go:140 +0x140
github.com/jandedobbeleer/oh-my-posh/src/template.(*fields).init(0x40000fb5e0, {0x7ff6ceaf1e00, 0x40000a6c90})
        d:/oh-my-posh/src/template/text.go:161 +0x2dc
github.com/jandedobbeleer/oh-my-posh/src/template.(*fields).init(0x40000fb5e0, {0x7ff6ceb2fa60, 0x4000410060})
        d:/oh-my-posh/src/template/text.go:182 +0x1cc
github.com/jandedobbeleer/oh-my-posh/src/template.(*Text).patchTemplate(0x40000fb748)
        d:/oh-my-posh/src/template/text.go:34 +0x3c
github.com/jandedobbeleer/oh-my-posh/src/template.(*Text).Render(0x40000fb748)
        d:/oh-my-posh/src/template/text.go:24 +0xd0
github.com/jandedobbeleer/oh-my-posh/src/config.(*Segment).string(0x40003d8600)
        d:/oh-my-posh/src/config/segment.go:324 +0xdc
github.com/jandedobbeleer/oh-my-posh/src/config.(*Segment).Render(0x40003d8600, 0x7ff6ce31ebd8?)
        d:/oh-my-posh/src/config/segment.go:155 +0x40
github.com/jandedobbeleer/oh-my-posh/src/prompt.(*Engine).writeSegments(0x40002a8630, 0x40003ea0e0, 0x40002a8360)
        d:/oh-my-posh/src/prompt/segments.go:80 +0x2ac
github.com/jandedobbeleer/oh-my-posh/src/prompt.(*Engine).writeBlockSegments(0x40002a8630, 0x40002a8360)
        d:/oh-my-posh/src/prompt/segments.go:32 +0x154
github.com/jandedobbeleer/oh-my-posh/src/prompt.(*Engine).renderBlock(0x40002a8630, 0x40002a8360, 0x0)
        d:/oh-my-posh/src/prompt/engine.go:197 +0x3c
github.com/jandedobbeleer/oh-my-posh/src/prompt.(*Engine).writePrimaryPrompt(0x40002a8630, 0x0)
        d:/oh-my-posh/src/prompt/primary.go:72 +0x410
github.com/jandedobbeleer/oh-my-posh/src/prompt.(*Engine).Primary(0x40002a8630)
        d:/oh-my-posh/src/prompt/primary.go:15 +0x30
github.com/jandedobbeleer/oh-my-posh/src/cli.createPrintCmd.func1(0x4000278308, {0x40002a81b0, 0x4?, 0x7ff6cebae239?})
        d:/oh-my-posh/src/cli/print.go:95 +0x444
github.com/spf13/cobra.(*Command).execute(0x4000278308, {0x40002a8120, 0x9, 0x9})
        C:/Users/jande/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1019 +0x810
github.com/spf13/cobra.(*Command).ExecuteC(0x7ff6cf3849a0)
        C:/Users/jande/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1148 +0x350
github.com/spf13/cobra.(*Command).Execute(...)
        C:/Users/jande/go/pkg/mod/github.com/spf13/cobra@v1.9.1/command.go:1071
github.com/jandedobbeleer/oh-my-posh/src/cli.Execute()
        d:/oh-my-posh/src/cli/root.go:46 +0x24
main.main()
        d:/oh-my-posh/src/main.go:8 +0x1c

goroutine 22 [runnable]:
reflect.intToReg(0x4000586fa0?, 0x0?, 0x8?, 0x4000510030?)
        C:/Program Files/Go/src/reflect/abi.go:480 +0x88
reflect.Value.call({0x7ff6ceacb800?, 0x7ff6cec1dd30?, 0x40002a5400?}, {0x7ff6cebae495, 0x4}, {0x4000508120, 0x2, 0x7ff6ce4720d8?})
        C:/Program Files/Go/src/reflect/value.go:546 +0x1044
reflect.Value.Call({0x7ff6ceacb800?, 0x7ff6cec1dd30?, 0x16?}, {0x4000508120?, 0x4000587448?, 0x7ff6ce46cf44?})
        C:/Program Files/Go/src/reflect/value.go:368 +0x94
text/template.safeCall({0x7ff6ceacb800?, 0x7ff6cec1dd30?, 0x40002a5400?}, {0x4000508120?, 0x7ff6ced4e590?, 0x7ff6ceba9580?})
        C:/Program Files/Go/src/text/template/funcs.go:375 +0x64
text/template.(*state).evalCall(0x4000514000, {0x7ff6ceaec980?, 0x40002a5400?, 0x40005876b8?}, {0x7ff6ceacb800?, 0x7ff6cec1dd30?, 0x400000?}, 0x1, {0x7ff6ced44ad0, 0x40002abcb0}, ...)
        C:/Program Files/Go/src/text/template/exec.go:870 +0x7f8
text/template.(*state).evalFunction(0x4000514000, {0x7ff6ceaec980?, 0x40002a5400?, 0x7ff6ce46faa8?}, 0x1b3ee8821c8?, {0x7ff6ced44ad0, 0x40002abcb0}, {0x4000504000, 0x3, 0x4}, ...)
        C:/Program Files/Go/src/text/template/exec.go:676 +0x168
text/template.(*state).evalCommand(0x4000514000, {0x7ff6ceaec980?, 0x40002a5400?, 0x7ff6ce2b6414?}, 0x4000512000?, {0x7ff6ceacfec0?, 0x7ff6cf3f6c00?, 0x7ff6ce2baee8?})
        C:/Program Files/Go/src/text/template/exec.go:563 +0x178
text/template.(*state).evalPipeline(0x4000514000, {0x7ff6ceaec980?, 0x40002a5400?, 0x7ff6ce2d74e4?}, 0x40002eecc0)
        C:/Program Files/Go/src/text/template/exec.go:532 +0x104
text/template.(*state).walkIfOrWith(0x4000514000, 0xa, {0x7ff6ceaec980?, 0x40002a5400?, 0x4000587a98?}, 0x7ff6ce2c7004?, 0x4000508000, 0x4000508060)
        C:/Program Files/Go/src/text/template/exec.go:301 +0x84
text/template.(*state).walk(0x4000514000, {0x7ff6ceaec980?, 0x40002a5400?, 0x30?}, {0x7ff6ced44d10?, 0x4000504040?})
        C:/Program Files/Go/src/text/template/exec.go:277 +0x18c
text/template.(*state).walk(0x4000514000, {0x7ff6ceaec980?, 0x40002a5400?, 0x1b3ee882268?}, {0x7ff6ced44b60?, 0x40002abc80?})
        C:/Program Files/Go/src/text/template/exec.go:280 +0x2c4
text/template.(*Template).execute(0x4000295600, {0x7ff6ced39878, 0x4000295650}, {0x7ff6ceaec980?, 0x40002a5400?})
        C:/Program Files/Go/src/text/template/exec.go:224 +0x254
text/template.(*Template).Execute(...)
        C:/Program Files/Go/src/text/template/exec.go:207
github.com/jandedobbeleer/oh-my-posh/src/template.(*renderer).execute(0x4000295640, 0x40003d4f40)
        d:/oh-my-posh/src/template/render_pool.go:59 +0x15c
github.com/jandedobbeleer/oh-my-posh/src/template.(*Text).Render(0x40003d4f40)
        d:/oh-my-posh/src/template/text.go:29 +0x118
github.com/jandedobbeleer/oh-my-posh/src/segments.(*Status).formatStatus(0x40002eeb40, 0x2, {0x0, 0x0})
        d:/oh-my-posh/src/segments/status.go:57 +0x170
github.com/jandedobbeleer/oh-my-posh/src/segments.(*Status).Enabled(0x40002eeb40)
        d:/oh-my-posh/src/segments/status.go:33 +0x44
github.com/jandedobbeleer/oh-my-posh/src/config.(*Segment).Execute(0x40003d8e00, {0x7ff6ced4e998, 0x40002a8480})
        d:/oh-my-posh/src/config/segment.go:126 +0x2a8
github.com/jandedobbeleer/oh-my-posh/src/prompt.(*Engine).writeBlockSegments.func1(0x40003d8e00)
        d:/oh-my-posh/src/prompt/segments.go:27 +0x3c
created by github.com/jandedobbeleer/oh-my-posh/src/prompt.(*Engine).writeBlockSegments in goroutine 1
        d:/oh-my-posh/src/prompt/segments.go:26 +0x7c
```

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
