### PR TITLE
feat: fvm flutter segment

### DIFF
--- a/src/segments/dart.go
+++ b/src/segments/dart.go
@@ -18,6 +18,11 @@ func (d *Dart) Enabled() bool {
 	d.folders = dartFolders
 	d.commands = []*cmd{
 		{
+			executable: "fvm",
+			args:       []string{"dart", "--version"},
+			regex:      `Dart SDK version: (?P<version>((?P<major>[0-9]+).(?P<minor>[0-9]+).(?P<patch>[0-9]+)))`,
+		},
+		{
 			executable: "dart",
 			args:       []string{"--version"},
 			regex:      `Dart SDK version: (?P<version>((?P<major>[0-9]+).(?P<minor>[0-9]+).(?P<patch>[0-9]+)))`,

--- a/src/segments/dart_test.go
+++ b/src/segments/dart_test.go
@@ -22,9 +22,13 @@ func TestDart(t *testing.T) {
 			versionOutput: tc.Version,
 			extension:     "*.dart",
 		}
+
 		env, props := getMockedLanguageEnv(params)
+		env.On("HasCommand", "fvm").Return(false)
+
 		d := &Dart{}
 		d.Init(props, env)
+
 		assert.True(t, d.Enabled(), fmt.Sprintf("Failed in case: %s", tc.Case))
 		assert.Equal(t, tc.ExpectedString, renderTemplate(env, d.Template(), d), fmt.Sprintf("Failed in case: %s", tc.Case))
 	}

--- a/src/segments/flutter.go
+++ b/src/segments/flutter.go
@@ -13,6 +13,11 @@ func (f *Flutter) Enabled() bool {
 	f.folders = dartFolders
 	f.commands = []*cmd{
 		{
+			executable: "fvm",
+			args:       []string{"flutter", "--version"},
+			regex:      `Flutter (?P<version>((?P<major>[0-9]+).(?P<minor>[0-9]+).(?P<patch>[0-9]+)))`,
+		},
+		{
 			executable: "flutter",
 			args:       []string{"--version"},
 			regex:      `Flutter (?P<version>((?P<major>[0-9]+).(?P<minor>[0-9]+).(?P<patch>[0-9]+)))`,

--- a/src/segments/flutter_test.go
+++ b/src/segments/flutter_test.go
@@ -22,9 +22,13 @@ func TestFlutter(t *testing.T) {
 			versionOutput: tc.Version,
 			extension:     "*.dart",
 		}
+
 		env, props := getMockedLanguageEnv(params)
+		env.On("HasCommand", "fvm").Return(false)
+
 		d := &Flutter{}
 		d.Init(props, env)
+
 		assert.True(t, d.Enabled(), fmt.Sprintf("Failed in case: %s", tc.Case))
 		assert.Equal(t, tc.ExpectedString, renderTemplate(env, d.Template(), d), fmt.Sprintf("Failed in case: %s", tc.Case))
 	}

--- a/website/docs/segments/cli/flutter.mdx
+++ b/website/docs/segments/cli/flutter.mdx
@@ -6,7 +6,7 @@ sidebar_label: Flutter
 
 ## What
 
-Display the currently active [flutter] version.
+Display the currently active [flutter] version. Supports [fvm].
 
 ## Sample Configuration
 
@@ -57,6 +57,7 @@ import Config from "@site/src/components/Config.js";
 | `.URL`   | `string` | URL of the version info / release notes            |
 | `.Error` | `string` | error encountered when fetching the version string |
 
+[fvm]: https://fvm.app/
 [go-text-template]: https://golang.org/pkg/text/template/
 [templates]: /docs/configuration/templates
 [flutter]: https://flutter.dev/

--- a/website/docs/segments/languages/dart.mdx
+++ b/website/docs/segments/languages/dart.mdx
@@ -6,7 +6,7 @@ sidebar_label: Dart
 
 ## What
 
-Display the currently active dart version.
+Display the currently active dart version. Supports [fvm].
 
 ## Sample Configuration
 
@@ -57,6 +57,7 @@ import Config from "@site/src/components/Config.js";
 | `.URL`   | `string` | URL of the version info / release notes            |
 | `.Error` | `string` | error encountered when fetching the version string |
 
+[fvm]: https://fvm.app/
 [go-text-template]: https://golang.org/pkg/text/template/
 [templates]: /docs/configuration/templates
 [time.ParseDuration]: https://golang.org/pkg/time/#ParseDuration


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description
This PR adds support for FVM (Flutter Version Manager) to show current directory fvm flutter version instead of the global flutter version

This fixes #6365

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
