### PR TITLE
fix(bash): only init features when relevant

### DIFF
--- a/src/shell/bash.go
+++ b/src/shell/bash.go
@@ -19,7 +19,37 @@ func (f Feature) Bash() Code {
 		return unixUpgrade
 	case Notice:
 		return unixNotice
-	case PromptMark, RPrompt, PoshGit, Azure, LineError, Jobs, Tooltips, Transient:
+	case RPrompt:
+		if !bashBLEsession {
+			return ""
+		}
+
+		return `bleopt prompt_rps1='$(
+	"$_omp_executable" print right \
+		--save-cache \
+		--shell=bash \
+		--shell-version="$BASH_VERSION" \
+		--status="$_omp_status" \
+		--pipestatus="${_omp_pipestatus[*]}" \
+		--no-status="$_omp_no_status" \
+		--execution-time="$_omp_execution_time" \
+		--stack-count="$_omp_stack_count" \
+		--terminal-width="${COLUMNS-0}" \
+		--escape=false
+)'`
+	case Transient:
+		if !bashBLEsession {
+			return ""
+		}
+
+		return `bleopt prompt_ps1_transient=always
+bleopt prompt_ps1_final='$(
+    "$_omp_executable" print transient \
+        --shell=bash \
+        --shell-version="$BASH_VERSION" \
+        --escape=false
+)'`
+	case PromptMark, PoshGit, Azure, LineError, Jobs, Tooltips:
 		fallthrough
 	default:
 		return ""

--- a/src/shell/bash_test.go
+++ b/src/shell/bash_test.go
@@ -19,6 +19,42 @@ _omp_cursor_positioning=1`
 	assert.Equal(t, want, got)
 }
 
+func TestBashFeaturesWithBLE(t *testing.T) {
+	bashBLEsession = true
+
+	got := allFeatures.Lines(BASH).String("// these are the features")
+
+	want := `// these are the features
+bleopt prompt_ps1_transient=always
+bleopt prompt_ps1_final='$(
+    "$_omp_executable" print transient \
+        --shell=bash \
+        --shell-version="$BASH_VERSION" \
+        --escape=false
+)'
+_omp_ftcs_marks=1
+"$_omp_executable" upgrade
+"$_omp_executable" notice
+bleopt prompt_rps1='$(
+	"$_omp_executable" print right \
+		--save-cache \
+		--shell=bash \
+		--shell-version="$BASH_VERSION" \
+		--status="$_omp_status" \
+		--pipestatus="${_omp_pipestatus[*]}" \
+		--no-status="$_omp_no_status" \
+		--execution-time="$_omp_execution_time" \
+		--stack-count="$_omp_stack_count" \
+		--terminal-width="${COLUMNS-0}" \
+		--escape=false
+)'
+_omp_cursor_positioning=1`
+
+	assert.Equal(t, want, got)
+
+	bashBLEsession = false
+}
+
 func TestQuotePosixStr(t *testing.T) {
 	tests := []struct {
 		str      string

--- a/src/shell/init.go
+++ b/src/shell/init.go
@@ -16,6 +16,11 @@ const (
 	noExe = "echo \"Unable to find Oh My Posh executable\""
 )
 
+var (
+	// identify ble.sh by validating the existence of BLE_SESSION_ID
+	bashBLEsession bool
+)
+
 func getExecutablePath(env runtime.Environment) (string, error) {
 	executable, err := os.Executable()
 	if err != nil {
@@ -83,6 +88,7 @@ func PrintInit(env runtime.Environment, features Features, startTime *time.Time)
 	shell := env.Flags().Shell
 	configFile := env.Flags().Config
 	sessionID := uuid.NewString()
+	bashBLEsession = len(env.Getenv("BLE_SESSION_ID")) != 0
 
 	var script string
 

--- a/src/shell/scripts/omp.bash
+++ b/src/shell/scripts/omp.bash
@@ -33,31 +33,6 @@ _omp_secondary_prompt=$(
         --shell-version="$BASH_VERSION"
 )
 
-# set transient and right when we have ble.sh by validating
-# the existence of BLE_SESSION_ID
-if [[ -n $BLE_SESSION_ID ]]; then
-    bleopt prompt_ps1_transient=always
-    bleopt prompt_ps1_final='$(
-        "$_omp_executable" print transient \
-            --shell=bash \
-            --shell-version="$BASH_VERSION" \
-            --escape=false
-    )'
-    bleopt prompt_rps1='$(
-        "$_omp_executable" print right \
-            --save-cache \
-            --shell=bash \
-            --shell-version="$BASH_VERSION" \
-            --status="$_omp_status" \
-            --pipestatus="${_omp_pipestatus[*]}" \
-            --no-status="$_omp_no_status" \
-            --execution-time="$_omp_execution_time" \
-            --stack-count="$_omp_stack_count" \
-            --terminal-width="${COLUMNS-0}" \
-            --escape=false
-    )'
-fi
-
 function _omp_set_cursor_position() {
     # not supported in Midnight Commander
     # see https://github.com/JanDeDobbeleer/oh-my-posh/issues/3415


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Resolves the issue where rprompt and transient would always be enabled when using ble.sh.
This ensures we only set the feature when the config has it defined, and we're running ble.sh.

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
