### PR TITLE
docs: add terraform icon to sample configuration

### DIFF
--- a/website/docs/segments/cli/terraform.mdx
+++ b/website/docs/segments/cli/terraform.mdx
@@ -19,7 +19,7 @@ import Config from "@site/src/components/Config.js";
     powerline_symbol: "\uE0B0",
     foreground: "#000000",
     background: "#ebcc34",
-    template: "{{.WorkspaceName}}",
+    template: " \ue69a {{.WorkspaceName}}",
   }}
 />
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Documentation:
- Add a [Terraform icon glyph](https://brand.hashicorp.com/product_logos) to the documented sample configuration template for the CLI segment.

| Before | After |
|--------|--------|
| <img width="372" height="56" alt="before" src="https://github.com/user-attachments/assets/0819d6f6-7383-409e-b943-503b90a41f12" /> | <img width="427" height="67" alt="after" src="https://github.com/user-attachments/assets/3a3fb6ff-cc98-4aa5-9112-7e7ac5622485" /> |

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
