### PR TITLE
docs: Add documentation for using fonts with Apple Terminal

### DIFF
--- a/website/docs/installation/fonts.mdx
+++ b/website/docs/installation/fonts.mdx
@@ -70,7 +70,8 @@ Make sure to **configure your terminal** to use the font you have installed. The
     values={[
         { label: 'Windows Terminal', value: 'wt' },
         { label: 'Visual Studio Code', value: 'code' },
-        { label: 'Visual Studio', value: 'vs' }
+        { label: 'Visual Studio', value: 'vs' },
+        { label: 'Apple Terminal', value: 'apple' }
     ]
 }>
 <TabItem value="wt">
@@ -115,6 +116,19 @@ in `Tools > Options > Fonts and Colors > Terminal` and selecting a font like `Me
 OTF fonts do not appear in Visual Studio's Terminal settings, only TTF fonts. See [here][vs-otf] for more information.
 :::
 
+</TabItem>
+<TabItem value="apple">
+
+When using Apple Terminal, you will need to configure the settings based on the profile you are using. This can be done by opening the settings in `Profiles > Select the appropriate profile from the left panel > Text > Font` and select a font like `MesloLGM Nerd Font`.
+
+This can also be configured via a terminal command. Example in case of `MesloLGM Nerd Font Mono` Nerd Font on the Basic profile for Apple Terminal:
+
+```bash
+osascript -e 'tell application "Terminal" to set font of settings set "Basic" to "MesloLGL Nerd Font Mono"'
+```
+:::warning
+The command has only been tested on macOS Sequoia 15.5 24F74.
+:::
 </TabItem>
 </Tabs>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->
This PR includes a change to the installation documentation related to fonts. The addition, creates an additional tab under the configuration section that walks users through how to use Nerd Fonts with the native Apple Terminal.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
