### PR TITLE
fix(markdown): use `markdownlint-cli2.yaml` configuration

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,3 @@
-<!--  markdownlint-disable MD041 -->
 ### Prerequisites
 
 - [ ] I have read and understood the [contributing guide][CONTRIBUTING.md].

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -15,5 +15,5 @@ jobs:
     - name: Lint files
       uses: DavidAnson/markdownlint-cli2-action@07035fd053f7be764496c0f8d8f9f41f98305101
       with:
-          config: .markdownlint.yaml
+          config: .markdownlint-cli2.yaml
           globs: '**/*.md'

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,11 @@
+config:
+  MD013:
+    line_length: 120
+    code_blocks: false
+  MD024: false
+fix: true
+gitignore: true
+ignores:
+  - node_modules/
+  - .github/agents/segment-docs.md
+  - .github/PULL_REQUEST_TEMPLATE.md

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,6 +1,0 @@
-MD014: false
-MD024: false
-MD038: false
-line-length:
-  line_length: 120
-  code_blocks: false

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,2 +1,0 @@
-node_modules/
-.github\agents\segment-docs.md

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,14 +25,5 @@
     "editor.codeActionsOnSave": {
       "source.fixAll.markdownlint": "explicit"
     }
-  },
-  "markdownlint.lintWorkspaceGlobs": [
-    "**/*.{md,mkd,mdwn,mdown,markdown,markdn,mdtxt,mdtext,workbook}",
-    "!**/*.code-search",
-    "!**/bower_components",
-    "!**/node_modules",
-    "!**/.git",
-    "!**/vendor",
-    "!**/AGENTS.md"
-  ]
+  }
 }

--- a/website/README.md
+++ b/website/README.md
@@ -5,13 +5,13 @@ This website is built using [Docusaurus](https://docusaurus.io/), a modern stati
 ## Installation
 
 ```shell
-$ npm install
+npm install
 ```
 
 ## Local Development
 
 ```shell
-$ npm run start
+npm run start
 ```
 
 This command starts a local development server and open up a browser window.


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Use [`.markdownlint-cli2.yaml`](https://github.com/DavidAnson/markdownlint-cli2?tab=readme-ov-file#markdownlint-cli2yaml) instead of [`markdownlint-yaml`](https://github.com/DavidAnson/markdownlint-cli2?tab=readme-ov-file#markdownlintyaml-or-markdownlintyml).

Follow up #7150
Fix [failed current markdown lint workflow](https://github.com/JanDeDobbeleer/oh-my-posh/actions/runs/21263917408).

### Why remove `.markdownlintignore` file?

[markdownlint-cli2 doesn't support `.markdownlintignore`](https://github.com/DavidAnson/markdownlint-cli2?tab=readme-ov-file#compatibility).

> The `INI` config format, `.markdownlintrc`, and `.markdownlintignore` are not supported.

In addition, you can describe the ignore files in `.markdownlint-cli2.yaml`

### Why remove MD014 and MD038 from new rule?

These rules don't violate any files now.
Then enable them.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
