### PR TITLE
theme(hunk): change the foreground color for the git part and add a s…

### DIFF
--- a/themes/hunk.omp.json
+++ b/themes/hunk.omp.json
@@ -53,14 +53,14 @@
             "{{ if gt .Ahead 0 }}#89d1dc{{ end }}",
             "{{ if gt .Behind 0 }}#f17c37{{ end }}"
           ],
-          "foreground": "#ffffff",
+          "foreground": "#333333",
           "powerline_symbol": "\ue0b0",
           "options": {
             "fetch_status": true,
             "fetch_upstream_icon": true
           },
           "style": "powerline",
-          "template": " {{ .UpstreamIcon }}{{ .HEAD }}{{ if .Staging.Changed }} \uf046 {{ .Staging.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Working.Changed }} \uf044 {{ .Working.String }}{{ end }} ",
+          "template": " {{ .UpstreamIcon }} {{ .HEAD }}{{ if .Staging.Changed }} \uf046 {{ .Staging.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Working.Changed }} \uf044 {{ .Working.String }}{{ end }} ",
           "type": "git"
         }
       ],
@@ -131,5 +131,5 @@
     }
   ],
   "final_space": true,
-  "version": 4
+  "version": 5
 }


### PR DESCRIPTION
…pace between upstream icon and head icon

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

Improve the theme HUNK on two points:
- Foreground color for git branch section
- Upstream icon merged with head icon

BEFORE
<img width="1205" height="53" alt="image" src="https://github.com/user-attachments/assets/b0b23c7a-c60b-4960-ac81-57ca055c8753" />

AFTER
<img width="1209" height="52" alt="image" src="https://github.com/user-attachments/assets/3eeaeae5-3fc7-48d0-9ab6-c476f351d057" />

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
