### PR TITLE
Fix .Remotes returning empty map

### DIFF
--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -615,7 +615,7 @@ func (g *Git) getGitConfig() (*ini.File, error) {
 			return
 		}
 
-		cfg, err := ini.Load(configData)
+		cfg, err := ini.Load([]byte(configData))
 		if err != nil {
 			g.configErr = err
 			return


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description
Fix for [#6972](https://github.com/JanDeDobbeleer/oh-my-posh/issues/6972).

`getGitConfig` in `src/segments/git.go` passes git-config contents to `ini.Load()` as a string.
This leads to a bug because `ini.Load()` interprets strings as file-paths.

This PR fixes getGitConfig by passing the file contents as a byte slice.
