### PR TITLE
chore(src): fix various typos across src codebase

### DIFF
--- a/src/cli/config_export.go
+++ b/src/cli/config_export.go
@@ -70,7 +70,7 @@ Exports the current config to "~/new_config.omp.json" (in JSON format).`,
 				// usage error
 				fmt.Printf("export format must be one of these: %s\n", strings.Join(formats, ", "))
 				exitcode = 2
-				return errors.New("invalide export format")
+				return errors.New("invalid export format")
 			}
 
 			return nil

--- a/src/config/block.go
+++ b/src/config/block.go
@@ -5,7 +5,7 @@ import "fmt"
 // BlockType type of block
 type BlockType string
 
-// BlockAlignment aligment of a Block
+// BlockAlignment alignment of a Block
 type BlockAlignment string
 
 // Overflow defines how to handle a right block that overflows with the previous block

--- a/src/runtime/battery/battery_windows_nix.go
+++ b/src/runtime/battery/battery_windows_nix.go
@@ -40,7 +40,7 @@ func mapMostLogicalState(currentState, newState State) State {
 // Get returns information about all batteries in the system.
 //
 // If error != nil, it will be either ErrFatal or Errors.
-// If error is of type Errors, it is guaranteed that length of both returned slices is the same and that i-th error coresponds with i-th battery structure.
+// If error is of type Errors, it is guaranteed that length of both returned slices is the same and that i-th error corresponds with i-th battery structure.
 func Get() (*Info, error) {
 	parseBatteryInfo := func(batteries []*battery) *Info {
 		var info Info

--- a/src/runtime/http/oauth.go
+++ b/src/runtime/http/oauth.go
@@ -42,14 +42,14 @@ type OAuthRequest struct {
 
 func (o *OAuthRequest) getAccessToken() (string, error) {
 	// get directly from cache
-	if acccessToken, OK := cache.Get[string](cache.Device, o.AccessTokenKey); OK && len(acccessToken) != 0 {
-		return acccessToken, nil
+	if accessToken, OK := cache.Get[string](cache.Device, o.AccessTokenKey); OK && len(accessToken) != 0 {
+		return accessToken, nil
 	}
 
 	// use cached refresh token to get new access token
 	if refreshToken, OK := cache.Get[string](cache.Device, o.RefreshTokenKey); OK && len(refreshToken) != 0 {
-		if acccessToken, err := o.refreshToken(refreshToken); err == nil {
-			return acccessToken, nil
+		if accessToken, err := o.refreshToken(refreshToken); err == nil {
+			return accessToken, nil
 		}
 	}
 
@@ -63,8 +63,8 @@ func (o *OAuthRequest) getAccessToken() (string, error) {
 	}
 
 	// no need to let the user provide access token, we'll always verify the refresh token
-	acccessToken, err := o.refreshToken(o.RefreshToken)
-	return acccessToken, err
+	accessToken, err := o.refreshToken(o.RefreshToken)
+	return accessToken, err
 }
 
 func (o *OAuthRequest) refreshToken(refreshToken string) (string, error) {

--- a/src/runtime/path/home.go
+++ b/src/runtime/path/home.go
@@ -16,7 +16,7 @@ func Home() string {
 		return home
 	}
 
-	// fallback to older implemenations on Windows
+	// fallback to older implementations on Windows
 	home = os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
 
 	if home == "" {

--- a/src/runtime/win32_windows.go
+++ b/src/runtime/win32_windows.go
@@ -102,7 +102,7 @@ func queryWindowTitles(processName, windowTitleRegex string) (string, error) {
 		return 1 // continue enumeration
 	})
 	// Enumerates all top-level windows on the screen
-	// The error is not checked because if EnumWindows is stopped bofere enumerating all windows
+	// The error is not checked because if EnumWindows is stopped before enumerating all windows
 	// it returns 0(error occurred) instead of 1(success)
 	// In our case, title will equal "" or the title of the window anyway
 	err := enumWindows(cb, 0)

--- a/src/segments/copilot.go
+++ b/src/segments/copilot.go
@@ -80,7 +80,7 @@ func (c *Copilot) getAccessToken() string {
 func (c *Copilot) getResult() (*copilotAPIResponse, error) {
 	accessToken := c.getAccessToken()
 	if len(accessToken) == 0 {
-		return nil, &noAcccessTokenError{}
+		return nil, &noAccessTokenError{}
 	}
 
 	log.Debug("found access token")
@@ -199,8 +199,8 @@ func (e *noQuotaDataError) Error() string {
 	return "no quota data in response"
 }
 
-type noAcccessTokenError struct{}
+type noAccessTokenError struct{}
 
-func (e *noAcccessTokenError) Error() string {
+func (e *noAccessTokenError) Error() string {
 	return "no access token available, use 'oh-my-posh auth copilot' to authenticate"
 }

--- a/src/segments/git_test.go
+++ b/src/segments/git_test.go
@@ -960,7 +960,7 @@ func TestGitIgnoreSubmodules(t *testing.T) {
 		Expected         string
 	}{
 		{
-			Case:     "Overide",
+			Case:     "Override",
 			Expected: "--ignore-submodules=all",
 			IgnoreSubmodules: map[string]string{
 				"foo": "all",

--- a/src/segments/path.go
+++ b/src/segments/path.go
@@ -102,7 +102,7 @@ const (
 	MappedLocations options.Option = "mapped_locations"
 	// MappedLocationsEnabled enables overriding certain locations with an icon
 	MappedLocationsEnabled options.Option = "mapped_locations_enabled"
-	// MaxDepth Maximum path depth to display whithout shortening
+	// MaxDepth Maximum path depth to display without shortening
 	MaxDepth options.Option = "max_depth"
 	// MaxWidth Maximum path width to display for powerlevel style
 	MaxWidth options.Option = "max_width"

--- a/src/segments/path_windows_test.go
+++ b/src/segments/path_windows_test.go
@@ -250,7 +250,7 @@ var testAgnosterPathCases = []testAgnosterPathCase{
 		PathSeparator: `\`,
 	},
 	{
-		Case:          "Windows oustide home",
+		Case:          "Windows outside home",
 		Expected:      "~ > f > f > location",
 		Home:          homeDirWindows,
 		PWD:           homeDirWindows + "\\Documents\\Bill\\location",

--- a/src/segments/sitecore.go
+++ b/src/segments/sitecore.go
@@ -9,10 +9,10 @@ import (
 )
 
 const (
-	sitecoreFileName   = "sitecore.json"
-	sitecoreFolderName = ".sitecore"
-	userFileName       = "user.json"
-	defaultEnpointName = "default"
+	sitecoreFileName    = "sitecore.json"
+	sitecoreFolderName  = ".sitecore"
+	userFileName        = "user.json"
+	defaultEndpointName = "default"
 )
 
 type Sitecore struct {
@@ -48,7 +48,7 @@ func (s *Sitecore) Enabled() bool {
 
 	displayDefault := s.options.Bool(options.DisplayDefault, true)
 
-	if !displayDefault && s.EndpointName == defaultEnpointName {
+	if !displayDefault && s.EndpointName == defaultEndpointName {
 		log.Debug("displaying of the default environment is turned off")
 		return false
 	}
@@ -80,7 +80,7 @@ func (u *UserConfig) getDefaultEndpoint() string {
 		return u.DefaultEndpoint
 	}
 
-	return defaultEnpointName
+	return defaultEndpointName
 }
 
 func (u *UserConfig) getEndpoint(name string) *EndpointConfig {

--- a/src/shell/init.go
+++ b/src/shell/init.go
@@ -33,7 +33,7 @@ func getExecutablePath(env runtime.Environment) (string, error) {
 		return path.Base(executable), nil
 	}
 
-	// On Windows, it fails when the excutable is called in MSYS2 for example
+	// On Windows, it fails when the executable is called in MSYS2 for example
 	// which uses unix style paths to resolve the executable's location.
 	// PowerShell knows how to resolve both, so we can swap this without any issue.
 	if env.GOOS() == runtime.WINDOWS {

--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -239,7 +239,7 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
     }
 
     $promptFunction = {
-        # store the orignal last command execution status
+        # store the original last command execution status
         if ($global:NVS_ORIGINAL_LASTEXECUTIONSTATUS -is [bool]) {
             # make it compatible with NVS auto-switching, if enabled
             $script:OriginalLastExecutionStatus = $global:NVS_ORIGINAL_LASTEXECUTIONSTATUS
@@ -247,7 +247,7 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
         else {
             $script:OriginalLastExecutionStatus = $?
         }
-        # store the orignal last exit code
+        # store the original last exit code
         $script:OriginalLastExitCode = $global:LASTEXITCODE
 
         # Reset tooltip command.
@@ -286,7 +286,7 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
         # remove any posh-git status
         $env:POSH_GIT_STATUS = $null
 
-        # restore the orignal last exit code
+        # restore the original last exit code
         $global:LASTEXITCODE = $script:OriginalLastExitCode
     }
 

--- a/src/terminal/writer.go
+++ b/src/terminal/writer.go
@@ -355,7 +355,7 @@ func Write(background, foreground color.Ansi, txt string) {
 				continue
 			}
 
-			i = writeArchorOverride(match, background, i)
+			i = writeAnchorOverride(match, background, i)
 			continue
 		}
 
@@ -433,7 +433,7 @@ func writeSegmentColors() {
 		fg = currentColor.Foreground()
 	}
 
-	// ignore processing fully tranparent colors
+	// ignore processing fully transparent colors
 	isInvisible = fg.IsTransparent() && bg.IsTransparent()
 	if isInvisible {
 		return
@@ -461,7 +461,7 @@ func writeSegmentColors() {
 	currentColor.Add(bg, fg)
 }
 
-func writeArchorOverride(match map[string]string, background color.Ansi, i int) int {
+func writeAnchorOverride(match map[string]string, background color.Ansi, i int) int {
 	position := i
 	// check color reset first
 	if match[ANCHOR] == resetStyle.AnchorEnd {
@@ -490,7 +490,7 @@ func writeArchorOverride(match map[string]string, background color.Ansi, i int) 
 
 	bg, fg := asAnsiColors(bgColor, fgColor)
 
-	// ignore processing fully tranparent colors
+	// ignore processing fully transparent colors
 	isInvisible = fg.IsTransparent() && bg.IsTransparent()
 	if isInvisible {
 		return position


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Fix typos and naming inconsistencies across the codebase to improve readability and correctness of identifiers and messages.

Enhancements:
- Correct misspelled identifiers and types in OAuth, Copilot, Sitecore, terminal writer, and runtime utilities for clearer and more consistent code.
- Fix spelling in user-facing strings, comments, and test case names without changing functional behavior.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
