### PR TITLE
fix(docs): use JSX instead of html

### DIFF
--- a/website/blog/2022-03-20-whats-new-1.mdx
+++ b/website/blog/2022-03-20-whats-new-1.mdx
@@ -17,9 +17,17 @@ What a week it’s been! Oh My Posh turned 6 years old and we dropped a ton of s
 ## Swag
 
 After seeing Scott Hanselman wear his oh my zsh shirt while we got to talk about
-Oh My Posh on [Windows Wednesdays] [windows-wednesdays], I got the sudden urge to expand his wardrobe.
+Oh My Posh on [Windows Wednesdays][windows-wednesdays], I got the sudden urge to expand his wardrobe.
 
-<iframe class="youtube" src="https://www.youtube.com/embed/uO_F5W2LbSk" frameborder="0" allowfullscreen></iframe>
+<iframe
+  className="youtube"
+  src="https://www.youtube.com/embed/uO_F5W2LbSk"
+  title="Windows Wednesdays: Oh My Posh"
+  frameBorder="0"
+  referrerPolicy="strict-origin-when-cross-origin"
+  loading="lazy"
+  allowFullScreen
+/>
 
 And so, we did. Got in touch with [Marc Duiker][marc] and we got to work. The result? A ton of new goodies.
 Consider this to be **the first artist series** for Oh My Posh, a way to also highlight some talented


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Enhancements:
- Adjust blog link reference formatting and iframe attributes to conform to JSX/MDX conventions in [the documentation site](https://ohmypo.sh/blog/whats-new-1).

| Before | After |
|--------|--------|
| <img width="1637" height="1075" alt="before" src="https://github.com/user-attachments/assets/d6b31ad0-e9ea-464a-ad64-5364f4de22d1" /> | <img width="1637" height="1072" alt="after" src="https://github.com/user-attachments/assets/deceea8e-b551-4f37-bad4-a2443a9edc20" /> | 

### YouTube Error 153

[Error 153 Video player configuration error on YouTube embeds](https://til.simonwillison.net/youtube/fixing-153-embed)

> [YouTube's documentation](https://developers.google.com/youtube/terms/required-minimum-functionality#embedded-player-api-client-identity) explains that this header, which strips all Referer information on links to external sites, causes the error in YouTube.
> The fix is to send this HTTP header instead:
> `Referrer-Policy: strict-origin-when-cross-origin`

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
