### PR TITLE
fix(segments): fix winget segment header indexing

### DIFF
--- a/src/segments/winget.go
+++ b/src/segments/winget.go
@@ -74,10 +74,11 @@ func (w *WinGet) parseWinGetOutput(output string) []WinGetPackage {
 	}
 
 	// Determine column positions from header (calculated once)
-	idIndex := strings.Index(headerLine, "Id")
-	versionIndex := strings.Index(headerLine, "Version")
-	availableIndex := strings.Index(headerLine, "Available")
-	sourceIndex := strings.Index(headerLine, "Source")
+	nameIndex := strings.Index(headerLine, "Name")
+	idIndex := strings.Index(headerLine, "Id") - nameIndex
+	versionIndex := strings.Index(headerLine, "Version") - nameIndex
+	availableIndex := strings.Index(headerLine, "Available") - nameIndex
+	sourceIndex := strings.Index(headerLine, "Source") - nameIndex
 
 	// If we can't find column positions, return empty
 	if idIndex < 0 || versionIndex < 0 || availableIndex < 0 {

--- a/src/segments/winget_test.go
+++ b/src/segments/winget_test.go
@@ -151,6 +151,20 @@ Python 3.11        Python.Python.3.11          3.11.0    3.11.5    winget
 				Available: "3.11.5",
 			},
 		},
+		{
+			Case: "Output with extra characters before header line",
+			Output: `<THESE ARE SOME EXTRA CHARACTERS>Name               Id                          Version   Available Source
+-----------------------------------------------------------------------------------
+Python 3.11        Python.Python.3.11          3.11.0    3.11.5    winget
+2 upgrades available.`,
+			ExpectedCount: 1,
+			ExpectedFirst: WinGetPackage{
+				Name:      "Python 3.11",
+				ID:        "Python.Python.3.11",
+				Current:   "3.11.0",
+				Available: "3.11.5",
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
<!--  markdownlint-disable MD041 -->
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

The Winget segment does not work reliably when `winget upgrade` takes some time to complete. In that case `winget upgrade` emits some visual sugar (spinning `- \ | / -` chars and loading bars) to `stdout` before producing the desired output. All these [control] characters can end up in the header line which is assumed to just be the header fields.

In my case, printing `headerLine` with `%q` produces:
```
"- \r   \\ \r   | \r                                                                                                                        \r\r   - \r   \\ \r   | \r   / \r                                                                    
                                                    \rName               Id                 Version          Available        Source\r"
```

Within `parseWinGetOutput`, "Name" is assumed to be at index 0 while other header indices are taken from the actual string. This leads to all data lines being considered "too short" as they lack the gibberish prepended to the header line.

This PR fixes this by calculating the header field indices relative to the "Name" header, which matches the current behavior in the absence of any extra characters before the header line.


[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
