### PR TITLE
feat(zsh): pass --job-count

### DIFF
--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -59,6 +59,7 @@ function _omp_preexec() {
 function _omp_precmd() {
   _omp_status=$?
   _omp_pipestatus=(${pipestatus[@]})
+  _omp_job_count=${#jobstates}
   _omp_stack_count=${#dirstack[@]}
   _omp_execution_time=-1
   _omp_no_status=true
@@ -126,6 +127,7 @@ function _omp_get_prompt() {
     --pipestatus="${_omp_pipestatus[*]}" \
     --no-status=$_omp_no_status \
     --execution-time=$_omp_execution_time \
+    --job-count=$_omp_job_count \
     --stack-count=$_omp_stack_count \
     ${args[@]}
 }

--- a/website/docs/configuration/templates.mdx
+++ b/website/docs/configuration/templates.mdx
@@ -23,7 +23,7 @@ it with `.$` to reference it directly.
 | `.Root`         | `boolean`             | is the current user root/admin or not                             |
 | `.PWD`          | `string`              | the current working directory (`~` for `$HOME`)                   |
 | `.AbsolutePWD`  | `string`              | the current working directory (unaltered)                         |
-| `.PSWD       `  | `string`              | the current non-filesystem working directory in PowerShell        |
+| `.PSWD`         | `string`              | the current non-filesystem working directory in PowerShell        |
 | `.Folder`       | `string`              | the current working folder                                        |
 | `.Shell`        | `string`              | the current shell name                                            |
 | `.ShellVersion` | `string`              | the current shell version                                         |
@@ -31,6 +31,7 @@ it with `.$` to reference it directly.
 | `.UserName`     | `string`              | the current user name                                             |
 | `.HostName`     | `string`              | the host name                                                     |
 | `.Code`         | `int`                 | the last exit code                                                |
+| `.Jobs`         | `int`                 | number of background jobs (only available for zsh and PowerShell) |
 | `.OS`           | `string`              | the operating system                                              |
 | `.WSL`          | `boolean`             | in WSL yes/no                                                     |
 | `.Templates`    | `string`              | the [templates][templates] result                                 |

--- a/website/docs/segments/system/text.mdx
+++ b/website/docs/segments/system/text.mdx
@@ -23,15 +23,7 @@ import Config from '@site/src/components/Config.js';
 
 ### Properties
 
-| Name           | Type      | Description                                                               |
-| -------------- | --------- | ------------------------------------------------------------------------- |
-| `.Root`        | `boolean` | is the current user root/admin or not                                     |
-| `.Path`        | `string`  | the current working directory                                             |
-| `.Folder`      | `string`  | the current working folder                                                |
-| `.Shell`       | `string`  | the current shell name                                                    |
-| `.UserName`    | `string`  | the current user name                                                     |
-| `.HostName`    | `string`  | the host name                                                             |
-| `.Env.VarName` | `string`  | Any environment variable where `VarName` is the environment variable name |
+Text segments have no special properties. See ([info][templates]) for globally available properties.
 
 [coloring]: /docs/configuration/colors
 [templates]: /docs/configuration/templates


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

4a1aa2a7b43645b4e5bd4dc3f61c22ce3a75d514 added support for PowerShell background jobs
this brings in support for zsh as well
```toml
version = 3
[[blocks]]
  type = 'prompt'
  alignment = 'left'
  [[blocks.segments]]
    type = 'text'
    template = '{{ if gt .Jobs 0 }}{{ .Jobs }}{{ end }}'
```
```
$ go build -o posh
$ ./posh -c config.toml print primary -p --job-count 2
2
```
I also tested this with my actual `.zshrc` and a `sleep infinity` + ctrl+z

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
