### PR TITLE
feat(node): add krypton, lts/v24 codename

### DIFF
--- a/src/segments/node.go
+++ b/src/segments/node.go
@@ -136,9 +136,11 @@ func (n *Node) matchesVersionFile() (string, bool) {
 		case "hydrogen":
 			fileVersion = "18.20.8"
 		case "iron":
-			fileVersion = "20.19.3"
+			fileVersion = "20.19.6"
 		case "jod":
-			fileVersion = "22.17.0"
+			fileVersion = "22.21.1"
+		case "krypton":
+			fileVersion = "24.12.0"
 		}
 	}
 

--- a/src/segments/node_test.go
+++ b/src/segments/node_test.go
@@ -11,10 +11,10 @@ import (
 
 func TestNodeMatchesVersionFile(t *testing.T) {
 	nodeVersion := Version{
-		Full:  "22.17.0",
+		Full:  "22.21.1",
 		Major: "22",
-		Minor: "17",
-		Patch: "0",
+		Minor: "21",
+		Patch: "1",
 	}
 	cases := []struct {
 		Case            string
@@ -23,16 +23,16 @@ func TestNodeMatchesVersionFile(t *testing.T) {
 		Expected        bool
 	}{
 		{Case: "no file context", Expected: true, RCVersion: ""},
-		{Case: "version match", Expected: true, ExpectedVersion: "22.17.0", RCVersion: "22.17.0"},
-		{Case: "version match with newline", Expected: true, ExpectedVersion: "22.17.0", RCVersion: "22.17.0\n"},
+		{Case: "version match", Expected: true, ExpectedVersion: "22.21.1", RCVersion: "22.21.1"},
+		{Case: "version match with newline", Expected: true, ExpectedVersion: "22.21.1", RCVersion: "22.21.1\n"},
 		{Case: "version mismatch", Expected: false, ExpectedVersion: "3.2.1", RCVersion: "3.2.1"},
-		{Case: "version match in other format", Expected: true, ExpectedVersion: "22.17.0", RCVersion: "v22.17.0"},
-		{Case: "version match without patch", Expected: true, ExpectedVersion: "22.17", RCVersion: "22.17"},
-		{Case: "version match without patch in other format", Expected: true, ExpectedVersion: "22.17", RCVersion: "v22.17"},
+		{Case: "version match in other format", Expected: true, ExpectedVersion: "22.21.1", RCVersion: "v22.21.1"},
+		{Case: "version match without patch", Expected: true, ExpectedVersion: "22.21", RCVersion: "22.21"},
+		{Case: "version match without patch in other format", Expected: true, ExpectedVersion: "22.21", RCVersion: "v22.21"},
 		{Case: "version match without minor", Expected: true, ExpectedVersion: "22", RCVersion: "22"},
 		{Case: "version match without minor in other format", Expected: true, ExpectedVersion: "22", RCVersion: "v22"},
-		{Case: "lts match", Expected: true, ExpectedVersion: "22.17.0", RCVersion: "lts/jod"},
-		{Case: "lts match upper case", Expected: true, ExpectedVersion: "22.17.0", RCVersion: "lts/Jod"},
+		{Case: "lts match", Expected: true, ExpectedVersion: "22.21.1", RCVersion: "lts/jod"},
+		{Case: "lts match upper case", Expected: true, ExpectedVersion: "22.21.1", RCVersion: "lts/Jod"},
 		{Case: "lts mismatch", Expected: false, ExpectedVersion: "8.17.0", RCVersion: "lts/carbon"},
 	}
 


### PR DESCRIPTION
<!--  markdownlint-disable MD041 -->
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Update [Node LTS version](https://nodejs.org/en/about/previous-releases) mappings and corresponding tests for the latest releases, including support for the new [krypton (v24)](https://nodejs.org/en/blog/release/v24.12.0) codename.

Enhancements:
- Refresh Node LTS codename-to-version mapping for iron and jod and add mapping for the new krypton LTS line.

Tests:
- Adjust Node version-file matching tests to assert against the updated jod LTS version and new baseline Node version values.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
