### PR TITLE
Export image fonts

### DIFF
--- a/src/cli/config_export_image.go
+++ b/src/cli/config_export_image.go
@@ -53,7 +53,7 @@ Exports the config to an image file using customized output settings.`,
 		flags := &runtime.Flags{
 			Config:        cfg.Source,
 			Shell:         shell.GENERIC,
-			TerminalWidth: 150,
+			TerminalWidth: 120,
 		}
 
 		env := &runtime.Terminal{}

--- a/src/cli/config_export_image.go
+++ b/src/cli/config_export_image.go
@@ -92,6 +92,10 @@ Exports the config to an image file using customized output settings.`,
 			settings.Colors = image.NewColors()
 		}
 
+		if settings.Cursor == "" {
+			settings.Cursor = "_"
+		}
+
 		primaryPrompt := eng.Primary()
 
 		imageCreator := &image.Renderer{

--- a/src/cli/config_export_image.go
+++ b/src/cli/config_export_image.go
@@ -15,12 +15,10 @@ import (
 )
 
 var (
-	author string
-	// cursorPadding int
-	// rPromptOffset int
+	author            string
+	colorSettingsFile string
 	bgColor           string
 	outputImage       string
-	colorSettingsFile string
 )
 
 // imageCmd represents the image command
@@ -31,11 +29,9 @@ var imageCmd = &cobra.Command{
 
 You can tweak the output by using additional flags:
 
-- author: displays the author below the prompt
 - cursor-padding: the padding of the prompt cursor
 - rprompt-offset: the offset of the right prompt
-- background-color: the background color of the image
-- color-settings: JSON file with color overrides for ANSI color names
+- settings: JSON file with overrides
 
 Example usage:
 

--- a/src/cli/image/config.go
+++ b/src/cli/image/config.go
@@ -25,6 +25,7 @@ type Settings struct {
 	Author          string `json:"author"`
 	BackgroundColor string `json:"background_color"`
 	Fonts           *Fonts `json:"fonts"`
+	Cursor          string `json:"cursor,omitempty"`
 }
 
 type Colors map[string]HexColor

--- a/src/cli/image/config.go
+++ b/src/cli/image/config.go
@@ -24,6 +24,7 @@ type Settings struct {
 	Colors          Colors `json:"colors"`
 	Author          string `json:"author"`
 	BackgroundColor string `json:"background_color"`
+	Fonts           *Fonts `json:"fonts"`
 }
 
 type Colors map[string]HexColor

--- a/src/cli/image/fonts.go
+++ b/src/cli/image/fonts.go
@@ -1,0 +1,95 @@
+package image
+
+import (
+	"fmt"
+	stdOS "os"
+	"time"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/log"
+
+	"golang.org/x/image/font"
+	"golang.org/x/image/font/opentype"
+)
+
+const (
+	regular = "regular"
+)
+
+type Fonts struct {
+	Regular string `json:"regular"`
+	Bold    string `json:"bold"`
+	Italic  string `json:"italic"`
+}
+
+func (f *Fonts) IsValid() bool {
+	if f == nil {
+		return false
+	}
+
+	// Check that all required font paths are non-empty
+	return f.Regular != "" && f.Bold != "" && f.Italic != ""
+}
+
+func (f *Fonts) Load() (map[string]font.Face, error) {
+	defer log.Trace(time.Now(), "Load fonts")
+
+	result := make(map[string]font.Face)
+
+	fonts := map[string]Font{
+		regular: Font(f.Regular),
+		bold:    Font(f.Bold),
+		italic:  Font(f.Italic),
+	}
+
+	for name, fontPath := range fonts {
+		fontFace, err := fontPath.Load()
+		if err != nil {
+			return nil, fmt.Errorf("failed to load font %s: %w", fontPath, err)
+		}
+
+		result[name] = fontFace
+	}
+
+	return result, nil
+}
+
+type Font string
+
+func (f Font) Load() (font.Face, error) {
+	defer log.Trace(time.Now(), string(f))
+
+	data, err := stdOS.ReadFile(string(f))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read font file %s: %w", f, err)
+	}
+
+	fontObject, err := opentype.Parse(data)
+
+	// handle collections
+	if err != nil {
+		collection, err := opentype.ParseCollection(data)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse font %s as single font or collection: %w", f, err)
+		}
+
+		if collection.NumFonts() == 0 {
+			return nil, fmt.Errorf("font collection %s is empty", f)
+		}
+
+		fontObject, err = collection.Font(0)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get first font from collection %s: %w", f, err)
+		}
+	}
+
+	face, err := opentype.NewFace(fontObject, &opentype.FaceOptions{Size: 2.0 * 12, DPI: 144})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create font face for %s: %w", f, err)
+	}
+
+	if face == nil {
+		return nil, fmt.Errorf("failed to create font face for %s: face is nil", f)
+	}
+
+	return face, nil
+}

--- a/src/cli/image/image.go
+++ b/src/cli/image/image.go
@@ -476,12 +476,12 @@ func (ir *Renderer) measureContent() (width, height float64) {
 }
 
 func (ir *Renderer) SavePNG() error {
-	var f = func(value float64) float64 { return ir.factor * value }
+	var scale = func(value float64) float64 { return ir.factor * value }
 
 	var (
-		corner   = f(6)
-		radius   = f(9)
-		distance = f(25)
+		corner   = scale(6)
+		radius   = scale(9)
+		distance = scale(25)
 	)
 
 	contentWidth, contentHeight := ir.measureContent()
@@ -498,7 +498,7 @@ func (ir *Renderer) SavePNG() error {
 
 	xOffset := marginX
 	yOffset := marginY
-	titleOffset := f(40)
+	titleOffset := scale(40)
 
 	width := contentWidth + 2*marginX + 2*paddingX
 	height := contentHeight + 2*marginY + 2*paddingY + titleOffset
@@ -537,11 +537,11 @@ func (ir *Renderer) SavePNG() error {
 
 	dc.DrawRoundedRectangle(xOffset, yOffset, width-2*marginX, height-2*marginY, corner)
 	dc.SetHexColor("#404040")
-	dc.SetLineWidth(f(1))
+	dc.SetLineWidth(scale(1))
 	dc.Stroke()
 
 	for i, color := range []string{red, yellow, green} {
-		dc.DrawCircle(xOffset+paddingX+float64(i)*distance+f(4), yOffset+paddingY+f(4), radius)
+		dc.DrawCircle(xOffset+paddingX+float64(i)*distance+scale(4), yOffset+paddingY+scale(4), radius)
 		dc.SetHexColor(color)
 		dc.Fill()
 	}
@@ -590,6 +590,7 @@ func (ir *Renderer) SavePNG() error {
 			dc.DrawRectangle(x, bgY, w, bgHeight)
 			dc.Fill()
 		}
+
 		if ir.foregroundColor != nil {
 			dc.SetRGB255(ir.foregroundColor.r, ir.foregroundColor.g, ir.foregroundColor.b)
 		} else {
@@ -605,14 +606,14 @@ func (ir *Renderer) SavePNG() error {
 		dc.DrawString(str, x, y)
 
 		if ir.style == underline {
-			dc.DrawLine(x, y+f(4), x+w, y+f(4))
-			dc.SetLineWidth(f(1))
+			dc.DrawLine(x, y+scale(4), x+w, y+scale(4))
+			dc.SetLineWidth(scale(1))
 			dc.Stroke()
 		}
 
 		if ir.style == overline {
-			dc.DrawLine(x, y-f(22), x+w, y-f(22))
-			dc.SetLineWidth(f(1))
+			dc.DrawLine(x, y-scale(22), x+w, y-scale(22))
+			dc.SetLineWidth(scale(1))
 			dc.Stroke()
 		}
 

--- a/src/cli/image/image.go
+++ b/src/cli/image/image.go
@@ -392,9 +392,10 @@ func (ir *Renderer) cleanContent() {
 	// cursor indication
 	saveCursorAnsi := "\x1b7"
 	if !strings.Contains(ir.AnsiString, saveCursorAnsi) {
-		ir.AnsiString += "_"
+		ir.AnsiString += ir.Cursor
 	}
-	ir.AnsiString = strings.ReplaceAll(ir.AnsiString, saveCursorAnsi, "_")
+
+	ir.AnsiString = strings.ReplaceAll(ir.AnsiString, saveCursorAnsi, ir.Cursor)
 
 	// add watermarks
 	ir.AnsiString += "\n\n\x1b[1mohmyposh.dev\x1b[22m"

--- a/src/cli/image/image.go
+++ b/src/cli/image/image.go
@@ -570,7 +570,7 @@ func (ir *Renderer) SavePNG() error {
 			dc.SetFontFace(ir.regular)
 		}
 
-		w, h := dc.MeasureString(str)
+		w, _ := dc.MeasureString(str)
 		// The gg library unfortunately returns a single character width for *all* glyphs in a font.
 		// So if we know the glyph to occupy n additional characters in width, allocate that area
 		// e.g. this will double the space for Nerd Fonts, but some could even be 3 or 4 wide
@@ -579,10 +579,15 @@ func (ir *Renderer) SavePNG() error {
 
 		if ir.backgroundColor != nil {
 			dc.SetRGB255(ir.backgroundColor.r, ir.backgroundColor.g, ir.backgroundColor.b)
-			// The background for a character needs love to align to the font we're using
-			// Not all fonts are rendered the same height or starting position,
-			// so we're shifting the background rectangles vertically to correct
-			dc.DrawRectangle(x, y-h+3, w, h+9)
+			// Use consistent line height for all background rectangles
+			fontLineHeight := ir.fontHeight() * ir.lineSpacing
+
+			// Center all characters (including powerline glyphs) within the line height
+			// Position background to align properly with text baseline and ensure consistent height
+			bgY := y - fontLineHeight*0.75 // Adjusted for better centering with text
+			bgHeight := fontLineHeight
+
+			dc.DrawRectangle(x, bgY, w, bgHeight)
 			dc.Fill()
 		}
 		if ir.foregroundColor != nil {
@@ -593,7 +598,7 @@ func (ir *Renderer) SavePNG() error {
 
 		if str == "\n" {
 			x = xOffset + paddingX
-			y += h * ir.lineSpacing
+			y += ir.fontHeight() * ir.lineSpacing // Use consistent line height instead of character height
 			continue
 		}
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

(duplicate - reopened)

Re-implementation of custom font settings via 

```
config export image \
  [--font MyNerdFontExample.ttf/otf] \
  [--font-regular MyNerdFontExample.ttf/otf] \
  [--font-bold MyNerdFontExample-Bold.ttf/otf] \
  [--font-italic MyNerdFontExample-Italic.ttf/otf]
```

Reduced testing profile to only include new functionality in the PR, since golang opentype is responsible for reading fonts etc.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
