### PR TITLE
feat(theme): add takuya-goth theme.

### DIFF
--- a/themes/takuya-goth.omp.json
+++ b/themes/takuya-goth.omp.json
@@ -1,0 +1,101 @@
+{
+  "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
+  "blocks": [
+    {
+      "alignment": "left",
+      "segments": [
+        {
+          "background": "#000000",
+          "foreground": "#ffffff",
+          "style": "plain",
+          "template": " <#777777>\uf120</>  {{ .Name }} ",
+          "type": "shell"
+        },
+        {
+          "background": "#1e1e1e",
+          "foreground": "#ffffff",
+          "style": "powerline",
+          "template": " {{ .Path }} ",
+          "type": "path"
+        },
+        {
+          "background": "#ffffff",
+          "background_templates": [
+            "{{ if .IsClean }}#4caf50{{ end }}",
+            "{{ if .Rebasing }}#9c27b0{{ end }}",
+            "{{ if .UpstreamGone }}#607d8b{{ end }}",
+            "{{ if and (gt .Staging.Changed 0) (gt .Working.Changed 0) }}#ff5722{{ end }}",
+            "{{ if gt .Staging.Changed 0 }}#ff9800{{ end }}",
+            "{{ if gt .Working.Changed 0 }}#f44336{{ end }}"
+          ],
+
+          "foreground": "#000000",
+          "powerline_symbol": "\ue0b0",
+          "properties": {
+            "branch_icon": "\ue725 ",
+            "fetch_status": true,
+            "fetch_upstream_icon": true
+          },
+          "style": "powerline",
+          "template": " {{ .HEAD }} {{ if .Working.Changed }}{{ .Working.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }}\uf046 {{ .Staging.String }}{{ end }} ",
+          "type": "git"
+        }
+        
+      ],
+      "type": "prompt"
+    },
+    {
+      "alignment": "right",
+      "segments": [
+        {
+          "background": "#1c1c1c",
+          "foreground": "#aaaaaa",
+          "style": "diamond",
+          "leading_diamond": "\ue0b2",
+          "trailing_diamond": "",
+          "properties": {
+            "fetch_package_manager": true,
+            "npm_icon": " <#aa6666>\ue5fa</> ",
+            "yarn_icon": " <#6699aa>\ue6a7</>"
+          },
+          "template": " \ue718 {{ if .PackageManagerIcon }}{{ .PackageManagerIcon }} {{ end }}{{ .Full }} ",
+          "type": "node"
+        },                
+        {
+          "background": "#1c1c1c",
+          "foreground": "#888888",
+          "style": "plain",
+          "template": " <#5faad0>\ue641</> {{ .CurrentDate | date .Format }} ",
+          "type": "time"
+        }        
+      ],
+      "type": "prompt"
+    },
+    {
+      "alignment": "left",
+      "newline": true,
+      "segments": [
+        {
+          "foreground": "#e0e0e0",
+          "style": "plain",
+          "template": " ",
+          "type": "text"
+        },
+        {
+          "foreground": "#eeeeee",
+          "foreground_templates": [
+            "{{ if gt .Code 0 }}#ef5350{{ end }}"
+          ],
+          "properties": {
+            "always_enabled": true
+          },
+          "style": "plain",
+          "template": "❯ ",
+          "type": "status"
+        }
+      ],
+      "type": "prompt"
+    }
+  ],
+  "version": 1
+}


### PR DESCRIPTION
This theme is a simplified version of the Takuya theme from Oh My Posh, with a focus on dark and saturated colors for a modern and vibrant look. The theme is designed to be clean and efficient, providing a pleasant contrast for use in dark terminal environments.

**Theme Description**:
Color Palette: The colors were chosen to provide good contrast and readability in dark terminal environments. Saturation was adjusted to ensure the colors stand out without overwhelming the eyes. The background color dynamically changes based on the repository state.

**Conditional Colors**: The background color of the Git segment changes depending on the repository state. This includes:
- Clean: Green (#4caf50) — Indicates the repository is up-to-date.
- Staged Commits: Orange (#ff9800) — Indicates that files are staged for commit.
- Unstaged Commits: Red (#f44336) — Indicates there are unstaged changes.
- Rebase or Merge: Purple (#9c27b0) — Indicates an ongoing merge or rebase conflict.
- Upstream Gone: Bluish gray (#607d8b) — Indicates that the repository is out of sync with the upstream.

**Package Managers**: The theme includes dynamic icons for package managers like npm and yarn, displaying them next to the repository path in the terminal. The background color of the package manager segment can also change based on the repository state, with a triangular arrow appearing on the left to highlight each segment type.

**Theme Functionality**:
- Conditional State Segments: The theme adjusts the background color dynamically to reflect different repository states, such as staged, unstaged, or clean files, giving immediate visual feedback about the current code status.
- Package Managers: Icons and the full name of the package manager (npm, yarn) are displayed directly in the terminal for easy visibility of the development environment.
- Simplified Visual Design: Excess elements were removed, focusing on a clean layout with saturated colors for a streamlined and efficient experience.

![theme-in-usage](https://github.com/user-attachments/assets/e54b56f3-ef56-46c3-a0b6-c1573989802a)
