### PR TITLE
feat: faster fvm flutter version detection

### DIFF
--- a/src/segments/flutter.go
+++ b/src/segments/flutter.go
@@ -1,4 +1,5 @@
 package segments
+import "errors"
 
 type Flutter struct {
 	Language
@@ -13,9 +14,8 @@ func (f *Flutter) Enabled() bool {
 	f.folders = dartFolders
 	f.tooling = map[string]*cmd{
 		"fvm": {
-			executable: "fvm",
-			args:       []string{"flutter", "--version"},
-			regex:      `Flutter (?P<version>((?P<major>[0-9]+).(?P<minor>[0-9]+).(?P<patch>[0-9]+)))`,
+			regex:      `(?P<version>((?P<major>[0-9]+).(?P<minor>[0-9]+).(?P<patch>[0-9]+)))`,
+			getVersion: f.fvmVersion,
 		},
 		"flutter": {
 			executable: "flutter",
@@ -27,4 +27,52 @@ func (f *Flutter) Enabled() bool {
 	f.versionURLTemplate = "https://github.com/flutter/flutter/releases/tag/{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
 
 	return f.Language.Enabled()
+}
+
+func (f *Flutter) fvmVersion() (string, error) {
+	if !f.env.HasCommand("fvm") {
+		return "", errors.New(noVersion)
+	}
+
+	if !f.env.HasFolder(".fvm") {
+		return "", errors.New(noVersion)
+	}
+
+	if version, _ := f.parseFvmrc(); version != "" {
+		return version, nil
+	}
+
+	if version, _ := f.parseDartToolVersion(); version != "" {
+		return version, nil
+	}
+
+	return "", errors.New(noVersion)
+}
+
+func (f *Flutter) parseFvmrc() (string, error) {
+	fvmrcPath, err := f.env.HasParentFilePath(".fvmrc", false)
+	if err != nil {
+		return "", err
+	}
+
+	content := f.env.FileContent(fvmrcPath)
+	if content == "" {
+		return "", nil
+	}
+
+	return content, nil
+}
+
+func (f *Flutter) parseDartToolVersion() (string, error) {
+	dartToolVersionPath, err := f.env.HasParentFilePath(".dart_tool/version", false)
+	if err != nil {
+		return "", err
+	}
+
+	content := f.env.FileContent(dartToolVersionPath)
+	if content == "" {
+		return "", nil
+	}
+
+	return content, nil
 }


### PR DESCRIPTION
 ## What
  Read Flutter version from `.fvmrc` file instead of running `fvm flutter --version` command for faster detection.

  ## Why
  Terminal command execution is slow, reading file directly is much faster.

  ## How
  - Parse `.fvmrc` file (primary)
  - Parse `.dart_tool/version` (fallback)
  - Validate fvm environment with `.fvm` folder check