### PR TITLE
fix: add missing triple colon to ArgoCD

### DIFF
--- a/website/docs/segments/cli/argocd.mdx
+++ b/website/docs/segments/cli/argocd.mdx
@@ -31,6 +31,8 @@ import Config from "@site/src/components/Config.js";
 {{ .Name }}
 ```
 
+:::
+
 ### Properties
 
 | Name      | Type     | Description                       |


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Documentation:
- Restore a missing closing triple-colon in the [ArgoCD CLI documentation](https://ohmypo.sh/docs/segments/cli/argocd#template-infotemplates) to render the content block correctly.

| Before | After |
|--------|--------|
| <img width="954" height="975" alt="before" src="https://github.com/user-attachments/assets/73d7f1c5-39b1-4c67-8040-8bad2d8775c3" /> | <img width="905" height="1031" alt="after" src="https://github.com/user-attachments/assets/0907d033-307a-4b76-8377-fc94d0b960a7" /> |

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
