### PR TITLE
docs(system): polish system segment info

### DIFF
--- a/src/segments/os.go
+++ b/src/segments/os.go
@@ -74,6 +74,7 @@ func (oi *Os) getDistroIcon(distro string) string {
 		"mageia":              "\uF310",
 		"manjaro":             "\uF312",
 		"mint":                "\U000f08ed",
+		"neon":                "\uf331",
 		"nixos":               "\uF313",
 		"opensuse":            "\uF314",
 		"opensuse-tumbleweed": "\uF314",
@@ -83,7 +84,6 @@ func (oi *Os) getDistroIcon(distro string) string {
 		"sabayon":             "\uF317",
 		"slackware":           "\uF319",
 		"ubuntu":              "\uF31b",
-		"neon":                "\uf331",
 	}
 
 	if icon, ok := iconMap[distro]; ok {

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -1358,24 +1358,6 @@
                       "bluetooth"
                     ],
                     "default": "wifi|ethernet"
-                  },
-                  "unit": {
-                    "type": "string",
-                    "title": "Transfer speed unit",
-                    "enum": [
-                      "none",
-                      "b",
-                      "bps",
-                      "K",
-                      "Kbps",
-                      "M",
-                      "Mbps",
-                      "G",
-                      "Gbps",
-                      "T",
-                      "Tbps"
-                    ],
-                    "default": "none"
                   }
                 },
                 "additionalProperties": false
@@ -1672,7 +1654,7 @@
                     "default": false
                   },
                   "threshold": {
-                    "type": "number",
+                    "type": "integer",
                     "title": "Threshold",
                     "description": "minimum duration (milliseconds) required to enable this segment",
                     "default": 500
@@ -3338,6 +3320,12 @@
                     "description": "Custom glyph/text for specific paths",
                     "default": {}
                   },
+                  "mapped_locations_enabled": {
+                    "type": "boolean",
+                    "title": "Enable the Mapped Locations feature",
+                    "description": "Replace known locations in the path with the replacements before applying the style.",
+                    "default": true
+                  },
                   "max_depth": {
                     "type": "integer",
                     "title": "Maximum Depth",
@@ -3352,12 +3340,6 @@
                     "title": "Maximum Width",
                     "description": "Maximum path width to display for powerlevel style",
                     "default": 0
-                  },
-                  "mapped_locations_enabled": {
-                    "type": "boolean",
-                    "title": "Enable the Mapped Locations feature",
-                    "description": "Replace known locations in the path with the replacements before applying the style.",
-                    "default": true
                   },
                   "mixed_threshold": {
                     "type": "integer",
@@ -3418,6 +3400,12 @@
                     "type": "boolean",
                     "title": "Display the Cygwin (Linux) style path",
                     "description": "Display the Cygwin (Linux) style path using cygpath -u $PWD.",
+                    "default": false
+                  },
+                  "display_root": {
+                    "type": "boolean",
+                    "title": "Display the root directory (/) on Unix systems",
+                    "description": "Display the root directory (/) on Unix systems.",
                     "default": false
                   },
                   "dir_length": {
@@ -3655,8 +3643,7 @@
                     "description": "Always show the segment",
                     "default": false
                   }
-                },
-                "additionalProperties": false
+                }
               }
             }
           }
@@ -4020,20 +4007,7 @@
           },
           "then": {
             "title": "Session Segment",
-            "description": "https://ohmyposh.dev/docs/segments/system/session",
-            "properties": {
-              "options": {
-                "properties": {
-                  "ssh_icon": {
-                    "type": "string",
-                    "title": "SSH Icon",
-                    "description": "Text/icon to display first when in an active SSH session",
-                    "default": "\uf817"
-                  }
-                },
-                "additionalProperties": false
-              }
-            }
+            "description": "https://ohmyposh.dev/docs/segments/system/session"
           }
         },
         {
@@ -4157,7 +4131,7 @@
                     "type": "string",
                     "title": "Status Template",
                     "description": "The template to use for the status segment",
-                    "default": "|"
+                    "default": "{{ .Code }}"
                   },
                   "status_separator": {
                     "type": "string",
@@ -4570,7 +4544,7 @@
                 "properties": {
                   "cache_duration": {
                     "$ref": "#/definitions/cache_duration",
-                    "default": "none"
+                    "default": "168h"
                   }
                 },
                 "additionalProperties": false

--- a/website/docs/segments/system/battery.mdx
+++ b/website/docs/segments/system/battery.mdx
@@ -53,7 +53,7 @@ import Config from "@site/src/components/Config.js";
 :::note default template
 
 ```template
-{{ if not .Error }}{{ .Icon }}{{ .Percentage }}{{ end }}{{ .Error }}
+ {{ if not .Error }}{{ .Icon }}{{ .Percentage }}{{ end }}{{ .Error }}
 ```
 
 :::
@@ -73,6 +73,4 @@ import Config from "@site/src/components/Config.js";
 | `.Error`         | `string`  | the error in case fetching the battery information failed                                                                                                                                                                             |
 | `.Icon`          | `string`  | the icon based on the battery state                                                                                                                                                                                                   |
 
-[colors]: /docs/configuration/colors
-[battery]: https://github.com/distatus/battery/blob/master/battery.go#L78
 [templates]: /docs/configuration/templates

--- a/website/docs/segments/system/connection.mdx
+++ b/website/docs/segments/system/connection.mdx
@@ -4,7 +4,7 @@ title: Connection
 sidebar_label: Connection
 ---
 
-## Connection
+## What
 
 Show details about the currently connected network.
 
@@ -35,7 +35,7 @@ import Config from '@site/src/components/Config.js';
 :::note default template
 
 ```template
-{{ if eq .Type \"wifi\"}}\uf1eb{{ else if eq .Type \"ethernet\"}}\ueba9{{ end }}
+ {{ if eq .Type \"wifi\"}}\uf1eb{{ else if eq .Type \"ethernet\"}}\ueba9{{ end }}
 ```
 
 :::

--- a/website/docs/segments/system/executiontime.mdx
+++ b/website/docs/segments/system/executiontime.mdx
@@ -33,7 +33,7 @@ import Config from "@site/src/components/Config.js";
 | Name             |   Type    | Default  | Description                                                     |
 | ---------------- | :-------: | :------: | --------------------------------------------------------------- |
 | `always_enabled` | `boolean` | `false`  | always show the duration                                        |
-| `threshold`      | `number`  |  `500`   | minimum duration (milliseconds) required to enable this segment |
+| `threshold`      |   `int`   |  `500`   | minimum duration (milliseconds) required to enable this segment |
 | `style`          |  `enum`   | `austin` | one of the available format options                             |
 
 ### Style
@@ -57,7 +57,7 @@ Style specifies the format in which the time will be displayed. The table below 
 :::note default template
 
 ```template
-{{ .FormattedMs }}
+ {{ .FormattedMs }}
 ```
 
 :::

--- a/website/docs/segments/system/os.mdx
+++ b/website/docs/segments/system/os.mdx
@@ -70,7 +70,7 @@ import Config from "@site/src/components/Config.js";
 :::note default template
 
 ```template
-{{ if .WSL }}WSL at {{ end }}{{.Icon}}
+ {{ if .WSL }}WSL at {{ end }}{{.Icon}}
 ```
 
 :::

--- a/website/docs/segments/system/path.mdx
+++ b/website/docs/segments/system/path.mdx
@@ -187,7 +187,7 @@ number of folders specified by `full_length_dirs`, which will be displayed in fu
 :::note default template
 
 ```template
-{{ .Path }}
+ {{ .Path }}
 ```
 
 :::

--- a/website/docs/segments/system/root.mdx
+++ b/website/docs/segments/system/root.mdx
@@ -26,7 +26,7 @@ import Config from '@site/src/components/Config.js';
 :::note default template
 
 ``` template
-\uF0E7
+ \uF0E7
 ```
 
 :::

--- a/website/docs/segments/system/session.mdx
+++ b/website/docs/segments/system/session.mdx
@@ -27,7 +27,7 @@ import Config from '@site/src/components/Config.js';
 :::note default template
 
 ```template
-{{ if .SSHSession }}\ueba9 {{ end }}{{ .UserName }}@{{ .HostName }}
+ {{ if .SSHSession }}\ueba9 {{ end }}{{ .UserName }}@{{ .HostName }}
 ```
 
 :::

--- a/website/docs/segments/system/status.mdx
+++ b/website/docs/segments/system/status.mdx
@@ -42,7 +42,7 @@ import Config from "@site/src/components/Config.js";
 :::note default template
 
 ```template
-{{ .String }}
+ {{ .String }}
 ```
 
 :::

--- a/website/docs/segments/system/sysinfo.mdx
+++ b/website/docs/segments/system/sysinfo.mdx
@@ -4,7 +4,7 @@ title: System Info
 sidebar_label: System Info
 ---
 
-## SysInfo
+## What
 
 Display SysInfo.
 
@@ -37,7 +37,7 @@ import Config from "@site/src/components/Config.js";
 :::note default template
 
 ```template
-{{ round .PhysicalPercentUsed .Precision }}
+ {{ round .PhysicalPercentUsed .Precision }}
 ```
 
 :::
@@ -58,6 +58,5 @@ import Config from "@site/src/components/Config.js";
 | `.Load15`                  | `float64`  | is the current load15 (can be empty on windows)                                                                           |
 | `.Disks`                   | `[]struct` | an array of [IOCountersStat][ioinfo] object, you can use any property it has e.g. `.Disks.disk0.IoTime`                   |
 
-[cpuinfo]: https://github.com/shirou/gopsutil/blob/78065a7ce2021f6a78c8d6f586a2683ba501dcec/cpu/cpu.go#L32
 [ioinfo]: https://github.com/shirou/gopsutil/blob/e0ec1b9cda4470db704a862282a396986d7e930c/disk/disk.go#L32
 [templates]: /docs/configuration/templates

--- a/website/docs/segments/system/text.mdx
+++ b/website/docs/segments/system/text.mdx
@@ -25,5 +25,4 @@ import Config from '@site/src/components/Config.js';
 
 Text segments have no special options. See ([info][templates]) for globally available options.
 
-[coloring]: /docs/configuration/colors
 [templates]: /docs/configuration/templates

--- a/website/docs/segments/system/time.mdx
+++ b/website/docs/segments/system/time.mdx
@@ -34,7 +34,7 @@ import Config from "@site/src/components/Config.js";
 :::note default template
 
 ```template
-{{ .CurrentDate | date .Format }}
+ {{ .CurrentDate | date .Format }}
 ```
 
 :::

--- a/website/docs/segments/system/winreg.mdx
+++ b/website/docs/segments/system/winreg.mdx
@@ -47,7 +47,7 @@ import Config from "@site/src/components/Config.js";
 :::note default template
 
 ```template
-{{ .Value }}
+ {{ .Value }}
 ```
 
 :::


### PR DESCRIPTION
<!--  markdownlint-disable MD041 -->
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Polish system segment documentation and minor OS icon mapping.

Enhancements:
- Adjust OS distro icon mapping for Neon without changing behavior.

Documentation:
- Align default template code examples and headings across system segment docs, including clarifying the execution time threshold type.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
