### PR TITLE
fix(segment) Check folders is not empty

### DIFF
--- a/src/segments/path.go
+++ b/src/segments/path.go
@@ -353,6 +353,10 @@ func (pt *Path) getAgnosterLeftPath() string {
 	}
 
 	var elements []string
+	if len(folders) == 0 {
+		return pt.colorizePath(root, elements)
+	}
+
 	elements = append(elements, folders[0].Name)
 	for i, n := 1, len(folders); i < n; i++ {
 		if folders[i].Display {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

**Fix panic in `getAgnosterLeftPath` when in a root directory**  

This PR fixes a runtime panic caused by an out-of-range index error in `getAgnosterLeftPath`.  

### Problem  
The issue occurs when the current working directory is a root directory (e.g., `/data`), leading to an empty path segment list and triggering an out-of-bounds access:  

```
panic: runtime error: index out of range [0] with length 0

goroutine 11 [running]:
github.com/jandedobbeleer/oh-my-posh/src/segments.(*Path).getAgnosterLeftPath(0xc000596000)
        D:/a/oh-my-posh/oh-my-posh/src/segments/path.go:356 +0x318
```

### Solution  
The fix ensures that the function properly handles cases where the path segment list is empty, preventing the panic.  

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
