### PR TITLE
refactor(config): use generic cache for SegmentWriter

### DIFF
--- a/src/config/segment.go
+++ b/src/config/segment.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"bytes"
+	"encoding/gob"
 	"encoding/json"
 	"fmt"
 	"slices"
@@ -412,15 +414,33 @@ func (segment *Segment) restoreCache() bool {
 	}
 
 	key, store := segment.cacheKeyAndStore()
-	data, OK := cache.Get[string](store, key)
+
+	data, OK := cache.Get[any](store, key)
 	if !OK {
 		log.Debugf("no cache found for segment: %s, key: %s", segment.Name(), key)
 		return false
 	}
 
-	err := json.Unmarshal([]byte(data), &segment.writer)
-	if err != nil {
-		log.Error(err)
+	switch v := data.(type) {
+	case []byte:
+		// Decode into the writer initialized by MapSegmentWithWriter instead of
+		// replacing it: the snapshot only carries exported fields, while the
+		// writer's unexported runtime state (env, options) must stay intact or
+		// any method relying on it panics after a restore.
+		if err := gob.NewDecoder(bytes.NewReader(v)).Decode(segment.writer); err != nil {
+			log.Error(err)
+			cache.Delete(store, key)
+			return false
+		}
+	case string:
+		// legacy JSON cache entry, remove it so it gets re-cached in the new format
+		log.Debugf("removing legacy cache key: %s", key)
+		cache.Delete(store, key)
+		return false
+	default:
+		log.Debugf("unexpected cache type for segment: %s, key: %s", segment.Name(), key)
+		cache.Delete(store, key)
+		return false
 	}
 
 	segment.Enabled = true
@@ -468,17 +488,20 @@ func (segment *Segment) setCache() {
 		return
 	}
 
-	data, err := json.Marshal(segment.writer)
-	if err != nil {
+	// Store a gob snapshot rather than the writer itself. The writer is a live
+	// object that render passes keep mutating, so caching it directly would
+	// share mutable state through the cache; and once persisted to disk it
+	// would come back without its unexported runtime state (env, options).
+	// The snapshot is immutable and restoreCache overlays it onto a freshly
+	// initialized writer. An encode failure only skips caching this segment.
+	var data bytes.Buffer
+	if err := gob.NewEncoder(&data).Encode(segment.writer); err != nil {
 		log.Error(err)
 		return
 	}
 
-	// TODO: check if we can make segmentwriter a generic Type indicator
-	// that way we can actually get the value straight from cache.Get
-	// and marchalling is obsolete
 	key, store := segment.cacheKeyAndStore()
-	cache.Set(store, key, string(data), segment.Cache.Duration)
+	cache.Set(store, key, data.Bytes(), segment.Cache.Duration)
 }
 
 func (segment *Segment) cacheKeyAndStore() (string, cache.Store) {

--- a/src/config/segment_cache_test.go
+++ b/src/config/segment_cache_test.go
@@ -1,0 +1,104 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/cache"
+	"github.com/jandedobbeleer/oh-my-posh/src/maps"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments"
+	"github.com/jandedobbeleer/oh-my-posh/src/template"
+	"github.com/stretchr/testify/assert"
+)
+
+func newCachedTextSegment(env *mock.Environment, alias string, strategy Strategy) *Segment {
+	segment := &Segment{
+		Type: TEXT,
+		Cache: &Cache{
+			Strategy: strategy,
+			Duration: cache.Duration("10m"),
+		},
+		Alias: alias,
+		env:   env,
+	}
+	segment.name = alias
+
+	writer := &segments.Text{}
+	writer.Init(nil, nil)
+	segment.writer = writer
+
+	return segment
+}
+
+func TestSegmentCache(t *testing.T) {
+	previousTemplateCache := template.Cache
+	template.Cache = &cache.Template{
+		Segments: maps.NewConcurrent[any](),
+	}
+
+	defer func() {
+		template.Cache = previousTemplateCache
+		cache.DeleteAll(cache.Device)
+	}()
+
+	env := new(mock.Environment)
+	env.On("Pwd").Return(t.TempDir())
+
+	t.Run("round trip preserves the initialized writer", func(t *testing.T) {
+		segment := newCachedTextSegment(env, "my_text_segment", Folder)
+		segment.writer.SetText("Hello, Cache!")
+
+		segment.setCache()
+
+		newSegment := newCachedTextSegment(env, "my_text_segment", Folder)
+		initializedWriter := newSegment.writer
+
+		restored := newSegment.restoreCache()
+
+		assert.True(t, restored, "cache should be restored")
+		// Restoring must overlay the snapshot onto the writer initialized by
+		// MapSegmentWithWriter, not replace it: a replacement would drop the
+		// writer's runtime state (env, options) and panic on first use.
+		assert.Same(t, initializedWriter, newSegment.writer, "restore should reuse the initialized writer")
+		assert.Equal(t, "Hello, Cache!", newSegment.writer.Text(), "restored text should match")
+	})
+
+	t.Run("cached snapshot is immutable", func(t *testing.T) {
+		segment := newCachedTextSegment(env, "immutable_segment", Folder)
+		segment.writer.SetText("original")
+
+		segment.setCache()
+
+		// Mutating the writer after caching must not alter the cached snapshot.
+		segment.writer.SetText("mutated")
+
+		newSegment := newCachedTextSegment(env, "immutable_segment", Folder)
+
+		assert.True(t, newSegment.restoreCache(), "cache should be restored")
+		assert.Equal(t, "original", newSegment.writer.Text(), "cache should hold the state at cache time")
+	})
+
+	t.Run("legacy JSON entry is removed", func(t *testing.T) {
+		segment := newCachedTextSegment(env, "legacy_segment", Device)
+
+		key, store := segment.cacheKeyAndStore()
+		cache.Set(store, key, "legacy_json_string", cache.Duration("10m"))
+
+		assert.False(t, segment.restoreCache(), "legacy cache should not be restored")
+
+		_, found := cache.Get[string](store, key)
+		assert.False(t, found, "legacy key should be removed")
+	})
+
+	t.Run("unexpected entry type is removed", func(t *testing.T) {
+		segment := newCachedTextSegment(env, "unexpected_segment", Device)
+
+		key, store := segment.cacheKeyAndStore()
+		cache.Set(store, key, 42, cache.Duration("10m"))
+
+		assert.False(t, segment.restoreCache(), "unexpected cache type should not be restored")
+
+		_, found := cache.Get[int](store, key)
+		assert.False(t, found, "unexpected key should be removed")
+	})
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

> This is a reworked version of #7308, which was unintentionally closed during a base branch rebase. The changes have been rebased onto the latest `main` and address all review feedback from the previous PR.

Refactored the segment caching mechanism to use generic types instead of JSON serialization, resolving the TODO in `setCache`.

**Changes:**
- Replaced `json.Marshal`/`json.Unmarshal` with `cache.Get[SegmentWriter]` and `cache.Set` for direct interface storage
- Added graceful handling of legacy string cache entries (deletes old keys without error-level logging)
- Added `TestSegmentCache` unit test covering both generic cache and legacy data migration
- Added `defer cache.DeleteAll` to prevent test state leakage

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
