### PR TITLE
feat: Add timeout property to http segment

### DIFF
--- a/src/segments/http.go
+++ b/src/segments/http.go
@@ -16,7 +16,8 @@ type HTTP struct {
 }
 
 const (
-	METHOD properties.Property = "method"
+	METHOD  properties.Property = "method"
+	TIMEOUT properties.Property = "timeout"
 )
 
 func (h *HTTP) Template() string {
@@ -31,11 +32,13 @@ func (h *HTTP) Enabled() bool {
 
 	method := h.props.GetString(METHOD, "GET")
 
+	timeout := h.props.GetInt(TIMEOUT, 10000)
+
 	if resolved, err := template.Render(url, nil); err == nil {
 		url = resolved
 	}
 
-	result, err := h.getResult(url, method)
+	result, err := h.getResult(url, method, timeout)
 	if err != nil {
 		return false
 	}
@@ -44,12 +47,12 @@ func (h *HTTP) Enabled() bool {
 	return true
 }
 
-func (h *HTTP) getResult(url, method string) (map[string]any, error) {
+func (h *HTTP) getResult(url, method string, timeout int) (map[string]any, error) {
 	setMethod := func(request *http.Request) {
 		request.Method = method
 	}
 
-	resultBody, err := h.env.HTTPRequest(url, nil, 10000, setMethod)
+	resultBody, err := h.env.HTTPRequest(url, nil, timeout, setMethod)
 	if err != nil {
 		return nil, err
 	}

--- a/src/segments/http_test.go
+++ b/src/segments/http_test.go
@@ -16,6 +16,7 @@ func TestHTTPSegmentEnabled(t *testing.T) {
 		name        string
 		url         string
 		method      string
+		timeout     int
 		response    string
 		shouldError bool
 	}{
@@ -47,14 +48,22 @@ func TestHTTPSegmentEnabled(t *testing.T) {
 			method:      "GET",
 			shouldError: false,
 		},
+		{
+			name:        "Timeout test",
+			url:         "https://apifastmock.com/mock/SsGLwD_ht5I2_9NebQH0N5NaOaRMwMkww4eU37UC9s8fHBzBIcYERO5MSzH6LUWGevCemFq5LWgP8bG7aalV_Q0VYUFEakiqZ8xyHwszmnmqzRkZ5UGm9cjvjITfUNCB8K15SzW021Dm3yipsANIMNTO4QGGYdvNRcgx89w",
+			method:      "GET",
+			shouldError: false,
+			timeout:     1,
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			env := new(mock.Environment)
 			props := properties.Map{
-				URL:    tc.url,
-				METHOD: tc.method,
+				URL:     tc.url,
+				METHOD:  tc.method,
+				TIMEOUT: tc.timeout,
 			}
 
 			env.On("HTTPRequest", tc.url).Return([]byte(tc.response), func() error {

--- a/website/docs/segments/web/http.mdx
+++ b/website/docs/segments/web/http.mdx
@@ -35,7 +35,7 @@ import Config from "@site/src/components/Config.js";
 | --------- | :------: | :-----: | --------------------------------------------------- |
 | `url`     | `string` |   ``    | The HTTP URL you want to call, supports [templates] |
 | `method`  | `string` |  `GET`  | The HTTP method to use                              |
-| `timeout` |  `int`   | `10000` | The HTTP timeout                              |
+| `timeout` |  `int`   | `10000` | The HTTP request timeout in milliseconds      |
 
 ## Template ([info][templates])
 

--- a/website/docs/segments/web/http.mdx
+++ b/website/docs/segments/web/http.mdx
@@ -24,16 +24,18 @@ import Config from "@site/src/components/Config.js";
     properties: {
       url: "https://jsonplaceholder.typicode.com/posts/1",
       method: "GET",
+      timeout: 10000,
     },
   }}
 />
 
 ## Properties
 
-| Name     |   Type   | Default | Description                                         |
-| -------- | :------: | :-----: | --------------------------------------------------- |
-| `url`    | `string` |   ``    | The HTTP URL you want to call, supports [templates] |
-| `method` | `string` |  `GET`  | The HTTP method to use                              |
+| Name      |   Type   | Default | Description                                         |
+| --------- | :------: | :-----: | --------------------------------------------------- |
+| `url`     | `string` |   ``    | The HTTP URL you want to call, supports [templates] |
+| `method`  | `string` |  `GET`  | The HTTP method to use                              |
+| `timeout` |  `int`   | `10000` | The HTTP timeout                              |
 
 ## Template ([info][templates])
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [ ] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

I've added a `timeout` property to the http segment, because for some use cases, 10s is way too long until the prompt appears.
I hope I have followed all rules and updated all relevant places.
I used a specific mock url which waits 10s. Maybe you have a better idea how to test it in the tests. 