### PR TITLE
Docs(Linux): Adding cleaning Cache tip to linux

### DIFF
--- a/website/docs/installation/linux.mdx
+++ b/website/docs/installation/linux.mdx
@@ -49,6 +49,11 @@ If you want to install to a different location you can specify it using the `-d`
 curl -s https://ohmyposh.dev/install.sh | bash -s -- -d ~/bin
 ```
 
+:::tip Cleanup
+To fully remove Oh My Posh, delete the `~/.cache/oh-my-posh` directory.  
+This clears cached binaries and themes that remain after uninstalling.
+:::
+
 </TabItem>
 <TabItem value="homebrew">
 


### PR DESCRIPTION
### Prerequisites
- [x] I have read and understood the [contributing guide](CONTRIBUTING.md).
- [x] The commit message follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) guidelines.
- [x] Docs have been added/updated.

### Description
This PR adds a short **Uninstall → Cleanup** section to the installation docs for **Linux** .

The update documents that simply uninstalling the binary is not always enough — users also need to remove the `~/.cache/oh-my-posh` directory to fully clear cached binaries and themes. This directly addresses [issue #6694 ](<link-to-issue>).

### Rationale
- Users reported that leftover cache files (`.cache/oh-my-posh`) caused issues when reinstalling or removing Oh My Posh.
- Placing the tip under the **installation section** (next to install/update instructions) is the most intuitive location, since users look there first when managing Oh My Posh.

### Screenshots
<img width="998" height="763" alt="image" src="https://github.com/user-attachments/assets/ef539f28-f4f6-4fbc-89f0-370ad94f09dc" />

Closer look:
<img width="998" height="157" alt="image" src="https://github.com/user-attachments/assets/12aae8f6-5293-47c5-92a9-85ce342b24f5" />
