### PR TITLE
fix(theme): add space between upstream icon and branch name in emodip…

### DIFF
--- a/themes/emodipt-extend.omp.json
+++ b/themes/emodipt-extend.omp.json
@@ -42,7 +42,7 @@
               "fetch_upstream_icon": true
             },
             "style": "plain",
-            "template": " {{ .UpstreamIcon }}{{ .HEAD }}{{if .BranchStatus }} {{ .BranchStatus }}{{ end }}{{ if .Working.Changed }} \uf044 {{ .Working.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }} \uf046 {{ .Staging.String }}{{ end }}{{ if gt .StashCount 0 }} \ueb4b {{ .StashCount }}{{ end }} ",
+            "template": " {{ .UpstreamIcon }} {{ .HEAD }}{{if .BranchStatus }} {{ .BranchStatus }}{{ end }}{{ if .Working.Changed }} \uf044 {{ .Working.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }} \uf046 {{ .Staging.String }}{{ end }}{{ if gt .StashCount 0 }} \ueb4b {{ .StashCount }}{{ end }} ",
             "type": "git"
           }
         ],


### PR DESCRIPTION
This PR fixes a minor display issue in the `emodipt-extend.omp.json` theme.  
The upstream icon in the git segment was concatenated directly with the branch name, causing the prompt to look cramped.  
A space was added to improve readability.  

**Before**  
<img width="480" height="39" alt="Screenshot from 2025-09-25 18-23-16" src="https://github.com/user-attachments/assets/fba42872-ccda-4b54-a306-72e82e0e262a" />

**After**  
<img width="480" height="39" alt="Screenshot from 2025-09-25 18-32-30" src="https://github.com/user-attachments/assets/e135e222-1d33-4636-88a1-b6665a10c5cb" />


### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

Cosmetic fix only — added spacing in the git segment to prevent overlap between the upstream icon and branch name.  
No functional changes, tests, or docs required.

---

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md  
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
