### PR TITLE
fix(bash): append hook to PROMPT_COMMAND instead of prepending

### DIFF
--- a/src/shell/scripts/omp.bash
+++ b/src/shell/scripts/omp.bash
@@ -158,7 +158,7 @@ function _omp_install_hook() {
         prompt_command+=("$cmd")
     done
 
-    PROMPT_COMMAND=(_omp_hook "${prompt_command[@]}")
+    PROMPT_COMMAND=("${prompt_command[@]}" _omp_hook)
 }
 
 _omp_install_hook


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

I don't know if there's a particular reason to prepend `_omp_hook` to `PROMPT_COMMAND` as opposed to appending, but in case it doesn't matter: 

Provides for better coexistence with things that work on `PROMPT_COMMAND` as a scalar. They'll effectively access the array's first element only, and if we prepend an element, they won't be able to find their additions if they for example want to remove them.

https://gist.github.com/scop/210266a4351ecdb34ce7f2b6efb31750

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
