### PR TITLE
refactor(config): use generic SegmentWriter for cache storage

### DIFF
--- a/src/config/segment.go
+++ b/src/config/segment.go
@@ -311,48 +311,29 @@ func (segment *Segment) restoreCache() bool {
 	}
 
 	key, store := segment.cacheKeyAndStore()
-	data, OK := cache.Get[string](store, key)
+
+	data, OK := cache.Get[SegmentWriter](store, key)
 	if !OK {
 		log.Debugf("no cache found for segment: %s, key: %s", segment.Name(), key)
 		return false
 	}
 
-	err := json.Unmarshal([]byte(data), &segment.writer)
-	if err != nil {
-		log.Error(err)
-	}
-
+	segment.writer = data
 	segment.Enabled = true
 	template.Cache.AddSegmentData(segment.Name(), segment.writer)
-
-	log.Debug("restored segment from cache: ", segment.Name())
-
 	segment.restored = true
 
+	log.Debug("restored segment from cache: ", segment.Name())
 	return true
 }
 
 func (segment *Segment) setCache() {
-	if segment.restored || !segment.hasCache() {
+	if segment.restored || !segment.hasCache() || segment.Pending {
 		return
 	}
 
-	// Never cache pending state to avoid polluting cache with incomplete data
-	if segment.Pending {
-		return
-	}
-
-	data, err := json.Marshal(segment.writer)
-	if err != nil {
-		log.Error(err)
-		return
-	}
-
-	// TODO: check if we can make segmentwriter a generic Type indicator
-	// that way we can actually get the value straight from cache.Get
-	// and marchalling is obsolete
 	key, store := segment.cacheKeyAndStore()
-	cache.Set(store, key, string(data), segment.Cache.Duration)
+	cache.Set(store, key, segment.writer, segment.Cache.Duration)
 }
 
 func (segment *Segment) cacheKeyAndStore() (string, cache.Store) {

--- a/src/config/segment_cache_test.go
+++ b/src/config/segment_cache_test.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/cache"
+	"github.com/jandedobbeleer/oh-my-posh/src/maps"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments"
+	"github.com/jandedobbeleer/oh-my-posh/src/template"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSegmentCache(t *testing.T) {
+	template.Cache = &cache.Template{
+		Segments: maps.NewConcurrent[any](),
+	}
+	defer cache.DeleteAll(cache.Device)
+
+	env := new(mock.Environment)
+	env.On("Pwd").Return("/tmp")
+
+	segment := &Segment{
+		Type: TEXT,
+		Cache: &Cache{
+			Strategy: Folder,
+			Duration: cache.Duration("10m"),
+		},
+		Alias: "my_text_segment",
+		env:   env,
+	}
+
+	textWriter := &segments.Text{}
+	textWriter.Init(nil, nil)
+	textWriter.SetText("Hello, Cache!")
+	segment.writer = textWriter
+	segment.name = "my_text_segment"
+
+	segment.setCache()
+
+	newSegment := &Segment{
+		Type: TEXT,
+		Cache: &Cache{
+			Strategy: Folder,
+			Duration: cache.Duration("10m"),
+		},
+		Alias: "my_text_segment",
+		env:   env,
+	}
+	newSegment.name = "my_text_segment"
+
+	newTextWriter := &segments.Text{}
+	newTextWriter.Init(nil, nil)
+	newSegment.writer = newTextWriter
+
+	restored := newSegment.restoreCache()
+
+	assert.True(t, restored, "Cache should be restored")
+	assert.NotNil(t, newSegment.writer, "Writer should be restored")
+	assert.IsType(t, &segments.Text{}, newSegment.writer, "Writer should be of type *segments.Text")
+	if newSegment.writer != nil {
+		assert.Equal(t, "Hello, Cache!", newSegment.writer.Text(), "Restored text should match")
+	}
+}


### PR DESCRIPTION
### Prerequisites
- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).
### Description
- removed unnecessary JSON marshalling/unmarshalling for cache entries
- implemented generic cache.Get[SegmentWriter] and cache.Set
- resolved TODO regarding generic type indicator for SegmentWriter
- improved type safety and reduced serialization overhead