### PR TITLE
fix(python): better uv command

### DIFF
--- a/src/segments/python.go
+++ b/src/segments/python.go
@@ -56,7 +56,7 @@ func (p *Python) Enabled() bool {
 		},
 		"uv": {
 			executable: "uv",
-			args:       []string{"run", "python", "--version"},
+			args:       []string{"run", "--no-sync", "--quiet", "--no-python-downloads", "python", "--version"},
 			regex:      `(?:Python (?P<version>((?P<major>[0-9]+).(?P<minor>[0-9]+).(?P<patch>[0-9]+))))`,
 		},
 	}

--- a/src/segments/python_test.go
+++ b/src/segments/python_test.go
@@ -303,7 +303,7 @@ func TestPythonUVTooling(t *testing.T) {
 
 		if tc.HasUVCommand {
 			env.On("HasCommand", "uv").Return(true)
-			env.On("RunCommand", "uv", []string{"run", "python", "--version"}).Return(tc.UVVersionOutput, nil)
+			env.On("RunCommand", "uv", []string{"run", "--no-sync", "--quiet", "--no-python-downloads", "python", "--version"}).Return(tc.UVVersionOutput, nil)
 		} else {
 			env.On("HasCommand", "uv").Return(false)
 		}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

As I mentioned in the last comment of the Issue #6668 that probably get lost I think it is important to add these flags to ensure a better user experience. I'll put here the reason for each flag again just for visibility:

The main goal is to **invoke a command without any side effects**. By default, `uv run` performs several actions such as syncing the environment (`.venv`), updating dependencies (`uv.lock`), and downloading Python versions if needed.

The `--no-sync` flag prevents `uv` from synchronizing the environment (so it will not create or modify the `.venv` folder) and also implies the `--frozen` flag to avoid updating dependencies (so it will not read, create, or modify the `uv.lock` file).

The `--no-python-downloads` flag prevents `uv` from downloading any Python version. Normally, `uv run` checks files like `uv.toml` or `.python-version` to determine the required Python version, and if it is not available locally, it downloads it. This flag disables that behavior, but it will show the error `error: No interpreter found for Python 3.13.3 in virtual environments, managed installations, search path, or registry` if the required version is missing. This is acceptable since the goal is simply to run a command without side effects.

The `--quiet` flag suppresses unnecessary warnings from `uv`.
For example, when running the command outside a Python project, `uv` prints `warning: --no-sync has no effect when used outside of a project`. While the warning is reasonable, it is preferable to avoid running different commands depending on context, so suppressing these warnings is cleaner.

### Note

1. Only one test change to accept the new array of arguments.
2. No docs added or updated because this is only an implementation detail.

Sorry if I push on this but I think it really adds value to the tool.