### PR TITLE
fix: add missing zorin os icon

### DIFF
--- a/src/runtime/terminal_unix.go
+++ b/src/runtime/terminal_unix.go
@@ -122,7 +122,9 @@ func (term *Terminal) getSpecialLinuxDistros(platform string) string {
 	if platform == "arch" && strings.Contains(strings.ToLower(lsbInfo), "manjaro") {
 		// validate for Manjaro
 		return "manjaro"
-	} else if platform == "debian" && strings.Contains(strings.ToLower(lsbInfo), "zorin") {
+	}
+
+	if platform == "debian" && strings.Contains(strings.ToLower(lsbInfo), "zorin") {
 		// validate for Zorin OS
 		return "zorin"
 	}

--- a/src/runtime/terminal_unix.go
+++ b/src/runtime/terminal_unix.go
@@ -110,15 +110,23 @@ func (term *Terminal) Platform() string {
 	}
 
 	platform, _, _, _ = host.PlatformInformation()
-	if platform == "arch" {
-		// validate for Manjaro
-		lsbInfo := term.FileContent("/etc/lsb-release")
-		if strings.Contains(strings.ToLower(lsbInfo), "manjaro") {
-			platform = "manjaro"
-		}
-	}
+	platform = term.getSpecialLinuxDistros(platform)
 
 	log.Debug(platform)
+	return platform
+}
+
+func (term *Terminal) getSpecialLinuxDistros(platform string) string {
+	lsbInfo := term.FileContent("/etc/lsb-release")
+
+	if platform == "arch" && strings.Contains(strings.ToLower(lsbInfo), "manjaro") {
+		// validate for Manjaro
+		return "manjaro"
+	} else if platform == "debian" && strings.Contains(strings.ToLower(lsbInfo), "zorin") {
+		// validate for Zorin OS
+		return "zorin"
+	}
+
 	return platform
 }
 

--- a/src/segments/os.go
+++ b/src/segments/os.go
@@ -68,12 +68,12 @@ func (oi *Os) getDistroIcon(distro string) string {
 		"elementary":          "\uf309",
 		"endeavouros":         "\uf322",
 		"fedora":              "\uf30a",
-		"freebsd":             "\u000f08e0",
+		"freebsd":             "\U000f08e0",
 		"gentoo":              "\uf30d",
 		"kali":                "\uf327",
 		"mageia":              "\uf310",
 		"manjaro":             "\uf312",
-		"mint":                "\u000f08ed",
+		"mint":                "\U000f08ed",
 		"neon":                "\uf331",
 		"nixos":               "\uf313",
 		"opensuse":            "\uf314",
@@ -85,6 +85,7 @@ func (oi *Os) getDistroIcon(distro string) string {
 		"slackware":           "\uf319",
 		"ubuntu":              "\uf31b",
 		"void":                "\uf32e",
+		"zorin":               "\uf32f",
 	}
 
 	if icon, ok := iconMap[distro]; ok {

--- a/website/docs/segments/system/os.mdx
+++ b/website/docs/segments/system/os.mdx
@@ -65,6 +65,7 @@ import Config from "@site/src/components/Config.js";
 | `slackware`           | `string`  |    `\uF319`    | the icon to use for Slackware Linux                      |
 | `ubuntu`              | `string`  |    `\uF31b`    | the icon to use for Ubuntu                               |
 | `void`                | `string`  |    `\uf32e`    | the icon to use for Void Linux                           |
+| `zorin`               | `string`  |    `\uf32f`    | the icon to use for Zorin OS                             |
 
 ## Template ([info][templates])
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

The OS segment, for Linux systems, retrieves the platform information using this package https://github.com/shirou/gopsutil. In that package, there are some distros that are not recognized,
like Zorin OS or Manjaro, which had a workaround in the **Platform()** function in the **terminal_unix.go** file.
This fix extends that workaround to Zorin OS, and puts that basic check inside a new function **getSpecialLinuxDistros()**.
There is a small update to the unicode escape sequence for the freebsd and mint icons in os.go file.
