### PR TITLE
docs: add missing properties description

### DIFF
--- a/website/docs/configuration/segment.mdx
+++ b/website/docs/configuration/segment.mdx
@@ -111,6 +111,14 @@ segment background as their foreground color.
 Same as Powerline except that it will display even when disabled, but without text. That way it seems
 as if the segment is not expanded, just like an accordion.
 
+## Properties
+
+The `properties` attribute allows you to customize the behavior and appearance of a segment beyond the basic settings.
+It is a flexible object where you can define specific options that are unique to each segment type.
+These options can be anything from specific commands, icons, or additional styling details that will only apply to the segment in question.
+To understand the available properties for a particular segment, refer to its corresponding documentation section where each property is explained in detail.
+This customization helps adapt segments to your workflow and style.
+
 ## Cache
 
 The cache property allows you to control how often a segment is refreshed. This is useful when a segment is slow to


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Documentation:
- Introduce a new `Properties` subsection explaining the `properties` attribute for customizing segment behavior and appearance, and refer to segment-specific docs for detailed options.

### Why?

The `properties` in [Settings](https://ohmyposh.dev/docs/configuration/segment#settings) says "see [Properties](https://ohmyposh.dev/docs/configuration/segment#properties) below".
However this link doesn't navigate anywhere.
That's why I added the `properties` explanation.