### PR TITLE
fix(azfunc): remove `additionalProperties: false`

### DIFF
--- a/themes/schema.json
+++ b/themes/schema.json
@@ -779,8 +779,7 @@
                       "func"
                     ]
                   }
-                },
-                "additionalProperties": false
+                }
               }
             }
           }


### PR DESCRIPTION
<!--  markdownlint-disable MD041 -->
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Bug Fixes:
- Allow additional properties in the Azure Functions-related theme schema to prevent validation failures.

Follow up #7171 

### Why?

[`language_options`](https://github.com/JanDeDobbeleer/oh-my-posh/blob/c8f4c502d359d4ec9008f98612c7fedf39805edd/themes/schema.json#L123-L177) are not allowed when `"additionalProperties": false`.

<img width="374" height="268" alt="スクリーンショット 2026-01-07 054350" src="https://github.com/user-attachments/assets/07c4ed24-3829-485b-b1d8-1aa23ccb3afd" />

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
