### PR TITLE
Bug fixes

### DIFF
--- a/src/segments/path.go
+++ b/src/segments/path.go
@@ -770,6 +770,10 @@ func (pt *Path) normalize(inputPath string) string {
 		normalized = strings.ToLower(normalized)
 	}
 
+	if pt.cygPath {
+		return strings.ReplaceAll(normalized, `\`, "/")
+	}
+
 	return normalized
 }
 

--- a/src/segments/path_test.go
+++ b/src/segments/path_test.go
@@ -394,6 +394,7 @@ type testNormalizePathCase struct {
 	GOOS          string
 	PathSeparator string
 	Expected      string
+	Cygwin        bool
 }
 
 func TestNormalizePath(t *testing.T) {
@@ -408,7 +409,7 @@ func TestNormalizePath(t *testing.T) {
 
 		env.On("PathSeparator").Return(tc.PathSeparator)
 
-		pt := &Path{}
+		pt := &Path{cygPath: tc.Cygwin}
 		pt.Init(properties.Map{}, env)
 
 		got := pt.normalize(tc.Input)

--- a/src/segments/path_windows_test.go
+++ b/src/segments/path_windows_test.go
@@ -548,4 +548,13 @@ var testNormalizePathCases = []testNormalizePathCase{
 		PathSeparator: `\`,
 		Expected:      "\\\\localhost\\c$\\some",
 	},
+	{
+		Case:          "Windows: display Cygwin path",
+		Input:         fooBarMan,
+		HomeDir:       homeDirWindows,
+		GOOS:          runtime.WINDOWS,
+		PathSeparator: `\`,
+		Expected:      "/foo/bar/man",
+		Cygwin:        true,
+	},
 }

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -166,7 +166,13 @@ function _omp_zle-line-init() {
   local -i ret=$?
   (( $+zle_bracketed_paste )) && print -r -n - $zle_bracketed_paste[2]
 
-  eval "$(_omp_get_prompt transient --eval)"
+  # We need this workaround because when the `filler` is set,
+  # there will be a redundant blank line below the transient prompt if the input is empty.
+  if [[ -z $BUFFER ]]; then
+    local options="--terminal-width=$((${COLUMNS-0} - 1))"
+  fi
+
+  eval "$(_omp_get_prompt transient --eval $options)"
   zle .reset-prompt
 
   if ((ret)); then


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

Fix 3 bugs:

- In Elvish, newlines are not properly printed on Windows. (The alternative of using control sequences to move the cursor does not work at all.)
- In Zsh, when the `filler` for the transient prompt is set, there will be a redundant blank line below the prompt if the input command line is empty. (The bug is also seen in Windows CMD with [Clink][clink-issue], but it's going to be fixed in the next version of Clink, so we don't have to do special handling in OMP.)
- On Windows, when the `display_cygpath` property is `true` in a `path` segment, backslashes in path normalization causes `mapped_locations` to fail in path matching.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[clink-issue]: https://github.com/chrisant996/clink/issues/763
