### PR TITLE
fix(claude): reset gauge to 0 when context is cleared

### DIFF
--- a/src/segments/claude_test.go
+++ b/src/segments/claude_test.go
@@ -44,7 +44,7 @@ func TestClaudeSegment(t *testing.T) {
 					TotalInputTokens:  15234,
 					TotalOutputTokens: 4521,
 					ContextWindowSize: 200000,
-					CurrentUsage: ClaudeCurrentUsage{
+					CurrentUsage: &ClaudeCurrentUsage{
 						InputTokens:  8500,
 						OutputTokens: 1200,
 					},
@@ -102,28 +102,63 @@ func TestClaudeSegment(t *testing.T) {
 
 func TestClaudeTokenUsagePercent(t *testing.T) {
 	cases := []struct {
-		Case            string
-		InputTokens     int
-		OutputTokens    int
-		ContextWindow   int
-		ExpectedPercent text.Percentage
+		UsedPercentage           *int
+		Case                     string
+		InputTokens              int
+		OutputTokens             int
+		CurrentInput             int
+		CacheCreationInputTokens int
+		CacheReadInputTokens     int
+		ContextWindow            int
+		ExpectedPercent          text.Percentage
+		HasCurrentUsage          bool
 	}{
 		{
-			Case:            "Zero context window",
+			Case:            "Uses UsedPercentage when available",
+			UsedPercentage:  intPtr(42),
+			ContextWindow:   200000,
+			ExpectedPercent: 42,
+		},
+		{
+			Case:            "UsedPercentage capped at 100",
+			UsedPercentage:  intPtr(150),
+			ContextWindow:   200000,
+			ExpectedPercent: 100,
+		},
+		{
+			Case:            "UsedPercentage zero is valid",
+			UsedPercentage:  intPtr(0),
+			ContextWindow:   200000,
+			ExpectedPercent: 0,
+		},
+		{
+			Case:            "Context reset - both UsedPercentage and CurrentUsage nil",
+			UsedPercentage:  nil,
+			HasCurrentUsage: false,
+			InputTokens:     50000, // High cumulative total - should be ignored
+			OutputTokens:    50000,
+			ContextWindow:   200000,
+			ExpectedPercent: 0, // Should return 0 after reset, not fallback to total
+		},
+		{
+			Case:            "Zero context window (no UsedPercentage)",
+			HasCurrentUsage: true,
 			InputTokens:     1000,
 			OutputTokens:    500,
 			ContextWindow:   0,
 			ExpectedPercent: 0,
 		},
 		{
-			Case:            "10% usage",
+			Case:            "10% usage (fallback to total)",
+			HasCurrentUsage: true,
 			InputTokens:     8000,
 			OutputTokens:    2000,
 			ContextWindow:   100000,
 			ExpectedPercent: 10,
 		},
 		{
-			Case:            "50% usage",
+			Case:            "50% usage (fallback to total)",
+			HasCurrentUsage: true,
 			InputTokens:     50000,
 			OutputTokens:    50000,
 			ContextWindow:   200000,
@@ -131,10 +166,49 @@ func TestClaudeTokenUsagePercent(t *testing.T) {
 		},
 		{
 			Case:            "Over 100% usage (capped)",
+			HasCurrentUsage: true,
 			InputTokens:     100000,
 			OutputTokens:    50000,
 			ContextWindow:   100000,
 			ExpectedPercent: 100,
+		},
+		{
+			Case:            "Uses CurrentUsage input tokens",
+			HasCurrentUsage: true,
+			InputTokens:     100000, // High cumulative total
+			OutputTokens:    50000,
+			CurrentInput:    20000, // Current context input
+			ContextWindow:   200000,
+			ExpectedPercent: 10, // Should use current input (20000/200000 = 10%)
+		},
+		{
+			Case:                     "Uses CurrentUsage with cache tokens",
+			HasCurrentUsage:          true,
+			InputTokens:              100000, // High cumulative total
+			OutputTokens:             50000,
+			CurrentInput:             10000,
+			CacheCreationInputTokens: 5000,
+			CacheReadInputTokens:     5000,
+			ContextWindow:            200000,
+			ExpectedPercent:          10, // (10000+5000+5000)/200000 = 10%
+		},
+		{
+			Case:            "Uses CurrentUsage after compact (low current, high total)",
+			HasCurrentUsage: true,
+			InputTokens:     100000, // High cumulative total
+			OutputTokens:    50000,
+			CurrentInput:    6000, // Low current context (after compact)
+			ContextWindow:   200000,
+			ExpectedPercent: 3, // Should use current (6000/200000 = 3%)
+		},
+		{
+			Case:            "Fallback to total when CurrentUsage is zero",
+			HasCurrentUsage: true,
+			InputTokens:     20000,
+			OutputTokens:    10000,
+			CurrentInput:    0,
+			ContextWindow:   100000,
+			ExpectedPercent: 30, // Should fallback to total (30000/100000 = 30%)
 		},
 	}
 
@@ -142,11 +216,24 @@ func TestClaudeTokenUsagePercent(t *testing.T) {
 		claude := &Claude{}
 		claude.ContextWindow.TotalInputTokens = tc.InputTokens
 		claude.ContextWindow.TotalOutputTokens = tc.OutputTokens
+		if tc.HasCurrentUsage {
+			claude.ContextWindow.CurrentUsage = &ClaudeCurrentUsage{
+				InputTokens:              tc.CurrentInput,
+				CacheCreationInputTokens: tc.CacheCreationInputTokens,
+				CacheReadInputTokens:     tc.CacheReadInputTokens,
+			}
+		}
+		claude.ContextWindow.UsedPercentage = tc.UsedPercentage
 		claude.ContextWindow.ContextWindowSize = tc.ContextWindow
 
 		percent := claude.TokenUsagePercent()
 		assert.Equal(t, tc.ExpectedPercent, percent, tc.Case)
 	}
+}
+
+// intPtr is a helper to create a pointer to an int value
+func intPtr(i int) *int {
+	return &i
 }
 
 func TestClaudeFormattedCost(t *testing.T) {
@@ -188,34 +275,83 @@ func TestClaudeFormattedCost(t *testing.T) {
 
 func TestClaudeFormattedTokens(t *testing.T) {
 	cases := []struct {
-		Case           string
-		ExpectedFormat string
-		InputTokens    int
-		OutputTokens   int
+		Case                     string
+		ExpectedFormat           string
+		InputTokens              int
+		OutputTokens             int
+		CurrentInput             int
+		CacheCreationInputTokens int
+		CacheReadInputTokens     int
+		HasCurrentUsage          bool
 	}{
 		{
-			Case:           "Small token count",
-			InputTokens:    300,
-			OutputTokens:   200,
-			ExpectedFormat: "500",
+			Case:            "Small token count (fallback to total)",
+			HasCurrentUsage: true,
+			InputTokens:     300,
+			OutputTokens:    200,
+			ExpectedFormat:  "500",
 		},
 		{
-			Case:           "Thousands",
-			InputTokens:    8500,
-			OutputTokens:   1500,
-			ExpectedFormat: "10.0K",
+			Case:            "Thousands (fallback to total)",
+			HasCurrentUsage: true,
+			InputTokens:     8500,
+			OutputTokens:    1500,
+			ExpectedFormat:  "10.0K",
 		},
 		{
-			Case:           "Tens of thousands",
-			InputTokens:    50000,
-			OutputTokens:   25000,
-			ExpectedFormat: "75.0K",
+			Case:            "Tens of thousands (fallback to total)",
+			HasCurrentUsage: true,
+			InputTokens:     50000,
+			OutputTokens:    25000,
+			ExpectedFormat:  "75.0K",
 		},
 		{
-			Case:           "Millions",
-			InputTokens:    1500000,
-			OutputTokens:   500000,
-			ExpectedFormat: "2.0M",
+			Case:            "Millions (fallback to total)",
+			HasCurrentUsage: true,
+			InputTokens:     1500000,
+			OutputTokens:    500000,
+			ExpectedFormat:  "2.0M",
+		},
+		{
+			Case:            "Uses CurrentUsage input tokens",
+			HasCurrentUsage: true,
+			InputTokens:     100000, // High cumulative total
+			OutputTokens:    50000,
+			CurrentInput:    10000, // Current context input
+			ExpectedFormat:  "10.0K",
+		},
+		{
+			Case:                     "Uses CurrentUsage with cache tokens",
+			HasCurrentUsage:          true,
+			InputTokens:              100000, // High cumulative total
+			OutputTokens:             50000,
+			CurrentInput:             5000,
+			CacheCreationInputTokens: 2500,
+			CacheReadInputTokens:     2500,
+			ExpectedFormat:           "10.0K", // 5000+2500+2500 = 10000
+		},
+		{
+			Case:            "Uses CurrentUsage after compact (low current)",
+			HasCurrentUsage: true,
+			InputTokens:     500000, // High cumulative total
+			OutputTokens:    200000,
+			CurrentInput:    500, // Low current context (after compact)
+			ExpectedFormat:  "500",
+		},
+		{
+			Case:            "Fallback to total when CurrentUsage is zero",
+			HasCurrentUsage: true,
+			InputTokens:     50000,
+			OutputTokens:    25000,
+			CurrentInput:    0,
+			ExpectedFormat:  "75.0K", // Should fallback to total
+		},
+		{
+			Case:            "Nil CurrentUsage falls back to total",
+			HasCurrentUsage: false,
+			InputTokens:     50000,
+			OutputTokens:    25000,
+			ExpectedFormat:  "75.0K", // Should fallback to total
 		},
 	}
 
@@ -223,6 +359,13 @@ func TestClaudeFormattedTokens(t *testing.T) {
 		claude := &Claude{}
 		claude.ContextWindow.TotalInputTokens = tc.InputTokens
 		claude.ContextWindow.TotalOutputTokens = tc.OutputTokens
+		if tc.HasCurrentUsage {
+			claude.ContextWindow.CurrentUsage = &ClaudeCurrentUsage{
+				InputTokens:              tc.CurrentInput,
+				CacheCreationInputTokens: tc.CacheCreationInputTokens,
+				CacheReadInputTokens:     tc.CacheReadInputTokens,
+			}
+		}
 
 		formatted := claude.FormattedTokens()
 		assert.Equal(t, tc.ExpectedFormat, formatted, tc.Case)


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

 Summary

  Fixes the Claude Code segment's token usage gauge to accurately reflect current context window usage instead of cumulative
  session totals.

  Previously, TokenUsagePercent was calculated as (total_input_tokens + total_output_tokens) / context_window_size. Since these are cumulative session totals, the percentage would grow indefinitely and never decrease—even after /compact or /clear commands reduced the actual context window usage.

  Changes

  - Use UsedPercentage from Claude Code when available (pre-calculated, resets correctly)
  - Fall back to CurrentUsage tokens (actual context window content, not cumulative)
  - Include cache tokens in calculations for accuracy
  - Use pointer types to detect null values indicating a context reset
  - Preserve backwards compatibility by falling back to total tokens if newer fields aren't available

  Test Plan

  - Added tests for context reset scenarios
  - Added tests for UsedPercentage taking priority when available
  - Added tests for cache token inclusion in calculations
  - Added tests for fallback behavior
  - All existing tests continue to pass