### PR TITLE
docs(segments): add missing tooling options

### DIFF
--- a/website/docs/segments/cli/angular.mdx
+++ b/website/docs/segments/cli/angular.mdx
@@ -35,6 +35,7 @@ import Config from "@site/src/components/Config.js";
 | `version_url_template` |  `string`  |                | a go [text/template][go-text-template] [template][templates] that creates the URL of the version info / release notes                                                                                                                |
 | `extensions`           | `[]string` | `angular.json` | allows to override the default list of file extensions to validate                                                                                                                                                                   |
 | `folders`              | `[]string` |                | allows to override the list of folder names to validate                                                                                                                                                                              |
+| `tooling`              | `[]string` |   `angular`    | the tooling to use for fetching the version                                                                                                                                                                                          |
 
 ## Template ([info][templates])
 

--- a/website/docs/segments/cli/aurelia.mdx
+++ b/website/docs/segments/cli/aurelia.mdx
@@ -35,6 +35,7 @@ import Config from "@site/src/components/Config.js";
 | `version_url_template` |  `string`  |                | a go [text/template][go-text-template] [template][templates] that creates the URL of the version info / release notes                                                                                                                |
 | `extensions`           | `[]string` | `package.json` | allows to override the default list of file extensions to validate                                                                                                                                                                   |
 | `folders`              | `[]string` |                | allows to override the list of folder names to validate                                                                                                                                                                              |
+| `tooling`              | `[]string` |   `aurelia`    | the tooling to use for fetching the version                                                                                                                                                                                          |
 
 ## Template ([info][templates])
 

--- a/website/docs/segments/cli/buf.mdx
+++ b/website/docs/segments/cli/buf.mdx
@@ -33,6 +33,7 @@ import Config from "@site/src/components/Config.js";
 | `version_url_template` |  `string`  |                                         | a go [text/template][go-text-template] [template][templates] that creates the URL of the version info / release notes                                                                                                                |
 | `extensions`           | `[]string` | `buf.yaml, buf.gen.yaml, buf.work.yaml` | allows to override the default list of file extensions to validate                                                                                                                                                                   |
 | `folders`              | `[]string` |                                         | allows to override the list of folder names to validate                                                                                                                                                                              |
+| `tooling`              | `[]string` |                  `buf`                  | the tooling to use for fetching the version                                                                                                                                                                                          |
 
 ## Template ([info][templates])
 

--- a/website/docs/segments/cli/bun.mdx
+++ b/website/docs/segments/cli/bun.mdx
@@ -33,6 +33,7 @@ import Config from "@site/src/components/Config.js";
 | `version_url_template` |  `string`  |                       | a go [text/template][go-text-template] [template][templates] that creates the URL of the version info / release notes                                                                                                                |
 | `extensions`           | `[]string` | `bun.lockb, bun.lock` | allows to override the default list of file extensions to validate                                                                                                                                                                   |
 | `folders`              | `[]string` |                       | allows to override the list of folder names to validate                                                                                                                                                                              |
+| `tooling`              | `[]string` |         `bun`         | the tooling to use for fetching the version                                                                                                                                                                                          |
 
 ## Template ([info][templates])
 

--- a/website/docs/segments/cli/cmake.mdx
+++ b/website/docs/segments/cli/cmake.mdx
@@ -35,6 +35,7 @@ import Config from "@site/src/components/Config.js";
 | `version_url_template` |  `string`  |                           | a go [text/template][go-text-template] [template][templates] that creates the URL of the version info / release notes                                                                                                                |
 | `extensions`           | `[]string` | `*.cmake, CMakeLists.txt` | allows to override the default list of file extensions to validate                                                                                                                                                                   |
 | `folders`              | `[]string` |                           | allows to override the list of folder names to validate                                                                                                                                                                              |
+| `tooling`              | `[]string` |          `cmake`          | the tooling to use for fetching the version                                                                                                                                                                                          |
 
 ## Template ([info][templates])
 

--- a/website/docs/segments/cli/deno.mdx
+++ b/website/docs/segments/cli/deno.mdx
@@ -33,6 +33,7 @@ import Config from "@site/src/components/Config.js";
 | `version_url_template` |  `string`  |                         | a go [text/template][go-text-template] [template][templates] that creates the URL of the version info / release notes                                                                                                                |
 | `extensions`           | `[]string` | `*.ts, *.js, deno.json` | allows to override the default list of file extensions to validate                                                                                                                                                                   |
 | `folders`              | `[]string` |                         | allows to override the list of folder names to validate                                                                                                                                                                              |
+| `tooling`              | `[]string` |         `deno`          | the tooling to use for fetching the version                                                                                                                                                                                          |
 
 ## Template ([info][templates])
 

--- a/website/docs/segments/cli/flutter.mdx
+++ b/website/docs/segments/cli/flutter.mdx
@@ -35,6 +35,7 @@ import Config from "@site/src/components/Config.js";
 | `version_url_template` |  `string`  |                                                   | a go [text/template][go-text-template] [template][templates] that creates the URL of the version info / release notes                                                                                                                |
 | `extensions`           | `[]string` | `*.dart, pubspec.yaml, pubspec.yml, pubspec.lock` | allows to override the default list of file extensions to validate                                                                                                                                                                   |
 | `folders`              | `[]string` |                   `.dart_tool`                    | allows to override the list of folder names to validate                                                                                                                                                                              |
+| `tooling`              | `[]string` |                   `fvm, flutter`                  | the tooling to use for fetching the version                                                                                                                                                                                          |
 
 ## Template ([info][templates])
 

--- a/website/docs/segments/cli/mvn.mdx
+++ b/website/docs/segments/cli/mvn.mdx
@@ -35,6 +35,7 @@ import Config from "@site/src/components/Config.js";
 | `version_url_template` |  `string`  |           | a go [text/template][go-text-template] [template][templates] that creates the URL of the version info / release notes                                                                                                                |
 | `extensions`           | `[]string` | `pom.xml` | allows to override the default list of file extensions to validate                                                                                                                                                                   |
 | `folders`              | `[]string` |           | allows to override the list of folder names to validate                                                                                                                                                                              |
+| `tooling`              | `[]string` |   `mvn`   | the tooling to use for fetching the version                                                                                                                                                                                          |
 
 ## Template ([info][templates])
 

--- a/website/docs/segments/cli/npm.mdx
+++ b/website/docs/segments/cli/npm.mdx
@@ -35,6 +35,7 @@ import Config from "@site/src/components/Config.js";
 | `version_url_template` |  `string`  |                                   | a go [text/template][go-text-template] [template][templates] that creates the URL of the version info / release notes                                                                                                                |
 | `extensions`           | `[]string` | `package.json, package-lock.json` | allows to override the default list of file extensions to validate                                                                                                                                                                   |
 | `folders`              | `[]string` |                                   | allows to override the list of folder names to validate                                                                                                                                                                              |
+| `tooling`              | `[]string` |               `npm`               | the tooling to use for fetching the version                                                                                                                                                                                          |
 
 ## Template ([info][templates])
 

--- a/website/docs/segments/cli/nx.mdx
+++ b/website/docs/segments/cli/nx.mdx
@@ -35,6 +35,7 @@ import Config from "@site/src/components/Config.js";
 | `version_url_template` |  `string`  |                           | a go [text/template][go-text-template] [template][templates] that creates the URL of the version info / release notes                                                                                                                |
 | `extensions`           | `[]string` | `workspace.json, nx.json` | allows to override the default list of file extensions to validate                                                                                                                                                                   |
 | `folders`              | `[]string` |                           | allows to override the list of folder names to validate                                                                                                                                                                              |
+| `tooling`              | `[]string` |           `nx`            | the tooling to use for fetching the version                                                                                                                                                                                          |
 
 ## Template ([info][templates])
 

--- a/website/docs/segments/cli/pnpm.mdx
+++ b/website/docs/segments/cli/pnpm.mdx
@@ -35,6 +35,7 @@ import Config from "@site/src/components/Config.js";
 | `version_url_template` |  `string`  |                                | a go [text/template][go-text-template] [template][templates] that creates the URL of the version info / release notes                                                                                                                |
 | `extensions`           | `[]string` | `package.json, pnpm-lock.yaml` | allows to override the default list of file extensions to validate                                                                                                                                                                   |
 | `folders`              | `[]string` |                                | allows to override the list of folder names to validate                                                                                                                                                                              |
+| `tooling`              | `[]string` |             `pnpm`             | the tooling to use for fetching the version                                                                                                                                                                                          |
 
 ## Template ([info][templates])
 

--- a/website/docs/segments/cli/react.mdx
+++ b/website/docs/segments/cli/react.mdx
@@ -34,6 +34,7 @@ import Config from "@site/src/components/Config.js";
 | `version_url_template` |  `string`  |                | a go [text/template][go-text-template] [template][templates] that creates the URL of the version info / release notes                                                                                                                |
 | `extensions`           | `[]string` | `package.json` | allows to override the default list of file extensions to validate                                                                                                                                                                   |
 | `folders`              | `[]string` |                | allows to override the list of folder names to validate                                                                                                                                                                              |
+| `tooling`              | `[]string` |    `react`     | the tooling to use for fetching the version                                                                                                                                                                                          |
 
 ## Template ([info][templates])
 

--- a/website/docs/segments/cli/svelte.mdx
+++ b/website/docs/segments/cli/svelte.mdx
@@ -35,6 +35,7 @@ import Config from "@site/src/components/Config.js";
 | `version_url_template` |  `string`  |                    | a go [text/template][go-text-template] [template][templates] that creates the URL of the version info / release notes                                                                                                                |
 | `extensions`           | `[]string` | `svelte.config.js` | allows to override the default list of file extensions to validate                                                                                                                                                                   |
 | `folders`              | `[]string` |                    | allows to override the list of folder names to validate                                                                                                                                                                              |
+| `tooling`              | `[]string` |      `svelte`      | the tooling to use for fetching the version                                                                                                                                                                                          |
 
 ## Template ([info][templates])
 

--- a/website/docs/segments/cli/tauri.mdx
+++ b/website/docs/segments/cli/tauri.mdx
@@ -35,6 +35,7 @@ import Config from "@site/src/components/Config.js";
 | `version_url_template` |  `string`  |                   | a go [text/template][go-text-template] [template][templates] that creates the URL of the version info / release notes                                                                                                                |
 | `extensions`           | `[]string` | `tauri.conf.json` | allows to override the default list of file extensions to validate                                                                                                                                                                   |
 | `folders`              | `[]string` |    `src-tauri`    | allows to override the list of folder names to validate                                                                                                                                                                              |
+| `tooling`              | `[]string` |      `tauri`      | the tooling to use for fetching the version                                                                                                                                                                                          |
 
 ## Template ([info][templates])
 

--- a/website/docs/segments/cli/ui5tooling.mdx
+++ b/website/docs/segments/cli/ui5tooling.mdx
@@ -36,6 +36,7 @@ import Config from "@site/src/components/Config.js";
 | `version_url_template` |  `string`  |              | a go [text/template][go-text-template] [template][templates] that creates the URL of the version info / release notes                                                                                                                |
 | `extensions`           | `[]string` | `*ui5*.y*ml` | allows to override the default list of file extensions to validate                                                                                                                                                                   |
 | `folders`              | `[]string` |              | allows to override the list of folder names to validate                                                                                                                                                                              |
+| `tooling`              | `[]string` |    `ui5`     | the tooling to use for fetching the version                                                                                                                                                                                          |
 
 ## Template ([info][templates])
 

--- a/website/docs/segments/cli/yarn.mdx
+++ b/website/docs/segments/cli/yarn.mdx
@@ -35,6 +35,7 @@ import Config from "@site/src/components/Config.js";
 | `version_url_template` |  `string`  |                           | a go [text/template][go-text-template] [template][templates] that creates the URL of the version info / release notes                                                                                                                |
 | `extensions`           | `[]string` | `package.json, yarn.lock` | allows to override the default list of file extensions to validate                                                                                                                                                                   |
 | `folders`              | `[]string` |                           | allows to override the list of folder names to validate                                                                                                                                                                              |
+| `tooling`              | `[]string` |          `yarn`           | the tooling to use for fetching the version                                                                                                                                                                                          |
 
 ## Template ([info][templates])
 

--- a/website/docs/segments/cloud/azfunc.mdx
+++ b/website/docs/segments/cloud/azfunc.mdx
@@ -39,6 +39,7 @@ import Config from "@site/src/components/Config.js";
 | `version_url_template` |  `string`  |                                                 | a go [text/template][go-text-template] [template][templates] that creates the URL of the version info / release notes                                                                                                                |
 | `extensions`           | `[]string` | `host.json, local.settings.json, function.json` | allows to override the default list of file extensions to validate                                                                                                                                                                   |
 | `folders`              | `[]string` |                                                 | allows to override the list of folder names to validate                                                                                                                                                                              |
+| `tooling`              | `[]string` |                     `func`                      | the tooling to use for fetching the version                                                                                                                                                                                          |
 
 ## Template ([info][templates])
 

--- a/website/docs/segments/cloud/cds.mdx
+++ b/website/docs/segments/cloud/cds.mdx
@@ -35,6 +35,7 @@ import Config from "@site/src/components/Config.js";
 | `version_url_template` |  `string`  |                                           | a go [text/template][go-text-template] [template][templates] that creates the URL of the version info / release notes                                                                                                                |
 | `extensions`           | `[]string` | `.cdsrc.json, .cdsrc-private.json, *.cds` | allows to override the default list of file extensions to validate                                                                                                                                                                   |
 | `folders`              | `[]string` |                                           | allows to override the list of folder names to validate                                                                                                                                                                              |
+| `tooling`              | `[]string` |                   `cds`                   | the tooling to use for fetching the version                                                                                                                                                                                          |
 
 ## Template ([info][templates])
 

--- a/website/docs/segments/cloud/cf.mdx
+++ b/website/docs/segments/cloud/cf.mdx
@@ -35,6 +35,7 @@ import Config from "@site/src/components/Config.js";
 | `version_url_template` |  `string`  |                          | a go [text/template][go-text-template] [template][templates] that creates the URL of the version info / release notes                                                                                                                |
 | `extensions`           | `[]string` | `manifest.yml, mta.yaml` | allows to override the default list of file extensions to validate                                                                                                                                                                   |
 | `folders`              | `[]string` |                          | allows to override the list of folder names to validate                                                                                                                                                                              |
+| `tooling`              | `[]string` |           `cf`           | the tooling to use for fetching the version                                                                                                                                                                                          |
 
 ## Template ([info][templates])
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Document the tooling configuration option across multiple CLI and cloud segment pages to clarify how versions are fetched.

Documentation:
- Add the `tooling` configuration option to various CLI segment docs (Angular, Aurelia, Buf, Bun, CMake, Deno, Flutter, Maven, npm, Nx, pnpm, React, Svelte, Tauri, UI5 tooling, Yarn) describing how their versions are fetched.
- Document the `tooling` option for cloud segments (Azure Functions, CDS, Cloud Foundry) to explain which tools are used for version retrieval.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
