### PR TITLE
feat(path): allow pattern matching in maped_locations

### DIFF
--- a/src/regex/regex.go
+++ b/src/regex/regex.go
@@ -110,21 +110,21 @@ func MatchString(pattern, text string) bool {
 	return re.MatchString(text)
 }
 
-func FindStringMatch(pattern, text string, index int) string {
+func FindStringMatch(pattern, text string, index int) (string, bool) {
 	re, err := GetCompiledRegex(pattern)
 	if err != nil {
-		return text
+		return text, false
 	}
 
 	matches := re.FindStringSubmatch(text)
 	if len(matches) <= index {
-		return text
+		return text, false
 	}
 
 	match := matches[index]
 	if len(match) == 0 {
-		return text
+		return text, false
 	}
 
-	return match
+	return match, true
 }

--- a/src/regex/regex_test.go
+++ b/src/regex/regex_test.go
@@ -66,7 +66,7 @@ func TestFindStringMatch(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		got := FindStringMatch(tc.Pattern, tc.Text, tc.Index)
+		got, _ := FindStringMatch(tc.Pattern, tc.Text, tc.Index)
 		assert.Equal(t, tc.Expected, got, tc.Case)
 	}
 }

--- a/src/segments/golang.go
+++ b/src/segments/golang.go
@@ -80,7 +80,7 @@ func (g *Golang) parseWorkFile() (string, error) {
 	}
 
 	contents := g.env.FileContent(goWork.Path)
-	version := regex.FindStringMatch(`go (\d(\.\d{1,2})?(\.\d{1,2})?)`, contents, 1)
+	version, _ := regex.FindStringMatch(`go (\d(\.\d{1,2})?(\.\d{1,2})?)`, contents, 1)
 	if len(version) > 0 {
 		return version, nil
 	}

--- a/src/segments/path_windows_test.go
+++ b/src/segments/path_windows_test.go
@@ -13,21 +13,21 @@ var testParentCases = []testParentCase{
 		HomePath:      homeDirWindows,
 		Pwd:           homeDirWindows,
 		GOOS:          runtime.WINDOWS,
-		PathSeparator: "\\",
+		PathSeparator: `\`,
 	},
 	{
 		Case:          "Windows drive root",
 		HomePath:      homeDirWindows,
 		Pwd:           "C:",
 		GOOS:          runtime.WINDOWS,
-		PathSeparator: "\\",
+		PathSeparator: `\`,
 	},
 	{
 		Case:          "Windows drive root with a trailing separator",
 		HomePath:      homeDirWindows,
 		Pwd:           "C:\\",
 		GOOS:          runtime.WINDOWS,
-		PathSeparator: "\\",
+		PathSeparator: `\`,
 	},
 	{
 		Case:          "Windows drive root + 1",
@@ -35,14 +35,14 @@ var testParentCases = []testParentCase{
 		HomePath:      homeDirWindows,
 		Pwd:           "C:\\test",
 		GOOS:          runtime.WINDOWS,
-		PathSeparator: "\\",
+		PathSeparator: `\`,
 	},
 	{
 		Case:          "PSDrive root",
 		HomePath:      homeDirWindows,
 		Pwd:           "HKLM:",
 		GOOS:          runtime.WINDOWS,
-		PathSeparator: "\\",
+		PathSeparator: `\`,
 	},
 }
 
@@ -53,7 +53,7 @@ var testAgnosterPathStyleCases = []testAgnosterPathStyleCase{
 		HomePath:            homeDirWindows,
 		Pwd:                 "C:\\ab\\ab\\abcd",
 		GOOS:                runtime.WINDOWS,
-		PathSeparator:       "\\",
+		PathSeparator:       `\`,
 		FolderSeparatorIcon: " > ",
 	},
 	{
@@ -62,7 +62,7 @@ var testAgnosterPathStyleCases = []testAgnosterPathStyleCase{
 		HomePath:            homeDirWindows,
 		Pwd:                 "C:\\",
 		GOOS:                runtime.WINDOWS,
-		PathSeparator:       "\\",
+		PathSeparator:       `\`,
 		FolderSeparatorIcon: " > ",
 	},
 	{
@@ -71,7 +71,7 @@ var testAgnosterPathStyleCases = []testAgnosterPathStyleCase{
 		HomePath:            homeDirWindows,
 		Pwd:                 "C:\\something\\.whatever\\man",
 		GOOS:                runtime.WINDOWS,
-		PathSeparator:       "\\",
+		PathSeparator:       `\`,
 		FolderSeparatorIcon: " > ",
 	},
 	{
@@ -80,7 +80,7 @@ var testAgnosterPathStyleCases = []testAgnosterPathStyleCase{
 		HomePath:            homeDirWindows,
 		Pwd:                 homeDirWindows + "\\something\\man",
 		GOOS:                runtime.WINDOWS,
-		PathSeparator:       "\\",
+		PathSeparator:       `\`,
 		FolderSeparatorIcon: " > ",
 	},
 	{
@@ -89,7 +89,7 @@ var testAgnosterPathStyleCases = []testAgnosterPathStyleCase{
 		HomePath:            homeDirWindows,
 		Pwd:                 "C:\\Users\\foo\\foobar\\man",
 		GOOS:                runtime.WINDOWS,
-		PathSeparator:       "\\",
+		PathSeparator:       `\`,
 		FolderSeparatorIcon: " > ",
 	},
 	{
@@ -101,7 +101,7 @@ var testAgnosterPathStyleCases = []testAgnosterPathStyleCase{
 		Shell:               shell.BASH,
 		Cygwin:              true,
 		Cygpath:             "/c/Users/foo/foobar/man",
-		PathSeparator:       "\\",
+		PathSeparator:       `\`,
 		FolderSeparatorIcon: " > ",
 	},
 	{
@@ -112,7 +112,7 @@ var testAgnosterPathStyleCases = []testAgnosterPathStyleCase{
 		GOOS:                runtime.WINDOWS,
 		Shell:               shell.BASH,
 		CygpathError:        errors.New("oh no"),
-		PathSeparator:       "\\",
+		PathSeparator:       `\`,
 		FolderSeparatorIcon: " > ",
 	},
 	{
@@ -121,7 +121,7 @@ var testAgnosterPathStyleCases = []testAgnosterPathStyleCase{
 		HomePath:            homeDirWindows,
 		Pwd:                 "\\\\localhost\\c$\\some",
 		GOOS:                runtime.WINDOWS,
-		PathSeparator:       "\\",
+		PathSeparator:       `\`,
 		FolderSeparatorIcon: " > ",
 	},
 	{
@@ -130,7 +130,7 @@ var testAgnosterPathStyleCases = []testAgnosterPathStyleCase{
 		HomePath:            homeDirWindows,
 		Pwd:                 "\\\\localhost\\c$",
 		GOOS:                runtime.WINDOWS,
-		PathSeparator:       "\\",
+		PathSeparator:       `\`,
 		FolderSeparatorIcon: " > ",
 	},
 	{
@@ -139,7 +139,7 @@ var testAgnosterPathStyleCases = []testAgnosterPathStyleCase{
 		HomePath:            homeDirWindows,
 		Pwd:                 homeDirWindows + fooBarMan,
 		GOOS:                runtime.WINDOWS,
-		PathSeparator:       "\\",
+		PathSeparator:       `\`,
 		FolderSeparatorIcon: " > ",
 		MaxDepth:            2,
 		HideRootLocation:    true,
@@ -150,7 +150,7 @@ var testAgnosterPathStyleCases = []testAgnosterPathStyleCase{
 		HomePath:            homeDirWindows,
 		Pwd:                 "C:",
 		GOOS:                runtime.WINDOWS,
-		PathSeparator:       "\\",
+		PathSeparator:       `\`,
 		FolderSeparatorIcon: " > ",
 	},
 	{
@@ -159,7 +159,7 @@ var testAgnosterPathStyleCases = []testAgnosterPathStyleCase{
 		HomePath:            homeDirWindows,
 		Pwd:                 "C:\\usr\\foo\\bar\\man",
 		GOOS:                runtime.WINDOWS,
-		PathSeparator:       "\\",
+		PathSeparator:       `\`,
 		FolderSeparatorIcon: " > ",
 		MaxDepth:            2,
 	},
@@ -169,7 +169,7 @@ var testAgnosterPathStyleCases = []testAgnosterPathStyleCase{
 		HomePath:            homeDirWindows,
 		Pwd:                 "C:\\usr\\foo\\bar\\man",
 		GOOS:                runtime.WINDOWS,
-		PathSeparator:       "\\",
+		PathSeparator:       `\`,
 		FolderSeparatorIcon: " > ",
 		MaxDepth:            3,
 	},
@@ -179,7 +179,7 @@ var testAgnosterPathStyleCases = []testAgnosterPathStyleCase{
 		HomePath:            homeDirWindows,
 		Pwd:                 homeDirWindows + fooBarMan,
 		GOOS:                runtime.WINDOWS,
-		PathSeparator:       "\\",
+		PathSeparator:       `\`,
 		FolderSeparatorIcon: " > ",
 		MaxDepth:            2,
 	},
@@ -189,7 +189,7 @@ var testAgnosterPathStyleCases = []testAgnosterPathStyleCase{
 		HomePath:            homeDirWindows,
 		Pwd:                 homeDirWindows + fooBarMan,
 		GOOS:                runtime.WINDOWS,
-		PathSeparator:       "\\",
+		PathSeparator:       `\`,
 		FolderSeparatorIcon: " > ",
 		MaxDepth:            3,
 	},
@@ -199,7 +199,7 @@ var testAgnosterPathStyleCases = []testAgnosterPathStyleCase{
 		HomePath:            homeDirWindows,
 		Pwd:                 homeDirWindows,
 		GOOS:                runtime.WINDOWS,
-		PathSeparator:       "\\",
+		PathSeparator:       `\`,
 		FolderSeparatorIcon: " > ",
 		MaxDepth:            1,
 		HideRootLocation:    true,
@@ -210,7 +210,7 @@ var testAgnosterPathStyleCases = []testAgnosterPathStyleCase{
 		HomePath:            homeDirWindows,
 		Pwd:                 homeDirWindows + "\\foo",
 		GOOS:                runtime.WINDOWS,
-		PathSeparator:       "\\",
+		PathSeparator:       `\`,
 		FolderSeparatorIcon: " > ",
 		MaxDepth:            1,
 		HideRootLocation:    true,
@@ -221,7 +221,7 @@ var testAgnosterPathStyleCases = []testAgnosterPathStyleCase{
 		HomePath:            homeDirWindows,
 		Pwd:                 homeDirWindows + "\\foo",
 		GOOS:                runtime.WINDOWS,
-		PathSeparator:       "\\",
+		PathSeparator:       `\`,
 		FolderSeparatorIcon: " > ",
 		MaxDepth:            2,
 		HideRootLocation:    true,
@@ -235,7 +235,7 @@ var testAgnosterPathCases = []testAgnosterPathCase{
 		Home:          homeDirWindows,
 		PWD:           "HKLM:\\SOFTWARE\\magnetic:TOAST\\",
 		GOOS:          runtime.WINDOWS,
-		PathSeparator: "\\",
+		PathSeparator: `\`,
 	},
 	{
 		Case:          "Windows outside home",
@@ -243,7 +243,7 @@ var testAgnosterPathCases = []testAgnosterPathCase{
 		Home:          homeDirWindows,
 		PWD:           "C:\\Program Files\\Go\\location",
 		GOOS:          runtime.WINDOWS,
-		PathSeparator: "\\",
+		PathSeparator: `\`,
 	},
 	{
 		Case:          "Windows oustide home",
@@ -251,7 +251,7 @@ var testAgnosterPathCases = []testAgnosterPathCase{
 		Home:          homeDirWindows,
 		PWD:           homeDirWindows + "\\Documents\\Bill\\location",
 		GOOS:          runtime.WINDOWS,
-		PathSeparator: "\\",
+		PathSeparator: `\`,
 	},
 	{
 		Case:          "Windows inside home zero levels",
@@ -259,7 +259,7 @@ var testAgnosterPathCases = []testAgnosterPathCase{
 		Home:          homeDirWindows,
 		PWD:           "C:\\location",
 		GOOS:          runtime.WINDOWS,
-		PathSeparator: "\\",
+		PathSeparator: `\`,
 	},
 	{
 		Case:          "Windows inside home one level",
@@ -267,7 +267,7 @@ var testAgnosterPathCases = []testAgnosterPathCase{
 		Home:          homeDirWindows,
 		PWD:           "C:\\Program Files\\location",
 		GOOS:          runtime.WINDOWS,
-		PathSeparator: "\\",
+		PathSeparator: `\`,
 	},
 	{
 		Case:          "Windows lower case drive letter",
@@ -275,7 +275,7 @@ var testAgnosterPathCases = []testAgnosterPathCase{
 		Home:          homeDirWindows,
 		PWD:           "C:\\Windows\\",
 		GOOS:          runtime.WINDOWS,
-		PathSeparator: "\\",
+		PathSeparator: `\`,
 	},
 	{
 		Case:          "Windows lower case drive letter (other)",
@@ -283,7 +283,7 @@ var testAgnosterPathCases = []testAgnosterPathCase{
 		Home:          homeDirWindows,
 		PWD:           "P:\\Other\\",
 		GOOS:          runtime.WINDOWS,
-		PathSeparator: "\\",
+		PathSeparator: `\`,
 	},
 	{
 		Case:          "Windows lower word drive",
@@ -291,7 +291,7 @@ var testAgnosterPathCases = []testAgnosterPathCase{
 		Home:          homeDirWindows,
 		PWD:           "some:\\some\\",
 		GOOS:          runtime.WINDOWS,
-		PathSeparator: "\\",
+		PathSeparator: `\`,
 	},
 	{
 		Case:          "Windows lower word drive (ending with c)",
@@ -299,7 +299,7 @@ var testAgnosterPathCases = []testAgnosterPathCase{
 		Home:          homeDirWindows,
 		PWD:           "src:\\source\\",
 		GOOS:          runtime.WINDOWS,
-		PathSeparator: "\\",
+		PathSeparator: `\`,
 	},
 	{
 		Case:          "Windows lower word drive (arbitrary cases)",
@@ -307,7 +307,7 @@ var testAgnosterPathCases = []testAgnosterPathCase{
 		Home:          homeDirWindows,
 		PWD:           "sRc:\\source\\",
 		GOOS:          runtime.WINDOWS,
-		PathSeparator: "\\",
+		PathSeparator: `\`,
 	},
 	{
 		Case:          "Windows registry drive",
@@ -315,7 +315,7 @@ var testAgnosterPathCases = []testAgnosterPathCase{
 		Home:          homeDirWindows,
 		PWD:           "HKLM:\\SOFTWARE\\magnetic:test\\",
 		GOOS:          runtime.WINDOWS,
-		PathSeparator: "\\",
+		PathSeparator: `\`,
 	},
 }
 
@@ -326,7 +326,7 @@ var testAgnosterLeftPathCases = []testAgnosterLeftPathCase{
 		Home:          homeDirWindows,
 		PWD:           homeDirWindows + "\\Documents\\Bill\\location",
 		GOOS:          runtime.WINDOWS,
-		PathSeparator: "\\",
+		PathSeparator: `\`,
 	},
 	{
 		Case:          "Windows outside home",
@@ -334,7 +334,7 @@ var testAgnosterLeftPathCases = []testAgnosterLeftPathCase{
 		Home:          homeDirWindows,
 		PWD:           "C:\\Program Files\\Go\\location",
 		GOOS:          runtime.WINDOWS,
-		PathSeparator: "\\",
+		PathSeparator: `\`,
 	},
 	{
 		Case:          "Windows inside home zero levels",
@@ -342,7 +342,7 @@ var testAgnosterLeftPathCases = []testAgnosterLeftPathCase{
 		Home:          homeDirWindows,
 		PWD:           "C:\\location",
 		GOOS:          runtime.WINDOWS,
-		PathSeparator: "\\",
+		PathSeparator: `\`,
 	},
 	{
 		Case:          "Windows inside home one level",
@@ -350,7 +350,7 @@ var testAgnosterLeftPathCases = []testAgnosterLeftPathCase{
 		Home:          homeDirWindows,
 		PWD:           "C:\\Program Files\\location",
 		GOOS:          runtime.WINDOWS,
-		PathSeparator: "\\",
+		PathSeparator: `\`,
 	},
 	{
 		Case:          "Windows lower case drive letter",
@@ -358,7 +358,7 @@ var testAgnosterLeftPathCases = []testAgnosterLeftPathCase{
 		Home:          homeDirWindows,
 		PWD:           "C:\\Windows\\",
 		GOOS:          runtime.WINDOWS,
-		PathSeparator: "\\",
+		PathSeparator: `\`,
 	},
 	{
 		Case:          "Windows lower case drive letter (other)",
@@ -366,7 +366,7 @@ var testAgnosterLeftPathCases = []testAgnosterLeftPathCase{
 		Home:          homeDirWindows,
 		PWD:           "P:\\Other\\",
 		GOOS:          runtime.WINDOWS,
-		PathSeparator: "\\",
+		PathSeparator: `\`,
 	},
 	{
 		Case:          "Windows lower word drive",
@@ -374,7 +374,7 @@ var testAgnosterLeftPathCases = []testAgnosterLeftPathCase{
 		Home:          homeDirWindows,
 		PWD:           "some:\\some\\",
 		GOOS:          runtime.WINDOWS,
-		PathSeparator: "\\",
+		PathSeparator: `\`,
 	},
 	{
 		Case:          "Windows lower word drive (ending with c)",
@@ -382,7 +382,7 @@ var testAgnosterLeftPathCases = []testAgnosterLeftPathCase{
 		Home:          homeDirWindows,
 		PWD:           "src:\\source\\",
 		GOOS:          runtime.WINDOWS,
-		PathSeparator: "\\",
+		PathSeparator: `\`,
 	},
 	{
 		Case:          "Windows lower word drive (arbitrary cases)",
@@ -390,7 +390,7 @@ var testAgnosterLeftPathCases = []testAgnosterLeftPathCase{
 		Home:          homeDirWindows,
 		PWD:           "sRc:\\source\\",
 		GOOS:          runtime.WINDOWS,
-		PathSeparator: "\\",
+		PathSeparator: `\`,
 	},
 	{
 		Case:          "Windows registry drive",
@@ -398,7 +398,7 @@ var testAgnosterLeftPathCases = []testAgnosterLeftPathCase{
 		Home:          homeDirWindows,
 		PWD:           "HKLM:\\SOFTWARE\\magnetic:test\\",
 		GOOS:          runtime.WINDOWS,
-		PathSeparator: "\\",
+		PathSeparator: `\`,
 	},
 	{
 		Case:          "Windows registry drive case sensitive",
@@ -406,21 +406,23 @@ var testAgnosterLeftPathCases = []testAgnosterLeftPathCase{
 		Home:          homeDirWindows,
 		PWD:           "HKLM:\\SOFTWARE\\magnetic:TOAST\\",
 		GOOS:          runtime.WINDOWS,
-		PathSeparator: "\\",
+		PathSeparator: `\`,
 	},
 }
 
 var testFullAndFolderPathCases = []testFullAndFolderPathCase{
-	{Style: FolderType, FolderSeparatorIcon: "\\", Pwd: "C:\\", Expected: "C:\\", PathSeparator: "\\", GOOS: runtime.WINDOWS},
-	{Style: FolderType, FolderSeparatorIcon: "\\", Pwd: "\\\\localhost\\d$", Expected: "\\\\localhost\\d$", PathSeparator: "\\", GOOS: runtime.WINDOWS},
-	{Style: FolderType, FolderSeparatorIcon: "\\", Pwd: homeDirWindows, Expected: "~", PathSeparator: "\\", GOOS: runtime.WINDOWS},
-	{Style: Full, FolderSeparatorIcon: "\\", Pwd: homeDirWindows, Expected: "~", PathSeparator: "\\", GOOS: runtime.WINDOWS},
-	{Style: Full, FolderSeparatorIcon: "\\", Pwd: homeDirWindows + "\\abc", Expected: "~\\abc", PathSeparator: "\\", GOOS: runtime.WINDOWS},
-	{Style: Full, FolderSeparatorIcon: "\\", Pwd: "C:\\Users\\posh", Expected: "C:\\Users\\posh", PathSeparator: "\\", GOOS: runtime.WINDOWS},
+	{Style: FolderType, FolderSeparatorIcon: `\`, Pwd: "C:\\", Expected: "C:\\", PathSeparator: `\`, GOOS: runtime.WINDOWS},
+	{Style: FolderType, FolderSeparatorIcon: `\`, Pwd: "\\\\localhost\\d$", Expected: "\\\\localhost\\d$", PathSeparator: `\`, GOOS: runtime.WINDOWS},
+	{Style: FolderType, FolderSeparatorIcon: `\`, Pwd: homeDirWindows, Expected: "~", PathSeparator: `\`, GOOS: runtime.WINDOWS},
+	{Style: Full, FolderSeparatorIcon: `\`, Pwd: homeDirWindows, Expected: "~", PathSeparator: `\`, GOOS: runtime.WINDOWS},
+	{Style: Full, FolderSeparatorIcon: `\`, Pwd: homeDirWindows + "\\abc", Expected: "~\\abc", PathSeparator: `\`, GOOS: runtime.WINDOWS},
+	{Style: Full, FolderSeparatorIcon: `\`, Pwd: "C:\\Users\\posh", Expected: "C:\\Users\\posh", PathSeparator: `\`, GOOS: runtime.WINDOWS},
 }
 
 var testFullPathCustomMappedLocationsCases = []testFullPathCustomMappedLocationsCase{
-	{Pwd: "\\a\\b\\c\\d", MappedLocations: map[string]string{"\\a\\b": "#"}, GOOS: runtime.WINDOWS, PathSeparator: "\\", Expected: "#\\c\\d"},
+	{Pwd: `\a\b\c\d`, MappedLocations: map[string]string{`\a\b`: "#"}, GOOS: runtime.WINDOWS, PathSeparator: `\`, Expected: `#\c\d`},
+	{Pwd: `\a\b\1234\d\e`, MappedLocations: map[string]string{`re:(\\a\\b\\[0-9]+\\d).*`: "#"}, GOOS: runtime.WINDOWS, PathSeparator: `\`, Expected: `#\e`},
+	{Pwd: `\a\b\1234\f\e`, MappedLocations: map[string]string{`re:(\\a\\b\\[0-9]+\\d).*`: "#"}, GOOS: runtime.WINDOWS, PathSeparator: `\`, Expected: `\a\b\1234\f\e`},
 }
 
 var testSplitPathCases = []testSplitPathCase{

--- a/src/template/regex.go
+++ b/src/template/regex.go
@@ -11,5 +11,6 @@ func replaceP(pattern, text, replaceText string) string {
 }
 
 func findP(pattern, text string, index int) string {
-	return regex.FindStringMatch(pattern, text, index)
+	match, _ := regex.FindStringMatch(pattern, text, index)
+	return match
 }

--- a/website/docs/segments/system/path.mdx
+++ b/website/docs/segments/system/path.mdx
@@ -87,6 +87,9 @@ For example, to swap out `C:\Users\Leet\GitHub` with a GitHub icon, you can do t
 - The match is case-insensitive on Windows and macOS, but case-sensitive on other operating systems. This means that for
   user Bill, who has a user account `Bill` on Windows and `bill` on Linux, `~/Foo` might match
   `C:\Users\Bill\Foo` or `C:\Users\Bill\foo` on Windows but only `/home/bill/Foo` on Linux.
+- For more complicated cases, you can use the `re:` prefix to use a regular expression with a capture group for matching.
+  For example, `"re:(C:\\[0-9]+\\Foo).*": "#"` will match `C:\123\Foo\Bar` and replace it with `#\Bar`. The regex is not
+  cross platform out of the box, unlike the first statement for non-regex matches.
 
 ## Style
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

resolves #6280

For more complicated `mapped_locations` cases, you can now use the `re:` prefix to use a regular expression with a capture group for matching. For example, `"re:(C:\\\\[0-9]+\\\\Foo).*": "#"` will match `C:\123\Foo\Bar` and replace it with `#\Bar`.

```json
"mapped_locations": {
    "re:(C:\\\\[0-9]+\\\\Foo).*": "#"
}
```

> [!IMPORTANT]  
> With #6327 this now becomes:
> ```json
> "mapped_locations": {
>     "re:(C:/[0-9]+/Foo).*": "#" 
> }
> ````

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
