### PR TITLE
fix: use most recent weight data in withings segment

### DIFF
--- a/src/segments/withings.go
+++ b/src/segments/withings.go
@@ -199,7 +199,7 @@ func (w *Withings) getMeasures() bool {
 	if len(data.Body.MeasureGroups) == 0 || len(data.Body.MeasureGroups[0].Measures) == 0 {
 		return false
 	}
-	measure := data.Body.MeasureGroups[0].Measures[0]
+	measure := data.Body.MeasureGroups[len(data.Body.MeasureGroups)-1].Measures[0]
 	weight := measure.Value
 	w.Weight = float64(weight) / math.Pow(10, math.Abs(float64(measure.Unit)))
 	return true

--- a/src/segments/withings_test.go
+++ b/src/segments/withings_test.go
@@ -71,6 +71,35 @@ func TestWithingsSegment(t *testing.T) {
 			ExpectedString:  "70.77kg",
 		},
 		{
+			Case: "Multiple Measuring Groups, only Measures data",
+			WithingsData: &WithingsData{
+				Body: &Body{
+					MeasureGroups: []*MeasureGroup{
+						{
+							Measures: []*Measure{
+								{
+									Value: 7123,
+									Unit:  -2,
+								},
+							},
+						},
+						{
+							Measures: []*Measure{
+								{
+									Value: 7754,
+									Unit:  -2,
+								},
+							},
+						},
+					},
+				},
+			},
+			ActivitiesError: errors.New("error"),
+			SleepError:      errors.New("error"),
+			ExpectedEnabled: true,
+			ExpectedString:  "77.54kg",
+		},
+		{
 			Case: "Measures, no data",
 			WithingsData: &WithingsData{
 				Body: &Body{},


### PR DESCRIPTION
Withings segment was using first element of measurement table, the newest measurement is the last entry

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

This PR fixes a problem with Withings segment, that made it show the oldest weight measurement, rather than the most recent
