### PR TITLE
docs: Remove the redundant TextRenderer warning

### DIFF
--- a/website/docs/installation/fonts.mdx
+++ b/website/docs/installation/fonts.mdx
@@ -75,11 +75,6 @@ Make sure to **configure your terminal** to use the font you have installed. The
 }>
 <TabItem value="wt">
 
-:::caution Text renderer
-To ensure correct rendering of the glyphs you will need to enable the option `Use the new text renderer ("AtlasEngine")` in your terminal settings.
-For further details, see [here][wt-issue-8993].
-:::
-
 Once you have installed a Nerd Font, you will need to configure the Windows Terminal to use it. This can be easily done
 by modifying the Windows Terminal settings (default shortcut: `CTRL + SHIFT + ,`). In your `settings.json` file, add the
 `font.face` attribute under the `defaults` attribute in `profiles`:


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

In Windows Terminal 1.20 released in January 2024, Microsoft has [made](<https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-20-release/#usability-updates>) the AtlasEngine the default text rendering engine

In 1.21 from May that year, they have [removed](<https://devblogs.microsoft.com/commandline/windows-terminal-preview-1-21-release/#rendering-updates>) the old DXEngine from the terminal.

This pull request removes the associated warning from the docs as it is no longer relevant.

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
