### PR TITLE
fix(zsh): use safe parameter presence check for _omp_start_time

### DIFF
--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -63,7 +63,7 @@ function _omp_precmd() {
   _omp_no_status=true
   _omp_tooltip_command=''
 
-  if [ $_omp_start_time ]; then
+  if [[ -v _omp_start_time ]]; then
     local omp_now=$($_omp_executable get millis)
     _omp_execution_time=$(($omp_now - $_omp_start_time))
     _omp_no_status=false


### PR DESCRIPTION
Use safe parameter presence test to avoid nounset fatal errors. See issue: https://github.com/JanDeDobbeleer/oh-my-posh/issues/7027