### PR TITLE
feat(executiontime): add ISO 8601 duration format

### DIFF
--- a/src/segments/executiontime_test.go
+++ b/src/segments/executiontime_test.go
@@ -362,3 +362,59 @@ func TestExecutionTimeFormatDurationLucky7(t *testing.T) {
 		assert.Equal(t, len(executionTime), 7)
 	}
 }
+
+func TestExecutionTimeFormatISO8601(t *testing.T) {
+	cases := []struct {
+		Input    string
+		Expected string
+	}{
+		{Input: "0.001s", Expected: "PT0S"},
+		{Input: "0.1s", Expected: "PT0S"},
+		{Input: "0.5s", Expected: "PT1S"},
+		{Input: "1s", Expected: "PT1S"},
+		{Input: "2.1s", Expected: "PT2S"},
+		{Input: "2.6s", Expected: "PT3S"},
+		{Input: "1m", Expected: "PT1M"},
+		{Input: "3m2.1s", Expected: "PT3M2S"},
+		{Input: "3m2.6s", Expected: "PT3M3S"},
+		{Input: "1h", Expected: "PT1H"},
+		{Input: "4h3m2.1s", Expected: "PT4H3M2S"},
+		{Input: "124h3m2.1s", Expected: "PT124H3M2S"},
+		{Input: "124h3m2.0s", Expected: "PT124H3M2S"},
+	}
+
+	for _, tc := range cases {
+		duration, _ := time.ParseDuration(tc.Input)
+		executionTime := &Executiontime{}
+		executionTime.Ms = duration.Milliseconds()
+		output := executionTime.formatDurationISO8601()
+		assert.Equal(t, tc.Expected, output, "Input: %s", tc.Input)
+	}
+}
+
+func TestExecutionTimeFormatISO8601Ms(t *testing.T) {
+	cases := []struct {
+		Input    string
+		Expected string
+	}{
+		{Input: "0.001s", Expected: "PT0.001S"},
+		{Input: "0.1s", Expected: "PT0.1S"},
+		{Input: "1s", Expected: "PT1S"},
+		{Input: "2.1s", Expected: "PT2.1S"},
+		{Input: "2.123s", Expected: "PT2.123S"},
+		{Input: "1m", Expected: "PT1M"},
+		{Input: "3m2.1s", Expected: "PT3M2.1S"},
+		{Input: "3m2.123s", Expected: "PT3M2.123S"},
+		{Input: "1h", Expected: "PT1H"},
+		{Input: "4h3m2.1s", Expected: "PT4H3M2.1S"},
+		{Input: "124h3m2.123s", Expected: "PT124H3M2.123S"},
+	}
+
+	for _, tc := range cases {
+		duration, _ := time.ParseDuration(tc.Input)
+		executionTime := &Executiontime{}
+		executionTime.Ms = duration.Milliseconds()
+		output := executionTime.formatDurationISO8601Ms()
+		assert.Equal(t, tc.Expected, output, "Input: %s", tc.Input)
+	}
+}

--- a/website/docs/segments/system/executiontime.mdx
+++ b/website/docs/segments/system/executiontime.mdx
@@ -51,6 +51,9 @@ Style specifies the format in which the time will be displayed. The table below 
 | `amarillo`    | `0.001s`       | `2.1s`         | `182.1s`       | `14,582.1s`      |
 | `round`       | `1ms`          | `2s`           | `3m 2s`        | `4h 3m`          |
 | `lucky7`      | `    1ms`      | ` 2.00s `      | ` 3m  2s`      | ` 4h  3m`        |
+| `iso8601`     | `PT0S`         | `PT2S`         | `PT3M2S`       | `PT4H3M2S`       |
+| `iso8601ms`   | `PT0.001S`     | `PT2.1S`       | `PT3M2.1S`     | `PT4H3M2.1S`     |
+
 
 ## Template ([info][templates])
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide](https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md).
- [x] The commit message follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Adds two new duration styles for the `executiontime` segment using the ISO 8601 duration format:

- **`iso8601`**: Displays time with second precision (e.g., `PT3M2S`)
- **`iso8601ms`**: Displays time with millisecond precision (e.g., `PT3M2.1S`)

This follows the same pattern as existing formats like `galveston` and `galvestonms`.

## Format Examples

| Duration | iso8601    | iso8601ms    |
|----------|------------|--------------|
| 0.001s   | PT0S       | PT0.001S     |
| 2.1s     | PT2S       | PT2.1S       |
| 3m2.1s   | PT3M2S     | PT3M2.1S     |
| 4h3m2.1s | PT4H3M2S   | PT4H3M2.1S   |

## Test Plan

- [x] Added unit tests for both formats (24 test cases total)
- [x] All tests pass (17/17 executiontime tests)
- [x] Documentation updated with examples

## Configuration Example

```json
{
  "type": "executiontime",
  "options": {
    "style": "iso8601",
    "threshold": 500
  }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)