### PR TITLE
feat(project segment): add deno and jsr project detection.

### DIFF
--- a/src/segments/project.go
+++ b/src/segments/project.go
@@ -156,58 +156,15 @@ func (n *Project) hasProjectFile(p *ProjectItem) bool {
 }
 
 func (n *Project) getNodePackage(item ProjectItem) *ProjectData {
-	content := n.env.FileContent(item.Files[0])
-
-	var data ProjectData
-	err := json.Unmarshal([]byte(content), &data)
-	if err != nil {
-		n.Error = err.Error()
-		return nil
-	}
-
-	return &data
+	return n.getJSONPackage(item, false)
 }
 
 func (n *Project) getDenoPackage(item ProjectItem) *ProjectData {
-	file := n.firstExistingFile(item.Files)
-	if len(file) == 0 {
-		return nil
-	}
-
-	content := n.env.FileContent(file)
-	if filepath.Ext(file) == ".jsonc" {
-		content = jsonutil.StripComments(content)
-	}
-
-	var data ProjectData
-	err := json.Unmarshal([]byte(content), &data)
-	if err != nil {
-		n.Error = err.Error()
-		return nil
-	}
-
-	return &data
+	return n.getJSONPackage(item, true)
 }
 
 func (n *Project) getJsrPackage(item ProjectItem) *ProjectData {
-	file := n.firstExistingFile(item.Files)
-	if len(file) == 0 {
-		return nil
-	}
-
-	content := n.env.FileContent(file)
-	if filepath.Ext(file) == ".jsonc" {
-		content = jsonutil.StripComments(content)
-	}
-
-	var data ProjectData
-	err := json.Unmarshal([]byte(content), &data)
-	if err != nil {
-		n.Error = err.Error()
-		return nil
-	}
-
-	return &data
+	return n.getJSONPackage(item, true)
 }
 
 func (n *Project) getCargoPackage(item ProjectItem) *ProjectData {
@@ -371,6 +328,27 @@ func (n *Project) getProjectData(item ProjectItem) *ProjectData {
 
 	var data ProjectData
 	err := toml.Unmarshal([]byte(content), &data)
+	if err != nil {
+		n.Error = err.Error()
+		return nil
+	}
+
+	return &data
+}
+
+func (n *Project) getJSONPackage(item ProjectItem, allowJSONC bool) *ProjectData {
+	file := n.firstExistingFile(item.Files)
+	if len(file) == 0 {
+		return nil
+	}
+
+	content := n.env.FileContent(file)
+	if allowJSONC && filepath.Ext(file) == ".jsonc" {
+		content = jsonutil.StripComments(content)
+	}
+
+	var data ProjectData
+	err := json.Unmarshal([]byte(content), &data)
 	if err != nil {
 		n.Error = err.Error()
 		return nil

--- a/src/segments/project.go
+++ b/src/segments/project.go
@@ -74,6 +74,11 @@ func (n *Project) Enabled() bool {
 			Fetcher: n.getDenoPackage,
 		},
 		{
+			Name:    "jsr",
+			Files:   []string{"jsr.json", "jsr.jsonc"},
+			Fetcher: n.getJsrPackage,
+		},
+		{
 			Name:    "cargo",
 			Files:   []string{"Cargo.toml"},
 			Fetcher: n.getCargoPackage,
@@ -164,6 +169,27 @@ func (n *Project) getNodePackage(item ProjectItem) *ProjectData {
 }
 
 func (n *Project) getDenoPackage(item ProjectItem) *ProjectData {
+	file := n.firstExistingFile(item.Files)
+	if len(file) == 0 {
+		return nil
+	}
+
+	content := n.env.FileContent(file)
+	if filepath.Ext(file) == ".jsonc" {
+		content = jsonutil.StripComments(content)
+	}
+
+	var data ProjectData
+	err := json.Unmarshal([]byte(content), &data)
+	if err != nil {
+		n.Error = err.Error()
+		return nil
+	}
+
+	return &data
+}
+
+func (n *Project) getJsrPackage(item ProjectItem) *ProjectData {
 	file := n.firstExistingFile(item.Files)
 	if len(file) == 0 {
 		return nil

--- a/src/segments/project_test.go
+++ b/src/segments/project_test.go
@@ -60,6 +60,22 @@ func TestPackage(t *testing.T) {
 			PackageContents: "{\"version\":\"1.0.0\",\"name\":\"test\"}",
 		},
 		{
+			Case:            "1.0.0 deno",
+			ExpectedEnabled: true,
+			ExpectedString:  "\uf487 1.0.0 test",
+			Name:            "deno",
+			File:            "deno.json",
+			PackageContents: "{\"version\":\"1.0.0\",\"name\":\"test\"}",
+		},
+		{
+			Case:            "1.0.0 deno jsonc",
+			ExpectedEnabled: true,
+			ExpectedString:  "\uf487 1.0.0 test",
+			Name:            "deno",
+			File:            "deno.jsonc",
+			PackageContents: "{\n// comment\n\"version\":\"1.0.0\",\n\"name\":\"test\"\n}",
+		},
+		{
 			Case:            "1.0.0 php",
 			ExpectedEnabled: true,
 			ExpectedString:  "\uf487 1.0.0 test",
@@ -163,6 +179,14 @@ func TestPackage(t *testing.T) {
 			PackageContents: "{\"name\":\"test\"}",
 		},
 		{
+			Case:            "No version present deno",
+			ExpectedEnabled: true,
+			ExpectedString:  "test",
+			Name:            "deno",
+			File:            "deno.json",
+			PackageContents: "{\"name\":\"test\"}",
+		},
+		{
 			Case:            "No version present dart",
 			ExpectedEnabled: true,
 			ExpectedString:  "test",
@@ -208,6 +232,14 @@ func TestPackage(t *testing.T) {
 			ExpectedString:  "\uf487 1.0.0",
 			Name:            "node",
 			File:            "package.json",
+			PackageContents: "{\"version\":\"1.0.0\"}",
+		},
+		{
+			Case:            "No name present deno",
+			ExpectedEnabled: true,
+			ExpectedString:  "\uf487 1.0.0",
+			Name:            "deno",
+			File:            "deno.json",
 			PackageContents: "{\"version\":\"1.0.0\"}",
 		},
 		{
@@ -258,6 +290,13 @@ func TestPackage(t *testing.T) {
 			PackageContents: "{}",
 		},
 		{
+			Case:            "Empty project package deno",
+			ExpectedEnabled: true,
+			Name:            "deno",
+			File:            "deno.json",
+			PackageContents: "{}",
+		},
+		{
 			Case:            "Empty project package dart",
 			ExpectedEnabled: true,
 			Name:            "dart",
@@ -290,6 +329,13 @@ func TestPackage(t *testing.T) {
 			ExpectedString:  "invalid character '}' looking for beginning of value",
 			Name:            "node",
 			File:            "package.json",
+			PackageContents: "}",
+		},
+		{
+			Case:            "Invalid json deno",
+			ExpectedString:  "invalid character '}' looking for beginning of value",
+			Name:            "deno",
+			File:            "deno.json",
 			PackageContents: "}",
 		},
 		{

--- a/src/segments/project_test.go
+++ b/src/segments/project_test.go
@@ -78,18 +78,18 @@ func TestPackage(t *testing.T) {
 		{
 			Case:            "1.0.0 jsr",
 			ExpectedEnabled: true,
-			ExpectedString:  "\uf487 1.0.0 @pinta365/test",
+			ExpectedString:  "\uf487 1.0.0 @scope/library",
 			Name:            "jsr",
 			File:            "jsr.json",
-			PackageContents: "{\"version\":\"1.0.0\",\"name\":\"@pinta365/test\"}",
+			PackageContents: "{\"version\":\"1.0.0\",\"name\":\"@scope/library\"}",
 		},
 		{
 			Case:            "1.0.0 jsr jsonc",
 			ExpectedEnabled: true,
-			ExpectedString:  "\uf487 1.0.0 @pinta365/test",
+			ExpectedString:  "\uf487 1.0.0 @scope/library",
 			Name:            "jsr",
 			File:            "jsr.jsonc",
-			PackageContents: "{\n// comment\n\"version\":\"1.0.0\",\n\"name\":\"@pinta365/test\"\n}",
+			PackageContents: "{\n// comment\n\"version\":\"1.0.0\",\n\"name\":\"@scope/library\"\n}",
 		},
 		{
 			Case:            "1.0.0 php",
@@ -205,10 +205,10 @@ func TestPackage(t *testing.T) {
 		{
 			Case:            "No version present jsr",
 			ExpectedEnabled: true,
-			ExpectedString:  "@pinta365/test",
+			ExpectedString:  "@scope/library",
 			Name:            "jsr",
 			File:            "jsr.json",
-			PackageContents: "{\"name\":\"@pinta365/test\"}",
+			PackageContents: "{\"name\":\"@scope/library\"}",
 		},
 		{
 			Case:            "No version present dart",
@@ -448,6 +448,23 @@ func TestPackage(t *testing.T) {
 			assert.Equal(t, tc.ExpectedString, renderTemplate(env, pkg.Template(), pkg), tc.Case)
 		}
 	}
+}
+
+func TestDenoProjectUsesJsrMetadata(t *testing.T) {
+	env := new(mock.Environment)
+	env.On(hasFiles, "deno.json").Return(true)
+	env.On(hasFiles, "deno.jsonc").Return(false)
+	env.On(hasFiles, "jsr.json").Return(true)
+	env.On(hasFiles, "jsr.jsonc").Return(false)
+	env.On(hasFiles, testify_.Anything).Return(false)
+	env.On("FileContent", "deno.json").Return("{\"name\":\"library\"}")
+	env.On("FileContent", "jsr.json").Return("{\"version\":\"1.0.0\",\"name\":\"@scope/library\"}")
+
+	pkg := &Project{}
+	pkg.Init(properties.Map{}, env)
+
+	assert.True(t, pkg.Enabled())
+	assert.Equal(t, "\uf487 1.0.0 @scope/library", renderTemplate(env, pkg.Template(), pkg))
 }
 
 func TestNuspecPackage(t *testing.T) {

--- a/src/segments/project_test.go
+++ b/src/segments/project_test.go
@@ -76,6 +76,22 @@ func TestPackage(t *testing.T) {
 			PackageContents: "{\n// comment\n\"version\":\"1.0.0\",\n\"name\":\"test\"\n}",
 		},
 		{
+			Case:            "1.0.0 jsr",
+			ExpectedEnabled: true,
+			ExpectedString:  "\uf487 1.0.0 @pinta365/test",
+			Name:            "jsr",
+			File:            "jsr.json",
+			PackageContents: "{\"version\":\"1.0.0\",\"name\":\"@pinta365/test\"}",
+		},
+		{
+			Case:            "1.0.0 jsr jsonc",
+			ExpectedEnabled: true,
+			ExpectedString:  "\uf487 1.0.0 @pinta365/test",
+			Name:            "jsr",
+			File:            "jsr.jsonc",
+			PackageContents: "{\n// comment\n\"version\":\"1.0.0\",\n\"name\":\"@pinta365/test\"\n}",
+		},
+		{
 			Case:            "1.0.0 php",
 			ExpectedEnabled: true,
 			ExpectedString:  "\uf487 1.0.0 test",
@@ -187,6 +203,14 @@ func TestPackage(t *testing.T) {
 			PackageContents: "{\"name\":\"test\"}",
 		},
 		{
+			Case:            "No version present jsr",
+			ExpectedEnabled: true,
+			ExpectedString:  "@pinta365/test",
+			Name:            "jsr",
+			File:            "jsr.json",
+			PackageContents: "{\"name\":\"@pinta365/test\"}",
+		},
+		{
 			Case:            "No version present dart",
 			ExpectedEnabled: true,
 			ExpectedString:  "test",
@@ -240,6 +264,14 @@ func TestPackage(t *testing.T) {
 			ExpectedString:  "\uf487 1.0.0",
 			Name:            "deno",
 			File:            "deno.json",
+			PackageContents: "{\"version\":\"1.0.0\"}",
+		},
+		{
+			Case:            "No name present jsr",
+			ExpectedEnabled: true,
+			ExpectedString:  "\uf487 1.0.0",
+			Name:            "jsr",
+			File:            "jsr.json",
 			PackageContents: "{\"version\":\"1.0.0\"}",
 		},
 		{
@@ -297,6 +329,13 @@ func TestPackage(t *testing.T) {
 			PackageContents: "{}",
 		},
 		{
+			Case:            "Empty project package jsr",
+			ExpectedEnabled: true,
+			Name:            "jsr",
+			File:            "jsr.json",
+			PackageContents: "{}",
+		},
+		{
 			Case:            "Empty project package dart",
 			ExpectedEnabled: true,
 			Name:            "dart",
@@ -336,6 +375,13 @@ func TestPackage(t *testing.T) {
 			ExpectedString:  "invalid character '}' looking for beginning of value",
 			Name:            "deno",
 			File:            "deno.json",
+			PackageContents: "}",
+		},
+		{
+			Case:            "Invalid json jsr",
+			ExpectedString:  "invalid character '}' looking for beginning of value",
+			Name:            "jsr",
+			File:            "jsr.json",
 			PackageContents: "}",
 		},
 		{

--- a/website/docs/segments/system/project.mdx
+++ b/website/docs/segments/system/project.mdx
@@ -11,6 +11,8 @@ Display the current version of your project defined in the package file.
 Supports:
 
 - Node.js project (`package.json`)
+- Deno project (`deno.json`, `deno.jsonc`)
+- JSR project (`jsr.json`, `jsr.jsonc`)
 - Cargo project (`Cargo.toml`)
 - Python project (`pyproject.toml`, supports metadata defined according to [PEP 621][pep621-standard] or [Poetry][poetry-standard])
 - Mojo project (`mojoproject.toml`)
@@ -58,7 +60,7 @@ import Config from "@site/src/components/Config.js";
 
 | Name       | Type     | Description                                                                                                                                                                                      |
 | ---------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `.Type`    | `string` | The type of project:<ul><li>`node`</li><li>`cargo`</li><li>`python`</li><li>`mojo`</li><li>`php`</li><li>`dart`</li><li>`nuspec`</li><li>`dotnet`</li><li>`julia`</li><li>`powershell`</li></ul> |
+| `.Type`    | `string` | The type of project:<ul><li>`node`</li><li>`deno`</li><li>`jsr`</li><li>`cargo`</li><li>`python`</li><li>`mojo`</li><li>`php`</li><li>`dart`</li><li>`nuspec`</li><li>`dotnet`</li><li>`julia`</li><li>`powershell`</li></ul> |
 | `.Version` | `string` | The version of your project                                                                                                                                                                      |
 | `.Target`  | `string` | The target framework/language version of your project                                                                                                                                            |
 | `.Name`    | `string` | The name of your project                                                                                                                                                                         |


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

This Pull Request introduces **support for Deno and JSR package files** within the `project` segment and refactors the underlying JSON package retrieval logic to consolidate code and remove duplication.

### Changes

#### 1\. Feature: Add Deno and JSR Support

  * Adds support for detecting project information from **Deno** (`deno.json`/`deno.jsonc`) and **JSR** (`jsr.json`/`jsr.jsonc`) configuration files.

#### 2\. Refactor: Consolidate JSON Package Retrieval

  * Consolidates the JSON file parsing and unmarshalling logic for Node.js (`package.json`), Deno, and JSR into a single reusable method (`getJSONPackage`).

#### 3\. Documentation Update

  * Updates the `project.mdx` documentation to explicitly list Deno and JSR as supported project types.
  * The `.Type` template property documentation has also been updated to include `deno` and `jsr` as possible return values.

### UPDATE
#### 4\. Fix: Prefer JSR Metadata for Deno Projects

  * Updates Deno project detection to merge in metadata (like Name and Version) from a co-located `jsr.json`/`jsr.jsonc` file, as Deno projects commonly use JSR for publishing..
  
[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
