### PR TITLE
feat(jujutsu): Add more information about the current change

### DIFF
--- a/src/segments/jujutsu.go
+++ b/src/segments/jujutsu.go
@@ -1,6 +1,8 @@
 package segments
 
 import (
+	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/log"
@@ -12,10 +14,19 @@ import (
 const (
 	JUJUTSUCOMMAND = "jj"
 
-	jjLogTemplate = `change_id.shortest() ++ "\n" ++ diff.summary()`
-
 	IgnoreWorkingCopy properties.Property = "ignore_working_copy"
+	MinChangeIDLen    properties.Property = "min_change_id_len"
+	MinCommitIDLen    properties.Property = "min_commit_id_len"
 )
+
+// JujutsuID is used for both change_id and commit_id
+type JujutsuID struct {
+	Shortest string
+	Full     string
+	Rest     string
+}
+
+func (id *JujutsuID) String() string { return id.Shortest + id.Rest }
 
 type JujutsuStatus struct {
 	ScmStatus
@@ -35,13 +46,30 @@ func (s *JujutsuStatus) add(code byte) {
 }
 
 type Jujutsu struct {
-	Working  *JujutsuStatus
-	ChangeID string
+	Working         *JujutsuStatus
+	ChangeID        string
+	Working         JujutsuStatus
+	ChangeID        JujutsuID
+	CommitID        JujutsuID
+	LocalBookmarks  []string
+	RemoteBookmarks []string
+	Description     string
+
+	Conflict  bool
+	Immutable bool
+	Empty     bool
+	Divergent bool
+	Hidden    bool
+	Mine      bool
+
+	AuthorID    User // defined in git.go
+	CommitterID User // defined in git.go
+
 	Scm
 }
 
 func (jj *Jujutsu) Template() string {
-	return " \uf1fa{{.ChangeID}}{{if .Working.Changed}} \uf044 {{ .Working.String }}{{ end }} "
+	return " \uf1fa{{ .ChangeID }}{{if .Working.Changed}} \uf044 {{ .Working.String }}{{ end }} "
 }
 
 func (jj *Jujutsu) Enabled() bool {
@@ -51,8 +79,8 @@ func (jj *Jujutsu) Enabled() bool {
 		return false
 	}
 
-	statusFormats := jj.props.GetKeyValueMap(StatusFormats, map[string]string{})
-	jj.Working = &JujutsuStatus{ScmStatus: ScmStatus{Formats: statusFormats}}
+	statusFormats := jj.props.GetKeyValueMap(StatusFormats, nil)
+	jj.Working = JujutsuStatus{ScmStatus: ScmStatus{Formats: statusFormats}}
 
 	if displayStatus {
 		jj.setJujutsuStatus()
@@ -102,20 +130,135 @@ func (jj *Jujutsu) setDir(dir string) {
 	jj.Dir = strings.TrimSuffix(dir, "/.jj")
 }
 
+type jjTemplate struct {
+	template string
+	action   func(jj *Jujutsu, result string)
+}
+
+func (jj *Jujutsu) jjTemplates() []jjTemplate {
+	minChangeIDLen := jj.props.GetString(MinChangeIDLen, "8")
+	minCommitIDLen := jj.props.GetString(MinCommitIDLen, "8")
+
+	// https://jj-vcs.github.io/jj/latest/templates/
+	return []jjTemplate{
+		{
+			template: "diff.summary()",
+			action: func(jj *Jujutsu, v string) {
+				for _, line := range strings.Split(v, "\n") {
+					if len(line) == 0 {
+						continue
+					}
+					jj.Working.add(line[0])
+				}
+			},
+		},
+		{
+			template: "change_id",
+			action:   func(jj *Jujutsu, v string) { jj.ChangeID.Full = v },
+		},
+		{
+			template: fmt.Sprintf("change_id.shortest(%s).prefix()", minChangeIDLen),
+			action:   func(jj *Jujutsu, v string) { jj.ChangeID.Shortest = v },
+		},
+		{
+			template: fmt.Sprintf("change_id.shortest(%s).rest()", minChangeIDLen),
+			action:   func(jj *Jujutsu, v string) { jj.ChangeID.Rest = v },
+		},
+		{
+			template: "commit_id",
+			action:   func(jj *Jujutsu, v string) { jj.CommitID.Full = v },
+		},
+		{
+			template: fmt.Sprintf("commit_id.shortest(%s).prefix()", minCommitIDLen),
+			action:   func(jj *Jujutsu, v string) { jj.CommitID.Shortest = v },
+		},
+		{
+			template: fmt.Sprintf("commit_id.shortest(%s).rest()", minCommitIDLen),
+			action:   func(jj *Jujutsu, v string) { jj.CommitID.Rest = v },
+		},
+		{
+			template: "local_bookmarks.join('\n')",
+			action: func(jj *Jujutsu, v string) {
+				if strings.TrimSpace(v) == "" {
+					return
+				}
+				jj.LocalBookmarks = strings.Split(v, "\n")
+			},
+		},
+		{
+			template: "remote_bookmarks.join('\n')",
+			action: func(jj *Jujutsu, v string) {
+				if strings.TrimSpace(v) == "" {
+					return
+				}
+				jj.RemoteBookmarks = strings.Split(v, "\n")
+			},
+		},
+		{
+			template: "divergent",
+			action:   func(jj *Jujutsu, v string) { jj.Divergent, _ = strconv.ParseBool(v) },
+		},
+		{
+			template: "hidden",
+			action:   func(jj *Jujutsu, v string) { jj.Hidden, _ = strconv.ParseBool(v) },
+		},
+		{
+			template: "immutable",
+			action:   func(jj *Jujutsu, v string) { jj.Immutable, _ = strconv.ParseBool(v) },
+		},
+		{
+			template: "empty",
+			action:   func(jj *Jujutsu, v string) { jj.Empty, _ = strconv.ParseBool(v) },
+		},
+		{
+			template: "mine",
+			action:   func(jj *Jujutsu, v string) { jj.Mine, _ = strconv.ParseBool(v) },
+		},
+		{
+			template: "author().name",
+			action:   func(jj *Jujutsu, v string) { jj.AuthorID.Name = v },
+		},
+		{
+			template: "author().email",
+			action:   func(jj *Jujutsu, v string) { jj.AuthorID.Email = v },
+		},
+		{
+			template: "commiter().name",
+			action:   func(jj *Jujutsu, v string) { jj.CommitterID.Name = v },
+		},
+		{
+			template: "commiter().email",
+			action:   func(jj *Jujutsu, v string) { jj.CommitterID.Email = v },
+		},
+	}
+}
+
+// logTemplate will create a jj log template string with each template separated
+// by a newline.  Returns the template string and the keys in the order they
+// were specified.
+func logTemplate(templates []jjTemplate) string {
+	var sb strings.Builder
+	for i, tmpl := range templates {
+		sb.WriteString(tmpl.template)
+		if i < len(templates)-1 {
+			sb.WriteString(` ++ "\0" ++ `)
+		}
+	}
+	return sb.String()
+}
+
 func (jj *Jujutsu) setJujutsuStatus() {
-	// https://jj-vcs.github.io/jj/latest/templates/#commit-keywords
-	statusString, err := jj.getJujutsuCommandOutput("log", "-r", "@", "--no-graph", "-T", jjLogTemplate)
+	templates := jj.jjTemplates()
+	fmt.Println(templates)
+
+	statusString, err := jj.getJujutsuCommandOutput("log", "-r", "@", "--no-graph", "-T", logTemplate(templates))
 	if err != nil {
 		return
 	}
 
-	lines := strings.Split(statusString, "\n")
-	jj.ChangeID = lines[0]
-
-	for _, line := range lines[1:] {
-		if len(line) > 0 {
-			jj.Working.add(line[0])
-		}
+	statusString = strings.TrimSuffix(statusString, "\n")
+	for i, result := range strings.Split(statusString, string(rune(0))) {
+		templates[i].action(jj, result)
 	}
 }
 

--- a/website/docs/segments/scm/jujutsu.mdx
+++ b/website/docs/segments/scm/jujutsu.mdx
@@ -33,31 +33,47 @@ import Config from "@site/src/components/Config.js";
 As doing Jujutsu (jj) calls can slow down the prompt experience, we do not fetch information by default.
 Set `status_formats` to `true` to enable fetching additional information (and populate the template).
 
-| Name                  |        Type         | Default | Description                                                                                                                                                                                                                                                      |
-| --------------------- | :-----------------: | :-----: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `fetch_status`        |      `boolean`      | `false` | fetch the local changes                                                                                                                                                                                                                                          |
-| `ignore_working_copy` |      `boolean`      | `true`  | don't snapshot the working copy, and don't update it                                                                                                                                                                                                             |
-| `native_fallback`     |      `boolean`      | `false` | when set to `true` and `jj.exe` is not available when inside a WSL2 shared Windows drive, we will fallback to the native `jj` executable to fetch data. Not all information can be displayed in this case                                                        |
-| `status_formats`      | `map[string]string` |         | a key, value map allowing to override how individual status items are displayed. For example, `"status_formats": { "Added": "Added: %d" }` will display the added count as `Added: 1` instead of `+1`. See the [Status](#status) section for available overrides |
+| Name                  |        Type         | Default | Description                                                                                                                                                                                                                                                        |
+| --------------------- | :-----------------: | :-----: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `fetch_status`        |      `boolean`      | `false` | fetch the local changes                                                                                                                                                                                                                                            |
+| `ignore_working_copy` |      `boolean`      | `true`  | don't snapshot the working copy, and don't update it                                                                                                                                                                                                               |
+| `native_fallback`     |      `boolean`      | `false` | when set to `true` and `jj.exe` is not available when inside a WSL2 shared Windows drive, we will fallback to the native `jj` executable to fetch data. Not all information can be displayed in this case                                                          |
+| `status_formats`      | `map[string]string` |         | a key, value map allowing to override how individual status items are displayed. For example, `"status_formats": { "Added": "Added: %d" }` will display the added count as `Added: 1` instead of `+1`. See the [Status](#status) section for available overrides   |
+| `min_change_id_len`   |      `integer`      |   `8`   | The minimum length for the change_id in Jujutsu.  This affects `.ChangeID.Short` and .ChangeID.Rest` only (`.ChangeID.Full` will always be the full)                                                                                                               |
+| `min_commit_id_len`   |      `integer`      |   `8`   | The minimum length for the commit_id in Jujutsu.  This affects `.CommitID.Short` and .CommitID.Rest` only (`.CommitID.Full` will always be the full)                                                                                                               |
+
 
 ## Template ([info][templates])
 
 :::note default template
 
 ```template
-jj {{.ChangeID}}{{if .Working.Changed}} \uf044 {{ .Working.String }}{{ end }}
+\uf1fa {{ .ChangeID }}{{if .Working.Changed}} \uf044 {{ .Working.String }}{{ end }}
 ```
 
 :::
 
 ### Properties
 
-| Name        | Type     | Description                                           |
-| ----------- | -------- | ----------------------------------------------------- |
-| `.Working`  | `Status` | changes in the working copy (see below)               |
-| `.ChangeID` | `string` | The shortest unique prefix of the working copy change |
+| Name               | Type        | Description                                                |
+| ------------------ | ----------- | ---------------------------------------------------------- |
+| `.Working`         | `Status`    | changes in the working copy (see below)                    |
+| `.ChangeID`        | `JujutsuID` | The current change_id                                      |
+| `.CommitID`        | `JujutsuID` | The current commit_id                                      |
+| `.LocalBookmarks`  | `[]string`  | List of all local bookmarks                                |
+| `.RemoteBookmarks` | `[]string`  | List of all remote bookmarks                               |
+| `.Description`     | `boolean`   | Current change description                                 |
+| `.Conflict`        | `boolean`   | True if the current change conflicts with it's parent      |
+| `.Immutable`       | `boolean`   | True if the current change is marked as immutable          |
+| `.Empty`           | `boolean`   | True if the current change is without and changes          |
+| `.Divergent`       | `boolean`   | True if the current change is marked as immutable          |
+| `.Hidden`          | `boolean`   | True if the current change is hidden                       |
+| `.Mine`            | `boolean`   | True if the current change is authored by the current user |
+| `.AuthorID`        | `User`      | The current change's author                                |
+| `.CommiterID`      | `User`      | The current change's commiter                              |
 
-### Status
+
+#### Status
 
 | Name        | Type      | Description                                  |
 | ----------- | --------- | -------------------------------------------- |
@@ -76,5 +92,23 @@ Local changes use the following syntax:
 | `-`  | Deleted     |
 | `+`  | Added       |
 | `>`  | Moved       |
+
+
+#### JujutsuID
+
+| Name        | Type      | Description                                                                                                                 |
+| ----------- | --------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `.Full`     | `string`  | The full change/commit id                                                                                                   |
+| `.Shortest` | `string`  | The shortest unique change/commit id. This combined with `.Rest` will add up to the `min_change_id_len`/`min_commit_id_len` |
+| `.Rest`     | `string`  | The *rest* of the short change/commit id minus the unique prefix.  Seperated out to allow coloring                          |
+
+
+#### User
+
+| Name     | Type     | Description      |
+| -------- | -------- | ---------------- |
+| `.Name`  | `string` | the user's name  |
+| `.Email` | `string` | the user's email |
+
 
 [templates]: /docs/config-templates


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [X] The commit message follows the [conventional commits][cc] guidelines.
- [X] Tests for the changes have been added (for bug fixes / features).
- [X] Docs have been added/updated (for bug fixes / features).

### Description

The templating system in Jujutsu is very advanced.  Almost all the command output go though the template system and can provide vast amounts of details.  Today the Jujutsu segment hardcodes the change output to two items.  `change_id.shortest()` and `diff.summary()`.

This adds a a bunch of new properties along with some logic on how to pass and parse the information to the `jj log` command.

See the updated documentation the properties added. 


This is an alternative to #6671. This change originated from allowing users to specify their own changes but changed to a set of a common change properties that are clearer to use.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
