### PR TITLE
typo in customize.mdx

### DIFF
--- a/website/docs/installation/customize.mdx
+++ b/website/docs/installation/customize.mdx
@@ -9,7 +9,7 @@ import TabItem from "@theme/TabItem";
 
 The standard initialization sets Oh My Posh' default, built-in theme.
 
-To set a new configugration or theme you need to change the `--config` option of the `oh-my-posh init <shell>`
+To set a new configuration or theme you need to change the `--config` option of the `oh-my-posh init <shell>`
 line in your `profile` or `.<shell>rc` script (see [prompt][prompt]).
 
 These are the three possible values the `--config` flag can handle:


### PR DESCRIPTION
misspelled configuration

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
