### PR TITLE
docs: use `md` instead of `mdx` and lint them

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,13 @@
   "debug.internalConsoleOptions": "neverOpen",
   "azureFunctions.projectSubpath": "docs/api",
   "azureFunctions.preDeployTask": "npm prune (functions)",
+  "[markdown]": {
+    "editor.formatOnSave": true,
+    "editor.formatOnPaste": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.markdownlint": "explicit"
+    }
+  },
   "markdownlint.ignore": [
     "**/agents.md"
   ]

--- a/website/blog/2022-03-27-whats-new-2.md
+++ b/website/blog/2022-03-27-whats-new-2.md
@@ -67,10 +67,10 @@ oh-my-posh init fish | source
 
 ### Transient prompt
 
-Speaking of [transient][transient], it learned some new tricks. First, you can now use the `.Code` property to work with the last
-command's error code (if any) in the template. This can for example be used to color the transient prompt
-differently when the last command failed. That did imply we also needed support for color [templates][color-templates], as that
-wasn't possible just yet. Say no more, we now have a [transient prompt][transient] that supports color templates.
+Speaking of [transient][transient], it learned some new tricks. First, you can now use the `.Code` property to work with
+the last command's error code (if any) in the template. This can for example be used to color the transient prompt
+differently when the last command failed. That did imply we also needed support for color [templates][color-templates],
+as that wasn't possible just yet. Say no more, we now have a [transient prompt][transient] that supports color templates.
 
 ```json
 "transient_prompt": {
@@ -93,8 +93,8 @@ Which produces the following result:
 ### Config version 2
 
 Remember we did a migration to config version 1 in the beginning of the year? Well, we did a migration to version 2.
-Looking at Oh My Posh's architecture, the different prompts (transient, secondary, ...) were moving closer to the model used
-by segments. The only difference was that `template` wasn't a property, but a field of those prompts. As **all segments
+Looking at Oh My Posh's architecture, the different prompts (transient, secondary, ...) were moving closer to the model
+used by segments. The only difference was that `template` wasn't a property, but a field of those prompts. As **all segments
 now have template support**, it was a no-brainer to align both models and do a migration to config version 2 so nobody
 would have any manual work in the process.
 
@@ -137,7 +137,7 @@ Nonetheless, it's good to stay up-to-date, if you notice any quirks though, be s
 
 That's it for this week, see you for the next one 🤞🏻
 
-_Keep that prompt posh everyone! _
+_Keep that prompt posh everyone!_
 
 [blog-1]: /blog/whats-new-1
 [fish]: https://fishshell.com/

--- a/website/blog/2022-05-19-whats-new-3.md
+++ b/website/blog/2022-05-19-whats-new-3.md
@@ -148,7 +148,6 @@ That's it for this time, see you for the next one 🤞🏻
 
 Keep that prompt posh everyone!
 
-
 [module]: https://www.powershellgallery.com/packages/oh-my-posh/7.85.2
 [hurdles]: /docs/migrating#problem-statement
 [migration]: /docs/migrating

--- a/website/blog/2024-07-22-bash-rprompt.md
+++ b/website/blog/2024-07-22-bash-rprompt.md
@@ -33,9 +33,9 @@ bash' readline can interpret the prompt correctly. In bash, every character that
 like color codes, needs to be wrapped in `\[` and `\]`. This is necessary to make sure bash can **calculate the length**
 of the prompt and ultimately **position the cursor** correctly.
 
-It turned out that for [`rprompt`][rprompt], this _needed to be done differently_. The [`rprompt`][rprompt] is printed after what
-bash interprets as the end of the prompt. We found out that we need to wrap the entire [`rprompt`][rprompt] in `\[` and `\]`,
-and not escape individual non-printable characters.
+It turned out that for [`rprompt`][rprompt], this _needed to be done differently_. The [`rprompt`][rprompt] is printed
+after what bash interprets as the end of the prompt. We found out that we need to wrap the entire [`rprompt`][rprompt] in
+`\[` and `\]`, and not escape individual non-printable characters.
 
 We did that for a while, but apparently this approach was **not very robust**. It was easy to break readline's
 cursor position calculation, and it was hard to debug. The behaviour of this was also different cross platform,
@@ -43,9 +43,10 @@ so we had to go back to the drawing board.
 
 ### Second implementation
 
-The second implementation of the [`rprompt`][rprompt] was a lot more robust. We decided to print the [`rprompt`][rprompt] in a separate
-CLI call, so we could control the output more easily. It leveraged the use of the `PROMPT_COMMAND` variable in bash, which
-is a hook that is executed before the prompt is printed. We would first print the [`rprompt`][rprompt] in the `PROMPT_COMMAND`,
+The second implementation of the [`rprompt`][rprompt] was a lot more robust. We decided to print the [`rprompt`][rprompt]
+in a separate CLI call, so we could control the output more easily. It leveraged the use of the `PROMPT_COMMAND`
+variable in bash, which is a hook that is executed before the prompt is printed. We would first print the
+[`rprompt`][rprompt] in the `PROMPT_COMMAND`,
 and then set the primary prompt in the `PS1` variable so bash would not bother about the [`rprompt`][rprompt] being there.
 
 This approach was a lot **cleaner from an achitectural point of view**, but it came with its own challenges.
@@ -53,10 +54,10 @@ The most obvious one is needing two CLI calls to print the prompt, which made re
 
 Additionally, as we print before `PS1` is evaluated, we noticed the following issues along the way:
 
-1. when the output of the previous command didn't end with a newline, the [`rprompt`][rprompt] would be printed on the same line
-  as the output of the previous command
-2. when the prompt was at the bottom of the terminal buffer, the [`rprompt`][rprompt] would be printed on the same line as the
-  prompt, which would break the prompt
+1. when the output of the previous command didn't end with a newline, the [`rprompt`][rprompt] would be printed on the
+  same line as the output of the previous command
+2. when the prompt was at the bottom of the terminal buffer, the [`rprompt`][rprompt] would be printed on the same line
+  as the prompt, which would break the prompt
 3. depending on the platform, it would still break command history navigation
 4. it required different logic for multiline prompts as we print before `PS1` and need to reposition the cursor correctly
 
@@ -64,10 +65,12 @@ Of these issues, **only bullet 4 could be fixed**. Everything else was outside o
 
 ## Conclusion
 
-Oh My Posh is a tool that needs to be easy to use, maintain and be 100% reliable. One of the core principles of Oh My Posh is that it should
-**never break the shell**. The [`rprompt`][rprompt] feature in bash has never been reliable enough, and it was _hard to debug_ when it broke.
+Oh My Posh is a tool that needs to be easy to use, maintain and be 100% reliable. One of the core principles of
+Oh My Posh is that it should **never break the shell**. The [`rprompt`][rprompt] feature in bash has never been reliable
+enough, and it was _hard to debug_ when it broke.
 I spent countless hours debugging issues with the [`rprompt`][rprompt] in bash, but it's **time to move on**. If you
-want to use the [`rprompt`][rprompt] feature, I would recommend using a shell that supports it natively, like [nushell], [zsh] or [fish].
+want to use the [`rprompt`][rprompt] feature, I would recommend using a shell that supports it natively, like
+[nushell], [zsh] or [fish].
 
 ## What about Powershell?
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Convert existing blog posts from MDX to Markdown and clean up formatting for improved readability and consistency.

Documentation:
- Rename blog posts from .mdx to .md and reflow long lines for better readability.
- Fix minor Markdown formatting issues such as stray spaces in emphasis and list wrapping.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
