### PR TITLE
fix(zsh): disable shwordsplit localy for tooltips

### DIFF
--- a/src/cli/toggle.go
+++ b/src/cli/toggle.go
@@ -58,7 +58,7 @@ var toggleCmd = &cobra.Command{
 			newToggles = append(newToggles, segment)
 		}
 
-		env.Session().Set(cache.TOGGLECACHE, strings.Join(newToggles, ","), cache.ONEDAY)
+		env.Session().Set(cache.TOGGLECACHE, strings.Join(newToggles, ","), cache.INFINITE)
 	},
 }
 

--- a/src/cli/toggle.go
+++ b/src/cli/toggle.go
@@ -10,10 +10,10 @@ import (
 
 // toggleCmd represents the toggle command
 var toggleCmd = &cobra.Command{
-	Use:   "toggle",
-	Short: "Toggle a segment on/off",
-	Long:  "Toggle a segment on/off on the fly.",
-	Args:  cobra.ExactArgs(1),
+	Use:   "toggle [segment1,segment2,...]",
+	Short: "Toggle one or more segments on/off",
+	Long:  "Toggle one or more segments on/off on the fly. Multiple segments can be specified separated by spaces.",
+	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
 			_ = cmd.Help()
@@ -29,28 +29,48 @@ var toggleCmd = &cobra.Command{
 		defer env.Close()
 
 		togglesCache, _ := env.Session().Get(cache.TOGGLECACHE)
-		var toggles []string
+		var currentToggles []string
 		if len(togglesCache) != 0 {
-			toggles = strings.Split(togglesCache, ",")
+			currentToggles = strings.Split(togglesCache, ",")
 		}
-		segment := args[0]
 
-		newToggles := []string{}
-		var match bool
-		for _, toggle := range toggles {
-			if toggle == segment {
-				match = true
+		segmentsToToggle := parseSegments(args)
+
+		// Get current toggles as a set for efficient operations
+		currentToggleSet := make(map[string]bool)
+		for _, toggle := range currentToggles {
+			currentToggleSet[toggle] = true
+		}
+
+		// Toggle segments: remove if present, add if not present
+		for _, segment := range segmentsToToggle {
+			if currentToggleSet[segment] {
+				delete(currentToggleSet, segment)
 				continue
 			}
-			newToggles = append(newToggles, toggle)
+
+			currentToggleSet[segment] = true
 		}
 
-		if !match {
+		// Convert back to slice
+		newToggles := make([]string, 0, len(currentToggleSet))
+		for segment := range currentToggleSet {
 			newToggles = append(newToggles, segment)
 		}
 
 		env.Session().Set(cache.TOGGLECACHE, strings.Join(newToggles, ","), cache.ONEDAY)
 	},
+}
+
+func parseSegments(args []string) []string {
+	var segments []string
+	for _, arg := range args {
+		if segment := strings.TrimSpace(arg); segment != "" {
+			segments = append(segments, segment)
+		}
+	}
+
+	return segments
 }
 
 func init() {

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -139,6 +139,8 @@ function _omp_render_tooltip() {
     return
   fi
 
+  setopt local_options no_shwordsplit
+
   # Get the first word of command line as tip.
   local tooltip_command=${${(MS)BUFFER##[[:graph:]]*}%%[[:space:]]*}
 
@@ -147,8 +149,8 @@ function _omp_render_tooltip() {
     return
   fi
 
-  _omp_tooltip_command="${tooltip_command}"
-  local tooltip=$(_omp_get_prompt tooltip --command="${tooltip_command}")
+  _omp_tooltip_command="$tooltip_command"
+  local tooltip=$(_omp_get_prompt tooltip --command="$tooltip_command")
   if [[ -z $tooltip ]]; then
     return
   fi


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

relates to #6606

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
