### PR TITLE
feat(config): add refresh interval for periodic prompt updates

### DIFF
--- a/src/cli/init.go
+++ b/src/cli/init.go
@@ -115,13 +115,18 @@ func runInit(sh, command string) {
 
 	feats := cfg.Features(env)
 
+	// Set refresh interval as environment variable
+	if cfg.RefreshInterval > 0 {
+		os.Setenv("POSH_REFRESH_INTERVAL", fmt.Sprintf("%d", cfg.RefreshInterval))
+	}
+
 	var output string
 
 	switch {
 	case printOutput, debug:
-		output = shell.PrintInit(env, feats, &startTime)
+		output = shell.PrintInit(env, feats, &startTime, cfg.RefreshInterval)
 	default:
-		output = shell.Init(env, feats)
+		output = shell.Init(env, feats, cfg.RefreshInterval)
 	}
 
 	shellDSC := shell.DSC()

--- a/src/cli/init.go
+++ b/src/cli/init.go
@@ -115,11 +115,6 @@ func runInit(sh, command string) {
 
 	feats := cfg.Features(env)
 
-	// Set refresh interval as environment variable
-	if cfg.RefreshInterval > 0 {
-		os.Setenv("POSH_REFRESH_INTERVAL", fmt.Sprintf("%d", cfg.RefreshInterval))
-	}
-
 	var output string
 
 	switch {

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -63,6 +63,7 @@ type Config struct {
 	Extends                 string                 `json:"extends,omitempty" toml:"extends,omitempty" yaml:"extends,omitempty"`
 	AccentColor             color.Ansi             `json:"accent_color,omitempty" toml:"accent_color,omitempty" yaml:"accent_color,omitempty"`
 	ConsoleTitleTemplate    string                 `json:"console_title_template,omitempty" toml:"console_title_template,omitempty" yaml:"console_title_template,omitempty"`
+	RefreshInterval         int                    `json:"refresh_interval,omitempty" toml:"refresh_interval,omitempty" yaml:"refresh_interval,omitempty"`
 	PWD                     string                 `json:"pwd,omitempty" toml:"pwd,omitempty" yaml:"pwd,omitempty"`
 	Source                  string                 `json:"-" toml:"-" yaml:"-"`
 	Format                  string                 `json:"-" toml:"-" yaml:"-"`
@@ -155,6 +156,14 @@ func (cfg *Config) Features(env runtime.Environment) shell.Features {
 	if len(cfg.Tooltips) > 0 {
 		log.Debug("tooltips enabled")
 		feats |= shell.Tooltips
+	}
+
+	if cfg.RefreshInterval > 0 {
+		supportedShells := []string{shell.PWSH, shell.ZSH, shell.BASH, shell.FISH}
+		if slices.Contains(supportedShells, env.Shell()) {
+			log.Debug("refresh interval enabled")
+			feats |= shell.RefreshInterval
+		}
 	}
 
 	if env.Shell() == shell.FISH && cfg.ITermFeatures != nil && cfg.ITermFeatures.Contains(terminal.PromptMark) {

--- a/src/shell/bash.go
+++ b/src/shell/bash.go
@@ -49,6 +49,8 @@ bleopt prompt_ps1_final='$(
         --shell-version="$BASH_VERSION" \
         --escape=false
 )'`
+	case RefreshInterval:
+		return "enable_posh_refresh_interval"
 	case PromptMark, PoshGit, Azure, LineError, Jobs, Tooltips, Async:
 		fallthrough
 	default:

--- a/src/shell/bash_test.go
+++ b/src/shell/bash_test.go
@@ -14,7 +14,8 @@ func TestBashFeatures(t *testing.T) {
 _omp_ftcs_marks=1
 "$_omp_executable" upgrade --auto
 "$_omp_executable" notice
-_omp_cursor_positioning=1`
+_omp_cursor_positioning=1
+enable_posh_refresh_interval`
 
 	assert.Equal(t, want, got)
 }
@@ -48,7 +49,8 @@ bleopt prompt_rps1='$(
 		--terminal-width="${COLUMNS-0}" \
 		--escape=false
 )'
-_omp_cursor_positioning=1`
+_omp_cursor_positioning=1
+enable_posh_refresh_interval`
 
 	assert.Equal(t, want, got)
 

--- a/src/shell/features.go
+++ b/src/shell/features.go
@@ -18,6 +18,7 @@ const (
 	RPrompt
 	CursorPositioning
 	Async
+	RefreshInterval
 )
 
 // getAllFeatures returns all defined feature flags by iterating through bit positions

--- a/src/shell/fish.go
+++ b/src/shell/fish.go
@@ -23,6 +23,8 @@ func (f Features) Fish() Code {
 		return unixUpgrade
 	case Notice:
 		return unixNotice
+	case RefreshInterval:
+		return "enable_posh_refresh_interval"
 	case RPrompt, PoshGit, Azure, LineError, Jobs, CursorPositioning, Async:
 		fallthrough
 	default:

--- a/src/shell/fish_test.go
+++ b/src/shell/fish_test.go
@@ -16,7 +16,8 @@ set --global _omp_transient_prompt 1
 set --global _omp_ftcs_marks 1
 "$_omp_executable" upgrade --auto
 "$_omp_executable" notice
-set --global _omp_prompt_mark 1`
+set --global _omp_prompt_mark 1
+enable_posh_refresh_interval`
 
 	assert.Equal(t, want, got)
 }

--- a/src/shell/init.go
+++ b/src/shell/init.go
@@ -43,11 +43,11 @@ func getExecutablePath(env runtime.Environment) (string, error) {
 	return executable, nil
 }
 
-func Init(env runtime.Environment, feats Features) string {
+func Init(env runtime.Environment, feats Features, refreshInterval int) string {
 	switch env.Flags().Shell {
 	case ELVISH, PWSH:
 		if env.Flags().Shell != ELVISH && !env.Flags().Eval {
-			return PrintInit(env, feats, nil)
+			return PrintInit(env, feats, nil, refreshInterval)
 		}
 
 		executable, err := getExecutablePath(env)
@@ -79,13 +79,13 @@ func Init(env runtime.Environment, feats Features) string {
 
 		return fmt.Sprintf(command, executable, env.Flags().Shell, config, additionalParams)
 	case ZSH, BASH, FISH, CMD, XONSH, NU:
-		return PrintInit(env, feats, nil)
+		return PrintInit(env, feats, nil, refreshInterval)
 	default:
 		return fmt.Sprintf(`echo "%s is not supported by Oh My Posh"`, env.Flags().Shell)
 	}
 }
 
-func PrintInit(env runtime.Environment, features Features, startTime *time.Time) string {
+func PrintInit(env runtime.Environment, features Features, startTime *time.Time, refreshInterval int) string {
 	async := features&Async != 0
 
 	if scriptPath, OK := hasScript(env); OK {
@@ -133,6 +133,7 @@ func PrintInit(env runtime.Environment, features Features, startTime *time.Time)
 	init := strings.NewReplacer(
 		"::OMP::", executable,
 		"::SESSION_ID::", cache.SessionID(),
+		"::REFRESH_INTERVAL::", fmt.Sprintf("%d", refreshInterval),
 	).Replace(script)
 
 	shellScript := features.Lines(env.Flags().Shell).String(init)

--- a/src/shell/pwsh.go
+++ b/src/shell/pwsh.go
@@ -29,6 +29,8 @@ func (f Features) Pwsh() Code {
 		return "& $global:_ompExecutable upgrade --auto"
 	case Notice:
 		return "& $global:_ompExecutable notice"
+	case RefreshInterval:
+		return "Enable-PoshRefreshInterval"
 	case PromptMark, RPrompt, CursorPositioning, Async:
 		fallthrough
 	default:

--- a/src/shell/pwsh_test.go
+++ b/src/shell/pwsh_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var allFeatures = Tooltips | LineError | Transient | Jobs | Azure | PoshGit | FTCSMarks | Upgrade | Notice | PromptMark | RPrompt | CursorPositioning
+var allFeatures = Tooltips | LineError | Transient | Jobs | Azure | PoshGit | FTCSMarks | Upgrade | Notice | PromptMark | RPrompt | CursorPositioning | RefreshInterval
 
 func TestPwshFeatures(t *testing.T) {
 	got := allFeatures.Lines(PWSH).String("")
@@ -21,7 +21,8 @@ Enable-PoshTooltips
 Enable-PoshTransientPrompt
 $global:_ompFTCSMarks = $true
 & $global:_ompExecutable upgrade --auto
-& $global:_ompExecutable notice`
+& $global:_ompExecutable notice
+Enable-PoshRefreshInterval`
 
 	assert.Equal(t, want, got)
 }

--- a/src/shell/scripts/omp.bash
+++ b/src/shell/scripts/omp.bash
@@ -167,8 +167,8 @@ function enable_posh_refresh_interval() {
         return
     fi
 
-    # Convert milliseconds to seconds for bash
-    local timeout_seconds=$(( interval / 1000 ))
+    # Convert milliseconds to seconds for bash (preserve sub-second precision)
+    local timeout_seconds=$(awk "BEGIN {print $interval/1000}")
     
     function _omp_refresh_prompt() {
         # Trigger prompt refresh by calling the hook

--- a/src/shell/scripts/omp.bash
+++ b/src/shell/scripts/omp.bash
@@ -186,7 +186,7 @@ function enable_posh_refresh_interval() {
     
     _omp_refresh_pid=$!
     # Ensure background process is killed when shell exits
-    trap 'kill $_omp_refresh_pid 2>/dev/null' EXIT
+    trap '[ -n "$_omp_refresh_pid" ] && kill $_omp_refresh_pid 2>/dev/null' EXIT
     # Set up SIGWINCH handler to refresh prompt
     trap '_omp_hook' WINCH
 }

--- a/src/shell/scripts/omp.bash
+++ b/src/shell/scripts/omp.bash
@@ -184,7 +184,7 @@ function enable_posh_refresh_interval() {
         done
     ) &
     
-    _omp_refresh_pid=$!
+    local _omp_refresh_pid=$!
     # Ensure background process is killed when shell exits
     trap '[ -n "$_omp_refresh_pid" ] && kill $_omp_refresh_pid 2>/dev/null' EXIT
     # Set up SIGWINCH handler to refresh prompt

--- a/src/shell/scripts/omp.bash
+++ b/src/shell/scripts/omp.bash
@@ -176,7 +176,7 @@ function enable_posh_refresh_interval() {
     }
 
     # Use a background process with sleep to trigger refresh
-    parent_pid=$$
+    local parent_pid=$$
     (
         while true; do
             sleep "$timeout_seconds"

--- a/src/shell/scripts/omp.bash
+++ b/src/shell/scripts/omp.bash
@@ -190,7 +190,7 @@ function enable_posh_refresh_interval() {
         done
     ) &
     
-    local _omp_refresh_pid=$!
+    _omp_refresh_pid=$!
     # Ensure background process is killed when shell exits
     trap '[ -n "$_omp_refresh_pid" ] && kill $_omp_refresh_pid 2>/dev/null' EXIT
     # Set up SIGWINCH handler to refresh prompt

--- a/src/shell/scripts/omp.bash
+++ b/src/shell/scripts/omp.bash
@@ -167,6 +167,12 @@ function enable_posh_refresh_interval() {
         return
     fi
 
+    # Kill existing timer if running
+    if [[ -n "$_omp_refresh_pid" ]]; then
+        kill "$_omp_refresh_pid" 2>/dev/null
+        _omp_refresh_pid=
+    fi
+
     # Convert milliseconds to seconds for bash (preserve sub-second precision)
     local timeout_seconds=$(awk "BEGIN {print $interval/1000}")
     

--- a/src/shell/scripts/omp.bash
+++ b/src/shell/scripts/omp.bash
@@ -185,7 +185,8 @@ function enable_posh_refresh_interval() {
     ) &
     
     _omp_refresh_pid=$!
-    
+    # Ensure background process is killed when shell exits
+    trap 'kill $_omp_refresh_pid 2>/dev/null' EXIT
     # Set up SIGWINCH handler to refresh prompt
     trap '_omp_hook' WINCH
 }

--- a/src/shell/scripts/omp.bash
+++ b/src/shell/scripts/omp.bash
@@ -176,10 +176,11 @@ function enable_posh_refresh_interval() {
     }
 
     # Use a background process with sleep to trigger refresh
+    parent_pid=$$
     (
         while true; do
             sleep "$timeout_seconds"
-            kill -WINCH $$  2>/dev/null
+            kill -WINCH $parent_pid  2>/dev/null
         done
     ) &
     

--- a/src/shell/scripts/omp.fish
+++ b/src/shell/scripts/omp.fish
@@ -249,7 +249,7 @@ function enable_posh_refresh_interval
     end
     
     # Start background timer process
-    fish -c "while true; sleep $timeout_seconds; kill -SIGUSR1 %self; end" &
+    fish -c "set parent_pid %self; while true; sleep $timeout_seconds; kill -SIGUSR1 \$parent_pid; end" &
     set --global _omp_refresh_pid $last_pid
 end
 

--- a/src/shell/scripts/omp.fish
+++ b/src/shell/scripts/omp.fish
@@ -242,7 +242,7 @@ function enable_posh_refresh_interval
     end
 
     # Convert milliseconds to seconds for fish
-    set --local timeout_seconds (math "$interval / 1000")
+    set --local timeout_seconds (math "$interval / 1000.0")
     
     function _omp_refresh_timer --on-signal SIGUSR1
         omp_repaint_prompt

--- a/src/shell/scripts/omp.fish
+++ b/src/shell/scripts/omp.fish
@@ -249,7 +249,7 @@ function enable_posh_refresh_interval
     end
     
     # Start background timer process
-    fish -c "set parent_pid %self; while true; sleep $timeout_seconds; kill -SIGUSR1 \$parent_pid; end" &
+    fish -c "set parent_pid $fish_pid; while true; sleep $timeout_seconds; kill -SIGUSR1 \$parent_pid; end" &
     set --global _omp_refresh_pid $last_pid
 end
 

--- a/src/shell/scripts/omp.fish
+++ b/src/shell/scripts/omp.fish
@@ -235,6 +235,24 @@ bind \cc _omp_ctrl_c_key_handler -M default
 bind \cc _omp_ctrl_c_key_handler -M insert
 bind \cc _omp_ctrl_c_key_handler -M visual
 
+function enable_posh_refresh_interval
+    set --local interval ::REFRESH_INTERVAL::
+    if test $interval -le 0
+        return
+    end
+
+    # Convert milliseconds to seconds for fish
+    set --local timeout_seconds (math "$interval / 1000")
+    
+    function _omp_refresh_timer --on-signal SIGUSR1
+        omp_repaint_prompt
+    end
+    
+    # Start background timer process
+    fish -c "while true; sleep $timeout_seconds; kill -SIGUSR1 %self; end" &
+    set --global _omp_refresh_pid $last_pid
+end
+
 # legacy functions
 function enable_poshtransientprompt
     return

--- a/src/shell/scripts/omp.fish
+++ b/src/shell/scripts/omp.fish
@@ -255,7 +255,9 @@ end
 
 # Clean up background timer process on shell exit
 function _omp_cleanup_refresh --on-event fish_exit
-    kill $_omp_refresh_pid 2>/dev/null
+    if set -q _omp_refresh_pid
+        kill $_omp_refresh_pid 2>/dev/null
+    end
 end
 # legacy functions
 function enable_poshtransientprompt

--- a/src/shell/scripts/omp.fish
+++ b/src/shell/scripts/omp.fish
@@ -253,6 +253,10 @@ function enable_posh_refresh_interval
     set --global _omp_refresh_pid $last_pid
 end
 
+# Clean up background timer process on shell exit
+function _omp_cleanup_refresh --on-event fish_exit
+    kill $_omp_refresh_pid 2>/dev/null
+end
 # legacy functions
 function enable_poshtransientprompt
     return

--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -416,6 +416,13 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
             return
         }
 
+        # Cleanup existing timer if present
+        if ($null -ne $script:PoshRefreshTimer) {
+            $script:PoshRefreshTimer.Stop()
+            $script:PoshRefreshTimer.Dispose()
+            Unregister-Event -SourceIdentifier "Posh.RefreshTimer.Elapsed" -ErrorAction SilentlyContinue
+        }
+
         $script:PoshRefreshTimer = New-Object -Type Timers.Timer
         $script:PoshRefreshTimer.Interval = $interval
 

--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -297,7 +297,9 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
 
     ### Exported Functions ###
 
-    function Set-PoshContext([bool]$originalStatus) {}
+    function Set-PoshContext([bool]$originalStatus) {
+        Start-PoshRefreshTimer
+    }
 
     function Enable-PoshTooltips {
         if ($script:ConstrainedLanguageMode) {
@@ -408,6 +410,32 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
         Set-PSReadLineOption -PromptText $validLine, $errorLine
     }
 
+    function Enable-PoshRefreshInterval {
+        $interval = ::REFRESH_INTERVAL::
+        if ($interval -le 0) {
+            return
+        }
+
+        $script:PoshRefreshTimer = New-Object -Type Timers.Timer
+        $script:PoshRefreshTimer.Interval = $interval
+
+        Register-ObjectEvent -InputObject $script:PoshRefreshTimer -EventName Elapsed -SourceIdentifier "Posh.RefreshTimer.Elapsed" -Action {
+            [Microsoft.PowerShell.PSConsoleReadLine]::InvokePrompt()
+        } | Out-Null
+    }
+
+    function Start-PoshRefreshTimer {
+        if ($null -eq $script:PoshRefreshTimer) {
+            return
+        }
+
+        if ($script:PoshRefreshTimer.Enabled) {
+            $script:PoshRefreshTimer.Stop()
+        }
+
+        $script:PoshRefreshTimer.Start()
+    }
+
     # perform cleanup on removal so a new initialization in current session works
     if (!$script:ConstrainedLanguageMode) {
         $ExecutionContext.SessionState.Module.OnRemove += {
@@ -417,6 +445,12 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
 
             (Get-PSReadLineOption).ContinuationPrompt = $script:OriginalContinuationPrompt
             (Get-PSReadLineOption).PromptText = $script:OriginalPromptText
+
+            if ($null -ne $script:PoshRefreshTimer) {
+                $script:PoshRefreshTimer.Stop()
+                $script:PoshRefreshTimer.Dispose()
+                Unregister-Event -SourceIdentifier "Posh.RefreshTimer.Elapsed" -ErrorAction SilentlyContinue
+            }
 
             if ((Get-PSReadLineKeyHandler Spacebar).Function -eq 'OhMyPoshSpaceKeyHandler') {
                 Remove-PSReadLineKeyHandler Spacebar
@@ -443,6 +477,7 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
         "Enable-PoshTooltips"
         "Enable-PoshTransientPrompt"
         "Enable-PoshLineError"
+        "Enable-PoshRefreshInterval"
         "Set-TransientPrompt"
         "prompt"
     )

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -241,8 +241,14 @@ function enable_posh_refresh_interval() {
     return
   fi
 
+  # TMOUT in zsh only supports integer seconds; sub-second values are unreliable.
+  if [[ $interval -lt 1000 ]]; then
+    print "Warning: zsh TMOUT does not support intervals less than 1000ms. Setting refresh interval to 1000ms."
+    interval=1000
+  fi
+
   # Convert milliseconds to seconds for zsh's TMOUT
-  local timeout_seconds=$(( interval / 1000.0 ))
+  local timeout_seconds=$(( interval / 1000 ))
   
   function _omp_refresh_prompt() {
     # Only refresh if we're at the command prompt (not during command execution)

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -252,7 +252,7 @@ function enable_posh_refresh_interval() {
   }
 
   # Use TMOUT to trigger prompt refresh
-  export TMOUT=$timeout_seconds
+  TMOUT=$timeout_seconds
   
   function TRAPALRM() {
     _omp_refresh_prompt

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -249,7 +249,7 @@ function enable_posh_refresh_interval() {
 
   # Convert milliseconds to seconds for zsh's TMOUT
   local timeout_seconds=$(( interval / 1000 ))
-  
+
   function _omp_refresh_prompt() {
     # Only refresh if we're at the command prompt (not during command execution)
     if [[ -z $BUFFER ]]; then
@@ -259,7 +259,7 @@ function enable_posh_refresh_interval() {
 
   # Use TMOUT to trigger prompt refresh
   TMOUT=$timeout_seconds
-  
+
   function TRAPALRM() {
     _omp_refresh_prompt
   }

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -235,5 +235,29 @@ function enable_poshtooltips() {
   _omp_create_widget $widget _omp_render_tooltip
 }
 
+function enable_posh_refresh_interval() {
+  local interval=::REFRESH_INTERVAL::
+  if [[ $interval -le 0 ]]; then
+    return
+  fi
+
+  # Convert milliseconds to seconds for zsh's TMOUT
+  local timeout_seconds=$(( interval / 1000.0 ))
+  
+  function _omp_refresh_prompt() {
+    # Only refresh if we're at the command prompt (not during command execution)
+    if [[ -z $BUFFER ]]; then
+      zle && zle .reset-prompt
+    fi
+  }
+
+  # Use TMOUT to trigger prompt refresh
+  export TMOUT=$timeout_seconds
+  
+  function TRAPALRM() {
+    _omp_refresh_prompt
+  }
+}
+
 # legacy functions
 function enable_poshtransientprompt() {}

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -243,7 +243,7 @@ function enable_posh_refresh_interval() {
 
   # TMOUT in zsh only supports integer seconds; sub-second values are unreliable.
   if [[ $interval -lt 1000 ]]; then
-    print "Warning: zsh TMOUT does not support intervals less than 1000ms. Setting refresh interval to 1000ms."
+    print "Warning: zsh TMOUT does not support intervals less than 1000ms. Setting refresh interval to 1000ms." >&2
     interval=1000
   fi
 

--- a/src/shell/zsh.go
+++ b/src/shell/zsh.go
@@ -21,6 +21,8 @@ func (f Features) Zsh() Code {
 		return unixUpgrade
 	case Notice:
 		return unixNotice
+	case RefreshInterval:
+		return "enable_posh_refresh_interval"
 	case PromptMark, RPrompt, PoshGit, Azure, LineError, Jobs, Async:
 		fallthrough
 	default:

--- a/src/shell/zsh_test.go
+++ b/src/shell/zsh_test.go
@@ -15,7 +15,8 @@ _omp_create_widget zle-line-init _omp_zle-line-init
 _omp_ftcs_marks=1
 "$_omp_executable" upgrade --auto
 "$_omp_executable" notice
-_omp_cursor_positioning=1`
+_omp_cursor_positioning=1
+enable_posh_refresh_interval`
 
 	assert.Equal(t, want, got)
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

## Issue
Fixes #5036

## Problem
Prompt only refreshes when executing commands. Users had to press Enter repeatedly to see updated git status, time, battery, and other dynamic segments.

## Solution
Added `refresh_interval` config option (in milliseconds) to automatically refresh the prompt on a timer. Implemented using native shell mechanisms for PowerShell, Zsh, Bash, and Fish.

## Changes Made
- Added `RefreshInterval` field to `Config` struct and feature detection logic
- Implemented timer-based refresh for PowerShell (using `System.Timers.Timer`)
- Implemented timer-based refresh for Zsh (using `TMOUT` and `TRAPALRM`)
- Implemented timer-based refresh for Bash (using background process with `SIGWINCH`)
- Implemented timer-based refresh for Fish (using background process with `SIGUSR1`)
- Added `TestRefreshIntervalFeature` and updated all shell feature tests

## Testing
- ✅ All existing tests pass - no breaking changes
- ✅ New unit test validates feature detection for all shells
- ✅ Shell feature tests updated to include RefreshInterval

## Usage Example
```json
{
  "refresh_interval": 5000,
  "blocks": [...]
}
```

Prompt now refreshes every 5 seconds, automatically updating git status, time, and all dynamic segments without pressing Enter.

**Supported shells**: PowerShell, Zsh, Bash, Fish  
**Implementation**: Non-blocking, uses native shell timers, opt-in only, proper resource cleanup

[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
