### PR TITLE
[WIP] feat(peard): add segment

### DIFF
--- a/src/config/segment_types.go
+++ b/src/config/segment_types.go
@@ -96,6 +96,7 @@ func init() {
 	gob.Register(&segments.Owm{})
 	gob.Register(&segments.Path{})
 	gob.Register(&segments.Folders{})
+	gob.Register(&segments.PearDesktop{})
 	gob.Register(&segments.Perl{})
 	gob.Register(&segments.Php{})
 	gob.Register(&segments.Plastic{})
@@ -281,6 +282,8 @@ const (
 	OWM SegmentType = "owm"
 	// PATH represents the current path segment
 	PATH SegmentType = "path"
+	// PEARD writes the currently playing song in Pear Desktop
+	PEARD SegmentType = "peard"
 	// PERL writes which perl version is currently active
 	PERL SegmentType = "perl"
 	// PHP writes which php version is currently active
@@ -433,6 +436,7 @@ var Segments = map[SegmentType]func() SegmentWriter{
 	OS:              func() SegmentWriter { return &segments.Os{} },
 	OWM:             func() SegmentWriter { return &segments.Owm{} },
 	PATH:            func() SegmentWriter { return &segments.Path{} },
+	PEARD:           func() SegmentWriter { return &segments.PearDesktop{} },
 	PERL:            func() SegmentWriter { return &segments.Perl{} },
 	PHP:             func() SegmentWriter { return &segments.Php{} },
 	PLASTIC:         func() SegmentWriter { return &segments.Plastic{} },

--- a/src/segments/peard.go
+++ b/src/segments/peard.go
@@ -1,0 +1,91 @@
+package segments
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/log"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+)
+
+type PearDesktop struct {
+	Base
+
+	Status         string
+	Artist         string
+	Track          string
+	TrackUrl       string
+	ArtistUrl      string
+	MediaType      string
+	IsPaused       bool
+	SongDuration   int
+	ElapsedSeconds int
+	Icon           string
+}
+
+const (
+	// Port is the port to connect to Pear Desktop API
+	Port options.Option = "port"
+)
+
+func (p *PearDesktop) Template() string {
+	return " {{ .Icon }}{{ if ne .Status \"paused\" }}{{ .Artist }} - {{ .Track }}{{ end }} "
+}
+
+func (p *PearDesktop) Enabled() bool {
+	err := p.setStatus()
+	if err != nil {
+		log.Error(err)
+		return false
+	}
+
+	return true
+}
+
+type pearDesktopResponse struct {
+	Title          string `json:"title"`
+	Artist         string `json:"artist"`
+	ArtistUrl      string `json:"artistUrl"`
+	IsPaused       bool   `json:"isPaused"`
+	SongDuration   int    `json:"songDuration"`
+	ElapsedSeconds int    `json:"elapsedSeconds"`
+	Url            string `json:"url"`
+	// MediaType can be AUDIO, ORIGINAL_MUSIC_VIDEO, USER_GENERATED_CONTENT, PODCAST_EPISODE, or OTHER_VIDEO
+	MediaType string `json:"mediaType"`
+	// ignore everything else, they don't provide good info in a cli env
+}
+
+func (p *PearDesktop) setStatus() error {
+	port := p.options.Int(Port, 26538)
+	url := fmt.Sprintf("http://127.0.0.1:%d/api/v1/song-info", port)
+
+	httpTimeout := p.options.Int(options.HTTPTimeout, 5000)
+	response, err := p.env.HTTPRequest(url, nil, httpTimeout)
+	if err != nil {
+		return err
+	}
+
+	var result pearDesktopResponse
+	if err := json.Unmarshal(response, &result); err != nil {
+		return err
+	}
+
+	p.Track = result.Title
+	p.Artist = result.Artist
+	p.TrackUrl = result.Url
+	p.ArtistUrl = result.ArtistUrl
+	p.MediaType = result.MediaType
+	p.IsPaused = result.IsPaused
+	p.SongDuration = result.SongDuration
+	p.ElapsedSeconds = result.ElapsedSeconds
+
+	if result.IsPaused {
+		p.Status = paused
+		p.Icon = p.options.String(PausedIcon, "\uf04c ")
+		return nil
+	}
+
+	p.Status = playing
+	p.Icon = p.options.String(PlayingIcon, "\uf04b ")
+	return nil
+}

--- a/src/segments/peard_test.go
+++ b/src/segments/peard_test.go
@@ -1,0 +1,127 @@
+package segments
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPearDesktop(t *testing.T) {
+	cases := []struct {
+		Case            string
+		JSONResponse    string
+		ExpectedString  string
+		ExpectedEnabled bool
+		ExpectedStatus  string
+		Port            int
+		HTTPError       error
+	}{
+		{
+			Case:            "playing",
+			ExpectedEnabled: true,
+			ExpectedStatus:  "playing",
+			JSONResponse: `{
+				"title": "Title",
+				"artist": "Artist",
+				"isPaused": false,
+				"songDuration": 221,
+				"elapsedSeconds": 100
+			}`,
+			ExpectedString: "Playing Artist - Title",
+		},
+		{
+			Case:            "paused",
+			ExpectedEnabled: true,
+			ExpectedStatus:  "paused",
+			JSONResponse: `{
+				"title": "Title",
+				"artist": "Artist",
+				"isPaused": true,
+				"songDuration": 221,
+				"elapsedSeconds": 100
+			}`,
+			ExpectedString: "Paused",
+		},
+		{
+			Case:            "http error",
+			ExpectedEnabled: false,
+			HTTPError:       assert.AnError,
+		},
+		{
+			Case:            "empty response",
+			ExpectedEnabled: false,
+			JSONResponse:    "",
+		},
+		{
+			Case:            "invalid json",
+			ExpectedEnabled: false,
+			JSONResponse:    "invalid json",
+		},
+		{
+			Case:            "custom port",
+			ExpectedEnabled: true,
+			ExpectedStatus:  "playing",
+			Port:            12345,
+			JSONResponse: `{
+				"title": "Title",
+				"artist": "Artist",
+				"isPaused": false
+			}`,
+			ExpectedString: "Playing Artist - Title",
+		},
+		{
+			Case:            "with all fields",
+			ExpectedEnabled: true,
+			ExpectedStatus:  "playing",
+			JSONResponse: `{
+				"title": "Title",
+				"artist": "Artist",
+				"artistUrl": "https://music.youtube.com/channel/test",
+				"url": "https://music.youtube.com/watch?v=test",
+				"mediaType": "AUDIO",
+				"isPaused": false,
+				"songDuration": 221,
+				"elapsedSeconds": 100
+			}`,
+			ExpectedString: "Playing Artist - Title",
+		},
+	}
+
+	for _, tc := range cases {
+		env := new(mock.Environment)
+
+		port := tc.Port
+		if port == 0 {
+			port = 26538
+		}
+
+		url := fmt.Sprintf("http://127.0.0.1:%d/api/v1/song-info", port)
+		env.On("HTTPRequest", url).Return([]byte(tc.JSONResponse), tc.HTTPError)
+
+		props := options.Map{
+			PlayingIcon: "Playing ",
+			PausedIcon:  "Paused ",
+		}
+
+		if tc.Port != 0 {
+			props[Port] = tc.Port
+		}
+
+		peard := &PearDesktop{}
+		peard.Init(props, env)
+
+		enabled := peard.Enabled()
+		assert.Equal(t, tc.ExpectedEnabled, enabled, tc.Case)
+
+		if !tc.ExpectedEnabled {
+			continue
+		}
+
+		assert.Equal(t, tc.ExpectedStatus, peard.Status, tc.Case)
+		assert.Equal(t, tc.ExpectedString, renderTemplate(env, peard.Template(), peard), tc.Case)
+	}
+}

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -404,6 +404,7 @@
             "os",
             "owm",
             "path",
+            "peard",
             "perl",
             "php",
             "plastic",
@@ -3080,6 +3081,49 @@
                   }
                 },
                 "additionalProperties": false
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "peard"
+              }
+            }
+          },
+          "then": {
+            "title": "Pear Desktop Segment",
+            "description": "https://ohmyposh.dev/docs/segments/music/peard",
+            "properties": {
+              "options": {
+                "properties": {
+                  "port": {
+                    "type": "integer",
+                    "title": "Port",
+                    "description": "Port to connect to Pear Desktop API",
+                    "default": 26538
+                  },
+                  "playing_icon": {
+                    "type": "string",
+                    "title": "Playing Icon",
+                    "description": "Text/icon to show when playing",
+                    "default": "\uf04b "
+                  },
+                  "paused_icon": {
+                    "type": "string",
+                    "title": "Paused Icon",
+                    "description": "Text/icon to show when paused",
+                    "default": "\uf04c "
+                  },
+                  "http_timeout": {
+                    "type": "integer",
+                    "title": "HTTP request timeout",
+                    "description": "HTTP request timeout in milliseconds",
+                    "default": 5000
+                  }
+                }
               }
             }
           }

--- a/website/docs/segments/music/peard.mdx
+++ b/website/docs/segments/music/peard.mdx
@@ -1,0 +1,72 @@
+---
+id: peard
+title: Pear Desktop
+sidebar_label: Pear Desktop
+---
+
+## What
+
+Shows the currently playing song in [Pear Desktop][pear-desktop].
+
+## Setup
+
+You need to enable the API Server plugin in the Pear Desktop settings.
+To do this, open the app, go to `Plugins > API Server [Beta]` and enable it.
+
+You must also disable authorization in `Plugins > API Server [Beta] > Authorization Strategy` for the segment to work.
+
+## Sample Configuration
+
+import Config from "@site/src/components/Config.js";
+
+<Config
+data={{
+    type: "peard",
+    style: "powerline",
+    powerline_symbol: "\uE0B0",
+    foreground: "#ffffff",
+    background: "#FF0000",
+    options: {
+      port: 26538,
+      playing_icon: "\uf04b ",
+      paused_icon: "\uf04c ",
+    },
+  }}
+/>
+
+## Options
+
+| Name           |   Type   |  Default  | Description                          |
+| -------------- | :------: | :-------: | ------------------------------------ |
+| `port`         |  `int`   |  `26538`  | Port to connect to Pear Desktop API  |
+| `playing_icon` | `string` | `\uf04b ` | Text/icon to show when playing       |
+| `paused_icon`  | `string` | `\uf04c ` | Text/icon to show when paused        |
+| `http_timeout` |  `int`   |  `5000`   | HTTP request timeout in milliseconds |
+
+## Template ([info][templates])
+
+:::note default template
+
+```template
+{{ .Icon }}{{ if ne .Status "paused" }}{{ .Artist }} - {{ .Track }}{{ end }}
+```
+
+:::
+
+### Properties
+
+| Name              | Type     | Description                                                                                              |
+| ----------------- | -------- | -------------------------------------------------------------------------------------------------------- |
+| `.Status`         | `string` | Player status (`playing`, `paused`)                                                                      |
+| `.Artist`         | `string` | Current artist                                                                                           |
+| `.Track`          | `string` | Current track                                                                                            |
+| `.TrackUrl`       | `string` | YouTube Music URL for the track                                                                          |
+| `.ArtistUrl`      | `string` | YouTube Music URL for the artist                                                                         |
+| `.MediaType`      | `string` | Media type (`AUDIO`, `ORIGINAL_MUSIC_VIDEO`, `USER_GENERATED_CONTENT`, `PODCAST_EPISODE`, `OTHER_VIDEO`) |
+| `.IsPaused`       | `bool`   | Whether playback is paused                                                                               |
+| `.SongDuration`   | `int`    | Total song duration in seconds                                                                           |
+| `.ElapsedSeconds` | `int`    | Elapsed playback time in seconds                                                                         |
+| `.Icon`           | `string` | Icon based on status                                                                                     |
+
+[templates]: /docs/configuration/templates
+[pear-desktop]: https://github.com/pear-devs/pear-desktop

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -161,6 +161,7 @@ module.exports = {
           collapsed: true,
           items: [
             "segments/music/lastfm",
+            "segments/music/peard",
             "segments/music/spotify",
             "segments/music/ytm",
           ]


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Adds an integration with pear desktop as a segment.

Would like some help with this, because it renders the prompt once, then falls back to the default prompt

<img width="1188" height="370" alt="image" src="https://github.com/user-attachments/assets/2efd8a93-9544-4ef1-ab59-0f6fdeb71b6c" />

AI was used in the creation of this PR for scaffolding purposese, I wanted to rawdog my way through as part of my second interaction with GoLang. Code may be scuffed, I copy-pasted it from other segments like YTM

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary