### PR TITLE
Support Alpine liniux distros

### DIFF
--- a/src/.goreleaser.yml
+++ b/src/.goreleaser.yml
@@ -42,6 +42,34 @@ builds:
     hooks:
       post:
         - pwsh -c "if ('{{ .Path }}'.EndsWith('.exe')) { & '{{ .Env.SIGNTOOL }}' sign /v /debug /fd SHA256 /tr 'http://timestamp.acs.microsoft.com' /td SHA256 /dlib '{{ .Env.SIGNTOOLDLIB }}' /dmdf './metadata.json' '{{ .Path }}' }"
+  -
+    id: musl
+    binary: "posh-{{ .Os }}-{{ .Arch }}-musl"
+    no_unique_dist_dir: true
+    flags:
+      - -a
+    ldflags:
+      - -s -w
+      - -X github.com/jandedobbeleer/oh-my-posh/src/build.Version={{ .Version }}
+      - -X github.com/jandedobbeleer/oh-my-posh/src/build.Date={{ .Date }}
+      - -extldflags "-static"
+    tags:
+      - netgo
+      - osusergo
+      - static_build
+      - timetzdata
+    env:
+      - CGO_ENABLED=0
+      - GOEXPERIMENT=greenteagc,jsonv2
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+      - arm
+    hooks:
+      post:
+        - pwsh -c "# musl builds do not require code signing"
 archives:
   - id: oh-my-posh
     format: binary

--- a/src/cli/upgrade.go
+++ b/src/cli/upgrade.go
@@ -74,6 +74,9 @@ var upgradeCmd = &cobra.Command{
 		fmt.Print(terminal.StartProgress())
 
 		cfg := config.Get(configFlag, false)
+		
+		// Pass environment to upgrade config
+		cfg.Upgrade.Environment = env
 
 		defer func() {
 			fmt.Print(terminal.StopProgress())
@@ -111,6 +114,7 @@ var upgradeCmd = &cobra.Command{
 
 		if force {
 			log.Debug("forced upgrade")
+			cfg.Upgrade.Environment = env
 			exitcode = executeUpgrade(cfg.Upgrade)
 			return
 		}
@@ -124,6 +128,7 @@ var upgradeCmd = &cobra.Command{
 
 		if build.Version != latest {
 			log.Debug("upgrade available")
+			cfg.Upgrade.Environment = env
 			exitcode = executeUpgrade(cfg.Upgrade)
 			return
 		}

--- a/src/cli/upgrade/config.go
+++ b/src/cli/upgrade/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jandedobbeleer/oh-my-posh/src/cache"
 	"github.com/jandedobbeleer/oh-my-posh/src/cli/progress"
 	"github.com/jandedobbeleer/oh-my-posh/src/log"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime/http"
 )
 
@@ -26,6 +27,7 @@ type Config struct {
 	Auto          bool           `json:"auto" toml:"auto" yaml:"auto"`
 	DisplayNotice bool           `json:"notice" toml:"notice" yaml:"notice"`
 	Force         bool           `json:"-" toml:"-" yaml:"-"`
+	Environment   runtime.Environment `json:"-" toml:"-" yaml:"-"`
 }
 
 type Source string

--- a/src/runtime/environment.go
+++ b/src/runtime/environment.go
@@ -56,6 +56,7 @@ type Environment interface {
 	IsWsl() bool
 	IsWsl2() bool
 	IsCygwin() bool
+	IsMusl() bool
 	StackCount() int
 	TerminalWidth() (int, error)
 	Logs() string

--- a/src/runtime/terminal_windows.go
+++ b/src/runtime/terminal_windows.go
@@ -75,6 +75,11 @@ func (term *Terminal) IsCygwin() bool {
 	return len(term.Getenv("OSTYPE")) != 0 || term.Getenv("BROWSER") == "cygstart"
 }
 
+func (term *Terminal) IsMusl() bool {
+	defer log.Trace(time.Now())
+	return false
+}
+
 func (term *Terminal) TerminalWidth() (int, error) {
 	defer log.Trace(time.Now())
 

--- a/website/docs/installation/linux.mdx
+++ b/website/docs/installation/linux.mdx
@@ -30,6 +30,11 @@ The installation script requires the following tools to be installed:
 
 :::
 
+:::tip Alpine Linux
+Oh My Posh fully supports Alpine Linux on both x86_64 and ARM64 architectures, including when running in Docker containers.
+The installation script automatically detects musl-based systems and downloads optimized builds.
+:::
+
 Install the latest version for your system by running the following command:
 
 ```bash
@@ -42,6 +47,27 @@ If you want to install to a different location you can specify it using the `-d`
 
 ```bash
 curl -s https://ohmyposh.dev/install.sh | bash -s -- -d ~/bin
+```
+
+### Alpine Linux Specific
+
+Alpine Linux uses musl libc instead of glibc. Oh My Posh provides optimized builds for Alpine systems.
+The installation script will automatically detect your system type and download the appropriate build.
+
+If you're using Alpine in a Docker container, you can also install Oh My Posh like this:
+
+```dockerfile
+FROM alpine:latest
+
+RUN apk add --no-cache bash curl unzip realpath
+
+RUN curl -s https://ohmyposh.dev/install.sh | bash -s -- -d /usr/local/bin
+```
+
+Then configure your shell to use Oh My Posh:
+
+```bash
+eval "$(oh-my-posh init bash)"
 ```
 
 <Next />


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description
feat(upgrade): add Alpine Linux musl support to upgrade pipeline
- Add IsMusl() method to Environment interface to detect musl-based systems
- Implement musl detection in Unix systems checking ldd, /etc/lsb-release, and /proc/self/maps
- Update upgrade verification code to prioritize musl builds on Alpine systems
- Add musl build variant to .goreleaser.yml (posh-linux-{arch}-musl binaries)
- Enhance install.sh to detect musl and automatically download optimized builds
- Pass environment to upgrade config to enable runtime platform detection
- Gracefully fallback to standard build if musl variant unavailable

This enables native Alpine Linux ARM64 support for:
- Docker containers using Alpine base images
- Kubernetes microservices (K3s, Talos)
- Home Assistant OS add-ons
- IoT and edge devices with musl
- CI/CD runners using Alpine

Fixes https://github.com/JanDeDobbeleer/oh-my-posh/issues/7261

<!---

Tips:

If you're not comfortable with working with Git,
we're working on a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D)
as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
