### PR TITLE
docs(docusaurus): use ESM instead of CJS on config

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -1,6 +1,4 @@
-const path = require('path');
-
-module.exports = {
+export default {
   title: 'Oh My Posh',
   tagline: 'The most customizable and fastest prompt engine for any shell.',
   url: 'https://ohmyposh.dev',
@@ -10,7 +8,7 @@ module.exports = {
   projectName: 'oh-my-posh',
   onBrokenLinks: 'ignore',
   plugins: [
-    path.resolve(__dirname, 'plugins', 'appinsights')
+    './plugins/appinsights'
   ],
   stylesheets: [
     "https://rsms.me/inter/inter.css",
@@ -172,13 +170,13 @@ module.exports = {
       '@docusaurus/preset-classic',
       {
         docs: {
-          sidebarPath: require.resolve('./sidebars.js'),
+          sidebarPath: './sidebars.js',
           editUrl: 'https://github.com/jandedobbeleer/oh-my-posh/edit/main/website/',
         },
         theme: {
           customCss: [
-            require.resolve('./src/css/prism-rose-pine-moon.css'),
-            require.resolve('./src/css/custom.css')
+            './src/css/prism-rose-pine-moon.css',
+            './src/css/custom.css'
           ],
         },
         blog: {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Migrate the Docusaurus site configuration to use an ES module export and path strings instead of CommonJS and Node-specific path resolution.

Enhancements:
- Switch Docusaurus config from CommonJS to ES module syntax for compatibility with ESM tooling.
- Replace Node-specific path resolution in Docusaurus config with relative path strings for plugins and assets.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
