### PR TITLE
feat(theme): add rohit.omp.json with dynamic battery-aware icons

### DIFF
--- a/themes/rohit.omp.json
+++ b/themes/rohit.omp.json
@@ -1,0 +1,221 @@
+{
+    "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
+    "console_title_template": "{{ if .Root }}root @ {{ end }}{{ .Shell }} in {{ .Folder }}",
+    "blocks": [
+        {
+            "alignment": "left",
+            "segments": [
+                {
+                    "background": "#575656",
+                    "foreground": "#D6DEEB",
+                    "leading_diamond": "\ue0b2",
+                    "properties": {
+                        "alpine": "\uf300",
+                        "arch": "\uf303",
+                        "centos": "\uf304",
+                        "debian": "\uf306",
+                        "elementary": "\uf309",
+                        "fedora": "\uf30a",
+                        "gentoo": "\uf30d",
+                        "linux": "\ue712",
+                        "macos": "\ue711",
+                        "manjaro": "\uf312",
+                        "mint": "\uf30f",
+                        "opensuse": "\uf314",
+                        "raspbian": "\uf315",
+                        "ubuntu": "\uf31c",
+                        "windows": "\ue70f"
+                    },
+                    "style": "diamond",
+                    "template": " {{ if .WSL }}\ue712 on {{ end }}{{ .Icon }} ",
+                    "type": "os"
+                },
+                {
+                    "background": "#00C7FC",
+                    "foreground": "#011627",
+                    "powerline_symbol": "\ue0b0",
+                    "style": "powerline",
+                    "template": " \uf489 {{ .Name }} ",
+                    "type": "shell"
+                },
+                {
+                    "background": "#EF541C",
+                    "foreground": "#D6DEEB",
+                    "powerline_symbol": "\ue0b0",
+                    "style": "powerline",
+                    "template": " \uf09c admin ",
+                    "type": "root"
+                },
+                {
+                    "type": "cmake",
+                    "style": "powerline",
+                    "powerline_symbol": "\ue0b0",
+                    "foreground": "#E8EAEE",
+                    "background": "#1E9748",
+                    "template": " \ue61e \ue61d cmake {{ .Full }} "
+                },
+                {
+                    "type": "python",
+                    "style": "powerline",
+                    "powerline_symbol": "\ue0b0",
+                    "properties": {
+                        "display_mode": "context"
+                    },
+                    "foreground": "#011627",
+                    "background": "#FFDE57",
+                    "template": " \ue73c {{ if .Venv }}{{ .Venv }} {{ end }}{{ .Full }} "
+                },
+                {
+                    "type": "go",
+                    "style": "powerline",
+                    "powerline_symbol": "\ue0b0",
+                    "foreground": "#ffffff",
+                    "background": "#7FD5EA",
+                    "template": " \u202d\ue626 {{ .Full }} "
+                },
+                {
+                    "type": "rust",
+                    "style": "powerline",
+                    "powerline_symbol": "\ue0b0",
+                    "foreground": "#193549",
+                    "background": "#99908A",
+                    "template": " \ue7a8 {{ .Full }} "
+                },
+                {
+                    "background": "#1BD4CD",
+                    "background_templates": [
+                        "{{ if or (.Working.Changed) (.Staging.Changed) }}#16B1AC{{ end }}",
+                        "{{ if and (gt .Ahead 0) (gt .Behind 0) }}#16B1AC{{ end }}",
+                        "{{ if gt .Ahead 0 }}#B787D7{{ end }}",
+                        "{{ if gt .Behind 0 }}#B787D7{{ end }}"
+                    ],
+                    "foreground": "#011627",
+                    "powerline_symbol": "\ue0b0",
+                    "properties": {
+                        "branch_icon": "\ue725 ",
+                        "fetch_stash_count": true,
+                        "fetch_status": true,
+                        "fetch_upstream_icon": true,
+                        "fetch_worktree_count": true
+                    },
+                    "style": "powerline",
+                    "template": " {{ .UpstreamIcon }}{{ .HEAD }}{{if .BranchStatus }} {{ .BranchStatus }}{{ end }}{{ if .Working.Changed }} \uf044 {{ .Working.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }}<#CAEBE1> \uf046 {{ .Staging.String }}</>{{ end }}{{ if gt .StashCount 0 }} \ueb4b {{ .StashCount }}{{ end }} ",
+                    "type": "git"
+                }
+            ],
+            "type": "prompt"
+        },
+        {
+            "alignment": "right",
+            "segments": [
+                {
+                    "type": "battery",
+                    "style": "diamond",
+                    "leading_diamond": "\ue0b6",
+                    "trailing_diamond": "\ue0b0",
+                    "template": " \uf240  {{ .Percentage }}% ",
+                    "foreground": "#011627",
+                    "background": "#777777",
+                    "background_templates": [
+                        "{{ if lt .Percentage 10 }}#FF1744{{ end }}",
+                        "{{ if and (ge .Percentage 10) (lt .Percentage 25) }}#FF4081{{ end }}",
+                        "{{ if and (ge .Percentage 25) (lt .Percentage 40) }}#FF9800{{ end }}",
+                        "{{ if and (ge .Percentage 40) (lt .Percentage 65) }}#FFEB3B{{ end }}",
+                        "{{ if and (ge .Percentage 65) (lt .Percentage 85) }}#69F0AE{{ end }}",
+                        "{{ if ge .Percentage 85 }}#00E676{{ end }}"
+                    ],
+                    "properties": {
+                        "display_percentage": true
+                    }
+                },
+                {
+                    "type": "text",
+                    "style": "powerline",
+                    "powerline_symbol": "\ue0b0",
+                    "template": "",
+                    "background": "#03C4EC",
+                    "foreground": "#03C4EC"
+                },
+                {
+                    "type": "time",
+                    "style": "diamond",
+                    "template": " {{ .CurrentDate | date \"15:04\" }} ({{ .CurrentDate | date \"Mon\" }}) ",
+                    "foreground": "#011627",
+                    "background": "#78C5F9",
+                    "trailing_diamond": "\ue0b4"
+                }
+            ],
+            "type": "prompt"
+        },
+        {
+            "alignment": "left",
+            "newline": true,
+            "segments": [
+                {
+                    "foreground": "#D6DEEB",
+                    "style": "plain",
+                    "template": "\u256d\u2500",
+                    "type": "text"
+                },
+                {
+                    "foreground": "#F2D3B6",
+                    "properties": {
+                        "time_format": "<#D6DEEB>\ue641 15:04:05</> <#79DFE1>|</> \uf073 2 Jan, Monday"
+                    },
+                    "style": "plain",
+                    "template": "{{ .CurrentDate | date .Format }} <#79DFE1>|</>",
+                    "type": "time"
+                },
+                {
+                    "foreground": "#B6D6F2",
+                    "leading_diamond": "<#00C7FC> \uf07b </><#B6D6F2> in </>",
+                    "properties": {
+                        "folder_icon": " \uf07c ",
+                        "folder_separator_icon": " \uf061 ",
+                        "home_icon": "\ueb06 ",
+                        "style": "agnoster_short",
+                        "max_depth": 3
+                    },
+                    "style": "diamond",
+                    "template": " {{ .Path }} ",
+                    "type": "path"
+                }
+            ],
+            "type": "prompt"
+        },
+        {
+            "alignment": "left",
+            "newline": true,
+            "segments": [
+                {
+                    "foreground": "#D6DEEB",
+                    "style": "plain",
+                    "template": "\u2570\u2500",
+                    "type": "text"
+                },
+                {
+                    "foreground": "#D6DEEB",
+                    "properties": {
+                        "always_enabled": true
+                    },
+                    "style": "plain",
+                    "template": "\u276f ",
+                    "type": "status"
+                }
+            ],
+            "type": "prompt"
+        }
+    ],
+    "osc99": true,
+    "transient_prompt": {
+        "background": "transparent",
+        "foreground": "#FEF5ED",
+        "template": "\ue285 "
+    },
+    "secondary_prompt": {
+        "background": "transparent",
+        "foreground": "#D6DEEB",
+        "template": "\u2570\u2500\u276f "
+    },
+    "version": 3
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features). *(Not required for theme)*
- [x] Docs have been added/updated (for bug fixes / features). *(Theme added to themes directory)*

---

### Description

This PR adds a new custom theme: `rohit.omp.json`.

> 🔗 **Inspired by the [`kushal`](https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/themes/kushal.omp.json) theme**, with enhancements tailored for battery-aware and developer-centric workflows.

#### ✨ Theme Highlights

- 📊 **Battery segment with a dynamic folder icon**, changing color based on battery percentage
- ⚙️ Git segment with upstream icon, status, stash, and branch information
- 🧠 Developer-ready: includes support for Python, Go, Rust, and CMake
- 🎨 Dual-aligned layout (left + right blocks) for clean separation of system and contextual info
- 📦 Multi-line prompt with clear powerline visuals and Nerd Font icons
- 🖥️ Designed for PowerShell, VS Code terminal, and Windows Terminal, wsl

---

### Screenshots

<img width="1816" alt="prompt-preview" src="https://github.com/user-attachments/assets/5f35d729-cbe4-4636-b404-47d5761f9f44" />
<img width="1477" alt="prompt-preview" src="https://github.com/user-attachments/assets/599dd23b-b507-437c-a1a4-cb6f5d791ff6" />
<img width="1477" alt="prompt-preview" src="https://github.com/user-attachments/assets/c262295d-8c04-4780-8818-46a9c81f71a9" />

---

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md  
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
