### PR TITLE
fix(docs): add missing default folders to bazel

### DIFF
--- a/website/docs/segments/cli/bazel.mdx
+++ b/website/docs/segments/cli/bazel.mdx
@@ -34,7 +34,7 @@ import Config from "@site/src/components/Config.js";
 | `version_url_template` |  `string`  |                                                             | a go [text/template][go-text-template] [template][templates] that creates the URL of the version info documentation                                                                                                                  |
 | `icon`                 |  `string`  |                          `\ue63a`                           | the icon for the segment                                                                                                                                                                                                             |
 | `extensions`           | `[]string` | `*.bazel, *.bzl, BUILD, WORKSPACE, .bazelrc, .bazelversion` | allows to override the default list of file extensions to validate                                                                                                                                                                   |
-| `folders`              | `[]string` |                                                             |                                                                                                                                                                                                                                      |
+| `folders`              | `[]string` |          `bazel-bin`, `bazel-out`, `bazel-testlogs`         | allows to override the list of folder names to validate                                                                                                                                                                              |
 
 ## Template ([info][templates])
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Documentation:
- Add the default Bazel folders (bazel-bin, bazel-out, bazel-testlogs) to the CLI segment configuration documentation.

https://github.com/JanDeDobbeleer/oh-my-posh/blob/d06c02593b5a172d523a043f8b8484d5903ff61d/src/segments/bazel.go#L19-L35

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
