### PR TITLE
feat(gcp): allow obtaining active config from env var

### DIFF
--- a/src/segments/gcp.go
+++ b/src/segments/gcp.go
@@ -28,14 +28,14 @@ func (g *Gcp) Template() string {
 
 func (g *Gcp) Enabled() bool {
 	cfgDir := g.getConfigDirectory()
-	configFile, err := g.getActiveConfig(cfgDir)
+	cfgName, err := g.getActiveConfig(cfgDir)
 	if err != nil {
 		log.Error(err)
 		return false
 	}
 
-	cfgpath := path.Join(cfgDir, "configurations", "config_"+configFile)
-	cfg := g.env.FileContent(cfgpath)
+	cfgPath := path.Join(cfgDir, "configurations", "config_"+cfgName)
+	cfg := g.env.FileContent(cfgPath)
 
 	if len(cfg) == 0 {
 		log.Error(errors.New("config file is empty"))
@@ -56,12 +56,18 @@ func (g *Gcp) Enabled() bool {
 }
 
 func (g *Gcp) getActiveConfig(cfgDir string) (string, error) {
+	activeCfg := g.env.Getenv("CLOUDSDK_ACTIVE_CONFIG_NAME")
+	if len(activeCfg) != 0 {
+		return activeCfg, nil
+	}
+
 	ap := path.Join(cfgDir, "active_config")
-	fileContent := g.env.FileContent(ap)
-	if len(fileContent) == 0 {
+	activeCfg = g.env.FileContent(ap)
+	if len(activeCfg) == 0 {
 		return "", errors.New(GCPNOACTIVECONFIG)
 	}
-	return fileContent, nil
+
+	return activeCfg, nil
 }
 
 func (g *Gcp) getConfigDirectory() string {

--- a/src/segments/gcp.go
+++ b/src/segments/gcp.go
@@ -17,9 +17,10 @@ const (
 type Gcp struct {
 	base
 
-	Account string
-	Project string
-	Region  string
+	Account      string
+	Project      string
+	Region       string
+	ActiveConfig string
 }
 
 func (g *Gcp) Template() string {
@@ -34,6 +35,7 @@ func (g *Gcp) Enabled() bool {
 		return false
 	}
 
+	g.ActiveConfig = cfgName
 	cfgPath := path.Join(cfgDir, "configurations", "config_"+cfgName)
 	cfg := g.env.FileContent(cfgPath)
 

--- a/website/docs/segments/cloud/gcp.mdx
+++ b/website/docs/segments/cloud/gcp.mdx
@@ -10,16 +10,18 @@ Display the currently active GCP project, region and account
 
 ## Sample Configuration
 
-import Config from '@site/src/components/Config.js';
+import Config from "@site/src/components/Config.js";
 
-<Config data={{
-  "type": "gcp",
-  "style": "powerline",
-  "powerline_symbol": "\uE0B0",
-  "foreground": "#ffffff",
-  "background": "#47888d",
-  "template": " \uE7B2 {{.Project}} :: {{.Account}} "
-}}/>
+<Config
+  data={{
+    type: "gcp",
+    style: "powerline",
+    powerline_symbol: "\uE0B0",
+    foreground: "#ffffff",
+    background: "#47888d",
+    template: " \uE7B2 {{.Project}} :: {{.Account}} ",
+  }}
+/>
 
 ## Template ([info][templates])
 
@@ -33,11 +35,12 @@ import Config from '@site/src/components/Config.js';
 
 ### Properties
 
-| Name       | Type     | Description                                                              |
-| ---------- | -------- | ------------------------------------------------------------------------ |
-| `.Project` | `string` | the currently active project                                             |
-| `.Account` | `string` | the currently active account                                             |
-| `.Region`  | `string` | default region for the active context                                    |
-| `.Error`   | `string` | contains any error messages generated when trying to load the GCP config |
+| Name            | Type     | Description                                                              |
+| --------------- | -------- | ------------------------------------------------------------------------ |
+| `.Project`      | `string` | the currently active project                                             |
+| `.Account`      | `string` | the currently active account                                             |
+| `.Region`       | `string` | default region for the active context                                    |
+| `.ActiveConfig` | `string` | the active configuration name                                            |
+| `.Error`        | `string` | contains any error messages generated when trying to load the GCP config |
 
 [templates]: /docs/configuration/templates


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

Allow using the env variable `CLOUDSDK_ACTIVE_CONFIG_NAME` to set the active gcloud configuration.

In the cases where the variable is not set, the active configuration will be determined by reading gcloud's configuration file, like before.

Documentation: 

I have not updated the docs since there is no mention on how the GCP segment obtains the configuration properties. Nonetheless, I'm happy to update them if you believe that would be necessary. 