### PR TITLE
fix: adjusting spotify segment latency on macos by ~600ms

### DIFF
--- a/src/segments/spotify_darwin.go
+++ b/src/segments/spotify_darwin.go
@@ -5,11 +5,9 @@ package segments
 import "strings"
 
 func (s *Spotify) Enabled() bool {
-	/*
-		Batching commands to reduce latency. Each individual call to `osascript` creates additional delays.
-	  Using '|' as a delimiter in the batched command since it's unlikely
-		to appear in track or artist names, making it safe for splitting the output
-	*/
+	// Batching commands to reduce latency. Each individual call to `osascript` creates additional delays.
+	// Using '|' as a delimiter in the batched command since it's unlikely
+	// to appear in track or artist names, making it safe for splitting the output
 	batchedCommand := `
 	if application "Spotify" is running then
 		tell application "Spotify"
@@ -30,15 +28,14 @@ func (s *Spotify) Enabled() bool {
 	batchedOutput := s.runAppleScriptCommand(batchedCommand)
 
 	outputStrings := strings.SplitN(batchedOutput, "|", 4)
-
-	if outputStrings[0] == "false" || outputStrings[0] == "" || len(outputStrings) != 4 {
+	if outputStrings[0] == "false" || len(outputStrings[0]) == 0 || len(outputStrings) != 4 {
 		s.Status = stopped
 		return false
 	}
+
 	s.Status = outputStrings[1]
 
 	// Check if running
-
 	if len(s.Status) == 0 {
 		s.Status = stopped
 		return false
@@ -47,9 +44,9 @@ func (s *Spotify) Enabled() bool {
 	if s.Status == stopped {
 		return false
 	}
+
 	s.Artist = outputStrings[2]
 	s.Track = outputStrings[3]
-
 	s.resolveIcon()
 
 	return true

--- a/website/docs/segments/music/spotify.mdx
+++ b/website/docs/segments/music/spotify.mdx
@@ -9,7 +9,8 @@ sidebar_label: Spotify
 Show the currently playing song in the [Spotify][spotify] client.
 
 :::caution
-Be aware this can make the prompt a tad bit slower as it needs to get a response from the Spotify player.
+Be aware this can make the prompt a tad bit slower as it needs to get a response from the Spotify player.<br />
+<span style={{ fontSize: "0.6em" }}>Recent optimizations have decreased latency on macOS by about ~600ms per prompt load.</span>
 
 On _macOS & Linux_, all states are supported (playing/paused/stopped).
 

--- a/website/docs/segments/music/spotify.mdx
+++ b/website/docs/segments/music/spotify.mdx
@@ -9,8 +9,7 @@ sidebar_label: Spotify
 Show the currently playing song in the [Spotify][spotify] client.
 
 :::caution
-Be aware this can make the prompt a tad bit slower as it needs to get a response from the Spotify player.<br />
-<span style={{ fontSize: "0.6em" }}>Recent optimizations have decreased latency on macOS by about ~600ms per prompt load.</span>
+Be aware this can make the prompt a tad bit slower as it needs to get a response from the Spotify player.
 
 On _macOS & Linux_, all states are supported (playing/paused/stopped).
 


### PR DESCRIPTION
Using a single batched command to query spotify with oascript, instead of several individual calls. (￣^￣)ゞ

Included is a small shell script that compares prompt latency with the `time` command.

```
#!/bin/bash
for i in {1..10}; do
  #original bin
  ORIGINAL="$(brew --prefix oh-my-posh)/bin/oh-my-posh"
  #new bin
  FORKED="$HOME/CODE/open-source/oh-my-posh-pfork/oh-my-posh"
  #CHANGE these to match your theme path 
  CONFIG="/usr/local/opt/oh-my-posh/themes/tokyo.omp.json"

  echo "Original oh-my-posh:"
  time "$ORIGINAL" print primary --config "$CONFIG" --pwd "$PWD"

  echo ""
  echo "Forked oh-my-posh:"
  time "$FORKED" print primary --config "$CONFIG" --pwd "$PWD"

done
```

**Example Output**:

`Original oh-my-posh:
real    0m1.088s
user    0m1.638s
sys     0m0.549s`

`Forked oh-my-posh:
real    0m0.415s
user    0m0.547s
sys     0m0.177s`

### Prerequisites

- [✅] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [✅] The commit message follows the [conventional commits][cc] guidelines.
- [✅] Tests for the changes have been added (for bug fixes / features).
- [✅] Docs have been added/updated (for bug fixes / features).
