### PR TITLE
fix(zsh): safe nounset guard for _omp_start_time

### DIFF
--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -9,7 +9,7 @@ export OSTYPE=$OSTYPE
 export VIRTUAL_ENV_DISABLE_PROMPT=1
 export PYENV_VIRTUALENV_DISABLE_PROMPT=1
 
-_omp_executable=::OMP::
+_omp_executable=/tmp/omp_exec_mock
 _omp_tooltip_command=''
 
 # switches to enable/disable features

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -63,7 +63,7 @@ function _omp_precmd() {
   _omp_no_status=true
   _omp_tooltip_command=''
 
-  if [ $_omp_start_time ]; then
+  if [[ -v _omp_start_time ]]; then
     local omp_now=$($_omp_executable get millis)
     _omp_execution_time=$(($omp_now - $_omp_start_time))
     _omp_no_status=false


### PR DESCRIPTION
Use safe parameter presence test to avoid nounset errors. Patch from seattled23.