### PR TITLE
fix: `Failed to write init script` when multiple instances of OMP are started simultaneously

### DIFF
--- a/src/shell/filesystem.go
+++ b/src/shell/filesystem.go
@@ -48,10 +48,8 @@ func hasScript(env runtime.Environment) (string, bool) {
 func setFile(name string, data []byte, perm os.FileMode) error {
 	f, err := os.ReadFile(name)
 
-	if err == nil {
-		if slices.Equal(data, f) {
-			return nil
-		}
+	if err == nil && slices.Equal(data, f) {
+		return nil
 	}
 
 	return os.WriteFile(name, data, perm)

--- a/src/shell/filesystem.go
+++ b/src/shell/filesystem.go
@@ -45,7 +45,6 @@ func hasScript(env runtime.Environment) (string, bool) {
 	return path, true
 }
 
-
 func filesEqual(name string, data []byte, perm os.FileMode) bool {
 	fStat, err := os.Stat(name)
 	if err != nil {
@@ -111,7 +110,6 @@ func writeScript(env runtime.Environment, script string) (string, error) {
 	if firstErr != nil {
 		return "", firstErr
 	}
-
 
 	log.Debug("init script written successfully")
 	cache.Set(cache.Device, cacheKey(env.Flags().Shell), cacheValue(env), cache.INFINITE)

--- a/src/shell/filesystem.go
+++ b/src/shell/filesystem.go
@@ -57,12 +57,11 @@ func filesEqual(name string, data []byte, perm os.FileMode) bool {
 		return false
 	}
 
-
-	if !bytes.Equal(f, data) {
+	if fStat.Mode().Perm() != perm {
 		return false
 	}
 
-	if fStat.Mode().Perm() != perm {
+	if !bytes.Equal(f, data) {
 		return false
 	}
 

--- a/src/shell/filesystem.go
+++ b/src/shell/filesystem.go
@@ -45,10 +45,32 @@ func hasScript(env runtime.Environment) (string, bool) {
 	return path, true
 }
 
-func setFile(name string, data []byte, perm os.FileMode) error {
-	f, err := os.ReadFile(name)
 
-	if err == nil && bytes.Equal(data, f) {
+func filesEqual(name string, data []byte, perm os.FileMode) bool {
+	fStat, err := os.Stat(name)
+	if err != nil {
+		return false
+	}
+
+	f, err := os.ReadFile(name)
+	if err != nil {
+		return false
+	}
+
+
+	if !bytes.Equal(f, data) {
+		return false
+	}
+
+	if fStat.Mode().Perm() != perm {
+		return false
+	}
+
+	return true
+}
+
+func setFile(name string, data []byte, perm os.FileMode) error {
+	if filesEqual(name, data, perm) {
 		return nil
 	}
 

--- a/src/shell/filesystem.go
+++ b/src/shell/filesystem.go
@@ -47,10 +47,11 @@ func hasScript(env runtime.Environment) (string, bool) {
 
 func setFile(name string, data []byte, perm os.FileMode) error {
 	f, err := os.ReadFile(name)
-	if err != nil { return err }
 
-	if slices.Equal(data, f) {
-		return nil
+	if err == nil {
+		if slices.Equal(data, f) {
+			return nil
+		}
 	}
 
 	return os.WriteFile(name, data, perm)

--- a/src/shell/filesystem.go
+++ b/src/shell/filesystem.go
@@ -1,11 +1,11 @@
 package shell
 
 import (
+	"bytes"
 	"fmt"
 	"hash/fnv"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 	"time"
 
@@ -48,7 +48,7 @@ func hasScript(env runtime.Environment) (string, bool) {
 func setFile(name string, data []byte, perm os.FileMode) error {
 	f, err := os.ReadFile(name)
 
-	if err == nil && slices.Equal(data, f) {
+	if err == nil && bytes.Equal(data, f) {
 		return nil
 	}
 


### PR DESCRIPTION
<!--  markdownlint-disable MD041 -->
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description
i was getting an error when i was using oh-my-posh with a terminal that restores all the tabs on startup:
```
Failed to write init script: open C:\Users\irlname\AppData\Local\oh-my-posh\init.16695873114097618080.ps1: The process cannot access the file because it is being used by another process.
```

i implemented a function that only writes a file if it's different from the one on disk already and made the `writeScript` function retry until a deadline is reached

<!---

Tips:

If you're not comfortable with working with Git,
we're working on a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D)
as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
