### PR TITLE
fix(msi): Add MSI signing description

### DIFF
--- a/packages/msi/build.ps1
+++ b/packages/msi/build.ps1
@@ -60,7 +60,7 @@ if ($Sign) {
     $signtoolDlib = $signtoolDlib -Replace '\\', '/'
 
     # sign installer
-    & $signtool sign /v /debug /fd SHA256 /tr 'http://timestamp.acs.microsoft.com' /td SHA256 /dlib "$signtoolDlib" /dmdf ../../src/metadata.json "$installer"
+    & $signtool sign /v /debug /d "Oh My Posh" /fd SHA256 /tr 'http://timestamp.acs.microsoft.com' /td SHA256 /dlib "$signtoolDlib" /dmdf ../../src/metadata.json "$installer"
 }
 
 Write-Host "Creating MSIX package"
@@ -84,7 +84,7 @@ $makeappx = "C:/Program Files (x86)/Windows Kits/10/bin/$SDKVersion/x64/makeappx
 
 if ($Sign) {
     Write-Host "Signing MSIX"
-    & "$signtool" sign /v /debug /fd SHA256 /tr 'http://timestamp.acs.microsoft.com' /td SHA256 /dlib "$signtoolDlib" /dmdf ../../src/metadata.json "$installerMSIX"
+    & "$signtool" sign /v /debug /d "Oh My Posh" /fd SHA256 /tr 'http://timestamp.acs.microsoft.com' /td SHA256 /dlib "$signtoolDlib" /dmdf ../../src/metadata.json "$installerMSIX"
 }
 
 Write-Host "Creating hash files"


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

Add a description to the MSI when signed.

This should then show the name of the project when the UAC elevation prompt is displayed to the user, rather than the random internal MSI file name.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
