### PR TITLE
feat(node): match lts versions

### DIFF
--- a/src/segments/node.go
+++ b/src/segments/node.go
@@ -133,9 +133,11 @@ func (n *Node) matchesVersionFile() (string, bool) {
 		case "gallium":
 			fileVersion = "16.20.2"
 		case "hydrogen":
-			fileVersion = "18.20.3"
+			fileVersion = "18.20.8"
 		case "iron":
-			fileVersion = "20.14.0"
+			fileVersion = "20.19.2"
+		case "jod":
+			fileVersion = "22.16.0"
 		}
 	}
 

--- a/src/segments/node_test.go
+++ b/src/segments/node_test.go
@@ -11,9 +11,9 @@ import (
 
 func TestNodeMatchesVersionFile(t *testing.T) {
 	nodeVersion := version{
-		Full:  "20.14.0",
-		Major: "20",
-		Minor: "14",
+		Full:  "22.16.0",
+		Major: "22",
+		Minor: "16",
 		Patch: "0",
 	}
 	cases := []struct {
@@ -23,16 +23,16 @@ func TestNodeMatchesVersionFile(t *testing.T) {
 		Expected        bool
 	}{
 		{Case: "no file context", Expected: true, RCVersion: ""},
-		{Case: "version match", Expected: true, ExpectedVersion: "20.14.0", RCVersion: "20.14.0"},
-		{Case: "version match with newline", Expected: true, ExpectedVersion: "20.14.0", RCVersion: "20.14.0\n"},
+		{Case: "version match", Expected: true, ExpectedVersion: "22.16.0", RCVersion: "22.16.0"},
+		{Case: "version match with newline", Expected: true, ExpectedVersion: "22.16.0", RCVersion: "22.16.0\n"},
 		{Case: "version mismatch", Expected: false, ExpectedVersion: "3.2.1", RCVersion: "3.2.1"},
-		{Case: "version match in other format", Expected: true, ExpectedVersion: "20.14.0", RCVersion: "v20.14.0"},
-		{Case: "version match without patch", Expected: true, ExpectedVersion: "20.14", RCVersion: "20.14"},
-		{Case: "version match without patch in other format", Expected: true, ExpectedVersion: "20.14", RCVersion: "v20.14"},
-		{Case: "version match without minor", Expected: true, ExpectedVersion: "20", RCVersion: "20"},
-		{Case: "version match without minor in other format", Expected: true, ExpectedVersion: "20", RCVersion: "v20"},
-		{Case: "lts match", Expected: true, ExpectedVersion: "20.14.0", RCVersion: "lts/iron"},
-		{Case: "lts match upper case", Expected: true, ExpectedVersion: "20.14.0", RCVersion: "lts/Iron"},
+		{Case: "version match in other format", Expected: true, ExpectedVersion: "22.16.0", RCVersion: "v22.16.0"},
+		{Case: "version match without patch", Expected: true, ExpectedVersion: "22.16", RCVersion: "22.16"},
+		{Case: "version match without patch in other format", Expected: true, ExpectedVersion: "22.16", RCVersion: "v22.16"},
+		{Case: "version match without minor", Expected: true, ExpectedVersion: "22", RCVersion: "22"},
+		{Case: "version match without minor in other format", Expected: true, ExpectedVersion: "22", RCVersion: "v22"},
+		{Case: "lts match", Expected: true, ExpectedVersion: "22.16.0", RCVersion: "lts/jod"},
+		{Case: "lts match upper case", Expected: true, ExpectedVersion: "22.16.0", RCVersion: "lts/Jod"},
 		{Case: "lts mismatch", Expected: false, ExpectedVersion: "8.17.0", RCVersion: "lts/carbon"},
 	}
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Update Node segment version resolution to include the new "jod" LTS release and bump existing LTS versions, with corresponding test updates.

New Features:
- Map Node.js codename "jod" to version 22.16.0

Enhancements:
- Bump default file versions for Node.js codenames "hydrogen" to 18.20.8 and "iron" to 20.19.2

Tests:
- Update version matching tests to expect Node.js 22.16.0 and adjust related cases

Reference: [Node.js Releases](https://nodejs.org/en/about/previous-releases)