### PR TITLE
Replace weird unicode character with space.

### DIFF
--- a/themes/atomic.omp.json
+++ b/themes/atomic.omp.json
@@ -59,7 +59,7 @@
             "threshold": 0
           },
           "style": "diamond",
-          "template": " \ueba2 {{ .FormattedMs }}\u2800",
+          "template": " \ueba2 {{ .FormattedMs }} ",
           "trailing_diamond": "\ue0b4",
           "type": "executiontime"
         }


### PR DESCRIPTION
This character does'nt work with my font, after searching it online i've discovered it is blank, like a space, so i replaced it with space, for better font compatibility and also because it is not needed(not needed to be unicode), so i did it. I use this modified version so it's pretty much already ready to merge.

<!--  markdownlint-disable MD041 -->
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!---

Tips:

If you're not comfortable with working with Git,
we're working on a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D)
as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
