### PR TITLE
fix(python): do not query pyenv when PYENV_ROOT is empty

### DIFF
--- a/src/segments/python.go
+++ b/src/segments/python.go
@@ -138,7 +138,7 @@ func (p *Python) pyenvVersion() (string, error) {
 	}
 
 	pyEnvRoot := p.env.Getenv("PYENV_ROOT")
-	if !strings.HasPrefix(cmdPath, pyEnvRoot) {
+	if len(pyEnvRoot) == 0 || !strings.HasPrefix(cmdPath, pyEnvRoot) {
 		return "", fmt.Errorf("executable at %s is not a pyenv shim", cmdPath)
 	}
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

resolves #6345

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
