### PR TITLE
feat: FreeBSD support

### DIFF
--- a/src/runtime/environment.go
+++ b/src/runtime/environment.go
@@ -16,6 +16,7 @@ const (
 	WINDOWS = "windows"
 	DARWIN  = "darwin"
 	LINUX   = "linux"
+	FREEBSD = "freebsd"
 	CMD     = "cmd"
 
 	PRIMARY = "primary"

--- a/src/segments/os.go
+++ b/src/segments/os.go
@@ -33,15 +33,7 @@ func (oi *Os) Enabled() bool {
 		oi.Icon = oi.props.GetString(Windows, "\uE62A")
 	case runtime.DARWIN:
 		oi.Icon = oi.props.GetString(MacOS, "\uF179")
-	case runtime.LINUX:
-		pf := oi.env.Platform()
-		displayDistroName := oi.props.GetBool(DisplayDistroName, false)
-		if displayDistroName {
-			oi.Icon = oi.props.GetString(properties.Property(pf), pf)
-			break
-		}
-		oi.Icon = oi.getDistroIcon(pf)
-	case runtime.FREEBSD:
+	case runtime.LINUX, runtime.FREEBSD:
 		pf := oi.env.Platform()
 		displayDistroName := oi.props.GetBool(DisplayDistroName, false)
 		if displayDistroName {
@@ -72,7 +64,7 @@ func (oi *Os) getDistroIcon(distro string) string {
 		"elementary":          "\uF309",
 		"endeavouros":         "\uF322",
 		"fedora":              "\uF30a",
-		"freebsd":             "󰣠",
+		"freebsd":             "\U000f08e0",
 		"gentoo":              "\uF30d",
 		"kali":                "\uf327",
 		"mageia":              "\uF310",

--- a/src/segments/os.go
+++ b/src/segments/os.go
@@ -41,6 +41,14 @@ func (oi *Os) Enabled() bool {
 			break
 		}
 		oi.Icon = oi.getDistroIcon(pf)
+	case runtime.FREEBSD:
+		pf := oi.env.Platform()
+		displayDistroName := oi.props.GetBool(DisplayDistroName, false)
+		if displayDistroName {
+			oi.Icon = oi.props.GetString(properties.Property(pf), pf)
+			break
+		}
+		oi.Icon = oi.getDistroIcon(pf)
 	default:
 		oi.Icon = goos
 	}
@@ -64,6 +72,7 @@ func (oi *Os) getDistroIcon(distro string) string {
 		"elementary":          "\uF309",
 		"endeavouros":         "\uF322",
 		"fedora":              "\uF30a",
+		"freebsd":             "󰣠",
 		"gentoo":              "\uF30d",
 		"kali":                "\uf327",
 		"mageia":              "\uF310",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description
this PR adds support for FreeBSD, it just uses the same code as Linux, i did it like this because it was simple and it should also allow adding separate icons for OPNsense or pfSense in the future

P.S. i used the icon directly in the string because `nf-md-freebsd` when i copied `UTF` gave me `\udb82\udce0` which my lsp said was an error: `escape sequence is invalid Unicode code point`

P.P.S. i tested this on OPNsense not base FreeBSD
<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
