### PR TITLE
[WIP] perf: early check for .git directory to reduce check time

### DIFF
--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -337,23 +337,29 @@ func (g *Git) LatestTag() string {
 }
 
 func (g *Git) shouldDisplay() bool {
-	gitdir, err := g.env.HasParentFilePath(".git", true)
-	if err != nil {
-		return false
-	}
-
-	if !g.hasCommand(GITCOMMAND) {
-		return false
-	}
-
 	if g.props.GetBool(FetchBareInfo, false) {
 		g.repoRootDir = g.env.Pwd()
+
+		if !g.hasCommand(GITCOMMAND) {
+			return false
+		}
+
 		bare := g.getGitCommandOutput("rev-parse", "--is-bare-repository")
 		if bare == trueStr {
 			g.IsBare = true
 			g.mainSCMDir = g.repoRootDir
 			return true
 		}
+	}
+
+	gitdir, err := g.env.HasParentFilePath(".git", true)
+	if err != nil {
+		return false
+	}
+
+	// g.hasCommand may have already run previously due to bareinfo check
+	if g.command == "" && !g.hasCommand(GITCOMMAND) {
+		return false
 	}
 
 	return g.isRepo(gitdir)

--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -337,6 +337,11 @@ func (g *Git) LatestTag() string {
 }
 
 func (g *Git) shouldDisplay() bool {
+	gitdir, err := g.env.HasParentFilePath(".git", true)
+	if err != nil {
+		return false
+	}
+
 	if !g.hasCommand(GITCOMMAND) {
 		return false
 	}
@@ -349,11 +354,6 @@ func (g *Git) shouldDisplay() bool {
 			g.mainSCMDir = g.repoRootDir
 			return true
 		}
-	}
-
-	gitdir, err := g.env.HasParentFilePath(".git", true)
-	if err != nil {
-		return false
 	}
 
 	return g.isRepo(gitdir)

--- a/src/segments/git_test.go
+++ b/src/segments/git_test.go
@@ -26,7 +26,7 @@ const (
 func TestEnabledGitNotFound(t *testing.T) {
 	env := new(mock.Environment)
 	env.On("InWSLSharedDrive").Return(false)
-	env.On("HasCommand", "git").Return(false)
+	env.On("HasParentFilePath", ".git", true).Return((*runtime.FileInfo)(nil), errors.New("no .git found (mock)"))
 	env.On("GOOS").Return("")
 	env.On("IsWsl").Return(false)
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

To determine whether pwd is a git repository, it utilizes a `HasCommand` check. However, this command is rather slow. Instead, it should do a `.git` folder check first. ~~I have read segment docs and code base to see if this would change any previous behavior but as far as I can tell, nothing would change.~~

!! Git bare bone segment users will still have hasCommand called. I'm not sure how to work around this. Read discussion below for more info

---

Logs have been sorted by time

### Before

```
[TRACE] 23:08:49.252 terminal.go:Init() - 555.4µs
[TRACE] 23:08:49.277 segment.go:string(<transparent></>  {{ .FormattedMs }} ) - 1.0993ms
[TRACE] 23:08:49.251 terminal.go(C:\Users\n\AppData\Local\oh-my-posh\omp.cache.614c7e6f-2fe6-48b6-a9fb-bbdf13021f9a) - 6.875ms
[TRACE] 23:08:49.252 debug.go() - 7.9847ms
[TRACE] 23:08:49.276 terminal.go:HasCommand(git.exe) - 22.4231ms
Run duration: 33.6155ms
```

### After

```

[TRACE] 23:08:59.761 path.go:Path() - 509.5µs
[TRACE] 23:08:59.769 terminal_windows.go:Root() - 519.5µs
[TRACE] 23:08:59.769 text.go:Render({{{ .Folder }}) - 523.4µs
[TRACE] 23:08:59.770 text.go:Render( {{ .UserName }} ) - 524.4µs
[TRACE] 23:08:59.771 terminal_windows.go:DirIsWritable() - 525.5µs
[TRACE] 23:08:59.772 text.go:Render({{ if gt .Code 0 }}#000000{{ end }}) - 639.8µs
[TRACE] 23:08:59.770 text.go:Render({{ .Code }}) - 1.1314ms
[TRACE] 23:08:59.768 file.go:Init(C:\Users\n\AppData\Local\oh-my-posh\omp.cache.614c7e6f-2fe6-48b6-a9fb-bbdf13021f9a) - 6.8048ms
[TRACE] 23:08:59.768 terminal.go:Init() - 7.3143ms
Run duration: 12.7818ms
```

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
