### PR TITLE
Add the ability to install local theme's and make loading the configuration extension agnostic.

### DIFF
--- a/src/build/version.go
+++ b/src/build/version.go
@@ -2,5 +2,5 @@ package build
 
 var (
 	Date    string
-	Version = "0.0.0-dev"
+	Version = "29.1.0"
 )

--- a/src/build/version.go
+++ b/src/build/version.go
@@ -2,5 +2,5 @@ package build
 
 var (
 	Date    string
-	Version = "29.1.0"
+	Version = "0.0.0-dev"
 )

--- a/src/config/load.go
+++ b/src/config/load.go
@@ -387,10 +387,6 @@ func isTheme(config string) (string, bool) {
 
 	log.Debug(config, "is a theme")
 
-	if themeFilePath, err := getMSIXThemePath(themeFile); err == nil {
-		return themeFilePath, true
-	}
-
 	log.Debug("building theme URL for:", themeFile)
 	url := fmt.Sprintf("https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/refs/tags/v%s/themes/%s", build.Version, themeFile)
 	return url, true

--- a/website/docs/installation/customize.mdx
+++ b/website/docs/installation/customize.mdx
@@ -33,7 +33,7 @@ These are the three possible values the `--config` flag can handle:
   ```
 
 :::info
-Using a theme name (like `jandedobbeleer`) or a remote URL requires an active internet connection
+Using a theme name (like `jandedobbeleer`) that is not locally installed, or a remote URL requires an active internet connection
 and will download the configuration on shell start. Caching is in place, but for better performance,
 it's recommended to use a local configuration file.
 :::

--- a/website/docs/installation/customize.mdx
+++ b/website/docs/installation/customize.mdx
@@ -38,6 +38,14 @@ and will download the configuration on shell start. Caching is in place, but for
 it's recommended to use a local configuration file.
 :::
 
+:::info
+Please note that, on Linux, themes inside `/usr/share/oh-my-posh/themes` or `~/.config/oh-my-posh/themes`
+can be loaded using the theme name.
+
+Please also note that these folders can be used to override the default themes,
+because they are searched for before the default, internet versions are used.
+:::
+
 ## Set the configuration
 
 The example below uses a local path to the [jandedobbeleer][jandedobbeleer] theme, adjust the `--config` value

--- a/website/docs/installation/customize.mdx
+++ b/website/docs/installation/customize.mdx
@@ -12,7 +12,7 @@ The standard initialization sets Oh My Posh' default, built-in theme.
 To set a new configuration or theme you need to change the `--config` option of the `oh-my-posh init <shell>`
 line in your `profile` or `.<shell>rc` script (see [prompt][prompt]).
 
-These are the three possible values the `--config` flag can handle:
+These are the four possible values the `--config` flag can handle:
 
 - a path to a local configuration file
 
@@ -20,7 +20,13 @@ These are the three possible values the `--config` flag can handle:
   --config 'C:/Users/Posh/myconfig.omp.json'
   ```
 
-- a pointer to a theme, without the extensions
+- a pointer to a theme
+
+  ```powershell
+  --config 'jandedobbeleer.omp.json'
+  ```
+
+- a pointer to a theme, but without the extensions
 
   ```powershell
   --config 'jandedobbeleer'

--- a/website/docs/installation/linux.mdx
+++ b/website/docs/installation/linux.mdx
@@ -27,13 +27,15 @@ The installation script requires the following tools to be installed:
 - `unzip`
 - `realpath`
 - `dirname`
+- `sudo`
+- `test`
 
 :::
 
 Install the latest version for your system by running the following command:
 
 ```bash
-curl -s https://ohmyposh.dev/install.sh | bash -s
+curl -sL https://ohmyposh.dev/install.sh | bash -s
 ```
 
 By default the script will install to `~/bin` or `~/.local/bin` depending on which one exists,
@@ -41,7 +43,13 @@ or the existing Oh My Posh executable's installation folder.
 If you want to install to a different location you can specify it using the `-d` flag:
 
 ```bash
-curl -s https://ohmyposh.dev/install.sh | bash -s -- -d ~/bin
+curl -sL https://ohmyposh.dev/install.sh | bash -s -- -d ~/bin
+```
+
+For more information:
+
+```bash
+curl -sL https://ohmyposh.dev/install.sh | bash -s -- -h
 ```
 
 <Next />

--- a/website/docs/installation/linux.mdx
+++ b/website/docs/installation/linux.mdx
@@ -27,8 +27,6 @@ The installation script requires the following tools to be installed:
 - `unzip`
 - `realpath`
 - `dirname`
-- `sudo`
-- `test`
 
 :::
 

--- a/website/static/install.sh
+++ b/website/static/install.sh
@@ -1,13 +1,9 @@
 #!/usr/bin/env bash
 
-# Immediate exit on ^C
-trap "echo '' && exit 0" SIGINT
-
 install_dir=""
 themes_dir=""
 executable=""
 version=""
-scope=""
 
 error() {
     printf "\e[31m$1\e[0m\n"
@@ -65,22 +61,6 @@ validate_dependencies() {
     validate_dependency unzip
     validate_dependency realpath
     validate_dependency dirname
-    validate_dependency sudo
-    validate_dependency test
-}
-
-set_owner() {
-    if [[ "$1" == "/home/"* ]]; then
-        sudo chown -R "$USER:$USER" "$1"
-    fi
-}
-
-get_themes_directory_user() {
-    if [[ "$1" == "/home/"* ]]; then
-        echo "$USER"
-    else
-        echo "root"
-    fi
 }
 
 set_install_directory() {
@@ -101,22 +81,15 @@ set_install_directory() {
         return 0
     fi
 
-    if [[ "$scope" == "local" || "$scope" == "custom" ]]; then
-        # check if $HOME/bin exists and is writable
-        if [ -d "$HOME/bin" ] && [ -w "$HOME/bin" ]; then
-            install_dir="$HOME/bin"
-            return 0
-        fi
-
-        # check if $HOME/.local/bin exists and is writable
-        if ([ -d "$HOME/.local/bin" ] && [ -w "$HOME/.local/bin" ]) || mkdir -p "$HOME/.local/bin"; then
-            install_dir="$HOME/.local/bin"
-            return 0
-        fi
+    # check if $HOME/bin exists and is writable
+    if [ -d "$HOME/bin" ] && [ -w "$HOME/bin" ]; then
+        install_dir="$HOME/bin"
+        return 0
     fi
 
-    if [[ "$scope" == "global" ]]; then
-        install_dir="/usr/bin"
+    # check if $HOME/.local/bin exists and is writable
+    if ([ -d "$HOME/.local/bin" ] && [ -w "$HOME/.local/bin" ]) || mkdir -p "$HOME/.local/bin"; then
+        install_dir="$HOME/.local/bin"
         return 0
     fi
 
@@ -129,8 +102,8 @@ validate_install_directory() {
         error "Directory ${install_dir} does not exist, set a different directory and try again."
     fi
 
-    # Check if root user has write permission
-    if ! sudo test "$install_dir" > /dev/null 2>&1; then
+    # Check if regular user has write permission
+    if [ ! -w "$install_dir" ]; then
         error "Cannot write to ${install_dir}. Please check write permissions or set a different directory and try again: \ncurl -s https://ohmyposh.dev/install.sh | bash -s -- -d {directory}"
     fi
 
@@ -153,12 +126,12 @@ validate_install_directory() {
 validate_themes_directory() {
 
     # Validate if the themes directory exists
-    if ! sudo -u "$(get_themes_directory_user '$themes_dir')" mkdir -p "$themes_dir" > /dev/null 2>&1; then
+    if ! mkdir -p "$themes_dir" > /dev/null 2>&1; then
         error "Cannot write to ${themes_dir}. Please check write permissions or set a different directory and try again: \ncurl -s https://ohmyposh.dev/install.sh | bash -s -- -t {directory}"
     fi
 
     #check user write permission
-    if ! sudo -u "$(get_themes_directory_user '$themes_dir')" test "$themes_dir" > /dev/null 2>&1; then
+    if [ ! -w "$themes_dir" ]; then
         error "Cannot write to ${themes_dir}. Please check write permissions or set a different directory and try again: \ncurl -s https://ohmyposh.dev/install.sh | bash -s -- -t {directory}"
     fi
 }
@@ -173,13 +146,7 @@ install_themes() {
 
     # validate if the user set the path to the themes directory
     if [ -z "$themes_dir" ]; then
-        if [[ "$scope" == "local" ]]; then
-            themes_dir="$HOME/.config/oh-my-posh/themes"
-        elif [[ "$scope" == "global" ]]; then
-            themes_dir="/usr/share/oh-my-posh/themes"
-        else
-            themes_dir="${cache_dir}/themes"
-        fi
+        themes_dir="${cache_dir}/themes"
     fi
 
     validate_themes_directory
@@ -193,10 +160,9 @@ install_themes() {
     http_response=$(curl -s -f -L $url -o $zip_file -w "%{http_code}")
 
     if [ $http_response = "200" ] && [ -f $zip_file ]; then
-        sudo unzip -o -q $zip_file -d $themes_dir
-        # make sure the files are readable and executable for all users
-        sudo chmod 755 ${themes_dir}/*
-        set_owner "$themes_dir"
+        unzip -o -q $zip_file -d $themes_dir
+        # make sure the files are readable and writable for all users
+        chmod a+rwX ${themes_dir}/*.omp.*
         rm $zip_file
     else
         warn "Unable to download themes at ${url}\nPlease validate your curl, connection and/or proxy settings"
@@ -232,14 +198,13 @@ install() {
 
     info "⬇️  Downloading oh-my-posh from ${url}"
 
-    http_response=$(sudo curl -s -f -L $url -o $executable -w "%{http_code}")
+    http_response=$(curl -s -f -L $url -o $executable -w "%{http_code}")
 
     if [ $http_response != "200" ] || [ ! -f $executable ]; then
         error "Unable to download executable at ${url}\nPlease validate your curl, connection and/or proxy settings"
     fi
 
-    sudo chmod 755 $executable
-    set_owner "$executable"
+    chmod +x $executable
 
     install_themes
 
@@ -280,30 +245,6 @@ detect_platform() {
   printf '%s' "${platform}"
 }
 
-ask_for_install_scope() {
-    if [[ "$themes_dir" != "" || "$install_dir" != "" ]]; then
-        scope="custom"
-        return 0
-    fi
-    echo -n "🌐 Would you like to install globally or just for your user(locally)? [G/l]: "
-    read -r -n 1 scope_input < /dev/tty
-    echo ""
-    if [[ "$scope_input" == "l" || "$scope_input" == "L" ]]; then
-        scope="local"
-    elif [[ "$scope_input" == "g" || "$scope_input" == "G" ]]; then
-        scope="global"
-    elif [[ -z "$scope_input" ]]; then
-        scope="global"
-    else
-        warn "Invalid option selected. Please run the script again and select 'g' for global or 'l' for local installation."
-        ask_for_install_scope
-    fi
-}
-
-# Request sudo permissions upfront
-sudo true > /dev/null 2>&1 || error "Sudo permissions are required to install Oh My Posh. Please run the script again and provide sudo access."
-
-ask_for_install_scope
 validate_dependencies
 set_install_directory
 validate_install_directory

--- a/website/static/install.sh
+++ b/website/static/install.sh
@@ -146,7 +146,7 @@ install_themes() {
 
     # validate if the user set the path to the themes directory
     if [ -z "$themes_dir" ]; then
-        themes_dir="${cache_dir}/themes"
+        themes_dir="$HOME/.config/oh-my-posh/themes"
     fi
 
     validate_themes_directory

--- a/website/static/install.sh
+++ b/website/static/install.sh
@@ -119,7 +119,7 @@ validate_install_directory() {
     )
 
     if [ "${good}" != "1" ]; then
-        warn "Installation directory ${install_dir} is not in your \$PATH, add it using \nexport PATH=\$PATH:${install_dir}"
+        warn "Installation directory ${install_dir} is not in your \$PATH, add it using: \nexport PATH=\"\$PATH:${install_dir}\""
     fi
 }
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [ ] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

I've made it so user's can add local configuration under `/usr/share/oh-my-posh/themes` and `~/.config/oh-my-posh/themes`.
I've also made it so that, when loading the configuration without the full path(locally on specified location's), or when a theme is not locally present, and is downloaded online, the extension will automatically get trimmed.
I've also made it install theme's under `~/.config/oh-my-posh/themes` instead of in the cache(`~/.cache/oh-my-posh/themes`).
I've also made the small change to make the `This directory is NOT in your $PATH!` warning to include quote's and i also added a `:` to the end of the first line of the warning.
I'd like to note i tested EVERYTHING, and i mean EVERYTHING.
Also, sorry for not following Conventional Commit's, in later pull request's i will do it.

<!---

Tips:

If you're not comfortable with working with Git,
we're working on a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D)
as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
