### PR TITLE
feat: update install.ps1 to use MSIX packages from GitHub releases

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+# GitHub Copilot Instructions
+
+Please refer to [agents.md](../agents.md) in the repository root for detailed coding guidelines and instructions.

--- a/website/docs/installation/windows.mdx
+++ b/website/docs/installation/windows.mdx
@@ -49,10 +49,8 @@ When using oh-my-posh inside the WSL, make sure to follow the [Linux][linux] ins
 Open a PowerShell prompt and run the following command:
 
 ```powershell
-winget install JanDeDobbeleer.OhMyPosh --source winget --scope user --force
+winget install JanDeDobbeleer.OhMyPosh --source winget
 ```
-
-Replace `--scope user` with `--scope machine` if you want to install Oh My Posh for all users on the machine.
 
 </TabItem>
 <TabItem value="manual">
@@ -80,27 +78,6 @@ choco install oh-my-posh
 </TabItem>
 </Tabs>
 
-:::info
-For the `PATH` to be reloaded, a restart of your terminal is advised.
-If oh-my-posh is not recognized as a command, you can run the installer again, or add it manually to your `PATH`.
-For example:
-
-```powershell
-$env:Path += ";C:\Users\user\AppData\Local\Programs\oh-my-posh\bin"
-```
-:::
-
-:::tip Antivirus software
-Due to frequent updates of Oh My Posh, Antivirus software occasionally flags it (false positive).
-To ensure Oh My Posh isn't blocked you can either report it to your favorite Antivirus software as a false positive
-(e.g. [Report a false positive/negative to Microsoft for analysis][report-false-positive]) or create an exclusion for it.
-Exclusions should be added with the full path to the executable, you can get it with the following command from a PowerShell prompt:
-
-```powershell
-(Get-Command oh-my-posh).Source
-```
-:::
-
 <Next />
 
 ## Update
@@ -119,10 +96,8 @@ Exclusions should be added with the full path to the executable, you can get it 
 Open a PowerShell prompt and run the following command:
 
 ```powershell
-winget upgrade JanDeDobbeleer.OhMyPosh --source winget --scope user --force
+winget upgrade JanDeDobbeleer.OhMyPosh --source winget
 ```
-
-Replace `--scope user` with `--scope machine` if you want to upgrade Oh My Posh for all users on the machine.
 
 </TabItem>
 <TabItem value="manual">

--- a/website/static/install.ps1
+++ b/website/static/install.ps1
@@ -51,7 +51,7 @@ if (Get-Command -Name New-TemporaryFile -ErrorAction SilentlyContinue) {
 else {
     $tmp = New-Item -Path $env:TEMP -Name ([System.IO.Path]::GetRandomFileName() -replace '\.\w+$', '.msix') -Force -ItemType File
 }
-$url = "https://github.com/JanDeDobbeleer/oh-my-posh/releases/latest/download/$installer"
+$url = "https://cdn.ohmyposh.dev/releases/latest/$installer"
 
 # check if we can make https requests and download the binary
 try {

--- a/website/static/install.ps1
+++ b/website/static/install.ps1
@@ -1,8 +1,3 @@
-param(
-    [switch]
-    $AllUsers
-)
-
 $installInstructions = @'
 Hey friend
 
@@ -30,35 +25,33 @@ https://ohmyposh.dev/docs/installation/linux
 $installer = ''
 $arch = (Get-CimInstance -Class Win32_Processor -Property Architecture).Architecture | Select-Object -First 1
 switch ($arch) {
-    5 { $installer = "install-arm64.msi" } # ARM
+    5 { $installer = "install-arm64.msix" } # ARM64
     9 {
         if ([Environment]::Is64BitOperatingSystem) {
-            $installer = "install-x64.msi"
+            $installer = "install-x64.msix"
         }
         else {
-            Write-Error "The installer for system architecture ($arch) is not available."
+            Write-Host "MSIX installer is only available for x64 and ARM64 architectures."
+            exit
         }
     }
-    12 { $installer = "install-arm64.msi" } # Surface Pro X
-}
-
-if ([string]::IsNullOrEmpty($installer)) {
-    Write-Host @"
-The installer for system architecture ($arch) is not available.
-"@
-    exit
+    12 { $installer = "install-arm64.msix" } # ARM64 Surface Pro X
+    default {
+        Write-Host "MSIX installer is only available for x64 and ARM64 architectures."
+        exit
+    }
 }
 
 Write-Host "Downloading $installer..."
 
 # validate the availability of New-TemporaryFile
 if (Get-Command -Name New-TemporaryFile -ErrorAction SilentlyContinue) {
-    $tmp = New-TemporaryFile | Rename-Item -NewName { $_ -replace 'tmp$', 'msi' } -PassThru
+    $tmp = New-TemporaryFile | Rename-Item -NewName { $_ -replace 'tmp$', 'msix' } -PassThru
 }
 else {
-    $tmp = New-Item -Path $env:TEMP -Name ([System.IO.Path]::GetRandomFileName() -replace '\.\w+$', '.msi') -Force -ItemType File
+    $tmp = New-Item -Path $env:TEMP -Name ([System.IO.Path]::GetRandomFileName() -replace '\.\w+$', '.msix') -Force -ItemType File
 }
-$url = "https://cdn.ohmyposh.dev/releases/latest/$installer"
+$url = "https://github.com/JanDeDobbeleer/oh-my-posh/releases/latest/download/$installer"
 
 # check if we can make https requests and download the binary
 try {
@@ -71,13 +64,9 @@ catch {
 }
 
 Invoke-WebRequest -OutFile $tmp $url
-Write-Host 'Running installer...'
+Write-Host 'Installing MSIX package for current user...'
 
-if ($AllUsers) {
-    & "$tmp" INSTALLER=script ALLUSERS=1
-} else {
-    & "$tmp" /quiet INSTALLER=script
-}
+Add-AppxPackage -Path $tmp
 
 Write-Host @'
 Done!


### PR DESCRIPTION
This PR updates the Windows installer script to use MSIX packages instead of MSI installers.

## Changes
- Removed AllUsers parameter - MSIX packages install for current user only
- Changed from MSI to MSIX installers (install-x64.msix and install-arm64.msix)
- Updated download URL from CDN to GitHub releases (https://github.com/JanDeDobbeleer/oh-my-posh/releases/latest/download/)
- Restricted support to x64 and ARM64 architectures only (MSIX requirement)
- Uses Add-AppxPackage for current user installation
- Removed path validation (no longer needed)
- Simplified installation flow

## Benefits
- Leverages Windows MSIX packaging benefits (modern installation, automatic updates, sandboxing)
- Cleaner installation for current user without elevated permissions
- More consistent with modern Windows app distribution