### PR TITLE
fix(theme): add space to git branch segment to avoid icon overlap in illusi0n.omp.json

### DIFF
--- a/themes/illusi0n.omp.json
+++ b/themes/illusi0n.omp.json
@@ -65,7 +65,7 @@
             "fetch_upstream_icon": true
           },
           "style": "plain",
-          "template": "<#ff8800>on</> {{.UpstreamIcon }}{{ .HEAD }}{{if .BranchStatus }} {{ .BranchStatus }}{{ end }}{{ if .Working.Changed }} \uf044 {{ .Working.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }} \uf046 {{ .Staging.String }}{{ end }}{{ if gt .StashCount 0 }} \ueb4b {{ .StashCount }}{{ end }} ",
+          "template": "<#ff8800>on</> {{.UpstreamIcon }} {{ .HEAD }}{{if .BranchStatus }} {{ .BranchStatus }}{{ end }}{{ if .Working.Changed }} \uf044 {{ .Working.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }} \uf046 {{ .Staging.String }}{{ end }}{{ if gt .StashCount 0 }} \ueb4b {{ .StashCount }}{{ end }} ",
           "type": "git"
         },
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide](https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md).
- [x] The commit message follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

This PR fixes a single-line issue in the illusi0n theme:

- What I changed: Inserted a single space in the git branch representation so the segment icons render properly.
- Why: Previously the segment caused two icons to overlap, making them unreadable.

Notes:
- No additional tests were added because themes are not covered by unit tests. If you want, I can add a small snapshot test or visual example.