### PR TITLE
fix(bash): remove TTY check

### DIFF
--- a/src/shell/scripts/omp.bash
+++ b/src/shell/scripts/omp.bash
@@ -142,8 +142,6 @@ function _omp_hook() {
 }
 
 function _omp_install_hook() {
-    [[ $TERM = linux ]] && return
-
     local cmd
     for cmd in "${PROMPT_COMMAND[@]}"; do
         if [[ $cmd = _omp_hook ]]; then


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

The sourced script of bash doesn't run if we are on a TTY. Other shells don't do that, so this PR removes the check from bash.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
