### PR TITLE
perf: use CutPrefix/Suffix instead of Has+Trim

### DIFF
--- a/src/cli/font/fonts.go
+++ b/src/cli/font/fonts.go
@@ -132,9 +132,11 @@ func fetchFontAssets(repo string) ([]*Asset, error) {
 
 	var fonts []*Asset
 	for _, asset := range release.Assets {
-		if asset.State == "uploaded" && strings.HasSuffix(asset.Name, ".zip") {
-			asset.Name = strings.TrimSuffix(asset.Name, ".zip")
-			fonts = append(fonts, asset)
+		if asset.State == "uploaded" {
+			if name, found := strings.CutSuffix(asset.Name, ".zip"); found {
+				asset.Name = name
+				fonts = append(fonts, asset)
+			}
 		}
 	}
 

--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -283,18 +283,18 @@ func (g *Git) Commit() *Commit {
 			refs := strings.SplitSeq(line, ", ")
 			for ref := range refs {
 				ref = strings.TrimSpace(ref)
-				switch {
-				case strings.HasSuffix(ref, "HEAD"):
+				if strings.HasSuffix(ref, "HEAD") {
 					continue
-				case strings.HasPrefix(ref, "tag: refs/tags/"):
-					g.commit.Refs.Tags = append(g.commit.Refs.Tags, strings.TrimPrefix(ref, "tag: refs/tags/"))
-				case strings.HasPrefix(ref, "refs/remotes/"):
-					g.commit.Refs.Remotes = append(g.commit.Refs.Remotes, strings.TrimPrefix(ref, "refs/remotes/"))
-				case strings.HasPrefix(ref, "HEAD -> refs/heads/"):
-					g.commit.Refs.Heads = append(g.commit.Refs.Heads, strings.TrimPrefix(ref, "HEAD -> refs/heads/"))
-				case strings.HasPrefix(ref, "refs/heads/"):
-					g.commit.Refs.Heads = append(g.commit.Refs.Heads, strings.TrimPrefix(ref, "refs/heads/"))
-				default:
+				}
+				if tag, found := strings.CutPrefix(ref, "tag: refs/tags/"); found {
+					g.commit.Refs.Tags = append(g.commit.Refs.Tags, tag)
+				} else if remote, found := strings.CutPrefix(ref, "refs/remotes/"); found {
+					g.commit.Refs.Remotes = append(g.commit.Refs.Remotes, remote)
+				} else if head, found := strings.CutPrefix(ref, "HEAD -> refs/heads/"); found {
+					g.commit.Refs.Heads = append(g.commit.Refs.Heads, head)
+				} else if head, found := strings.CutPrefix(ref, "refs/heads/"); found {
+					g.commit.Refs.Heads = append(g.commit.Refs.Heads, head)
+				} else {
 					g.commit.Refs.Heads = append(g.commit.Refs.Heads, ref)
 				}
 			}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

Avoid repeated Has+Trim string operations by using relevant Cut*. Should be good for performance (no numbers), but also arguably simplifies code.

<!---

Tips:

If you're not comfortable with working with Git,
we're working on a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D)
as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
