### PR TITLE
theme(robbyrussell): fix missing space between arrow and path

### DIFF
--- a/themes/robbyrussell.omp.json
+++ b/themes/robbyrussell.omp.json
@@ -16,7 +16,7 @@
             "style": "folder"
           },
           "style": "plain",
-          "template": " {{ .Path }}",
+          "template": "  {{ .Path }}",
           "type": "path"
         },
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

This pr fix the following issue of #6470, there should be *two* spaces between the arrow and folder name.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
