### PR TITLE
feat: remove unused block properties

### DIFF
--- a/src/config/block.go
+++ b/src/config/block.go
@@ -35,8 +35,6 @@ type Block struct {
 	LeadingDiamond  string         `json:"leading_diamond,omitempty" toml:"leading_diamond,omitempty" yaml:"leading_diamond,omitempty"`
 	TrailingDiamond string         `json:"trailing_diamond,omitempty" toml:"trailing_diamond,omitempty" yaml:"trailing_diamond,omitempty"`
 	Segments        []*Segment     `json:"segments,omitempty" toml:"segments,omitempty" yaml:"segments,omitempty"`
-	MaxWidth        int            `json:"max_width,omitempty" toml:"max_width,omitempty" yaml:"max_width,omitempty"`
-	MinWidth        int            `json:"min_width,omitempty" toml:"min_width,omitempty" yaml:"min_width,omitempty"`
 	Newline         bool           `json:"newline,omitempty" toml:"newline,omitempty" yaml:"newline,omitempty"`
 	Force           bool           `json:"force,omitempty" toml:"force,omitempty" yaml:"force,omitempty"`
 	Index           int            `json:"index,omitempty" toml:"index,omitempty" yaml:"index,omitempty"`

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -305,6 +305,18 @@
           "description": "https://ohmyposh.dev/docs/configuration/block#newline",
           "default": false
         },
+        "filler": {
+          "type": "string",
+          "title": "Filler",
+          "description": "https://ohmyposh.dev/docs/configuration/block#filler",
+          "default": ""
+        },
+        "overflow": {
+          "type": "string",
+          "title": "Overflow",
+          "description": "https://ohmyposh.dev/docs/configuration/block#overflow",
+          "default": ""
+        },
         "leading_diamond": {
           "type": "string",
           "title": "Leading diamond",
@@ -325,6 +337,17 @@
           "items": {
             "$ref": "#/definitions/segment"
           }
+        },
+        "force": {
+          "type": "boolean",
+          "title": "Force",
+          "description": "https://ohmyposh.dev/docs/configuration/block#force",
+          "default": false
+        },
+        "index": {
+          "type": "integer",
+          "title": "Index",
+          "description": "https://ohmyposh.dev/docs/configuration/block#index"
         }
       }
     },

--- a/website/docs/configuration/block.mdx
+++ b/website/docs/configuration/block.mdx
@@ -66,10 +66,12 @@ to be repeated to this property. Add this property to the _right_ aligned block.
 
 <Config
   data={{
-    block: {
-      alignment: "right",
-      filler: ".",
-    },
+    blocks: [
+      {
+        alignment: "right",
+        filler: ".",
+      },
+    ],
   }}
 />
 
@@ -86,11 +88,13 @@ empty space when the right block is hidden or drawn on a newline due to overflow
 
 <Config
   data={{
-    block: {
-      alignment: "right",
-      overflow: "hide",
-      filler: "{{ if .Overflow }} {{ else }}-{{ end }}",
-    },
+    blocks: [
+      {
+        alignment: "right",
+        overflow: "hide",
+        filler: "{{ if .Overflow }} {{ else }}-{{ end }}",
+      },
+    ],
   }}
 />
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Remove unused block width properties from configuration and align documentation examples with the current blocks array format.

Enhancements:
- Remove deprecated max_width and min_width fields from the Block configuration struct and associated theme schema.
- Update block configuration documentation examples to use the blocks array instead of the legacy block key.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
