### PR TITLE
docs(docusaurus): add metastring prop for highlight code

### DIFF
--- a/website/docs/configuration/templates.mdx
+++ b/website/docs/configuration/templates.mdx
@@ -129,12 +129,10 @@ $env.SET_POSHCONTEXT = {
 <Config
   data={{
     version: 4,
-    // highlight-start
     var: {
       Hello: "hello",
       World: "world",
     },
-    // highlight-end
     blocks: [
       {
         type: "prompt",
@@ -144,12 +142,16 @@ $env.SET_POSHCONTEXT = {
             type: "text",
             style: "plain",
             foreground: "p:white",
-            // highlight-next-line
             template: "{{ .Var.Hello }} {{ .Var.World }} ",
           },
         ],
       },
     ],
+  }}
+  metastring={{
+    json: "{3-6,16}",
+    yaml: "{2-4,12}",
+    toml: "{3-5,15}",
   }}
 />
 

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -21,7 +21,7 @@ export default {
       respectPrefersColorScheme: true,
     },
     prism: {
-      additionalLanguages: ['powershell', 'lua', 'jsstacktrace', 'toml', 'json'],
+      additionalLanguages: ['powershell', 'lua', 'jsstacktrace', 'toml'],
     },
     docs: {
         sidebar: {

--- a/website/src/components/Config.js
+++ b/website/src/components/Config.js
@@ -7,7 +7,7 @@ import TOML from 'smol-toml';
 
 function Config(props) {
 
-  const {data} = props;
+  const { data, metastring = { json: "", yaml: "", toml: "" } } = props;
 
   const patchTomlData = () => {
     if (data?.properties) {
@@ -38,17 +38,17 @@ function Config(props) {
         ]
       }>
       <TabItem value="json">
-        <CodeBlock className="language-json">
+        <CodeBlock language="json" metastring={metastring.json}>
           {JSON.stringify(data, null, 2)}
         </CodeBlock>
       </TabItem>
       <TabItem value="yaml">
-        <CodeBlock className="language-yaml">
+        <CodeBlock language="yaml" metastring={metastring.yaml}>
           {YAML.stringify(data)}
         </CodeBlock>
       </TabItem>
       <TabItem value="toml">
-        <CodeBlock className="language-toml">
+        <CodeBlock language="toml" metastring={metastring.toml}>
           {TOML.stringify(patchTomlData())}
         </CodeBlock>
       </TabItem>


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Support [metastring-based code highlighting](https://docusaurus.io/docs/markdown-features/code-blocks#usage-in-jsx) for configuration examples in the Docusaurus docs.

New Features:
- Allow the Config documentation component to accept per-language metastrings and pass them through to [Docusaurus CodeBlock](https://docusaurus.io/docs/markdown-features/code-blocks#usage-in-jsx) for [code highlighting](https://docusaurus.io/docs/markdown-features/code-blocks#line-highlighting).

Enhancements:
- Update the configuration templates documentation to use the new `metastring` prop instead of inline highlight comments.
- Simplify CodeBlock usage by switching from language-specific class names to the language and `metastring` props.

Build:
- Adjust Docusaurus Prism configuration by removing JSON from the list of additional languages, relying on the default support instead.

Documentation:
- Document `metastring` usage for highlighting JSON, YAML, and TOML configuration examples in the templates docs.

| Type | Before | After |
|--------|--------|--------|
| Code | <img width="491" height="536" alt="code_before" src="https://github.com/user-attachments/assets/a4379d2e-d277-4330-941e-6a6e19c4fbcd" /> | <img width="500" height="563" alt="code_after" src="https://github.com/user-attachments/assets/50e784ea-5a1d-4700-9ab8-9eb2feb9ef31" /> |
| Render | <img width="1042" height="1289" alt="before" src="https://github.com/user-attachments/assets/4737fbd3-bf3b-402e-b0a7-8d954cb2c1bc" /> | <img width="1040" height="1288" alt="after" src="https://github.com/user-attachments/assets/13fea2fb-af78-40ba-b2b9-2f53d3564015" /> | 

### Why use metastring instead of comments?

[Highlight with comments](https://docusaurus.io/docs/markdown-features/code-blocks#highlighting-with-comments) doesn't work because we use through [a `Config` component](https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/website/src/components/Config.js).

> [!NOTE]
> The `metastring` prop accepted is `highlight_line_number`, `title` and `showLineNumbers`, in the same way as you write Markdown code blocks.
> ```js
> <Config
>   data={{
>     version: 4,
>     var: {
>       Hello: "hello",
>       World: "world",
>     },
>     blocks: [
>       {
>         type: "prompt",
>         alignment: "left",
>         segments: [
>           {
>             type: "text",
>             style: "plain",
>             foreground: "p:white",
>             template: "{{ .Var.Hello }} {{ .Var.World }} ",
>           },
>         ],
>       },
>     ],
>   }}
>   metastring={{
>     json: "{3-6,16} title='example.omp.json' showLineNumbers",
>     yaml: "{2-4,12} title='example.omp.json' showLineNumbers",
>     toml: "{3-5,15} title='example.omp.json' showLineNumbers",
>   }}
> />
> ```
> <img width="1601" height="1466" alt="image" src="https://github.com/user-attachments/assets/d10d030d-aada-496f-b343-4a279017acac" />

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
