### PR TITLE
docs(python): update example colors towards python.org ones

### DIFF
--- a/website/docs/segments/languages/python.mdx
+++ b/website/docs/segments/languages/python.mdx
@@ -18,8 +18,8 @@ import Config from "@site/src/components/Config.js";
     type: "python",
     style: "powerline",
     powerline_symbol: "\uE0B0",
-    foreground: "#100e23",
-    background: "#906cff",
+    foreground: "#ffd43b",
+    background: "#306998",
     template: " \uE235 {{ .Full }} ",
   }}
 />


### PR DESCRIPTION
<!--  markdownlint-disable MD041 -->
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

I think it's cute and recognizable to use the python.org colors for the Python segment, so I thought I'd share what I have in my config in the example.

<!---

Tips:

If you're not comfortable with working with Git,
we're working on a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D)
as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
