### PR TITLE
Fix the right prompt caching and update the config schema

### DIFF
--- a/src/prompt/primary.go
+++ b/src/prompt/primary.go
@@ -2,8 +2,10 @@ package prompt
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
+	"github.com/jandedobbeleer/oh-my-posh/src/cache"
 	"github.com/jandedobbeleer/oh-my-posh/src/config"
 	"github.com/jandedobbeleer/oh-my-posh/src/shell"
 	"github.com/jandedobbeleer/oh-my-posh/src/terminal"
@@ -13,6 +15,13 @@ func (e *Engine) Primary() string {
 	needsPrimaryRightPrompt := e.needsPrimaryRightPrompt()
 
 	e.writePrimaryPrompt(needsPrimaryRightPrompt)
+
+	defer func() {
+		if needsPrimaryRightPrompt {
+			e.Env.Session().Set(RPromptKey, e.rprompt, cache.INFINITE)
+			e.Env.Session().Set(RPromptLengthKey, strconv.Itoa(e.rpromptLength), cache.INFINITE)
+		}
+	}()
 
 	switch e.Env.Shell() {
 	case shell.ZSH:

--- a/src/prompt/rprompt.go
+++ b/src/prompt/rprompt.go
@@ -44,8 +44,8 @@ func (e *Engine) RPrompt() string {
 		text += " "
 	}
 
-	e.Env.Cache().Set(RPromptKey, text, cache.INFINITE)
-	e.Env.Cache().Set(RPromptLengthKey, strconv.Itoa(e.rpromptLength), cache.INFINITE)
+	e.Env.Session().Set(RPromptKey, text, cache.INFINITE)
+	e.Env.Session().Set(RPromptLengthKey, strconv.Itoa(e.rpromptLength), cache.INFINITE)
 
 	return text
 }

--- a/src/prompt/tooltip.go
+++ b/src/prompt/tooltip.go
@@ -1,10 +1,9 @@
 package prompt
 
 import (
+	"slices"
 	"strconv"
 	"strings"
-
-	"slices"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/config"
 	"github.com/jandedobbeleer/oh-my-posh/src/shell"
@@ -73,12 +72,12 @@ func (e *Engine) handleToolTipAction(text string, length int) (string, int) {
 		return text, length
 	}
 
-	rprompt, OK := e.Env.Cache().Get(RPromptKey)
+	rprompt, OK := e.Env.Session().Get(RPromptKey)
 	if !OK {
 		return text, length
 	}
 
-	rpromptLengthStr, OK := e.Env.Cache().Get(RPromptLengthKey)
+	rpromptLengthStr, OK := e.Env.Session().Get(RPromptLengthKey)
 	if !OK {
 		return text, length
 	}

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -140,7 +140,7 @@
       "title": "Filler",
       "description": "Right aligned filler text, will span the remaining width."
     },
-    "alias": {
+    "aliases": {
       "type": "object",
       "title": "Aliases",
       "description": "Custom value replacement for template parts",
@@ -5414,24 +5414,40 @@
       "description": "https://ohmyposh.dev/docs/configuration/templates#config-variables",
       "default": {}
     },
-    "aliases": {
+    "maps": {
       "type": "object",
-      "title": "Aliases",
-      "description": "https://ohmyposh.dev/docs/configuration/aliases",
+      "title": "Custom text mappings",
+      "description": "https://ohmyposh.dev/docs/configuration/general#maps",
       "default": {},
       "items": {
         "properties": {
           "user_name": {
-            "$ref": "#/definitions/alias"
+            "$ref": "#/definitions/aliases"
           },
           "host_name": {
-            "$ref": "#/definitions/alias"
+            "$ref": "#/definitions/aliases"
           },
           "shell_name": {
-            "$ref": "#/definitions/alias"
+            "$ref": "#/definitions/aliases"
           }
         }
       }
+    },
+    "async": {
+      "type": "boolean",
+      "title": "Async loading",
+      "default": false
+    },
+    "tooltips_action": {
+      "type": "string",
+      "title": "Tooltips action",
+      "description": "https://ohmyposh.dev/docs/configuration/tooltips#tooltips-action",
+      "enum": [
+        "replace",
+        "extend",
+        "prepend"
+      ],
+      "default": "replace"
     }
   }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

- Fix a bug where the right prompt is mistakenly stored in the device cache instead of a session cache.
- Update the config schema.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
