### PR TITLE
feat(clojure): add segment

### DIFF
--- a/src/config/segment_types.go
+++ b/src/config/segment_types.go
@@ -42,6 +42,7 @@ func init() {
 	gob.Register(&segments.Copilot{})
 	gob.Register(&segments.Cf{})
 	gob.Register(&segments.CfTarget{})
+	gob.Register(&segments.Clojure{})
 	gob.Register(&segments.Cmake{})
 	gob.Register(&segments.Connection{})
 	gob.Register(&segments.Crystal{})
@@ -185,6 +186,8 @@ const (
 	CF SegmentType = "cf"
 	// Cloud Foundry logged in target
 	CFTARGET SegmentType = "cftarget"
+	// CLOJURE writes the active clojure version
+	CLOJURE SegmentType = "clojure"
 	// CMAKE writes the active cmake version
 	CMAKE SegmentType = "cmake"
 	// CONNECTION writes a connection's information
@@ -380,6 +383,7 @@ var Segments = map[SegmentType]func() SegmentWriter{
 	CDS:             func() SegmentWriter { return &segments.Cds{} },
 	CF:              func() SegmentWriter { return &segments.Cf{} },
 	CFTARGET:        func() SegmentWriter { return &segments.CfTarget{} },
+	CLOJURE:         func() SegmentWriter { return &segments.Clojure{} },
 	CMAKE:           func() SegmentWriter { return &segments.Cmake{} },
 	CONNECTION:      func() SegmentWriter { return &segments.Connection{} },
 	COPILOT:         func() SegmentWriter { return &segments.Copilot{} },

--- a/src/segments/clojure.go
+++ b/src/segments/clojure.go
@@ -1,0 +1,44 @@
+package segments
+
+type Clojure struct {
+	Language
+}
+
+func (c *Clojure) Template() string {
+	return languageTemplate
+}
+
+func (c *Clojure) Enabled() bool {
+	c.init()
+	return c.Language.Enabled()
+}
+
+func (c *Clojure) init() {
+	options := c.options.StringArray(Tooling, []string{})
+	if len(options) == 0 {
+		c.defaultTooling = []string{"clojure", "lein"}
+	}
+
+	c.extensions = []string{
+		"project.clj",
+		"deps.edn",
+		"build.boot",
+		"bb.edn",
+		"*.clj",
+		"*.cljc",
+		"*.cljs",
+	}
+
+	c.tooling = map[string]*cmd{
+		"clojure": {
+			executable: "clojure",
+			args:       []string{"--version"},
+			regex:      `Clojure CLI version (?P<version>(?P<major>[0-9]+)\.(?P<minor>[0-9]+)\.(?P<patch>[0-9]+)(?:\.(?P<build>[0-9]+))?)`,
+		},
+		"lein": {
+			executable: "lein",
+			args:       []string{"--version"},
+			regex:      `Leiningen (?P<version>(?P<major>[0-9]+)\.(?P<minor>[0-9]+)\.(?P<patch>[0-9]+))`,
+		},
+	}
+}

--- a/src/segments/clojure_test.go
+++ b/src/segments/clojure_test.go
@@ -1,0 +1,47 @@
+package segments
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClojure(t *testing.T) {
+	cases := []struct {
+		Case           string
+		ExpectedString string
+		Version        string
+		Cmd            string
+	}{
+		{
+			Case:           "Clojure CLI 1.11.1.1113",
+			ExpectedString: "1.11.1.1113",
+			Version:        "Clojure CLI version 1.11.1.1113",
+			Cmd:            "clojure",
+		},
+		{
+			Case:           "Leiningen 2.9.8",
+			ExpectedString: "2.9.8",
+			Version:        "Leiningen 2.9.8 on Java 11.0.11 OpenJDK 64-Bit Server VM",
+			Cmd:            "lein",
+		},
+	}
+	for _, tc := range cases {
+		params := &mockedLanguageParams{
+			cmd:           tc.Cmd,
+			versionParam:  "--version",
+			versionOutput: tc.Version,
+			extension:     "*.clj",
+		}
+		env, props := getMockedLanguageEnv(params)
+		props[LanguageExtensions] = []string{params.extension}
+		if tc.Cmd != "clojure" {
+			env.On("HasCommand", "clojure").Return(false)
+		}
+		c := &Clojure{}
+		c.Init(props, env)
+		assert.True(t, c.Enabled(), fmt.Sprintf("Failed in case: %s", tc.Case))
+		assert.Equal(t, tc.ExpectedString, renderTemplate(env, c.Template(), c), fmt.Sprintf("Failed in case: %s", tc.Case))
+	}
+}

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -359,6 +359,7 @@
             "cds",
             "cf",
             "cftarget",
+            "clojure",
             "cmake",
             "copilot",
             "connection",
@@ -1116,6 +1117,41 @@
                   }
                 },
                 "additionalProperties": false
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "clojure"
+              }
+            }
+          },
+          "then": {
+            "title": "Clojure Segment",
+            "description": "https://ohmyposh.dev/docs/segments/languages/clojure",
+            "properties": {
+              "options": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/language_options"
+                  }
+                ],
+                "properties": {
+                  "extensions": {
+                    "default": [
+                      "project.clj",
+                      "deps.edn",
+                      "build.boot",
+                      "bb.edn",
+                      "*.clj",
+                      "*.cljc",
+                      "*.cljs"
+                    ]
+                  }
+                }
               }
             }
           }

--- a/website/docs/segments/languages/clojure.mdx
+++ b/website/docs/segments/languages/clojure.mdx
@@ -1,0 +1,62 @@
+---
+id: clojure
+title: Clojure
+sidebar_label: Clojure
+---
+
+## What
+
+Display the currently active [Clojure](https://clojure.org/) version.
+
+## Sample Configuration
+
+import Config from "@site/src/components/Config.js";
+
+<Config
+  data={{
+    type: "clojure",
+    style: "powerline",
+    powerline_symbol: "\uE0B0",
+    foreground: "#ffffff",
+    background: "#9068B0",
+    template: " \uE768 {{ .Full }}",
+  }}
+/>
+
+## Options
+
+| Name                   |    Type    |                                                        Default                                                        | Description                                                                                                                                                                                                                          |
+| ---------------------- | :--------: | :-------------------------------------------------------------------------------------------------------------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `home_enabled`         | `boolean`  |                                                        `false`                                                        | display the segment in the HOME folder or not                                                                                                                                                                                        |
+| `fetch_version`        | `boolean`  |                                                        `true`                                                         | fetch the clojure version                                                                                                                                                                                                            |
+| `cache_duration`       |  `string`  |                                                        `none`                                                         | the duration for which the version will be cached. The duration is a string in the format `1h2m3s` and is parsed using the [time.ParseDuration] function from the Go standard library. To disable the cache, use `none`              |
+| `missing_command_text` |  `string`  |                                                                                                                       | text to display when the command is missing                                                                                                                                                                                          |
+| `display_mode`         |  `string`  |                                                       `context`                                                       | <ul><li>`always`: the segment is always displayed</li><li>`files`: the segment is only displayed when file `extensions` listed are present</li><li>`context`: displays the segment when the environment or files is active</li></ul> |
+| `version_url_template` |  `string`  |                                                                                                                       | a go [text/template][go-text-template] [template][templates] that creates the URL of the version info / release notes                                                                                                                |
+| `extensions`           | `[]string` | `project.clj, deps.edn, build.boot, bb.edn, *.clj, *.cljc, *.cljs`                                                    | allows to override the default list of file extensions to validate                                                                                                                                                                   |
+| `folders`              | `[]string` |                                                                                                                       | allows to override the list of folder names to validate                                                                                                                                                                              |
+| `tooling`              | `[]string` |                                                  `clojure`, `lein`                                                    | the tooling to use for fetching the version                                                                                                                                                                                          |
+
+## Template ([info][templates])
+
+:::note default template
+
+```template
+{{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }}
+```
+
+:::
+
+### Properties
+
+| Name     | Type     | Description                                        |
+| -------- | -------- | -------------------------------------------------- |
+| `.Full`  | `string` | the full version                                   |
+| `.Major` | `string` | major number                                       |
+| `.Minor` | `string` | minor number                                       |
+| `.Patch` | `string` | patch number                                       |
+| `.Error` | `string` | error encountered when fetching the version string |
+
+[go-text-template]: https://golang.org/pkg/text/template/
+[templates]: configuration/templates.mdx
+[time.ParseDuration]: https://golang.org/pkg/time/#ParseDuration

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -126,6 +126,7 @@ module.exports = {
           label: "✍️ Languages",
           collapsed: true,
           items: [
+            "segments/languages/clojure",
             "segments/languages/crystal",
             "segments/languages/dart",
             "segments/languages/dotnet",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

This PR adds a new segment for **Clojure**.

It enables displaying the currently active Clojure version in the prompt when working with Clojure projects.

**Features:**
- Detects Clojure projects via: `project.clj`, `deps.edn`, `build.boot`, `bb.edn`, `*.clj`, `*.cljc`, `*.cljs`.
- Supports version fetching using `clojure` (default) or `lein` (Leiningen).
- Custom icon support (default: `\uE768`).

**Changes:**
- Added `src/segments/clojure.go` implementation.
- Added `src/segments/clojure_test.go` with unit tests covering both `clojure` and `lein` scenarios.
- Registered segment in `src/config/segment_types.go`.
- Added documentation in `website/docs/segments/languages/clojure.mdx`.
- Updated `website/sidebars.js` and `themes/schema.json`.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
