### PR TITLE
fix(bash): avoid init error on nounset BP_PIPESTATUS

### DIFF
--- a/src/shell/scripts/omp.bash
+++ b/src/shell/scripts/omp.bash
@@ -109,7 +109,7 @@ function _omp_get_secondary() {
 function _omp_hook() {
     _omp_status=$? _omp_pipestatus=("${PIPESTATUS[@]}")
 
-    if [[ ${#BP_PIPESTATUS[@]} -ge ${#_omp_pipestatus[@]} ]]; then
+    if [[ -v BP_PIPESTATUS && ${#BP_PIPESTATUS[@]} -ge ${#_omp_pipestatus[@]} ]]; then
         _omp_pipestatus=("${BP_PIPESTATUS[@]}")
     fi
 


### PR DESCRIPTION

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

With the shell in `nounset` mode and `BP_PIPESTATUS` unset, init would fail with:
```
bash: BP_PIPESTATUS: unbound variable
```

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
