### PR TITLE
fix(zsh): do not allow variable expansion when using shwordsplit

### DIFF
--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -147,8 +147,8 @@ function _omp_render_tooltip() {
     return
   fi
 
-  _omp_tooltip_command="$tooltip_command"
-  local tooltip=$(_omp_get_prompt tooltip --command="$tooltip_command")
+  _omp_tooltip_command="${tooltip_command}"
+  local tooltip=$(_omp_get_prompt tooltip --command="${tooltip_command}")
   if [[ -z $tooltip ]]; then
     return
   fi


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

resolves #6606

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
