### PR TITLE
ci: use DavidAnson markdown lint GitHub Actions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,4 @@
+<!--  markdownlint-disable MD041 -->
 ### Prerequisites
 
 - [ ] I have read and understood the [contributing guide][CONTRIBUTING.md].
@@ -12,8 +13,9 @@
 Tips:
 
 If you're not comfortable with working with Git,
-we're working a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
-Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D) as your preferred cross platform Git GUI power tool.
+we're working on a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
+Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D)
+as your preferred cross platform Git GUI power tool.
 
 -->
 

--- a/.github/prompts/segment.prompt.md
+++ b/.github/prompts/segment.prompt.md
@@ -1,11 +1,11 @@
 ---
-description: "Generate a new Oh My Posh segment (code, registration, docs, schema, sidebar)"
-mode: 'agent'
-model: Claude Sonnet 4
-tools: ['githubRepo', 'codebase', 'createFile', 'editFiles', 'problems', 'runCommands', 'runTasks', 'runTests', 'search', 'testFailure', 'usages']
+description: 'Generate a new Oh My Posh segment (code, registration, docs, schema, sidebar)'
+agent: 'agent'
+model: 'Claude Sonnet 4'
+tools: ['web/githubRepo', 'search/codebase', 'edit/createFile', 'edit/editFiles', 'read/problems', 'execute/getTerminalOutput', 'execute/runInTerminal', 'read/terminalLastCommand', 'read/terminalSelection', 'execute/createAndRunTask', 'execute/runTask', 'read/getTaskOutput', 'execute/runTests', 'search', 'execute/testFailure', 'search/usages']
 ---
 
-## New Segment Prompt
+# New Segment Prompt
 
 Provide the inputs below. Keep this prompt minimal;
 the detailed steps live in `.instructions/segment.md`.

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
     - name: Lint files
-      uses: articulate/actions-markdownlint@17b8abe7407cd17590c006ecc837c35e1ac3ed83
+      uses: DavidAnson/markdownlint-cli2-action@07035fd053f7be764496c0f8d8f9f41f98305101
       with:
-          files: .
           config: .markdownlint.yaml
+          globs: '**/*.md'

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,5 +1,5 @@
-MD024: false
 MD014: false
+MD024: false
 MD038: false
 line-length:
   line_length: 120

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,7 +26,13 @@
       "source.fixAll.markdownlint": "explicit"
     }
   },
-  "markdownlint.ignore": [
-    "**/agents.md"
+  "markdownlint.lintWorkspaceGlobs": [
+    "**/*.{md,mkd,mdwn,mdown,markdown,markdn,mdtxt,mdtext,workbook}",
+    "!**/*.code-search",
+    "!**/bower_components",
+    "!**/node_modules",
+    "!**/.git",
+    "!**/vendor",
+    "!**/AGENTS.md"
   ]
 }

--- a/website/blog/2022-03-20-whats-new-1.mdx
+++ b/website/blog/2022-03-20-whats-new-1.mdx
@@ -23,7 +23,6 @@ Oh My Posh on [Windows Wednesdays][windows-wednesdays], I got the sudden urge to
   className="youtube"
   src="https://www.youtube.com/embed/uO_F5W2LbSk"
   title="Windows Wednesdays: Oh My Posh"
-  frameBorder="0"
   referrerPolicy="strict-origin-when-cross-origin"
   loading="lazy"
   allowFullScreen


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Update markdown linting workflow and related GitHub configuration for prompts and PR templates.

Enhancements:
- Align segment prompt configuration with updated agent, model, and tool identifiers.
- Adjust PR template markdown formatting and add a markdownlint rule exemption for the heading.

CI:
- Switch markdown lint workflow to use the [DavidAnson markdownlint-cli2 GitHub Action](https://github.com/DavidAnson/markdownlint-cli2-action) with glob-based file selection.

### Why?

[Previous GitHub Action](https://github.com/articulate/actions-markdownlint) is deprecated.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
