### PR TITLE
chore(deps): migrate from gopkg.in/yaml.v3 to go.yaml.in/yaml/v3

### DIFF
--- a/src/config/backup.go
+++ b/src/config/backup.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	toml "github.com/pelletier/go-toml/v2"
-	yaml "gopkg.in/yaml.v3"
+	yaml "go.yaml.in/yaml/v3"
 )
 
 func (cfg *Config) Backup() {

--- a/src/config/load.go
+++ b/src/config/load.go
@@ -21,7 +21,7 @@ import (
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime/path"
 
 	toml "github.com/pelletier/go-toml/v2"
-	yaml "gopkg.in/yaml.v3"
+	yaml "go.yaml.in/yaml/v3"
 )
 
 // custom no config error

--- a/src/go.mod
+++ b/src/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/shirou/gopsutil/v4 v4.25.11
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/mod v0.31.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/src/go.sum
+++ b/src/go.sum
@@ -180,6 +180,7 @@ github.com/zclconf/go-cty v1.17.0 h1:seZvECve6XX4tmnvRzWtJNHdscMtYEx5R7bnnVyd/d0
 github.com/zclconf/go-cty v1.17.0/go.mod h1:wqFzcImaLTI6A5HfsRwB0nj5n0MRZFwmey8YoFPPs3U=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6ZMSMNJFMOjqrGHynW3DIBuR2H9j0ug+Mo=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
+go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=
 golang.org/x/crypto v0.45.0/go.mod h1:XTGrrkGJve7CYK7J8PEww4aY7gM3qMCElcJQ8n8JdX4=

--- a/src/segments/argocd.go
+++ b/src/segments/argocd.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/jandedobbeleer/oh-my-posh/src/log"
 	"github.com/spf13/pflag"
-	"gopkg.in/yaml.v3"
+	yaml "go.yaml.in/yaml/v3"
 )
 
 const (

--- a/src/segments/kubectl.go
+++ b/src/segments/kubectl.go
@@ -4,7 +4,8 @@ import (
 	"path/filepath"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
-	"gopkg.in/yaml.v3"
+
+	yaml "go.yaml.in/yaml/v3"
 )
 
 // Whether to use kubectl or read kubeconfig ourselves

--- a/src/segments/project.go
+++ b/src/segments/project.go
@@ -14,7 +14,7 @@ import (
 	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
 
 	toml "github.com/pelletier/go-toml/v2"
-	yaml "gopkg.in/yaml.v3"
+	yaml "go.yaml.in/yaml/v3"
 )
 
 type ProjectItem struct {

--- a/src/segments/pulumi.go
+++ b/src/segments/pulumi.go
@@ -10,7 +10,8 @@ import (
 	"github.com/jandedobbeleer/oh-my-posh/src/log"
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime/path"
 	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
-	"gopkg.in/yaml.v3"
+
+	yaml "go.yaml.in/yaml/v3"
 )
 
 const (

--- a/src/segments/talosctl.go
+++ b/src/segments/talosctl.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/log"
-	"gopkg.in/yaml.v3"
+	yaml "go.yaml.in/yaml/v3"
 )
 
 type TalosCTL struct {


### PR DESCRIPTION

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

The latter is a maintained version of the former. Many packages including some dependencies (latest in Cobra 1.10.2) have already switched over.

While at it, upgrade to 3.0.4 as the 3.0.1's are identical including the package and thus the latter 3.0.1 cannot be used from its new path and thus some bump would be required anyway.

Refs
- https://github.com/yaml/go-yaml#project-status
- https://gist.github.com/scop/6ec72debf62a9603cff9dc97e6814ddd

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
