### PR TITLE
docs: fix export anchor link

### DIFF
--- a/website/docs/faq.mdx
+++ b/website/docs/faq.mdx
@@ -351,7 +351,7 @@ This is a known problem with Xonsh. The issue is tracked [here][xonsh-issue].
 [latest]: https://github.com/JanDeDobbeleer/oh-my-posh/releases/latest
 [wt-glyph]: https://github.com/microsoft/terminal/issues/3546
 [wt-glyphs]: https://github.com/microsoft/terminal/issues?q=is%3Aissue+is%3Aopen+unicode+width
-[export]: installation/customize.mdx#adjust-a-theme
+[export]: installation/customize.mdx#custom-configuration
 [segment]: configuration/segment.mdx
 [nf]: https://www.nerdfonts.com/
 [font]: /docs/installation/fonts


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

At #5585, adjust-a-theme was renamed to [custom configuraiton](https://ohmyposh.dev/docs/installation/customize#custom-configuration).
This PR fixed this changes to navigate correctly.

Documentation:
- Correct the [export] link in faq.mdx to reference #custom-configuration instead of #adjust-a-theme