### PR TITLE
chore: add securityContext & remove allowPrerelease from winget config

### DIFF
--- a/.config/configuration.winget
+++ b/.config/configuration.winget
@@ -4,7 +4,6 @@ properties:
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       directives:
         description: Install Visual Studio Code
-        allowPrerelease: false
       settings:
         id: Microsoft.VisualStudioCode
         source: winget
@@ -12,7 +11,6 @@ properties:
       id: golang
       directives:
         description: Install Golang
-        allowPrerelease: false
       settings:
         id: GoLang.Go
         source: winget
@@ -20,14 +18,13 @@ properties:
       dependsOn: [golang]
       directives:
         description: Install golangci-lint
-        allowPrerelease: false
       settings:
         id: GolangCI.golangci-lint
         source: winget
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       directives:
         description: Install NodeJS
-        allowPrerelease: false
+        securityContext: elevated
       settings:
         id: OpenJS.NodeJS
         source: winget


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

`Microsoft.WinGet.DSC/WinGetPackage` is GA now so `allowPrerelease: true` directive can be removed. Also, installing NodeJS requires admin privileges, added `securityContext: elevated` for that resource. What this directive does is that it will prompt for a single UAC at the start of the configuration and then launch two separated process - one elevated & one with current privileges. The resources that require elevation will be run in the elevated process

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
