### PR TITLE
fixed typo/wrong style for root user

### DIFF
--- a/themes/cloud-context.omp.json
+++ b/themes/cloud-context.omp.json
@@ -184,7 +184,7 @@
       "segments": [
         {
           "background": "p:error-background",
-          "foreground": "p:backgrond-color",
+          "foreground": "p:git-text",
           "style": "diamond",
           "leading_diamond": "\ue0c7",
           "trailing_diamond": "\ue0c6",


### PR DESCRIPTION
The root user’s text color was misconfigured as "backgrond-color" (typo). It should be 'git-text'—using "background-color" would make invisible.