### PR TITLE
fix: correct google icon theme cloud-context.omp

### DIFF
--- a/themes/cloud-context.omp.json
+++ b/themes/cloud-context.omp.json
@@ -83,7 +83,7 @@
           "foreground": "p:cloud-text-gcp",
           "style": "powerline",
           "powerline_symbol": "\ue0b4",
-          "template": " <p:symbol-color>\ue7b2</> {{ .Project }}",
+          "template": " <p:symbol-color>\ue7f0</> {{ .Project }}",
           "type": "gcp"
         },
         {


### PR DESCRIPTION
<!--  markdownlint-disable MD041 -->
### Prerequisites

- [X] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [X] The commit message follows the [conventional commits][cc] guidelines.
- [X] Tests for the changes have been added (for bug fixes / features).
- [X] Docs have been added/updated (for bug fixes / features).

### Description

cloud-context.omp theme: for gcp section, use google logo instead of c sharp

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
