### PR TITLE
Jujutsu closest bokmakrs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
           az storage blob upload-batch --destination v${{ needs.changelog.outputs.version }} --source .
           az storage blob upload-batch --destination latest --overwrite true --source .
       - name: Release 🎓
-        uses: softprops/action-gh-release@62c96d0c4e8a889135c1f3a25910db8dbe0e85f7
+        uses: softprops/action-gh-release@aec2ec56f94eb8180ceec724245f64ef008b89f5
         with:
           tag_name: ${{ needs.changelog.outputs.tag }}
           body: ${{ needs.changelog.outputs.body }}

--- a/src/segments/jujutsu.go
+++ b/src/segments/jujutsu.go
@@ -35,10 +35,23 @@ func (s *JujutsuStatus) add(code byte) {
 }
 
 type Jujutsu struct {
-	Working  *JujutsuStatus
-	ChangeID string
-	ClosestBookmarks string
+	Working          *JujutsuStatus
+	ChangeID         string
+	closestBookmarks string
 	Scm
+}
+
+func (jj *Jujutsu) ClosestBookmarks() string {
+	if jj.closestBookmarks == "" {
+		statusString, err := jj.getJujutsuCommandOutput("log", "-r", "heads(::@ & bookmarks())", "--no-graph", "-T", "bookmarks")
+		if err != nil {
+			return ""
+		}
+		lines := strings.Split(statusString, "\n")
+		jj.closestBookmarks = lines[0]
+	}
+
+	return jj.closestBookmarks
 }
 
 func (jj *Jujutsu) Template() string {
@@ -118,12 +131,6 @@ func (jj *Jujutsu) setJujutsuStatus() {
 		}
 	}
 
-	statusString, err = jj.getJujutsuCommandOutput("log", "-r", "heads(::@ & bookmarks())", "--no-graph", "-T", "bookmarks")
-	if err != nil {
-		return
-	}
-	lines = strings.Split(statusString, "\n")
-	jj.ClosestBookmarks = lines[0]
 }
 
 func (jj *Jujutsu) logTemplate() string {

--- a/src/segments/jujutsu.go
+++ b/src/segments/jujutsu.go
@@ -37,11 +37,12 @@ func (s *JujutsuStatus) add(code byte) {
 type Jujutsu struct {
 	Working  *JujutsuStatus
 	ChangeID string
+	ClosestBookmarks string
 	Scm
 }
 
 func (jj *Jujutsu) Template() string {
-	return " \uf1fa{{.ChangeID}}{{if .Working.Changed}} \uf044 {{ .Working.String }}{{ end }} "
+	return " \uf1fa{{.ChangeID}} \ue0a0{{.ClosestBookmarks}} {{if .Working.Changed}} \uf044 {{ .Working.String }}{{ end }} "
 }
 
 func (jj *Jujutsu) Enabled() bool {
@@ -116,6 +117,13 @@ func (jj *Jujutsu) setJujutsuStatus() {
 			jj.Working.add(line[0])
 		}
 	}
+
+	statusString, err = jj.getJujutsuCommandOutput("log", "-r", "heads(::@ & bookmarks())", "--no-graph", "-T", "bookmarks")
+	if err != nil {
+		return
+	}
+	lines = strings.Split(statusString, "\n")
+	jj.ClosestBookmarks = lines[0]
 }
 
 func (jj *Jujutsu) logTemplate() string {

--- a/website/docs/segments/scm/jujutsu.mdx
+++ b/website/docs/segments/scm/jujutsu.mdx
@@ -46,17 +46,18 @@ Set `status_formats` to `true` to enable fetching additional information (and po
 :::note default template
 
 ```template
-jj {{.ChangeID}}{{if .Working.Changed}} \uf044 {{ .Working.String }}{{ end }}
+ \uf1fa{{.ChangeID}} \ue0a0{{.ClosestBookmarks}} {{if .Working.Changed}} \uf044 {{ .Working.String }}{{ end }}
 ```
 
 :::
 
 ### Properties
 
-| Name        | Type     | Description                                                                                  |
-| ----------- | -------- | -------------------------------------------------------------------------------------------- |
-| `.Working`  | `Status` | changes in the working copy (see below)                                                      |
-| `.ChangeID` | `string` | The shortest unique prefix of the working copy change that's at least change_id_min_len long |
+| Name                | Type     | Description                                                                                  |
+| ------------------- | -------- | -------------------------------------------------------------------------------------------- |
+| `.Working`          | `Status` | changes in the working copy (see below)                                                      |
+| `.ChangeID`         | `string` | The shortest unique prefix of the working copy change that's at least change_id_min_len long |
+| `.ClosestBookmarks` | `string` | Closest bookmark(s) on ancestors                                                             |
 
 ### Status
 


### PR DESCRIPTION
### Prerequisites

- [X] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [X] The commit message follows the [conventional commits][cc] guidelines.
- [X] Tests for the changes have been added (for bug fixes / features).
- [X] Docs have been added/updated (for bug fixes / features).

### Description

This PR extends the `jujutsu` component with the ability to display the closest bookmark, that is usually the git branch the user currently working on.

Screesnhot:

<img width="383" height="60" alt="image" src="https://github.com/user-attachments/assets/e8e2f6a9-0d50-46ff-ab41-d7c6b255cd6b" />
