### PR TITLE
feat(segment): update yarn icon

### DIFF
--- a/src/config/migrate_glyphs_test.go
+++ b/src/config/migrate_glyphs_test.go
@@ -26,8 +26,8 @@ func TestEscapeGlyphs(t *testing.T) {
 		{Input: "\ufd03", Expected: "\\ufd03"},
 		{Input: "}", Expected: "}"},
 		{Input: "🏚", Expected: "🏚"},
-		{Input: "\U000F011B", Expected: "\\udb80\\udd1b"},
-		{Input: "󰄛", Expected: "\\udb80\\udd1b"},
+		{Input: "\U000f0bc9", Expected: "\\udb82\\udfc9"},
+		{Input: "󰯉", Expected: "\\udb82\\udfc9"},
 	}
 	for _, tc := range cases {
 		assert.Equal(t, tc.Expected, EscapeGlyphs(tc.Input, false), tc.Input)

--- a/src/segments/node.go
+++ b/src/segments/node.go
@@ -70,7 +70,7 @@ func (n *Node) loadContext() {
 			fileName:     "yarn.lock",
 			name:         "yarn",
 			iconProperty: YarnIcon,
-			defaultIcon:  "\U000F011B",
+			defaultIcon:  "\ue6a7",
 		},
 		{
 			fileName:     "bun.lockb",

--- a/src/segments/yarn.go
+++ b/src/segments/yarn.go
@@ -5,7 +5,7 @@ type Yarn struct {
 }
 
 func (n *Yarn) Template() string {
-	return " \U000F011B {{.Full}} "
+	return " \ue6a7 {{.Full}} "
 }
 
 func (n *Yarn) Enabled() bool {

--- a/src/segments/yarn_test.go
+++ b/src/segments/yarn_test.go
@@ -13,7 +13,7 @@ func TestYarn(t *testing.T) {
 		ExpectedString string
 		Version        string
 	}{
-		{Case: "1.0.0", ExpectedString: "\U000F011B 1.0.0", Version: "1.0.0"},
+		{Case: "1.0.0", ExpectedString: "\ue6a7 1.0.0", Version: "1.0.0"},
 	}
 	for _, tc := range cases {
 		params := &mockedLanguageParams{

--- a/website/docs/segments/cli/yarn.mdx
+++ b/website/docs/segments/cli/yarn.mdx
@@ -19,7 +19,7 @@ import Config from "@site/src/components/Config.js";
     powerline_symbol: "\uE0B0",
     foreground: "#FFFFFF",
     background: "#2E2A65",
-    template: " \uDB80\uDD1B {{ .Full }} ",
+    template: " \ue6a7 {{ .Full }} ",
   }}
 />
 
@@ -41,7 +41,7 @@ import Config from "@site/src/components/Config.js";
 :::note default template
 
 ```template
-\uDB80\uDD1B {{.Full}}
+\ue6a7 {{.Full}}
 ```
 
 :::


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Update the [Yarn](https://yarnpkg.com/) CLI segment to use a new icon glyph across code, tests, and documentation.

Enhancements:
- Switch the default Yarn icon glyph to a new codepoint in the Node and Yarn segments.

Documentation:
- Update Yarn segment documentation examples to display the new icon glyph.

Tests:
- Adjust glyph escaping and Yarn segment tests to expect the new Yarn icon glyph.

| Before | After |
|--------|--------|
| <img width="514" height="52" alt="before" src="https://github.com/user-attachments/assets/f1dfcc73-bfdd-4328-aa38-67710d79686d" /> | <img width="509" height="47" alt="after" src="https://github.com/user-attachments/assets/8022abad-e63c-4d68-8174-75227b9bab22" /> |

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
