### PR TITLE
docs(advanced): add a mcp-server document to sidebar

### DIFF
--- a/website/docs/advanced/mcp-server.mdx
+++ b/website/docs/advanced/mcp-server.mdx
@@ -71,7 +71,7 @@ curl -X POST https://ohmyposh.dev/api/mcp \
     "params": {
       "name": "validate_config",
       "arguments": {
-        "content": "{\"$schema\":\"https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json\",\"version\":3,\"blocks\":[]}",
+        "content": "{\"$schema\":\"https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json\",\"version\":4,\"blocks\":[]}",
         "format": "json"
       }
     },
@@ -137,7 +137,7 @@ Each error in the `errors` array contains:
 ```json
 {
   "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
-  "version": 3,
+  "version": 4,
   "blocks": [
     {
       "type": "prompt",
@@ -213,7 +213,7 @@ oh-my-posh themes.
 ```json
 {
   "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
-  "version": 3,
+  "version": 4,
   "blocks": []
 }
 ```
@@ -222,14 +222,14 @@ oh-my-posh themes.
 
 ```yaml
 $schema: https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json
-version: 3
+version: 4
 blocks: []
 ```
 
 ### TOML
 
 ```toml
-version = 3
+version = 4
 blocks = []
 ```
 

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -232,6 +232,14 @@ module.exports = {
     "dsc",
     "themes",
     "share",
+    {
+      type: "category",
+      label: "🛠️ Advanced",
+      collapsed: true,
+      items: [
+        "advanced/mcp-server",
+      ],
+    },
     "faq",
     "migrating",
     "contributors",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Update MCP server documentation examples to use schema version 4 and expose the page under an Advanced section in the docs sidebar.

Documentation:
- Update [MCP server documentation](https://ohmyposh.dev/docs/advanced/mcp-server) examples to reference theme schema version 4 instead of version 3.
- Add the [MCP server documentation](https://ohmyposh.dev/docs/advanced/mcp-server) page to a new Advanced section in the docs sidebar.

| Before | After |
|--------|--------|
| <img width="1168" height="835" alt="before" src="https://github.com/user-attachments/assets/aea757d4-0600-4dcf-8c11-5ac8f0d8f87d" /> | <img width="1195" height="981" alt="after" src="https://github.com/user-attachments/assets/c17c8597-b019-41b1-b0e0-7eb6299c07e1" /> | 

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
