### PR TITLE
Bug fixes for Elvish support

### DIFF
--- a/src/cli/auth.go
+++ b/src/cli/auth.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"os"
+
 	"github.com/jandedobbeleer/oh-my-posh/src/cache"
 	"github.com/jandedobbeleer/oh-my-posh/src/cli/auth"
 	"github.com/jandedobbeleer/oh-my-posh/src/log"
@@ -28,13 +30,13 @@ Available services:
 		}
 
 		flags := &runtime.Flags{
-			Shell: shellName,
+			Shell: os.Getenv("POSH_SHELL"),
 		}
 
 		env := &runtime.Terminal{}
 		env.Init(flags)
 
-		cache.Init(shellName, cache.Persist)
+		cache.Init(env.Shell(), cache.Persist)
 
 		defer func() {
 			cache.Close()

--- a/src/cli/cache.go
+++ b/src/cli/cache.go
@@ -14,8 +14,8 @@ var (
 	session bool
 )
 
-// getCmd represents the get command
-var getCache = &cobra.Command{
+// cacheCmd represents the cache command
+var cacheCmd = &cobra.Command{
 	Use:   "cache [path|clear|ttl|show]",
 	Short: "Interact with the oh-my-posh cache",
 	Long: `Interact with the oh-my-posh cache.
@@ -24,7 +24,8 @@ You can do the following:
 
 - path: list cache path
 - clear: remove all cache values
-- ttl: get cache TTL in days`,
+- ttl: get cache TTL in days
+- show: print a detailed list of all cached values`,
 	ValidArgs: []string{
 		"path",
 		"clear",
@@ -80,6 +81,6 @@ You can do the following:
 }
 
 func init() {
-	getCache.Flags().BoolVarP(&session, "session", "s", false, "show the session cache")
-	RootCmd.AddCommand(getCache)
+	cacheCmd.Flags().BoolVarP(&session, "session", "s", false, "show the session cache")
+	RootCmd.AddCommand(cacheCmd)
 }

--- a/src/cli/init.go
+++ b/src/cli/init.go
@@ -62,7 +62,7 @@ See the documentation to initialize your shell: https://ohmyposh.dev/docs/instal
 	initCmd.Flags().BoolVarP(&printOutput, "print", "p", false, "print the init script")
 	initCmd.Flags().BoolVarP(&strict, "strict", "s", false, "run in strict mode")
 	initCmd.Flags().BoolVar(&debug, "debug", false, "enable/disable debug mode")
-	initCmd.Flags().BoolVar(&eval, "eval", false, "output the prompt for eval")
+	initCmd.Flags().BoolVar(&eval, "eval", false, "output the full init script for eval")
 
 	_ = initCmd.MarkPersistentFlagRequired("config")
 
@@ -167,7 +167,7 @@ func getFullCommand(cmd *cobra.Command, args []string) string {
 }
 
 func initCache(sh string) {
-	if !printOutput && eval && sh == shell.PWSH {
+	if !printOutput && (sh == shell.PWSH || sh == shell.ELVISH) {
 		cache.Init(sh)
 		return
 	}

--- a/src/cli/shell.go
+++ b/src/cli/shell.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/dsc"
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
@@ -28,7 +29,7 @@ This command retrieves the name of the current shell being used.`,
 		}
 
 		flags := &runtime.Flags{
-			Shell: shellName,
+			Shell: os.Getenv("POSH_SHELL"),
 		}
 
 		env := &runtime.Terminal{}

--- a/src/shell/init.go
+++ b/src/shell/init.go
@@ -58,6 +58,9 @@ func Init(env runtime.Environment, feats Features) string {
 		if env.Flags().Strict {
 			additionalParams += " --strict"
 		}
+		if env.Flags().Eval {
+			additionalParams += " --eval"
+		}
 
 		config := quotePwshOrElvishStr(env.Flags().ConfigPath)
 		executable = quotePwshOrElvishStr(executable)
@@ -66,7 +69,7 @@ func Init(env runtime.Environment, feats Features) string {
 
 		switch env.Flags().Shell {
 		case PWSH:
-			command = "(@(& %s init %s --config=%s --print --eval%s) -join \"`n\") | Invoke-Expression"
+			command = "(@(& %s init %s --config=%s --print%s) -join \"`n\") | Invoke-Expression"
 		case ELVISH:
 			command = "eval ((external %s) init %s --config=%s --print%s | slurp)"
 		}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

<details><summary>Bug fix 1</summary>

Currently, based on the following facts in the Elvish support:

- We HAVE TO call the CLI command `get width` to get the terminal width for printing prompts, while this always accesses cache files;
- The prompt functions `edit:prompt` and `edit:rprompt` are invoked asynchronously;

a race condition in cache access can be caused, and as a result, calls of the Windows API CreateFileW fail, resetting cache files. To fix the bug, we must handle both problems:

- Consider that for the CLI command `get`, when the argument is neither `toggles` nor `ttl`, there is no need to access cache files, therefore, it's just safe to initialize cache for other cases only.
- Unfortunately, Elvish does not natively provide a mutex that ensures synchronization, but we can simulate the mechanism.

</details>

<details><summary>Bug fix 2</summary>

Pass the `--eval` flag of the `init` command correctly for Elvish.

</details>

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary