### PR TITLE
docs(sidebar): remove a redundant getting started collapse

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -7,25 +7,18 @@ module.exports = {
       items: [
         {
           type: "category",
-          label: "🚀 Get started",
+          label: "📦 Installation",
           collapsed: false,
           items: [
-            {
-              type: "category",
-              label: "📦 Installation",
-              collapsed: false,
-              items: [
-                "installation/windows",
-                "installation/macos",
-                "installation/linux",
-              ],
-            },
-            "installation/fonts",
-            "installation/prompt",
-            "installation/customize",
-            "installation/upgrade",
+            "installation/windows",
+            "installation/macos",
+            "installation/linux",
           ],
         },
+        "installation/fonts",
+        "installation/prompt",
+        "installation/customize",
+        "installation/upgrade",
       ],
     },
     {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Documentation:
- Flatten the installation section in the docs sidebar by promoting installation guides and related pages to a single "Installation" category.

| Before | After |
|--------|--------|
| <img width="539" height="796" alt="before" src="https://github.com/user-attachments/assets/9a9073e5-2625-4433-bde8-c43d7a50d376" /> | <img width="555" height="723" alt="after" src="https://github.com/user-attachments/assets/0f60a2fa-73e9-45ba-a4d9-19c2b4ad85db" /> | 

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
