### PR TITLE
fix(dsc): persist cache for dsc config set

### DIFF
--- a/src/dsc/cli.go
+++ b/src/dsc/cli.go
@@ -38,7 +38,7 @@ func Command(r resource) *cobra.Command {
 			env := &runtime.Terminal{}
 			env.Init(&runtime.Flags{})
 
-			cache.Init(os.Getenv("POSH_SHELL"))
+			cache.Init(os.Getenv("POSH_SHELL"), cache.Persist)
 
 			defer func() {
 				cache.Close()


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

When running the following command:

```powershell
$themePath = Join-Path $env:POSH_THEMES_PATH "jandedobbeleer.omp.json"
$config = @{
    states = @(
        @{
            source = $themePath
            format = "json"
        }
    )
}
$state = $config | ConvertTo-Json -Compress
oh-my-posh config dsc set --state $state
```

And afterwards the `oh-my-posh config dsc get`, it returns empty (`{}`). The changes weren't persistent. Now added the `cache.persist` option flag telling the cache, save it.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
