### PR TITLE
feat(theme): material: show active Python venv

### DIFF
--- a/themes/material.omp.json
+++ b/themes/material.omp.json
@@ -19,6 +19,20 @@
           "template": " {{ .Path }} ",
           "type": "path"
         },
+ {
+          "type": "python",
+          "style": "plain",
+          "foreground": "#69FF94",
+          "properties": {
+            "display_mode": "environment",
+            "home_enabled": true,
+            "fetch_virtual_env": true,
+            "fetch_version": false,
+            "folder_name_fallback": false
+          },
+          "template": " ({{ .Venv }}) "
+        },
+
         {
           "foreground": "#D0666F",
           "properties": {


### PR DESCRIPTION
Adds a minimal python segment that renders only when a virtual environment is active (display_mode=environment) and disables folder-name fallback to avoid confusing folder-as-env rendering. The segment sits after the path and before git, matching material's minimal style.