### PR TITLE
chore: remove format from color_string

### DIFF
--- a/themes/schema.json
+++ b/themes/schema.json
@@ -19,8 +19,7 @@
       "type": "string",
       "pattern": "^(#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})|^([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$|black|red|green|yellow|blue|magenta|cyan|white|default|darkGray|lightRed|lightGreen|lightYellow|lightBlue|lightMagenta|lightCyan|lightWhite|transparent|parentBackground|parentForeground|background|foreground|accent)$",
       "title": "Color string",
-      "description": "https://ohmyposh.dev/docs/configuration/colors",
-      "format": "color"
+      "description": "https://ohmyposh.dev/docs/configuration/colors"
     },
     "palette_reference": {
       "type": "string",
@@ -2296,7 +2295,7 @@
                     "description": "The HTTP URL you want to call, supports templates",
                     "default": ""
                   },
-                  "method" : {
+                  "method": {
                     "type": "string",
                     "title": "HTTP Method",
                     "description": "The HTTP method to use",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

Remove `format` from the `color_string` inside the json schema definition.

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
