### PR TITLE
feat(gijsreyn): Add new dsc manifest command and fix dsc output

### DIFF
--- a/src/cli/font/dsc.go
+++ b/src/cli/font/dsc.go
@@ -32,3 +32,65 @@ func (s *Resource) Add(name string) {
 		Name: name,
 	})
 }
+
+func (s *Resource) Manifest() string {
+	manifest := `{
+  "$schema": "https://aka.ms/dsc/schemas/v3/bundled/resource/manifest.json",
+  "description": "Allows configuring the Oh My Posh font installs.",
+  "export": {
+    "executable": "oh-my-posh",
+    "input": "stdin",
+    "args": [
+      "font",
+      "dsc",
+      "export"
+    ]
+  },
+  "get": {
+    "executable": "oh-my-posh",
+    "input": "stdin",
+    "args": [
+      "font",
+      "dsc",
+      "get"
+    ]
+  },
+  "schema": {
+    "command": {
+      "executable": "oh-my-posh",
+      "args": [
+        "font",
+        "dsc",
+        "schema"
+      ]
+    }
+  },
+  "set": {
+    "executable": "oh-my-posh",
+    "implementsPretest": true,
+    "return": "stateAndDiff",
+    "args": [
+      "font",
+      "dsc",
+      "set",
+      {
+        "jsonInputArg": "--schema",
+        "mandatory": true
+      }
+    ]
+  },
+  "tags": [
+    "OhMyPosh",
+    "linux",
+    "macos",
+    "windows",
+    "powershell",
+    "terminal",
+    "theming",
+    "fonts"
+  ],
+  "type": "OhMyPosh/Font",
+  "version": "0.1.0"
+}`
+	return dsc.CompressJSON(manifest)
+}

--- a/src/config/dsc.go
+++ b/src/config/dsc.go
@@ -130,3 +130,66 @@ func (c *Configuration) Resolve() (*Configuration, bool) {
 
 	return parent, true
 }
+
+func (s *Resource) Manifest() string {
+	manifest := `{
+  "$schema": "https://aka.ms/dsc/schemas/v3/bundled/resource/manifest.json",
+  "description": "Allows configuring the Oh My Posh config files.",
+  "export": {
+    "executable": "oh-my-posh",
+    "input": "stdin",
+    "args": [
+      "config",
+      "dsc",
+      "export"
+    ]
+  },
+  "get": {
+    "executable": "oh-my-posh",
+    "input": "stdin",
+    "args": [
+      "config",
+      "dsc",
+      "get"
+    ]
+  },
+  "schema": {
+    "command": {
+      "executable": "oh-my-posh",
+      "args": [
+        "config",
+        "dsc",
+        "schema"
+      ]
+    }
+  },
+  "set": {
+    "executable": "oh-my-posh",
+    "implementsPretest": true,
+    "return": "stateAndDiff",
+    "args": [
+      "config",
+      "dsc",
+      "set",
+      {
+        "jsonInputArg": "--schema",
+        "mandatory": true
+      }
+    ]
+  },
+  "tags": [
+    "OhMyPosh",
+    "linux",
+    "macos",
+    "windows",
+    "shell",
+    "powershell",
+    "terminal",
+    "theming",
+    "configuration"
+  ],
+  "type": "OhMyPosh/Config",
+  "version": "0.1.0"
+}`
+	return dsc.CompressJSON(manifest)
+}

--- a/src/dsc/cli.go
+++ b/src/dsc/cli.go
@@ -18,6 +18,7 @@ type resource interface {
 	Resolve()
 	ToJSON() string
 	Schema() string
+	Manifest() string
 	Apply(schema string) error
 	Test(input string) error
 }
@@ -27,7 +28,7 @@ func Command(r resource) *cobra.Command {
 		Use:       "dsc",
 		Short:     "Manage Oh My Posh DSC (Desired State Configuration)",
 		Long:      "Manage Oh My Posh DSC (Desired State Configuration).",
-		ValidArgs: []string{"get", "set", "test", "schema", "export"},
+		ValidArgs: []string{"get", "set", "test", "schema", "export", "manifest"},
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) == 0 {
 				_ = cmd.Help()
@@ -55,6 +56,8 @@ func Command(r resource) *cobra.Command {
 				err = r.Apply(state)
 			case "schema":
 				fmt.Print(r.Schema())
+			case "manifest":
+				fmt.Print(r.Manifest())
 			case "test":
 				if state == "" {
 					err = newError("please provide a state configuration to test")

--- a/src/dsc/resource.go
+++ b/src/dsc/resource.go
@@ -12,12 +12,11 @@ import (
 	"github.com/jandedobbeleer/oh-my-posh/src/log"
 )
 
-// CompressJSON takes a JSON string and returns it in compressed format
 func CompressJSON(jsonStr string) string {
 	var buf bytes.Buffer
 	err := json.Compact(&buf, []byte(jsonStr))
 	if err != nil {
-		return jsonStr // return original if compression fails
+		return jsonStr
 	}
 	return buf.String()
 }

--- a/src/dsc/resource.go
+++ b/src/dsc/resource.go
@@ -12,6 +12,16 @@ import (
 	"github.com/jandedobbeleer/oh-my-posh/src/log"
 )
 
+// CompressJSON takes a JSON string and returns it in compressed format
+func CompressJSON(jsonStr string) string {
+	var buf bytes.Buffer
+	err := json.Compact(&buf, []byte(jsonStr))
+	if err != nil {
+		return jsonStr // return original if compression fails
+	}
+	return buf.String()
+}
+
 type Resource[T State[T]] struct {
 	Cache         cache.Cache `json:"-"`
 	JSONSchemaURL string      `json:"$schema,omitempty"`
@@ -141,7 +151,10 @@ func (resource *Resource[T]) ToJSON() string {
 	var result bytes.Buffer
 	jsonEncoder := json.NewEncoder(&result)
 	jsonEncoder.SetEscapeHTML(false)
-	jsonEncoder.SetIndent("", "  ")
 	_ = jsonEncoder.Encode(resource)
 	return result.String()
+}
+
+func (resource *Resource[T]) Manifest() string {
+	return "{}"
 }

--- a/src/shell/dsc.go
+++ b/src/shell/dsc.go
@@ -17,10 +17,78 @@ const (
 	initCommandRegex = `oh-my-posh(?:\.exe)?\s+init`
 )
 
-func DSC() *dsc.Resource[*Shell] {
-	return &dsc.Resource[*Shell]{
-		JSONSchemaURL: "https://ohmyposh.dev/dsc.shell.schema.json",
+func DSC() *Resource {
+	return &Resource{
+		Resource: dsc.Resource[*Shell]{
+			JSONSchemaURL: "https://ohmyposh.dev/dsc.shell.schema.json",
+		},
 	}
+}
+
+type Resource struct {
+	dsc.Resource[*Shell]
+}
+
+func (r *Resource) Manifest() string {
+	manifest := `{
+  "$schema": "https://aka.ms/dsc/schemas/v3/bundled/resource/manifest.json",
+  "description": "Allows configuring the Oh My Posh shell integration.",
+  "export": {
+    "executable": "oh-my-posh",
+    "input": "stdin",
+    "args": [
+      "shell",
+      "dsc",
+      "export"
+    ]
+  },
+  "get": {
+    "executable": "oh-my-posh",
+    "input": "stdin",
+    "args": [
+      "shell",
+      "dsc",
+      "get"
+    ]
+  },
+  "schema": {
+    "command": {
+      "executable": "oh-my-posh",
+      "args": [
+        "shell",
+        "dsc",
+        "schema"
+      ]
+    }
+  },
+  "set": {
+    "executable": "oh-my-posh",
+    "implementsPretest": true,
+    "return": "stateAndDiff",
+    "args": [
+      "shell",
+      "dsc",
+      "set",
+      {
+        "jsonInputArg": "--schema",
+        "mandatory": true
+      }
+    ]
+  },
+  "tags": [
+    "OhMyPosh",
+    "linux",
+    "macos",
+    "windows",
+    "shell",
+    "powershell",
+    "terminal",
+    "theming"
+  ],
+  "type": "OhMyPosh/Shell",
+  "version": "0.1.0"
+}`
+	return dsc.CompressJSON(manifest)
 }
 
 type Shell struct {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

Hey Jan! Thought of hitting this PR up after trying out the new DSC functionality you've created. The pull request contains a manifest command to generate the resource manifest. This allows users, for exampl,e to do:

```powershell
winget install JanDeDobbeleer.OhMyPosh

$resourceManifestPath = Join-Path (Split-Path (Get-Command -CommandType Application -Name oh-my-posh).Source -Parent) 'oh-my-posh.shell.dsc.resource.json'
oh-my-posh.exe shell dsc manifest | Set-Content -Path $resourceManifestPath -Encoding UTF8
```

It's then up to the user to add it to the `dsc.settings.json` file to be able to participate in DSC's operations. Lastly, when attempting to export through `dsc.exe`, it unfortunately failed. I slightly modified the output. Image with issue and resolution:

<img width="2282" height="717" alt="image" src="https://github.com/user-attachments/assets/fdaa1834-a9ab-4572-b531-e7643d5bf56f" />



[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
