### PR TITLE
docs: version up apiRuntime on Azure Static Web App

### DIFF
--- a/website/staticwebapp.config.json
+++ b/website/staticwebapp.config.json
@@ -1,5 +1,5 @@
 {
   "platform": {
-    "apiRuntime": "node:16"
+    "apiRuntime": "node:20"
   }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Documentation:
- Bump apiRuntime version in staticwebapp.config.json

### Why?

[Docusaurus requires](https://docusaurus.io/docs/installation#requirements) [Node.js](https://nodejs.org/en/download/) version 18.0 or above (which can be checked by running node -v).
In addition,  [`package.json`](https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/website/package.json) specifies v20.9.0 version.

Reference: [Select the API language runtime version](https://learn.microsoft.com/en-us/azure/static-web-apps/configuration#select-the-api-language-runtime-version)