### PR TITLE
feat: export 8 themes at a time

### DIFF
--- a/src/image/image.go
+++ b/src/image/image.go
@@ -111,7 +111,6 @@ func NewRGBColor(ansiColor string) *RGB {
 
 type Renderer struct {
 	italic                 font.Face
-	env                    runtime.Environment
 	bold                   font.Face
 	regular                font.Face
 	defaultForegroundColor *RGB
@@ -139,8 +138,6 @@ type Renderer struct {
 }
 
 func (ir *Renderer) Init(env runtime.Environment) error {
-	ir.env = env
-
 	ir.setOutputPath(env.Flags().Config)
 
 	ir.cleanContent()
@@ -376,7 +373,7 @@ func (ir *Renderer) cleanContent() {
 	}
 	ir.AnsiString = strings.ReplaceAll(ir.AnsiString, saveCursorAnsi, "_")
 
-	// replace rprompt with adding and mark right aligned blocks with a pointer
+	// replace rprompt with padding and mark right aligned blocks with a pointer
 	ir.AnsiString = strings.ReplaceAll(ir.AnsiString, "\x1b[1000C", strings.Repeat(" ", ir.RPromptOffset))
 
 	// add watermarks


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

export images 8 times faster by refactoring image generation into `exportTheme`
and tossing it into an `asyncPool`

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
