### PR TITLE
chore(deps): more gopkg.in/yaml.v3 to go.yaml.in/yaml/v3 migrating

### DIFF
--- a/src/config/segment.go
+++ b/src/config/segment.go
@@ -16,9 +16,9 @@ import (
 	"github.com/jandedobbeleer/oh-my-posh/src/template"
 
 	toml "github.com/pelletier/go-toml/v2"
+	"go.yaml.in/yaml/v3"
 	c "golang.org/x/text/cases"
 	"golang.org/x/text/language"
-	"gopkg.in/yaml.v3"
 )
 
 // SegmentStyle the style of segment, for more information, see the constants

--- a/src/config/segment_test.go
+++ b/src/config/segment_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/jandedobbeleer/oh-my-posh/src/segments"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 const (

--- a/src/go.mod
+++ b/src/go.mod
@@ -40,7 +40,6 @@ require (
 	github.com/spf13/pflag v1.0.10
 	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/mod v0.31.0
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -96,6 +95,7 @@ require (
 	golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/tools v0.39.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/atotto/clipboard v0.1.4 => github.com/jandedobbeleer/clipboard v0.1.4-1


### PR DESCRIPTION

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

<!---

Tips:

If you're not comfortable with working with Git,
we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.

-->

Another gopkg.in/yaml.v3 import snuck in since the main migration commit, in ae6d16638a6c2e6b9c7d69bb794c7da099fe6f9e.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
