### PR TITLE
docs(web): update web segment info

### DIFF
--- a/themes/schema.json
+++ b/themes/schema.json
@@ -1088,7 +1088,7 @@
           },
           "then": {
             "title": "Carbon Intensity Segment",
-            "description": "Displays the actual and forecast carbon intensity in gCO2/kWh using the Carbon Intensity API",
+            "description": "https://ohmyposh.dev/docs/segments/web/carbonintensity",
             "properties": {
               "options": {
                 "properties": {
@@ -2187,7 +2187,8 @@
                     "enum": [
                       "GET",
                       "POST"
-                    ]
+                    ],
+                    "default": "GET"
                   }
                 },
                 "additionalProperties": false
@@ -2217,6 +2218,10 @@
                   },
                   "http_timeout": {
                     "$ref": "#/definitions/http_timeout"
+                  },
+                  "cache_duration": {
+                    "$ref": "#/definitions/cache_duration",
+                    "default": "24h"
                   }
                 },
                 "additionalProperties": false
@@ -3194,7 +3199,7 @@
           },
           "then": {
             "title": "Open Weather Map Segment",
-            "description": "Displays the current weather from the Open Weather Map system",
+            "description": "https://ohmyposh.dev/docs/segments/web/owm",
             "properties": {
               "options": {
                 "properties": {
@@ -4624,14 +4629,14 @@
           },
           "then": {
             "title": "Wakatime",
-            "description": "Displays the tracked time on wakatime.com",
+            "description": "https://ohmyposh.dev/docs/segments/web/wakatime",
             "properties": {
               "options": {
                 "properties": {
-                  "apikey": {
+                  "url": {
                     "type": "string",
-                    "title": "apikey",
-                    "description": "The apikey used for the api call (Required)",
+                    "title": "URL",
+                    "description": "The url used for the api call (Required)",
                     "default": "."
                   },
                   "http_timeout": {

--- a/website/docs/segments/web/brewfather.mdx
+++ b/website/docs/segments/web/brewfather.mdx
@@ -50,33 +50,33 @@ import Config from "@site/src/components/Config.js";
 | `user_id`      |        `string`         |         | as provided by Brewfather's Generate API Key screen                                                                             |
 | `api_key`      | [`template`][templates] |         | as provided by Brewfather's Generate API Key screen                                                                             |
 | `batch_id`     |        `string`         |         | Get this by navigating to the desired batch on the brewfather website, the batch id is at the end of the URL in the address bar |
-| `http_timeout` |          `int`          |   `2`   | in milliseconds - How long to wait for the Brewfather service to answer the request                                             |
 | `day_icon`     |        `string`         |   `d`   | icon or letter to use to indicate days                                                                                          |
+| `http_timeout` |          `int`          |  `20`   | in milliseconds - How long to wait for the Brewfather service to answer the request                                             |
 
 ## Icons
 
 You can override the icons for temperature trend as used by template property `.TemperatureTrendIcon` with:
 
-| Name                 | Description                                     |
-| -------------------- | ----------------------------------------------- |
-| `doubleup_icon`      | for increases of more than 4°C, default is `↑↑` |
-| `singleup_icon`      | increase 2-4°C, default is `↑`                  |
-| `fortyfiveup_icon`   | increase 0.5-2°C, default is `↗`                |
-| `flat_icon`          | change less than 0.5°C, default is `→`          |
-| `fortyfivedown_icon` | decrease 0.5-2°C, default is `↘`                |
-| `singledown_icon`    | decrease 2-4°C, default is `↓`                  |
-| `doubledown_icon`    | decrease more than 4°C, default is `↓↓`         |
+| Name                 | Default | Description                |
+| -------------------- | ------- | -------------------------- |
+| `doubleup_icon`      | `↑↑`    | increases of more than 4°C |
+| `singleup_icon`      | `↑`     | increase 2-4°C             |
+| `fortyfiveup_icon`   | `↗`     | increase 0.5-2°C           |
+| `flat_icon`          | `→`     | change less than 0.5°C     |
+| `fortyfivedown_icon` | `↘`     | decrease 0.5-2°C           |
+| `singledown_icon`    | `↓`     | decrease 2-4°C             |
+| `doubledown_icon`    | `↓↓`    | decrease more than 4°C     |
 
 You can override the default icons for batch status as used by template property `.StatusIcon` with:
 
-| Name                       |
-| -------------------------- |
-| `planning_status_icon`     |
-| `brewing_status_icon`      |
-| `fermenting_status_icon`   |
-| `conditioning_status_icon` |
-| `completed_status_icon`    |
-| `archived_status_icon`     |
+| Name                       | Default  |
+| -------------------------- | -------- |
+| `planning_status_icon`     | `\uF8EA` |
+| `brewing_status_icon`      | `\uF7DE` |
+| `fermenting_status_icon`   | `\uF499` |
+| `conditioning_status_icon` | `\uE372` |
+| `completed_status_icon`    | `\uF7A5` |
+| `archived_status_icon`     | `\uF187` |
 
 ## Template ([info][templates])
 
@@ -90,45 +90,45 @@ You can override the default icons for batch status as used by template property
 
 ### Properties
 
-| Name                    | Type     | Description                                                                                      |
-| ----------------------- | -------- | ------------------------------------------------------------------------------------------------ |
-| .Status                 | `string` | One of "Planning", "Brewing", "Fermenting", "Conditioning", "Completed" or "Archived"            |
-| .StatusIcon             | `string` | Icon representing above stats. Can be overridden with properties shown above                     |
-| .TemperatureTrendIcon   | `string` | Icon showing temperature trend based on latest and previous reading                              |
-| .DaysFermenting         | `int`    | days since start of fermentation                                                                 |
-| .DaysBottled            | `int`    | days since bottled/kegged                                                                        |
-| .DaysBottledOrFermented | `int`    | one of the above, chosen automatically based on batch status                                     |
-| .Recipe.Name            | `string` | The recipe being brewed in this batch                                                            |
-| .BatchName              | `string` | The name of this batch                                                                           |
-| .BatchNumber            | `int`    | The number of this batch                                                                         |
-| .MeasuredAbv            | `float`  | The ABV for the batch - either estimated from recipe or calculated from entered OG and FG values |
-| .ReadingAge             | `int`    | age in hours of most recent reading or -1 if there are no readings available                     |
+| Name                      | Type     | Description                                                                                      |
+| ------------------------- | -------- | ------------------------------------------------------------------------------------------------ |
+| `.Status`                 | `string` | One of "Planning", "Brewing", "Fermenting", "Conditioning", "Completed" or "Archived"            |
+| `.StatusIcon`             | `string` | Icon representing above stats. Can be overridden with properties shown above                     |
+| `.TemperatureTrendIcon`   | `string` | Icon showing temperature trend based on latest and previous reading                              |
+| `.DaysFermenting`         | `int`    | days since start of fermentation                                                                 |
+| `.DaysBottled`            | `int`    | days since bottled/kegged                                                                        |
+| `.DaysBottledOrFermented` | `int`    | one of the above, chosen automatically based on batch status                                     |
+| `.Recipe.Name`            | `string` | The recipe being brewed in this batch                                                            |
+| `.BatchName`              | `string` | The name of this batch                                                                           |
+| `.BatchNumber`            | `int`    | The number of this batch                                                                         |
+| `.MeasuredAbv`            | `float`  | The ABV for the batch - either estimated from recipe or calculated from entered OG and FG values |
+| `.ReadingAge`             | `int`    | age in hours of most recent reading or -1 if there are no readings available                     |
 
 #### Reading
 
 `.Reading` contains the most recent data from devices or manual entry as visible on the Brewfather's batch Readings graph.
 If there are no readings available, `.Reading` will be null.
 
-| Name                 | Type     | Description                                |
-| -------------------- | -------- | ------------------------------------------ |
-| .Reading.Gravity     | `float`  | specific gravity (in decimal point format) |
-| .Reading.Temperature | `float`  | temperature in °C                          |
-| .Reading.Time        | `int`    | unix timestamp of reading                  |
-| .Reading.Comment     | `string` | comment attached to this reading           |
-| .Reading.DeviceType  | `string` | source of the reading, e.g. "Tilt"         |
-| .Reading.DeviceID    | `string` | id of the device, e.g. "PINK"              |
+| Name                   | Type     | Description                                |
+| ---------------------- | -------- | ------------------------------------------ |
+| `.Reading.Gravity`     | `float`  | specific gravity (in decimal point format) |
+| `.Reading.Temperature` | `float`  | temperature in °C                          |
+| `.Reading.Time`        | `int`    | unix timestamp of reading                  |
+| `.Reading.Comment`     | `string` | comment attached to this reading           |
+| `.Reading.DeviceType`  | `string` | source of the reading, e.g. "Tilt"         |
+| `.Reading.DeviceID`    | `string` | id of the device, e.g. "PINK"              |
 
 #### Additional properties
 
-| Name              | Type     | Description                                                           |
-| ----------------- | -------- | --------------------------------------------------------------------- |
-| .MeasuredOg       | `float`  | The OG for the batch as manually entered into Brewfather              |
-| .MeasuredFg       | `float`  | The FG for the batch as manually entered into Brewfather              |
-| .BrewDate         | `int`    | The unix timestamp of the brew day                                    |
-| .FermentStartDate | `int`    | The unix timestamp when fermentation was started                      |
-| .BottlingDate     | `time`   | The unix timestamp when bottled/kegged                                |
-| .TemperatureTrend | `float`  | The difference between the most recent and previous temperature in °C |
-| .DayIcon          | `string` | given by "day_icon", or "d" by default                                |
+| Name                | Type     | Description                                                           |
+| ------------------- | -------- | --------------------------------------------------------------------- |
+| `.MeasuredOg`       | `float`  | The OG for the batch as manually entered into Brewfather              |
+| `.MeasuredFg`       | `float`  | The FG for the batch as manually entered into Brewfather              |
+| `.BrewDate`         | `int`    | The unix timestamp of the brew day                                    |
+| `.FermentStartDate` | `int`    | The unix timestamp when fermentation was started                      |
+| `.BottlingDate`     | `time`   | The unix timestamp when bottled/kegged                                |
+| `.TemperatureTrend` | `float`  | The difference between the most recent and previous temperature in °C |
+| `.DayIcon`          | `string` | given by "day_icon", or "d" by default                                |
 
 #### Hyperlink support
 
@@ -156,17 +156,17 @@ The following conversion functions are available to the template to convert to o
 
 #### Temperature
 
-| Name           | Description                                                                |
-| -------------- | -------------------------------------------------------------------------- |
-| `DegCToF`      | input: `float` degrees in C; output `float` degrees in F (1 decimal place) |
-| `DegCToKelvin` | input: `float` degrees in C; output `float` Kelvin (1 decimal place)       |
+| Name            | Description                                                                |
+| --------------- | -------------------------------------------------------------------------- |
+| `.DegCToF`      | input: `float` degrees in C; output `float` degrees in F (1 decimal place) |
+| `.DegCToKelvin` | input: `float` degrees in C; output `float` Kelvin (1 decimal place)       |
 
 #### Gravity
 
-| Name      | Description                                                                |
-| --------- | -------------------------------------------------------------------------- |
-| SGToBrix  | input `float` SG in x.xxx decimal; output `float` Brix (2 decimal places)  |
-| SGToPlato | input `float` SG in x.xxx decimal; output `float` Plato (2 decimal places) |
+| Name         | Description                                                                |
+| ------------ | -------------------------------------------------------------------------- |
+| `.SGToBrix`  | input `float` SG in x.xxx decimal; output `float` Brix (2 decimal places)  |
+| `.SGToPlato` | input `float` SG in x.xxx decimal; output `float` Plato (2 decimal places) |
 
 _(These use the polynomial conversions from [Wikipedia][wikipedia_gravity_page])_
 

--- a/website/docs/segments/web/carbonintensity.mdx
+++ b/website/docs/segments/web/carbonintensity.mdx
@@ -53,7 +53,7 @@ import Config from "@site/src/components/Config.js";
 :::note default template
 
 ```template
-CO₂ {{ .Index.Icon }}{{ .Actual.String }} {{ .TrendIcon }} {{ .Forecast.String }}
+ CO₂ {{ .Index.Icon }}{{ .Actual.String }} {{ .TrendIcon }} {{ .Forecast.String }}
 ```
 
 :::

--- a/website/docs/segments/web/http.mdx
+++ b/website/docs/segments/web/http.mdx
@@ -33,14 +33,14 @@ import Config from "@site/src/components/Config.js";
 | Name     |   Type   | Default | Description                                         |
 | -------- | :------: | :-----: | --------------------------------------------------- |
 | `url`    | `string` |   ``    | The HTTP URL you want to call, supports [templates] |
-| `method` | `string` |  `GET`  | The HTTP method to use                              |
+| `method` | `string` |  `GET`  | The HTTP method to use, `GET` or `POST`             |
 
 ## Template ([info][templates])
 
 :::note default template
 
 ```template
-{{ .Body }}
+ {{ .Body }}
 ```
 
 :::

--- a/website/docs/segments/web/ipify.mdx
+++ b/website/docs/segments/web/ipify.mdx
@@ -40,16 +40,16 @@ import Config from "@site/src/components/Config.js";
 :::note default template
 
 ```template
-{{ .IP }}
+ {{ .IP }}
 ```
 
 :::
 
 ### Properties
 
-| Name | Type     | Description              |
-| ---- | -------- | ------------------------ |
-| .IP  | `string` | Your external IP address |
+| Name  | Type     | Description              |
+| ----- | -------- | ------------------------ |
+| `.IP` | `string` | Your external IP address |
 
 [ipify]: https://www.ipify.org/
 [templates]: /docs/configuration/templates

--- a/website/docs/segments/web/nba.mdx
+++ b/website/docs/segments/web/nba.mdx
@@ -46,40 +46,40 @@ import Config from "@site/src/components/Config.js";
 
 ## Options
 
-| Name           | Type     | Description                                                                                                                                        |
-| -------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `team`         | `string` | tri-code for the NBA team you want to get data for                                                                                                 |
-| `days_offset`  | `int`    | how many days in advance you wish to see that information for, defaults to 8                                                                       |
-| `http_timeout` | `int`    | How long do you want to wait before you want to see your prompt more than your sugar? I figure a half second is a good default - defaults to 500ms |
+| Name           | Type     | Default | Description                                                                                                                    |
+| -------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `team`         | `string` |         | tri-code for the NBA team you want to get data for                                                                             |
+| `days_offset`  | `int`    |   `8`   | how many days in advance you wish to see that information for                                                                  |
+| `http_timeout` | `int`    |   `20`  | How long do you want to wait before you want to see your prompt more than your sugar? I figure a half second is a good default |
 
 ## Template ([info][templates])
 
 :::note default template
 
 ```template
-\udb82\udc06 {{ .HomeTeam}}{{ if .HasStats }} ({{.HomeTeamWins}}-{{.HomeTeamLosses}}){{ end }}{{ if .Started }}:{{.HomeScore}}{{ end }} vs {{ .AwayTeam}}{{ if .HasStats }} ({{.AwayTeamWins}}-{{.AwayTeamLosses}}){{ end }}{{ if .Started }}:{{.AwayScore}}{{ end }} | {{ if not .Started }}{{.GameDate}} | {{ end }}{{.Time}}
+ \udb82\udc06 {{ .HomeTeam}}{{ if .HasStats }} ({{.HomeTeamWins}}-{{.HomeTeamLosses}}){{ end }}{{ if .Started }}:{{.HomeScore}}{{ end }} vs {{ .AwayTeam}}{{ if .HasStats }} ({{.AwayTeamWins}}-{{.AwayTeamLosses}}){{ end }}{{ if .Started }}:{{.AwayScore}}{{ end }} | {{ if not .Started }}{{.GameDate}} | {{ end }}{{.Time}}
 ```
 
 :::
 
 ### Properties
 
-| Name            | Type      | Description                                                 |
-| --------------- | --------- | ----------------------------------------------------------- |
-| .HomeTeam       | `string`  | home team for the upcoming game                             |
-| .AwayTeam       | `string`  | away team for the upcoming game                             |
-| .Time           | `string`  | time (EST) that the upcoming game will start                |
-| .GameDate       | `string`  | date the game will happen                                   |
-| .StartTimeUTC   | `string`  | time (UTC) the game will start                              |
-| .GameStatus     | `integer` | integer, 1 = scheduled, 2 = in progress, 3 = finished       |
-| .HomeScore      | `int`     | score of the home team                                      |
-| .AwayScore      | `int`     | score of the away team                                      |
-| .HomeTeamWins   | `int`     | number of wins the home team currently has for the season   |
-| .HomeTeamLosses | `int`     | number of losses the home team currently has for the season |
-| .AwayTeamWins   | `int`     | number of wins the away team currently has for the season   |
-| .AwayTeamLosses | `int`     | number of losses the away team currently has for the season |
-| .Started        | `boolean` | if the game was started or not                              |
-| .HasStats       | `boolean` | if the game has game stats or not                           |
+| Name              | Type      | Description                                                 |
+| ----------------- | --------- | ----------------------------------------------------------- |
+| `.HomeTeam`       | `string`  | home team for the upcoming game                             |
+| `.AwayTeam`       | `string`  | away team for the upcoming game                             |
+| `.Time`           | `string`  | time (EST) that the upcoming game will start                |
+| `.GameDate`       | `string`  | date the game will happen                                   |
+| `.StartTimeUTC`   | `string`  | time (UTC) the game will start                              |
+| `.GameStatus`     | `integer` | integer, 1 = scheduled, 2 = in progress, 3 = finished       |
+| `.HomeScore`      | `int`     | score of the home team                                      |
+| `.AwayScore`      | `int`     | score of the away team                                      |
+| `.HomeTeamWins`   | `int`     | number of wins the home team currently has for the season   |
+| `.HomeTeamLosses` | `int`     | number of losses the home team currently has for the season |
+| `.AwayTeamWins`   | `int`     | number of wins the away team currently has for the season   |
+| `.AwayTeamLosses` | `int`     | number of losses the away team currently has for the season |
+| `.Started`        | `boolean` | if the game was started or not                              |
+| `.HasStats`       | `boolean` | if the game has game stats or not                           |
 
 [color-schemes]: https://teamcolorcodes.com/nba-team-color-codes/
 [templates]: /docs/configuration/templates

--- a/website/docs/segments/web/owm.mdx
+++ b/website/docs/segments/web/owm.mdx
@@ -48,7 +48,7 @@ import Config from "@site/src/components/Config.js";
 :::note default template
 
 ```template
-{{ .Weather }} ({{ .Temperature }}{{ .UnitIcon }})
+ {{ .Weather }} ({{ .Temperature }}{{ .UnitIcon }})
 ```
 
 :::

--- a/website/docs/segments/web/wakatime.mdx
+++ b/website/docs/segments/web/wakatime.mdx
@@ -64,7 +64,7 @@ Please refer to the [Environment Variable][templates-environment-variables] page
 :::note default template
 
 ```template
-{{ secondsRound .CumulativeTotal.Seconds }}
+ {{ secondsRound .CumulativeTotal.Seconds }}
 ```
 
 :::

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -202,8 +202,8 @@ export default {
           items: [
             "segments/web/brewfather",
             "segments/web/carbonintensity",
-            "segments/web/ipify",
             "segments/web/http",
+            "segments/web/ipify",
             "segments/web/nba",
             "segments/web/owm",
             "segments/web/wakatime",


### PR DESCRIPTION
<!--  markdownlint-disable MD041 -->
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Update and clarify web segment documentation and navigation for multiple integrations.

Documentation:
- Document default values for Brewfather, NBA, and status/trend icons, and consistently format property names with backticks and leading dots across web segment docs.
- Clarify allowed HTTP methods for the generic HTTP web segment and tidy default template examples for several web segments.
- Adjust sidebar navigation ordering for web segment documentation entries.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
