### PR TITLE
Feat: add golang support to project segment

### DIFF
--- a/src/runtime/terminal.go
+++ b/src/runtime/terminal.go
@@ -444,6 +444,14 @@ func (term *Terminal) HTTPRequest(targetURL string, body io.Reader, timeout int,
 	return responseBody, nil
 }
 
+type ErrorTeminal string
+
+const ErrNoMatchAtRootLevel = ErrorTeminal("no match at root level")
+
+func (e ErrorTeminal) Error() string {
+	return string(e)
+}
+
 func (term *Terminal) HasParentFilePath(parent string, followSymlinks bool) (*FileInfo, error) {
 	defer log.Trace(time.Now(), parent)
 
@@ -475,7 +483,7 @@ func (term *Terminal) HasParentFilePath(parent string, followSymlinks bool) (*Fi
 		}
 
 		log.Error(err)
-		return nil, errors.New("no match at root level")
+		return nil, ErrNoMatchAtRootLevel
 	}
 }
 

--- a/website/docs/segments/system/project.mdx
+++ b/website/docs/segments/system/project.mdx
@@ -20,6 +20,7 @@ Supports:
 - .NET project (`*.sln`, `*.slnf`, `*.csproj`, `*.vbproj` or `*.fsproj`, first file match info is displayed)
 - Julia project (`JuliaProject.toml`, `Project.toml`)
 - PowerShell project (`*.psd1`, first file match info is displayed)
+- Go project (go.work and go.mod)
 
 ## Sample Configuration
 
@@ -56,13 +57,13 @@ import Config from "@site/src/components/Config.js";
 
 ### Properties
 
-| Name       | Type     | Description                                                                                                                                                                                      |
-| ---------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `.Type`    | `string` | The type of project:<ul><li>`node`</li><li>`cargo`</li><li>`python`</li><li>`mojo`</li><li>`php`</li><li>`dart`</li><li>`nuspec`</li><li>`dotnet`</li><li>`julia`</li><li>`powershell`</li></ul> |
-| `.Version` | `string` | The version of your project                                                                                                                                                                      |
-| `.Target`  | `string` | The target framework/language version of your project                                                                                                                                            |
-| `.Name`    | `string` | The name of your project                                                                                                                                                                         |
-| `.Error`   | `string` | The error context when we can't fetch the project info                                                                                                                                           |
+| Name       | Type     | Description                                                                                                                                                                                                       |
+| ---------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `.Type`    | `string` | The type of project:<ul><li>`node`</li><li>`cargo`</li><li>`python`</li><li>`mojo`</li><li>`php`</li><li>`dart`</li><li>`nuspec`</li><li>`dotnet`</li><li>`julia`</li><li>`powershell`</li><li>`golang`</li></ul> |
+| `.Version` | `string` | The version of your project (where applicable)                                                                                                                                                                    |
+| `.Target`  | `string` | The target framework/language version of your project                                                                                                                                                             |
+| `.Name`    | `string` | The name of your project  (where applicable)                                                                                                                                                                      |
+| `.Error`   | `string` | The error context when we can't fetch the project info                                                                                                                                                            |
 
 [templates]: /docs/configuration/templates
 [pep621-standard]: https://peps.python.org/pep-0621/


### PR DESCRIPTION
### Prerequisites

- [ x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [ x] The commit message follows the [conventional commits][cc] guidelines.
- [ x] Tests for the changes have been added (for bug fixes / features).
- [ x] Docs have been added/updated (for bug fixes / features).

### Description

Adding in support to display the Go version of a golang project as the `target` if the CWD is below a folder that contains either a go.work or go.mod file.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
