### PR TITLE
feat: support job count in Nushell

### DIFF
--- a/src/shell/scripts/omp.nu
+++ b/src/shell/scripts/omp.nu
@@ -40,6 +40,7 @@ def --wrapped _omp_get_prompt [
             $"--no-status=($no_status)"
             $"--execution-time=($execution_time)"
             $"--terminal-width=((term size).columns)"
+            $"--job-count=(job list | length)"
             ...$args
     )
 }

--- a/website/docs/configuration/templates.mdx
+++ b/website/docs/configuration/templates.mdx
@@ -18,26 +18,26 @@ These properties can be used anywhere, in any segment. If a segment contains a p
 the segment property value will be used instead. In case you want to use the global property, you can prefix
 it with `.$` to reference it directly.
 
-| Name            | Type                  | Description                                                       |
-| --------------- | --------------------- | ----------------------------------------------------------------- |
-| `.Root`         | `boolean`             | is the current user root/admin or not                             |
-| `.PWD`          | `string`              | the current working directory (`~` for `$HOME`)                   |
-| `.AbsolutePWD`  | `string`              | the current working directory (unaltered)                         |
-| `.PSWD`         | `string`              | the current non-filesystem working directory in PowerShell        |
-| `.Folder`       | `string`              | the current working folder                                        |
-| `.Shell`        | `string`              | the current shell name                                            |
-| `.ShellVersion` | `string`              | the current shell version                                         |
-| `.SHLVL`        | `int`                 | the current shell level                                           |
-| `.UserName`     | `string`              | the current user name                                             |
-| `.HostName`     | `string`              | the host name                                                     |
-| `.Code`         | `int`                 | the last exit code                                                |
-| `.Jobs`         | `int`                 | number of background jobs (only available for zsh and PowerShell) |
-| `.OS`           | `string`              | the operating system                                              |
-| `.WSL`          | `boolean`             | in WSL yes/no                                                     |
-| `.Templates`    | `string`              | the [templates][templates] result                                 |
-| `.PromptCount`  | `int`                 | the prompt counter, increments with 1 for every prompt invocation |
-| `.Version`      | `string`              | the Oh My Posh version                                            |
-| `.Segment`      | [`Segment`](#segment) | the current segment's metadata                                    |
+| Name            | Type                  | Description                                                                 |
+| --------------- | --------------------- | --------------------------------------------------------------------------- |
+| `.Root`         | `boolean`             | is the current user root/admin or not                                       |
+| `.PWD`          | `string`              | the current working directory (`~` for `$HOME`)                             |
+| `.AbsolutePWD`  | `string`              | the current working directory (unaltered)                                   |
+| `.PSWD`         | `string`              | the current non-filesystem working directory in PowerShell                  |
+| `.Folder`       | `string`              | the current working folder                                                  |
+| `.Shell`        | `string`              | the current shell name                                                      |
+| `.ShellVersion` | `string`              | the current shell version                                                   |
+| `.SHLVL`        | `int`                 | the current shell level                                                     |
+| `.UserName`     | `string`              | the current user name                                                       |
+| `.HostName`     | `string`              | the host name                                                               |
+| `.Code`         | `int`                 | the last exit code                                                          |
+| `.Jobs`         | `int`                 | number of background jobs (only available for zsh, PowerShell, and Nushell) |
+| `.OS`           | `string`              | the operating system                                                        |
+| `.WSL`          | `boolean`             | in WSL yes/no                                                               |
+| `.Templates`    | `string`              | the [templates][templates] result                                           |
+| `.PromptCount`  | `int`                 | the prompt counter, increments with 1 for every prompt invocation           |
+| `.Version`      | `string`              | the Oh My Posh version                                                      |
+| `.Segment`      | [`Segment`](#segment) | the current segment's metadata                                              |
 
 ### Segment
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
  - this isn't tested for zsh or Powershell either, and I don't think it needs to be
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Adds support for the `.Jobs` template value for Nushell.

Nu supports querying all running jobs with `job list`, and to get the number of jobs, we can simply pipe that to `length`.

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
