### PR TITLE
fixed a space for bubblesline.omp.json theme for python virtual envir…

### DIFF
--- a/themes/bubblesline.omp.json
+++ b/themes/bubblesline.omp.json
@@ -36,7 +36,7 @@
             "fetch_version": false
           },
           "style": "diamond",
-          "template": "\ue235{{ if .Error }}{{ .Error }}{{ else }}{{ if .Venv }}{{ .Venv }} {{ end }}{{ .Full }}{{ end }}",
+          "template": "\ue235 {{ if .Error }}{{ .Error }}{{ else }}{{ if .Venv }}{{ .Venv }} {{ end }}{{ .Full }}{{ end }}",
           "trailing_diamond": "\ue0b4",
           "type": "python"
         },


### PR DESCRIPTION
There's an issue while using bubblesline theme. When creating python virtual environment the spacing is wrong, so i added extra space and it looks nice.
<img width="444" height="320" alt="image" src="https://github.com/user-attachments/assets/1daa080b-e73b-43df-820c-e500b71059fd" />