### PR TITLE
docs(blog): add a docusaurus truncation marker

### DIFF
--- a/website/blog/2022-03-20-whats-new-1.mdx
+++ b/website/blog/2022-03-20-whats-new-1.mdx
@@ -13,7 +13,7 @@ hide_table_of_contents: false
 
 What a week it’s been! Oh My Posh turned 6 years old and we dropped a ton of stuff!
 
-<!--truncate-->
+{/* truncate */}
 ## Swag
 
 After seeing Scott Hanselman wear his oh my zsh shirt while we got to talk about

--- a/website/blog/2025-12-28-oh-my-posh-claude-code-integration.md
+++ b/website/blog/2025-12-28-oh-my-posh-claude-code-integration.md
@@ -26,6 +26,7 @@ development workflow and AI-powered coding assistance.
 
 ![Claude Code](/img/claude.png)
 
+<!--truncate-->
 ## What is Claude Code's statusline?
 
 Claude Code's `statusline` feature allows you to create custom status displays that appear at the bottom of


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Documentation:
- Update the Claude Code integration blog post to include [a truncation marker](https://docusaurus.io/docs/blog#blog-list) for better excerpt handling on listing pages.

### Why?

To remove the following warning.

<img width="2051" height="338" alt="image" src="https://github.com/user-attachments/assets/f5b32af9-ee18-4cf3-8631-9cc640b46abb" />

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
