### PR TITLE
fix(theme): typo/wrong style for root user

### DIFF
--- a/themes/cloud-context.omp.json
+++ b/themes/cloud-context.omp.json
@@ -184,7 +184,7 @@
       "segments": [
         {
           "background": "p:error-background",
-          "foreground": "p:backgrond-color",
+          "foreground": "p:git-text",
           "style": "diamond",
           "leading_diamond": "\ue0c7",
           "trailing_diamond": "\ue0c6",


### PR DESCRIPTION
The root user’s text color was incorrectly set to "backgrond-color" (a typo).

### Prerequisites

- [ ] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [ ] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
