### PR TITLE
theme(robbyrussell): fix extra gap when Git segment is hidden by moving trailing space into it

### DIFF
--- a/themes/robbyrussell.omp.json
+++ b/themes/robbyrussell.omp.json
@@ -16,7 +16,7 @@
             "style": "folder"
           },
           "style": "plain",
-          "template": " {{ .Path }} ",
+          "template": " {{ .Path }}",
           "type": "path"
         },
         {
@@ -25,7 +25,7 @@
             "branch_icon": ""
           },
           "style": "plain",
-          "template": "<#5FAAE8>git:(</>{{ .HEAD }}<#5FAAE8>)</>",
+          "template": " <#5FAAE8>git:(</>{{ .HEAD }}<#5FAAE8>)</>",
           "type": "git"
         },
         {


### PR DESCRIPTION
### Prerequisites

- [X] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [X] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

This PR fixes #6470, a layout issue in the `robbyrussell` prompt theme where an extra space appeared after the path segment when the Git segment was not visible (e.g., outside a Git repository).

The trailing space was originally placed outside the Git segment, causing it to be rendered unconditionally. This change moves the space inside the Git segment's template so it only appears when the segment is actually shown, restoring visual consistency across contexts.

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
