### PR TITLE
perf: make use of strings.Cut

### DIFF
--- a/src/cli/upgrade/tui.go
+++ b/src/cli/upgrade/tui.go
@@ -158,7 +158,8 @@ func IsMajorUpgrade(current, latest string) bool {
 	}
 
 	getMajorNumber := func(version string) string {
-		return strings.Split(version, ".")[0]
+		major, _, _ := strings.Cut(version, ".")
+		return major
 	}
 
 	return getMajorNumber(current) != getMajorNumber(latest)

--- a/src/runtime/terminal_unix.go
+++ b/src/runtime/terminal_unix.go
@@ -103,7 +103,8 @@ func (term *Terminal) Platform() string {
 	}()
 
 	if wsl := term.Getenv("WSL_DISTRO_NAME"); len(wsl) != 0 {
-		platform = strings.Split(strings.ToLower(wsl), "-")[0]
+		platform, _, _ := strings.Cut(wsl, "-")
+		platform = strings.ToLower(platform)
 		log.Debug(platform)
 		return platform
 	}

--- a/src/segments/cf_target.go
+++ b/src/segments/cf_target.go
@@ -56,12 +56,11 @@ func (c *CfTarget) setCFTargetStatus() bool {
 
 	lines := strings.SplitSeq(output, "\n")
 	for line := range lines {
-		splitted := strings.SplitN(line, ":", 2)
-		if len(splitted) < 2 {
+		key, value, found := strings.Cut(line, ":")
+		if !found {
 			continue
 		}
-		key := splitted[0]
-		value := strings.TrimSpace(splitted[1])
+		value = strings.TrimSpace(value)
 		switch key {
 		case "API endpoint":
 			c.URL = value

--- a/src/segments/fossil.go
+++ b/src/segments/fossil.go
@@ -51,18 +51,15 @@ func (f *Fossil) Enabled() bool {
 	lines := strings.SplitSeq(output, "\n")
 
 	for line := range lines {
-		if line == "" {
+		key, value, found := strings.Cut(line, " ")
+		if !found {
 			continue
 		}
-		context := strings.SplitN(line, " ", 2)
-		if len(context) < 2 {
-			continue
-		}
-		switch context[0] {
+		switch key {
 		case "tags:":
-			f.Branch = strings.TrimSpace(context[1])
+			f.Branch = strings.TrimSpace(value)
 		default:
-			f.Status.add(context[0])
+			f.Status.add(key)
 		}
 	}
 

--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -320,9 +320,7 @@ func (g *Git) StashCount() int {
 
 func (g *Git) Kraken() string {
 	root := g.getGitCommandOutput("rev-list", "--max-parents=0", "HEAD")
-	if strings.Contains(root, "\n") {
-		root = strings.Split(root, "\n")[0]
-	}
+	root, _, _ = strings.Cut(root, "\n")
 
 	if g.RawUpstreamURL == "" {
 		if g.Upstream == "" {

--- a/src/segments/project.go
+++ b/src/segments/project.go
@@ -329,12 +329,12 @@ func (n *Project) getPowerShellModuleData(_ ProjectItem) *ProjectData {
 	lines := strings.SplitSeq(content, "\n")
 
 	for line := range lines {
-		splitted := strings.SplitN(line, "=", 2)
-		if len(splitted) < 2 {
+		key, value, found := strings.Cut(line, "=")
+		if !found {
 			continue
 		}
-		key := strings.TrimSpace(splitted[0])
-		value := strings.TrimSpace(splitted[1])
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
 		value = strings.Trim(value, "'\"")
 
 		switch key {

--- a/src/segments/python.go
+++ b/src/segments/python.go
@@ -159,8 +159,8 @@ func (p *Python) pyenvVersion() (string, error) {
 		return "", err
 	}
 
-	versionString := strings.Split(cmdOutput, ":")[0]
-	if versionString == "" {
+	versionString, _, found := strings.Cut(cmdOutput, ":")
+	if !found || versionString == "" {
 		return "", errors.New("no pyenv version-name found")
 	}
 
@@ -206,14 +206,14 @@ func (p *Python) pyvenvCfgPrompt() string {
 
 	pyvenvCfg := p.env.FileContent(filepath.Join(pyvenvDir, "pyvenv.cfg"))
 	for line := range strings.SplitSeq(pyvenvCfg, "\n") {
-		lineSplit := strings.SplitN(line, "=", 2)
-		if len(lineSplit) != 2 {
+		key, value, found := strings.Cut(line, "=")
+		if !found {
 			continue
 		}
 
-		key := strings.TrimSpace(lineSplit[0])
+		key = strings.TrimSpace(key)
 		if key == "prompt" {
-			value := strings.TrimSpace(lineSplit[1])
+			value := strings.TrimSpace(value)
 			return value
 		}
 	}

--- a/src/segments/spotify_linux.go
+++ b/src/segments/spotify_linux.go
@@ -60,14 +60,14 @@ func (s *Spotify) enabledWsl() bool {
 		return false
 	}
 
-	infos := strings.SplitN(title, " - ", 2)
-	if len(infos) < 2 {
+	artist, track, found := strings.Cut(title, " - ")
+	if !found {
 		s.Status = stopped
 		return false
 	}
 
-	s.Artist = strings.TrimSpace(infos[0])
-	s.Track = strings.TrimSpace(infos[1])
+	s.Artist = strings.TrimSpace(artist)
+	s.Track = strings.TrimSpace(track)
 
 	if s.Artist == "" || s.Track == "" {
 		s.Status = stopped

--- a/src/template/text.go
+++ b/src/template/text.go
@@ -257,8 +257,7 @@ func (f *fields) hasField(field string) bool {
 	field = strings.TrimPrefix(field, ".")
 
 	// get the first part of the field
-	splitted := strings.Split(field, ".")
-	field = splitted[0]
+	field, _, _ = strings.Cut(field, ".")
 
 	f.RLock()
 	defer f.RUnlock()


### PR DESCRIPTION
<!--  markdownlint-disable MD041 -->
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

Make use of [strings.Cut](https://pkg.go.dev/strings#Cut). I haven't run any benchmarks, but this should be an improvement in performance and reduced allocations already by itself, and in some cases by avoiding splitting further than necessary. It also arguably simplifies code.

<!---

Tips:

If you're not comfortable with working with Git,
we're working on a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D)
as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
