### PR TITLE
fix(docs): add missing default folders to lua

### DIFF
--- a/website/docs/segments/languages/lua.mdx
+++ b/website/docs/segments/languages/lua.mdx
@@ -35,7 +35,7 @@ import Config from "@site/src/components/Config.js";
 | `version_url_template` |  `string`  |                     | a go [text/template][go-text-template] [template][templates] that creates the URL of the version info / release notes                                                                                                                |
 | `tooling`              | `[]string` |   `lua, luajit`     | the tooling to use for fetching the version                                                                                                                                                                                          |
 | `extensions`           | `[]string` | `*.lua, *.rockspec` | allows to override the default list of file extensions to validate                                                                                                                                                                   |
-| `folders`              | `[]string` |                     | allows to override the list of folder names to validate                                                                                                                                                                              |
+| `folders`              | `[]string` |        `lua`        | allows to override the list of folder names to validate                                                                                                                                                                              |
 
 ## Template ([info][templates])
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Documentation:
- Specify `lua` as the default folder name for Lua language validation configuration.

https://github.com/JanDeDobbeleer/oh-my-posh/blob/d06c02593b5a172d523a043f8b8484d5903ff61d/src/segments/lua.go#L11-L31

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
