### PR TITLE
feat(theme): add python venv segment to robbyrussell

### DIFF
--- a/themes/robbyrussell.omp.json
+++ b/themes/robbyrussell.omp.json
@@ -11,12 +11,18 @@
           "type": "text"
         },
         {
+          "type": "python",
+          "style": "plain",
+          "foreground": "#00c200",
+          "template": " ({{ if .Venv }}venv{{ end }})"
+        },
+        {
           "foreground": "#56B6C2",
           "options": {
             "style": "folder"
           },
           "style": "plain",
-          "template": "  {{ .Path }}",
+          "template": " {{ .Path }}",
           "type": "path"
         },
         {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

Adds a Python segment to the `robbyrussell` theme that displays the active
virtual environment name when one is detected.

### Behavior
- Shows `(venv)` when a Python virtual environment is active
- Does not render anything when no venv is present
- Does not affect users who don’t use Python

### Example
```text
➜ (venv) compiler git:(main)
