### PR TITLE
docs: fix readme docusaurus 2 ref

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -1,6 +1,6 @@
 # Website
 
-This website is built using [Docusaurus 2](https://v2.docusaurus.io/), a modern static website generator.
+This website is built using [Docusaurus](https://docusaurus.io/), a modern static website generator.
 
 ## Installation
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Documentation:
- Fix website README to refer to Docusaurus generally instead of Docusaurus 2 and update the link to the main site

Docusaurus original commit is [here](https://github.com/facebook/docusaurus/pull/9487).