### PR TITLE
Updated/Fixed Tokyo Theme

### DIFF
--- a/themes/tokyo-sameline.omp.json
+++ b/themes/tokyo-sameline.omp.json
@@ -102,7 +102,7 @@
     {
       "alignment": "left",
       "newline": true,
-      "leading_diamond": "<#7eb8da>\u2523</>",
+      "leading_diamond": "<#7eb8da>\u2517</>",
       "segments": [
         {
           "foreground": "#7eb8da",
@@ -123,18 +123,10 @@
           "style": "plain",
           "template": "[<#ffffff>{{ .UpstreamIcon }} </>{{ .HEAD }}{{if .BranchStatus }} {{ .BranchStatus }}{{ end }}{{ if .Working.Changed }} <#ffffff>\uf044</> {{ .Working.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }} <#ffffff>\uf046</> {{ .Staging.String }}{{ end }}{{ if gt .StashCount 0 }} <#ffffff>\ueb4b</> {{ .StashCount }}{{ end }}]",
           "type": "git"
-        }
-      ],
-      "type": "prompt"
-    },
-    {
-      "alignment": "left",
-      "newline": true,
-      "leading_diamond": "<#7eb8da>\u2514\u2500</>",
-      "segments": [
+        },
         {
           "style": "diamond",
-            "template": "<#ffff00>[#]</>",
+          "template": "<#ffff00>[#]</>",
           "type": "root"
         },
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Updated the theme layout and fixed a few minor bugs with the leading glyphs, as well as the root node position (there was a duplicate). Added a support for cloud info for devops/cloud engineers in an additional segment should the tools be used on the system (az, azd, gcp, kubctl, etc) and project information (name and target).

Added support for line error in powershell and used the universal # sign for SU/Admin shells behind the chevron.

Added another template for same line input as the path.

Added battery info in the top most segment.

Adjusted the time output to be more specific for time stamps when executing commands.

Simplified runner and hostname output.

Added glyphs for consistency, and fixed spacing in the GIT node so non-Mono fonts render properly.

Removed chevron when doing multiline inputs for easier copy and paste from terminal into scripts (don't have to remove the chevrons in the script after paste).

<img width="643" alt="image" src="https://github.com/user-attachments/assets/d250c663-6ca9-4d30-992f-d1071b7eb620" />


[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
