### PR TITLE
fix timezone issues on android

### DIFF
--- a/src/runtime/terminal.go
+++ b/src/runtime/terminal.go
@@ -38,7 +38,31 @@ type Terminal struct {
 	networks []*Connection
 }
 
+func initLoacl() {
+	var timeZone *time.Location
+
+	systemTimeZone, err := exec.CommandContext(context.Background(), "/system/bin/getprop", "persist.sys.timezone").Output()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Failed to get systemTimeZone from OS")
+
+		systemTimeZone = []byte("UTC")
+	}
+
+	timeZone, err = time.LoadLocation(strings.TrimSpace(string(systemTimeZone)))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to compute timeZone from systemTimeZone: %s\n", string(systemTimeZone))
+
+		timeZone = time.Now().UTC().Location()
+	}
+
+	time.Local = timeZone
+}
+
 func (term *Terminal) Init(flags *Flags) {
+	if term.GOOS() == ANDROID {
+		initLoacl()
+	}
+
 	defer log.Trace(time.Now())
 
 	term.CmdFlags = flags


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

on android `go` always reports time in **`UTC`** zone, this PR fixes the issue by getting the correct timezone from the `persist.sys.timezone` system property

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
