### PR TITLE
feat(segments): add Uno Platform support

### DIFF
--- a/src/config/segment_types.go
+++ b/src/config/segment_types.go
@@ -142,6 +142,7 @@ func init() {
 	gob.Register(&segments.Todoist{})
 	gob.Register(&segments.UI5Tooling{})
 	gob.Register(&segments.Umbraco{})
+	gob.Register(&segments.Uno{})
 	gob.Register(&segments.Unity{})
 	gob.Register(&segments.Upgrade{})
 	gob.Register(&segments.UpgradeCache{})
@@ -373,6 +374,8 @@ const (
 	UI5TOOLING SegmentType = "ui5tooling"
 	// UMBRACO writes the Umbraco version if Umbraco is present
 	UMBRACO SegmentType = "umbraco"
+	// UNO writes the Uno.Sdk version from global.json
+	UNO SegmentType = "uno"
 	// UNITY writes which Unity version is currently active
 	UNITY SegmentType = "unity"
 	// UPGRADE lets you know if you can upgrade Oh My Posh
@@ -508,6 +511,7 @@ var Segments = map[SegmentType]func() SegmentWriter{
 	TODOIST:         func() SegmentWriter { return &segments.Todoist{} },
 	UI5TOOLING:      func() SegmentWriter { return &segments.UI5Tooling{} },
 	UMBRACO:         func() SegmentWriter { return &segments.Umbraco{} },
+	UNO:             func() SegmentWriter { return &segments.Uno{} },
 	UNITY:           func() SegmentWriter { return &segments.Unity{} },
 	UPGRADE:         func() SegmentWriter { return &segments.Upgrade{} },
 	V:               func() SegmentWriter { return &segments.V{} },

--- a/src/segments/uno.go
+++ b/src/segments/uno.go
@@ -1,0 +1,39 @@
+package segments
+
+import (
+	"encoding/json"
+
+	"github.com/gookit/goutil/jsonutil"
+)
+
+type unoGlobalJSON struct {
+	MSBuildSDKs map[string]string `json:"msbuild-sdks"`
+}
+
+type Uno struct {
+	Base
+
+	Version string
+}
+
+func (u *Uno) Template() string {
+	return " {{ .Version }} "
+}
+
+func (u *Uno) Enabled() bool {
+	file, err := u.env.HasParentFilePath("global.json", false)
+	if err != nil {
+		return false
+	}
+
+	content := jsonutil.StripComments(u.env.FileContent(file.Path))
+
+	var globalJSON unoGlobalJSON
+	err = json.Unmarshal([]byte(content), &globalJSON)
+	if err != nil {
+		return false
+	}
+
+	u.Version = globalJSON.MSBuildSDKs["Uno.Sdk"]
+	return len(u.Version) > 0
+}

--- a/src/segments/uno_test.go
+++ b/src/segments/uno_test.go
@@ -42,6 +42,12 @@ func TestUnoSegment(t *testing.T) {
 			ExpectedEnabled: true,
 		},
 		{
+			Case:            "valid dotnet sdk global.json without Uno.Sdk",
+			HasGlobalJSON:   true,
+			GlobalJSON:      `{"sdk":{ "version": "10.0.103" }}`,
+			ExpectedEnabled: false,
+		},
+		{
 			Case:          "valid Uno.Sdk in commented global.json",
 			HasGlobalJSON: true,
 			GlobalJSON: `{

--- a/src/segments/uno_test.go
+++ b/src/segments/uno_test.go
@@ -1,0 +1,79 @@
+package segments
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnoSegment(t *testing.T) {
+	cases := []struct {
+		Case            string
+		GlobalJSON      string
+		ExpectedVersion string
+		ExpectedEnabled bool
+		HasGlobalJSON   bool
+	}{
+		{
+			Case:            "no global.json found",
+			ExpectedEnabled: false,
+		},
+		{
+			Case:            "invalid global.json",
+			HasGlobalJSON:   true,
+			GlobalJSON:      `invalid json`,
+			ExpectedEnabled: false,
+		},
+		{
+			Case:            "global.json without Uno.Sdk",
+			HasGlobalJSON:   true,
+			GlobalJSON:      `{"msbuild-sdks":{"Another.Sdk":"1.0.0"}}`,
+			ExpectedEnabled: false,
+		},
+		{
+			Case:            "valid Uno.Sdk in global.json",
+			HasGlobalJSON:   true,
+			GlobalJSON:      `{"msbuild-sdks":{"Uno.Sdk":"6.5.31"}}`,
+			ExpectedVersion: "6.5.31",
+			ExpectedEnabled: true,
+		},
+		{
+			Case:          "valid Uno.Sdk in commented global.json",
+			HasGlobalJSON: true,
+			GlobalJSON: `{
+  // Uno SDK version
+  "msbuild-sdks": {
+    "Uno.Sdk": "6.5.31"
+  }
+}`,
+			ExpectedVersion: "6.5.31",
+			ExpectedEnabled: true,
+		},
+	}
+
+	for _, tc := range cases {
+		env := new(mock.Environment)
+
+		if tc.HasGlobalJSON {
+			file := &runtime.FileInfo{Path: "/test/global.json"}
+			env.On("HasParentFilePath", "global.json", false).Return(file, nil)
+			env.On("FileContent", "/test/global.json").Return(tc.GlobalJSON)
+		} else {
+			env.On("HasParentFilePath", "global.json", false).Return(&runtime.FileInfo{}, errors.New("file not found"))
+		}
+
+		uno := &Uno{}
+		uno.Init(options.Map{}, env)
+
+		assert.Equal(t, tc.ExpectedEnabled, uno.Enabled(), tc.Case)
+		assert.Equal(t, tc.ExpectedVersion, uno.Version, tc.Case)
+
+		if tc.ExpectedEnabled {
+			assert.Equal(t, tc.ExpectedVersion, renderTemplate(env, "{{ .Version }}", uno), tc.Case)
+		}
+	}
+}

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -486,6 +486,7 @@
             "todoist",
             "ui5tooling",
             "umbraco",
+            "uno",
             "unity",
             "upgrade",
             "v",
@@ -4920,6 +4921,19 @@
           "then": {
             "title": "Umbraco Segment",
             "description": "https://ohmyposh.dev/docs/segments/cli/umbraco"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "uno"
+              }
+            }
+          },
+          "then": {
+            "title": "Uno Platform Segment",
+            "description": "https://ohmyposh.dev/docs/segments/cli/uno"
           }
         },
         {

--- a/website/docs/segments/cli/uno.mdx
+++ b/website/docs/segments/cli/uno.mdx
@@ -28,7 +28,7 @@ import Config from "@site/src/components/Config.js";
 :::note default template
 
 ```template
-{{ .Version }}
+ {{ .Version }} 
 ```
 
 :::

--- a/website/docs/segments/cli/uno.mdx
+++ b/website/docs/segments/cli/uno.mdx
@@ -1,0 +1,43 @@
+---
+id: uno
+title: Uno Platform
+sidebar_label: Uno Platform
+---
+
+## What
+
+Display the currently active [Uno Platform][uno] SDK version.
+
+## Sample Configuration
+
+import Config from "@site/src/components/Config.js";
+
+<Config
+  data={{
+    type: "uno",
+    style: "powerline",
+    powerline_symbol: "\uE0B0",
+    foreground: "#ffffff",
+    background: "#7D4698",
+    template: " \ue799 {{ .Version }} ",
+  }}
+/>
+
+## Template ([info][templates])
+
+:::note default template
+
+```template
+{{ .Version }}
+```
+
+:::
+
+### Properties
+
+| Name       | Type     | Description               |
+| ---------- | -------- | ------------------------- |
+| `.Version` | `string` | the Uno Platform SDK version |
+
+[uno]: https://platform.uno/
+[templates]: /docs/configuration/templates

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -89,6 +89,7 @@ export default {
             "segments/cli/terraform",
             "segments/cli/ui5tooling",
             "segments/cli/umbraco",
+            "segments/cli/uno",
             "segments/cli/unity",
             "segments/cli/xmake",
             "segments/cli/yarn",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description
This PR adds support for Uno Platform <https://platform.uno>. This new segment will display the Uno Platform version based on the information in global.json, which is very similar to what dotnet does.

Thank you!

<!---

Tips:

If you're not comfortable with working with Git,
we're working on a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D)
as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
