### PR TITLE
Document the need to upgrade bash on macOS

### DIFF
--- a/website/docs/installation/macos.mdx
+++ b/website/docs/installation/macos.mdx
@@ -42,6 +42,18 @@ sudo port install oh-my-posh
 
 Oh My Posh will be installed at `/opt/local/bin/oh-my-posh`.
 
+## Troubleshooting
+
+:::tip
+If you see an error that says, "[conditional binary operator expected][outdated-bash]" you probably need to update to a newer version of bash.
+
+```bash
+brew install bash
+grep -qxF "$(brew --prefix)/bin/bash" /etc/shells || sudo bash -c 'echo "$(brew --prefix)/bin/bash" >> /etc/shells'
+chsh -s "$(brew --prefix)/bin/bash" $USER
+```
+:::
+
 ## Updating
 
 ```bash
@@ -62,3 +74,4 @@ More details on the [ports page] for Oh My Posh.
 [MacPorts]: https://www.macports.org
 [ports page]: https://ports.macports.org/port/oh-my-posh
 [community]: https://ports.macports.org/port/oh-my-posh/
+[outdated-bash]: https://github.com/JanDeDobbeleer/oh-my-posh/discussions/3429


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] ~~Tests for the changes have been added (for bug fixes / features).~~
- [x] Docs have been added/updated (for bug fixes / features).

### Description

This adds a tip to the macOS instructions about the need to upgrade bash to a recent version, and make it load by default. Knowing this up front would have saved me 2 hours of trial-and-error, searching, chatgpt-ing, etc.

It seems like every macOS user will need to do this, and I'd guess that's a large percentage of the userbase.