### PR TITLE
docs(segments): add and update icons

### DIFF
--- a/website/docs/segments/cli/argocd.mdx
+++ b/website/docs/segments/cli/argocd.mdx
@@ -19,7 +19,7 @@ import Config from "@site/src/components/Config.js";
     powerline_symbol: "\uE0B0",
     foreground: "#ffffff",
     background: "#FFA400",
-    template: " {{ .Name }}:{{ .User }}@{{ .Server }} ",
+    template: " \ue734 {{ .Name }}:{{ .User }}@{{ .Server }} ",
   }}
 />
 

--- a/website/docs/segments/cli/cmake.mdx
+++ b/website/docs/segments/cli/cmake.mdx
@@ -19,7 +19,7 @@ import Config from "@site/src/components/Config.js";
     powerline_symbol: "\uE0B0",
     foreground: "#E8EAEE",
     background: "#1E9748",
-    template: " \ue61e \ue61d cmake {{ .Full }} ",
+    template: " \ue794 cmake {{ .Full }} ",
   }}
 />
 

--- a/website/docs/segments/cli/deno.mdx
+++ b/website/docs/segments/cli/deno.mdx
@@ -17,7 +17,7 @@ import Config from "@site/src/components/Config.js";
     type: "deno",
     style: "plain",
     foreground: "#3C82F6",
-    template: " \ue628 {{ .Full }} ",
+    template: " \ue7c0 {{ .Full }} ",
   }}
 />
 

--- a/website/docs/segments/cli/flutter.mdx
+++ b/website/docs/segments/cli/flutter.mdx
@@ -19,7 +19,7 @@ import Config from "@site/src/components/Config.js";
     powerline_symbol: "\uE0B0",
     foreground: "#ffffff",
     background: "#06A4CE",
-    template: " \ue28e {{ .Full }} ",
+    template: " \ue7dd {{ .Full }} ",
   }}
 />
 

--- a/website/docs/segments/cli/helm.mdx
+++ b/website/docs/segments/cli/helm.mdx
@@ -16,7 +16,7 @@ import Config from '@site/src/components/Config.js';
   "background": "#a7cae1",
   "foreground": "#100e23",
   "powerline_symbol": "\ue0b0",
-  "template": " Helm {{ .Version }}",
+  "template": " \ue7fb {{ .Version }}",
   "style": "powerline",
   "type": "helm"
 }}/>

--- a/website/docs/segments/cli/kubectl.mdx
+++ b/website/docs/segments/cli/kubectl.mdx
@@ -19,7 +19,7 @@ import Config from "@site/src/components/Config.js";
     powerline_symbol: "\uE0B0",
     foreground: "#000000",
     background: "#ebcc34",
-    template: " \uFD31 {{.Context}}{{if .Namespace}} :: {{.Namespace}}{{end}} ",
+    template: " \udb84\udcfe {{.Context}}{{if .Namespace}} :: {{.Namespace}}{{end}} ",
     options: {
       context_aliases: {
         "arn:aws:eks:eu-west-1:1234567890:cluster/posh": "posh",

--- a/website/docs/segments/cli/mvn.mdx
+++ b/website/docs/segments/cli/mvn.mdx
@@ -19,7 +19,7 @@ import Config from "@site/src/components/Config.js";
     powerline_symbol: "\uE0B0",
     foreground: "#FFFFFF",
     background: "#2E2A65",
-    template: " Maven {{ .Full }} ",
+    template: " \ue82c {{ .Full }} ",
   }}
 />
 

--- a/website/docs/segments/cli/nix-shell.mdx
+++ b/website/docs/segments/cli/nix-shell.mdx
@@ -18,7 +18,7 @@ import Config from "@site/src/components/Config.js";
     style: "powerline",
     foreground: "blue",
     background: "transparent",
-    template: "(nix-{{ .Type }})",
+    template: "(\udb84\udd05-{{ .Type }})",
   }}
 />
 

--- a/website/docs/segments/cloud/gcp.mdx
+++ b/website/docs/segments/cloud/gcp.mdx
@@ -19,7 +19,7 @@ import Config from "@site/src/components/Config.js";
     powerline_symbol: "\uE0B0",
     foreground: "#ffffff",
     background: "#47888d",
-    template: " \uE7B2 {{.Project}} :: {{.Account}} ",
+    template: " \udb84\uddf6 {{.Project}} :: {{.Account}} ",
   }}
 />
 

--- a/website/docs/segments/health/strava.mdx
+++ b/website/docs/segments/health/strava.mdx
@@ -49,7 +49,7 @@ import Config from "@site/src/components/Config.js";
       "{{ if and (lt .Hours 100) (gt .Hours 50) }}#343a40{{ end }}",
       "{{ if lt .Hours 50 }}#FFFFFF{{ end }}",
     ],
-    template: " {{.Name}} {{.Ago}} {{.Icon}} ",
+    template: " \ued52 {{.Name}} {{.Ago}} {{.Icon}} ",
     options: {
       access_token: "11111111111111111",
       refresh_token: "1111111111111111",

--- a/website/docs/segments/languages/crystal.mdx
+++ b/website/docs/segments/languages/crystal.mdx
@@ -19,7 +19,7 @@ import Config from "@site/src/components/Config.js";
     powerline_symbol: "\uE0B0",
     foreground: "#ffffff",
     background: "#4063D8",
-    template: " \uE370 {{ .Full }} ",
+    template: " \ue62f {{ .Full }} ",
   }}
 />
 

--- a/website/docs/segments/languages/kotlin.mdx
+++ b/website/docs/segments/languages/kotlin.mdx
@@ -19,7 +19,7 @@ import Config from "@site/src/components/Config.js";
     powerline_symbol: "\uE0B0",
     foreground: "#ffffff",
     background: "#906cff",
-    template: " <b>K</b> {{ .Full }} ",
+    template: " \ue634 {{ .Full }} ",
   }}
 />
 

--- a/website/docs/segments/languages/r.mdx
+++ b/website/docs/segments/languages/r.mdx
@@ -19,7 +19,7 @@ import Config from "@site/src/components/Config.js";
     powerline_symbol: "\uE0B0",
     foreground: "blue",
     background: "lightWhite",
-    template: " R {{ .Full }} ",
+    template: " \ue68a {{ .Full }} ",
   }}
 />
 

--- a/website/docs/segments/scm/mercurial.mdx
+++ b/website/docs/segments/scm/mercurial.mdx
@@ -21,8 +21,9 @@ import Config from "@site/src/components/Config.js";
     foreground: "#193549",
     background: "#ffeb3b",
     options: {
-      newprop: "\uEFF1",
-    },
+      fetch_status: true,
+      native_fallback: false
+    }
   }}
 />
 

--- a/website/docs/segments/web/nba.mdx
+++ b/website/docs/segments/web/nba.mdx
@@ -12,7 +12,7 @@ favorite NBA team!
 ## Sample Configuration
 
 In order to use the NBA segment, you need to provide a valid team
-[tri-code](https://liaison.reuters.com/tools/sports-team-codes) that you'd
+[tri-code][tri-code] that you'd
 like to get data for inside of the configuration. For example, if you'd like
 to get information for the Los Angeles Lakers, you'd need to use the "LAL"
 tri-code.
@@ -21,7 +21,7 @@ This example uses "LAL" to get information for the Los Angeles Lakers. It also
 sets the foreground and background colors to match the theming for the team.
 If you are interested in getting information about specific foreground and
 background colors you could use for other teams, you can explore some of
-the color schemes [here](https://teamcolorcodes.com/nba-team-color-codes/).
+the color schemes [here][color-schemes].
 
 It is recommended that you set the HTTP timeout to a higher value than the
 normal default in case it takes some time to gather the scoreboard information.
@@ -57,7 +57,7 @@ import Config from "@site/src/components/Config.js";
 :::note default template
 
 ```template
-\U000F0806 {{ .HomeTeam}}{{ if .HasStats }} ({{.HomeTeamWins}}-{{.HomeTeamLosses}}){{ end }}{{ if .Started }}:{{.HomeScore}}{{ end }} vs {{ .AwayTeam}}{{ if .HasStats }} ({{.AwayTeamWins}}-{{.AwayTeamLosses}}){{ end }}{{ if .Started }}:{{.AwayScore}}{{ end }} | {{ if not .Started }}{{.GameDate}} | {{ end }}{{.Time}}
+\udb82\udc06 {{ .HomeTeam}}{{ if .HasStats }} ({{.HomeTeamWins}}-{{.HomeTeamLosses}}){{ end }}{{ if .Started }}:{{.HomeScore}}{{ end }} vs {{ .AwayTeam}}{{ if .HasStats }} ({{.AwayTeamWins}}-{{.AwayTeamLosses}}){{ end }}{{ if .Started }}:{{.AwayScore}}{{ end }} | {{ if not .Started }}{{.GameDate}} | {{ end }}{{.Time}}
 ```
 
 :::
@@ -81,5 +81,6 @@ import Config from "@site/src/components/Config.js";
 | .Started        | `boolean` | if the game was started or not                              |
 | .HasStats       | `boolean` | if the game has game stats or not                           |
 
+[color-schemes]: https://teamcolorcodes.com/nba-team-color-codes/
 [templates]: /docs/configuration/templates
-[nf-search]: https://www.nerdfonts.com/cheat-sheet
+[tri-code]: https://liaison.reuters.com/tools/sports-team-codes

--- a/website/docs/segments/web/owm.mdx
+++ b/website/docs/segments/web/owm.mdx
@@ -62,8 +62,6 @@ import Config from "@site/src/components/Config.js";
 | `.UnitIcon`    | `string` | the current unit icon(based on units property) |
 | `.URL`         | `string` | the url of the current api call                |
 
-[go-text-template]: https://golang.org/pkg/text/template/
-[sprig]: http://masterminds.github.io/sprig/
 [templates]: /docs/configuration/templates
 [owm]: https://openweathermap.org
 [owm-price]: https://openweathermap.org/price


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Update segment documentation to use new icons and cleaned-up references across CLI, language, health, cloud, SCM, and web segments.

Documentation:
- Refresh CLI, language, health, cloud, and SCM segment examples to use updated icons in their templates.
- Improve NBA segment docs by switching to reference-style links, adding missing link targets, and correcting existing references.
- Tidy OpenWeatherMap docs by removing unused template-related reference links.

### CLI

| Segment | Before | After |
|--------|--------|--------|
| argocd | <img width="924" height="372" alt="argocd_before" src="https://github.com/user-attachments/assets/961da105-9eb4-4af7-b622-5d34904173fa" /> | <img width="958" height="378" alt="argocd_after" src="https://github.com/user-attachments/assets/b5abf93b-8381-4a57-9c34-f8ef387cef81" /> |
| cmake | <img width="657" height="369" alt="cmake_before" src="https://github.com/user-attachments/assets/cc99e5f7-b05b-4ab3-89cf-ef91cd81a4f2" /> | <img width="625" height="366" alt="cmake_after" src="https://github.com/user-attachments/assets/ce7ec52e-58eb-483f-9de2-99114fd3d2e6" /> |
| deno | <img width="532" height="279" alt="deno_before" src="https://github.com/user-attachments/assets/9ab955c4-7e44-470c-8c30-733a64450b50" /> | <img width="521" height="281" alt="deno_after" src="https://github.com/user-attachments/assets/6a06d353-3261-46d4-b3df-267a256acdca" /> |
| flutter | <img width="532" height="384" alt="flutter_before" src="https://github.com/user-attachments/assets/0c4260ea-8b6f-4f17-b5ff-10c49c7dfa64" /> | <img width="529" height="375" alt="flutter_after" src="https://github.com/user-attachments/assets/50f2ca3a-85a0-4747-b681-de2bf6dfab4f" /> |
| helm | <img width="628" height="377" alt="helm_before" src="https://github.com/user-attachments/assets/4f7deeb3-ee5d-4b10-ad2d-538f4e742530" /> | <img width="578" height="379" alt="helm_after" src="https://github.com/user-attachments/assets/1b33e4b9-966d-4e54-a83b-c362c00dab98" /> |
| kubectl | <img width="1260" height="740" alt="kubernetes_before" src="https://github.com/user-attachments/assets/6a62a1f6-81db-434a-9947-17156be84beb" /> | <img width="1258" height="747" alt="kubernetes_after" src="https://github.com/user-attachments/assets/b1cfbc6c-a6ce-45c9-99ca-64cc9a9ab945" /> |
| maven | <img width="592" height="378" alt="maven_before" src="https://github.com/user-attachments/assets/5cb098db-9b42-4d91-b314-987fb59d0b15" /> | <img width="526" height="375" alt="maven_after" src="https://github.com/user-attachments/assets/c6381ee5-2a91-449f-8fad-686a21e52e57" /> |
| nix shell | <img width="565" height="329" alt="nix_before" src="https://github.com/user-attachments/assets/c9570080-142d-46bf-ad80-8e6e204b34c0" /> | <img width="526" height="330" alt="nix_after" src="https://github.com/user-attachments/assets/c2db5cf2-7885-4385-83b9-40a6a0b22720" /> |

### Cloud

| Segment | Before | After |
|--------|--------|--------|
| GCP | <img width="812" height="376" alt="gcp_before" src="https://github.com/user-attachments/assets/3f90bf29-d1c7-4d6e-ade3-c72f4f3f1e80" /> | <img width="818" height="378" alt="gcp_after" src="https://github.com/user-attachments/assets/774dc752-191b-4d12-b645-26571612d3c4" /> | 

### Health

| Segment | Before | After |
|--------|--------|--------|
| strava | <img width="1100" height="1064" alt="strava_before" src="https://github.com/user-attachments/assets/e8b94df9-991c-4492-ba00-cd9be4cc172d" /> | <img width="1115" height="1060" alt="strava_after" src="https://github.com/user-attachments/assets/9718e854-6b9d-4553-98c6-8f1c4a578e4b" /> | 

### Language

| Segment | Before | After |
|--------|--------|--------|
| crystal | <img width="528" height="382" alt="crystal_before" src="https://github.com/user-attachments/assets/2bc16745-bada-485b-b4a1-24a68ef245b9" /> | <img width="534" height="391" alt="crystal_after" src="https://github.com/user-attachments/assets/113f1498-c3fa-4d72-a73e-dda665a91a23" /> | 
| kotlin | <img width="646" height="377" alt="kotlin_before" src="https://github.com/user-attachments/assets/baace1fb-7514-43c1-953d-0e2d6fb9e6fd" /> | <img width="521" height="383" alt="kotlin_after" src="https://github.com/user-attachments/assets/31e78ab8-90e5-40c4-ba69-f38baf0fe64c" /> |
| R | <img width="529" height="382" alt="r_before" src="https://github.com/user-attachments/assets/42ea0ebc-82c0-4994-be0c-74ae52ed86aa" /> | <img width="535" height="386" alt="r_after" src="https://github.com/user-attachments/assets/8105ea4f-cda5-4b21-83ef-22aeec5c5e44" /> |

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
