### PR TITLE
Feat/ramadan segment

### DIFF
--- a/.github/instructions/golang.md
+++ b/.github/instructions/golang.md
@@ -354,6 +354,12 @@ After making any Go code changes, run the following commands to ensure code qual
    fieldalignment --fix "./..."
    ```
 
+   > **Warning:** `fieldalignment` rewrites struct field order. Any inline struct
+   > literals that use **positional** (unnamed) field initialization — common in
+   > table-driven test files — will break after the reorder.
+   > **Always use named fields** in struct literals (e.g. `{Case: "foo", Now: t}`)
+   > so that the order of fields in the struct definition does not matter.
+
 2. **Code Modernization**: Apply modern Go best practices
 
    ```bash

--- a/src/config/segment_types.go
+++ b/src/config/segment_types.go
@@ -108,6 +108,7 @@ func init() {
 	gob.Register(&segments.Quasar{})
 	gob.Register(&segments.Package{})
 	gob.Register(&segments.R{})
+	gob.Register(&segments.Ramadan{})
 	gob.Register(&segments.React{})
 	gob.Register(&segments.Root{})
 	gob.Register(&segments.Ruby{})
@@ -303,6 +304,8 @@ const (
 	QUASAR SegmentType = "quasar"
 	// R version
 	R SegmentType = "r"
+	// RAMADAN displays Sehar and Iftar prayer times during Ramadan
+	RAMADAN SegmentType = "ramadan"
 	// REACT writes the current react version
 	REACT SegmentType = "react"
 	// ROOT writes root symbol
@@ -450,6 +453,7 @@ var Segments = map[SegmentType]func() SegmentWriter{
 	PYTHON:          func() SegmentWriter { return &segments.Python{} },
 	QUASAR:          func() SegmentWriter { return &segments.Quasar{} },
 	R:               func() SegmentWriter { return &segments.R{} },
+	RAMADAN:         func() SegmentWriter { return &segments.Ramadan{} },
 	REACT:           func() SegmentWriter { return &segments.React{} },
 	ROOT:            func() SegmentWriter { return &segments.Root{} },
 	RUBY:            func() SegmentWriter { return &segments.Ruby{} },

--- a/src/segments/ramadan.go
+++ b/src/segments/ramadan.go
@@ -1,0 +1,313 @@
+package segments
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/log"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+)
+
+// errNotRamadan is returned by setData when the segment is disabled because
+// it is not Ramadan and hide_outside_ramadan is true. It is not logged as an error.
+var errNotRamadan = errors.New("not in Ramadan")
+
+// Ramadan displays Sehar (Fajr) and Iftar (Maghrib) prayer timings
+// along with a countdown to the next event during Ramadan.
+type Ramadan struct {
+	Base
+	Fajr          string
+	Iftar         string
+	Imsak         string
+	NextEvent     string
+	TimeRemaining string
+	RozaNumber    int
+	Fasting       bool
+}
+
+const (
+	// RamadanLatitude is the latitude used for prayer time calculation.
+	RamadanLatitude options.Option = "latitude"
+	// RamadanLongitude is the longitude used for prayer time calculation.
+	RamadanLongitude options.Option = "longitude"
+	// RamadanCity is the city used for prayer time lookup.
+	RamadanCity options.Option = "city"
+	// RamadanCountry is the country used with city for prayer time lookup.
+	RamadanCountry options.Option = "country"
+	// RamadanMethod is the prayer calculation method (0-23, default 3 = Muslim World League).
+	RamadanMethod options.Option = "method"
+	// RamadanSchool is the madhab school (0=Shafi, 1=Hanafi).
+	RamadanSchool options.Option = "school"
+	// RamadanHideOutside hides the segment when not in Ramadan.
+	RamadanHideOutside options.Option = "hide_outside_ramadan"
+	// RamadanFirstRozaDate allows overriding the first day of Ramadan for local moon sighting.
+	RamadanFirstRozaDate options.Option = "first_roza_date"
+)
+
+type ramadanTimings struct {
+	Fajr    string `json:"Fajr"`
+	Imsak   string `json:"Imsak"`
+	Maghrib string `json:"Maghrib"`
+}
+
+type ramadanHijriMonth struct {
+	Number int `json:"number"`
+}
+
+type ramadanHijriDate struct {
+	Day   string            `json:"day"`
+	Month ramadanHijriMonth `json:"month"`
+}
+
+type ramadanDate struct {
+	Hijri ramadanHijriDate `json:"hijri"`
+}
+
+type ramadanData struct {
+	Timings ramadanTimings `json:"timings"`
+	Date    ramadanDate    `json:"date"`
+}
+
+type ramadanResponse struct {
+	Data ramadanData `json:"data"`
+}
+
+func (r *Ramadan) Template() string {
+	return " \U0001F319 Roza {{.RozaNumber}} \u00b7 {{.NextEvent}} in {{.TimeRemaining}} "
+}
+
+func (r *Ramadan) Enabled() bool {
+	err := r.setData()
+	if err != nil {
+		if !errors.Is(err, errNotRamadan) {
+			log.Error(err)
+		}
+		return false
+	}
+
+	return true
+}
+
+func (r *Ramadan) setData() error {
+	now := time.Now()
+	date := now.Format("02-01-2006")
+
+	apiURL, err := r.buildURL(date)
+	if err != nil {
+		return err
+	}
+
+	httpTimeout := r.options.Int(options.HTTPTimeout, options.DefaultHTTPTimeout)
+
+	body, err := r.env.HTTPRequest(apiURL, nil, httpTimeout)
+	if err != nil {
+		return err
+	}
+
+	var response ramadanResponse
+	if err = json.Unmarshal(body, &response); err != nil {
+		return err
+	}
+
+	data := response.Data
+
+	// Determine if we are currently in Ramadan and compute the roza number.
+	firstRozaStr := r.options.String(RamadanFirstRozaDate, "")
+	hideOutside := r.options.Bool(RamadanHideOutside, true)
+
+	inRamadan, rozaNumber := r.resolveRamadanDay(now, data, firstRozaStr)
+
+	if !inRamadan && hideOutside {
+		return errNotRamadan
+	}
+
+	if inRamadan {
+		r.RozaNumber = rozaNumber
+	}
+
+	fajrTime, err := parseEventTime(now, data.Timings.Fajr)
+	if err != nil {
+		return fmt.Errorf("failed to parse Fajr time: %w", err)
+	}
+
+	iftarTime, err := parseEventTime(now, data.Timings.Maghrib)
+	if err != nil {
+		return fmt.Errorf("failed to parse Iftar time: %w", err)
+	}
+
+	imsakTime, err := parseEventTime(now, data.Timings.Imsak)
+	if err != nil {
+		return fmt.Errorf("failed to parse Imsak time: %w", err)
+	}
+
+	r.Fajr = fajrTime.Format("15:04")
+	r.Iftar = iftarTime.Format("15:04")
+	r.Imsak = imsakTime.Format("15:04")
+
+	// When past Iftar, fetch tomorrow's Fajr from the API for a DST-accurate countdown.
+	// Falls back to the same wall-clock time on the next calendar day if the fetch fails.
+	var tomorrowFajr time.Time
+	if !now.Before(iftarTime) {
+		tomorrow := now.AddDate(0, 0, 1)
+		var fetchErr error
+		tomorrowFajr, fetchErr = r.fetchFajrTime(tomorrow)
+		if fetchErr != nil {
+			tomorrowFajr = time.Date(tomorrow.Year(), tomorrow.Month(), tomorrow.Day(),
+				fajrTime.Hour(), fajrTime.Minute(), 0, 0, fajrTime.Location())
+		}
+	}
+
+	r.computeNextEvent(now, fajrTime, iftarTime, tomorrowFajr)
+
+	return nil
+}
+
+// computeNextEvent sets NextEvent, TimeRemaining, and Fasting based on the current time
+// relative to today's Fajr and Iftar times. tomorrowFajrTime must be populated by the
+// caller when now is past Iftar; it is ignored otherwise.
+func (r *Ramadan) computeNextEvent(now, fajrTime, iftarTime, tomorrowFajrTime time.Time) {
+	r.Fasting = !now.Before(fajrTime) && now.Before(iftarTime)
+
+	if now.Before(fajrTime) {
+		r.NextEvent = "Sehar"
+		r.TimeRemaining = formatDuration(fajrTime.Sub(now))
+		return
+	}
+
+	if now.Before(iftarTime) {
+		r.NextEvent = "Iftar"
+		r.TimeRemaining = formatDuration(iftarTime.Sub(now))
+		return
+	}
+
+	// After Iftar — use tomorrow's Fajr time fetched from the API (or an AddDate fallback).
+	r.NextEvent = "Sehar"
+	r.TimeRemaining = formatDuration(tomorrowFajrTime.Sub(now))
+}
+
+// fetchFajrTime fetches the Fajr time for the given date from the Aladhan API.
+func (r *Ramadan) fetchFajrTime(date time.Time) (time.Time, error) {
+	dateStr := date.Format("02-01-2006")
+
+	apiURL, err := r.buildURL(dateStr)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	httpTimeout := r.options.Int(options.HTTPTimeout, options.DefaultHTTPTimeout)
+
+	body, err := r.env.HTTPRequest(apiURL, nil, httpTimeout)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	var response ramadanResponse
+	if err = json.Unmarshal(body, &response); err != nil {
+		return time.Time{}, err
+	}
+
+	return parseEventTime(date, response.Data.Timings.Fajr)
+}
+
+// buildURL constructs the Aladhan API URL for today's prayer timings.
+// City+country takes precedence over lat/lng when both are provided.
+func (r *Ramadan) buildURL(date string) (string, error) {
+	method := r.options.Int(RamadanMethod, 3)
+	school := r.options.Int(RamadanSchool, 0)
+
+	city := r.options.String(RamadanCity, "")
+	country := r.options.String(RamadanCountry, "")
+
+	if city != "" && country != "" {
+		return fmt.Sprintf(
+			"https://api.aladhan.com/v1/timingsByCity/%s?city=%s&country=%s&method=%d&school=%d",
+			date,
+			url.QueryEscape(city),
+			url.QueryEscape(country),
+			method,
+			school,
+		), nil
+	}
+
+	if r.options.Any(RamadanLatitude, nil) == nil || r.options.Any(RamadanLongitude, nil) == nil {
+		return "", errors.New("no location configured: set city+country or latitude+longitude")
+	}
+
+	lat := r.options.Float64(RamadanLatitude, 0)
+	lng := r.options.Float64(RamadanLongitude, 0)
+
+	return fmt.Sprintf(
+		"https://api.aladhan.com/v1/timings/%s?latitude=%g&longitude=%g&method=%d&school=%d",
+		date, lat, lng, method, school,
+	), nil
+}
+
+// resolveRamadanDay returns whether today is in Ramadan and the roza (day) number.
+// When first_roza_date is set it overrides the API's Hijri month detection.
+func (r *Ramadan) resolveRamadanDay(now time.Time, data ramadanData, firstRozaStr string) (bool, int) {
+	if firstRozaStr != "" {
+		firstRoza, err := time.ParseInLocation("2006-01-02", firstRozaStr, now.Location())
+		if err == nil {
+			// Use UTC noon arithmetic to avoid DST off-by-one errors.
+			ny, nm, nd := now.Date()
+			fy, fm, fd := firstRoza.Date()
+			nowDay := time.Date(ny, nm, nd, 12, 0, 0, 0, time.UTC)
+			firstDay := time.Date(fy, fm, fd, 12, 0, 0, 0, time.UTC)
+
+			daysSince := int(nowDay.Sub(firstDay).Hours() / 24)
+			if daysSince >= 0 && daysSince < 30 {
+				return true, daysSince + 1
+			}
+
+			return false, 0
+		}
+		// Parse error: fall through to API-based Hijri month detection.
+	}
+
+	if data.Date.Hijri.Month.Number != 9 {
+		return false, 0
+	}
+
+	rozaNumber := 0
+	if _, err := fmt.Sscanf(data.Date.Hijri.Day, "%d", &rozaNumber); err != nil {
+		return false, 0
+	}
+
+	return true, rozaNumber
+}
+
+// parseEventTime combines today's date with an HH:MM time string from the API.
+func parseEventTime(now time.Time, hhmm string) (time.Time, error) {
+	// The API may return timezone-suffixed values like "05:23 (PKT)"; strip any suffix.
+	timeStr := hhmm
+	if len(timeStr) > 5 {
+		timeStr = timeStr[:5]
+	}
+
+	parsed, err := time.ParseInLocation("15:04", timeStr, now.Location())
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	return time.Date(now.Year(), now.Month(), now.Day(), parsed.Hour(), parsed.Minute(), 0, 0, now.Location()), nil
+}
+
+// formatDuration formats a duration as "Xh Ym" or "Ym" when less than an hour.
+func formatDuration(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+
+	totalMinutes := int(d.Minutes())
+	h := totalMinutes / 60
+	m := totalMinutes % 60
+
+	if h > 0 {
+		return fmt.Sprintf("%dh %dm", h, m)
+	}
+
+	return fmt.Sprintf("%dm", m)
+}

--- a/src/segments/ramadan_test.go
+++ b/src/segments/ramadan_test.go
@@ -1,0 +1,325 @@
+package segments
+
+import (
+	"errors"
+	"testing"
+	libtime "time"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const ramadanTestResponse = `{
+  "code": 200,
+  "status": "OK",
+  "data": {
+    "timings": {
+      "Fajr": "05:15",
+      "Imsak": "05:05",
+      "Maghrib": "18:30"
+    },
+    "date": {
+      "hijri": {
+        "day": "5",
+        "month": { "number": 9 }
+      }
+    }
+  }
+}`
+
+const ramadanNonRamadanResponse = `{
+  "code": 200,
+  "status": "OK",
+  "data": {
+    "timings": {
+      "Fajr": "05:15",
+      "Imsak": "05:05",
+      "Maghrib": "18:30"
+    },
+    "date": {
+      "hijri": {
+        "day": "10",
+        "month": { "number": 7 }
+      }
+    }
+  }
+}`
+
+func TestRamadanSegment(t *testing.T) {
+	today := libtime.Now()
+	date := today.Format("02-01-2006")
+	// firstRoza 5 days before today so roza number is always 6 regardless of when tests run
+	firstRoza := today.AddDate(0, 0, -5).Format("2006-01-02")
+
+	cases := []struct {
+		APIError        error
+		Props           options.Map
+		Case            string
+		APIResponse     string
+		ExpectedRoza    int
+		ExpectedEnabled bool
+	}{
+		{
+			Case:        "in Ramadan via API hijri month",
+			APIResponse: ramadanTestResponse,
+			Props: options.Map{
+				RamadanLatitude:  51.5,
+				RamadanLongitude: -0.1,
+			},
+			ExpectedEnabled: true,
+			ExpectedRoza:    5,
+		},
+		{
+			Case:        "in Ramadan via first_roza_date override",
+			APIResponse: ramadanNonRamadanResponse,
+			Props: options.Map{
+				RamadanCity:          "Lahore",
+				RamadanCountry:       "Pakistan",
+				RamadanFirstRozaDate: firstRoza,
+			},
+			ExpectedEnabled: true,
+			ExpectedRoza:    6,
+		},
+		{
+			Case:        "not in Ramadan, hide=true (default)",
+			APIResponse: ramadanNonRamadanResponse,
+			Props: options.Map{
+				RamadanLatitude:  51.5,
+				RamadanLongitude: -0.1,
+			},
+			ExpectedEnabled: false,
+		},
+		{
+			Case:        "not in Ramadan, hide=false shows segment",
+			APIResponse: ramadanNonRamadanResponse,
+			Props: options.Map{
+				RamadanLatitude:    51.5,
+				RamadanLongitude:   -0.1,
+				RamadanHideOutside: false,
+			},
+			ExpectedEnabled: true,
+			ExpectedRoza:    0,
+		},
+		{
+			Case:        "API error returns false",
+			APIResponse: "",
+			APIError:    errors.New("network error"),
+			Props: options.Map{
+				RamadanLatitude:  51.5,
+				RamadanLongitude: -0.1,
+			},
+			ExpectedEnabled: false,
+		},
+		{
+			Case:            "no location configured returns false",
+			APIResponse:     ramadanTestResponse,
+			Props:           options.Map{},
+			ExpectedEnabled: false,
+		},
+	}
+
+	tomorrow := today.AddDate(0, 0, 1)
+	tomorrowDate := tomorrow.Format("02-01-2006")
+
+	for _, tc := range cases {
+		env := &mock.Environment{}
+
+		// Build the expected URL based on props to pass to the mock
+		city, hasCity := tc.Props[RamadanCity]
+		country, hasCountry := tc.Props[RamadanCountry]
+		_, hasLat := tc.Props[RamadanLatitude]
+		_, hasLng := tc.Props[RamadanLongitude]
+
+		var apiURL string
+		var tomorrowAPIURL string
+
+		switch {
+		case hasCity && hasCountry:
+			apiURL = "https://api.aladhan.com/v1/timingsByCity/" + date +
+				"?city=" + city.(string) + "&country=" + country.(string) + "&method=3&school=0"
+			tomorrowAPIURL = "https://api.aladhan.com/v1/timingsByCity/" + tomorrowDate +
+				"?city=" + city.(string) + "&country=" + country.(string) + "&method=3&school=0"
+		case hasLat && hasLng:
+			apiURL = "https://api.aladhan.com/v1/timings/" + date +
+				"?latitude=51.5&longitude=-0.1&method=3&school=0"
+			tomorrowAPIURL = "https://api.aladhan.com/v1/timings/" + tomorrowDate +
+				"?latitude=51.5&longitude=-0.1&method=3&school=0"
+		}
+
+		if apiURL != "" {
+			env.On("HTTPRequest", apiURL).Return([]byte(tc.APIResponse), tc.APIError)
+		}
+
+		// Also mock tomorrow's URL (called after Iftar for the next Sehar countdown).
+		// Marked as Maybe() so the test passes regardless of what time of day it runs.
+		if tomorrowAPIURL != "" {
+			env.On("HTTPRequest", tomorrowAPIURL).Maybe().Return([]byte(tc.APIResponse), nil)
+		}
+
+		r := &Ramadan{}
+		r.Init(tc.Props, env)
+
+		enabled := r.Enabled()
+		assert.Equal(t, tc.ExpectedEnabled, enabled, tc.Case)
+
+		if !enabled {
+			continue
+		}
+
+		assert.Equal(t, tc.ExpectedRoza, r.RozaNumber, tc.Case)
+	}
+}
+
+func TestComputeNextEvent(t *testing.T) {
+	base := libtime.Date(2026, 3, 1, 0, 0, 0, 0, libtime.UTC)
+	fajr := base.Add(5*libtime.Hour + 15*libtime.Minute)
+	iftar := base.Add(18*libtime.Hour + 30*libtime.Minute)
+	nextDay := fajr.AddDate(0, 0, 1)
+	tomorrowFajr := libtime.Date(nextDay.Year(), nextDay.Month(), nextDay.Day(), fajr.Hour(), fajr.Minute(), 0, 0, fajr.Location())
+
+	cases := []struct {
+		Now               libtime.Time
+		Case              string
+		ExpectedNextEvent string
+		ExpectedFasting   bool
+	}{
+		{Case: "before fajr", Now: fajr.Add(-10 * libtime.Minute), ExpectedFasting: false, ExpectedNextEvent: "Sehar"},
+		{Case: "exactly at fajr (boundary)", Now: fajr, ExpectedFasting: true, ExpectedNextEvent: "Iftar"},
+		{Case: "after fajr, before iftar", Now: fajr.Add(1 * libtime.Hour), ExpectedFasting: true, ExpectedNextEvent: "Iftar"},
+		{Case: "exactly at iftar", Now: iftar, ExpectedFasting: false, ExpectedNextEvent: "Sehar"},
+		{Case: "after iftar", Now: iftar.Add(30 * libtime.Minute), ExpectedFasting: false, ExpectedNextEvent: "Sehar"},
+	}
+
+	for _, tc := range cases {
+		r := &Ramadan{}
+		r.computeNextEvent(tc.Now, fajr, iftar, tomorrowFajr)
+		assert.Equal(t, tc.ExpectedFasting, r.Fasting, tc.Case)
+		assert.Equal(t, tc.ExpectedNextEvent, r.NextEvent, tc.Case)
+	}
+}
+
+func TestFormatDuration(t *testing.T) {
+	cases := []struct {
+		Case     string
+		Expected string
+		Input    libtime.Duration
+	}{
+		{"hours and minutes", "3h 42m", 3*libtime.Hour + 42*libtime.Minute},
+		{"minutes only", "25m", 25 * libtime.Minute},
+		{"zero", "0m", 0},
+		{"negative clamped to zero", "0m", -5 * libtime.Minute},
+		{"exact hour", "1h 0m", libtime.Hour},
+	}
+
+	for _, tc := range cases {
+		assert.Equal(t, tc.Expected, formatDuration(tc.Input), tc.Case)
+	}
+}
+
+func TestParseEventTime(t *testing.T) {
+	now := libtime.Date(2026, 2, 24, 12, 0, 0, 0, libtime.UTC)
+
+	cases := []struct {
+		Case           string
+		Input          string
+		ExpectedHour   int
+		ExpectedMinute int
+	}{
+		{"plain HH:MM", "05:23", 5, 23},
+		{"with timezone suffix", "05:23 (PKT)", 5, 23},
+		{"midnight", "00:04", 0, 4},
+	}
+
+	for _, tc := range cases {
+		result, err := parseEventTime(now, tc.Input)
+		assert.NoError(t, err, tc.Case)
+		assert.Equal(t, tc.ExpectedHour, result.Hour(), tc.Case)
+		assert.Equal(t, tc.ExpectedMinute, result.Minute(), tc.Case)
+		assert.Equal(t, 2026, result.Year(), tc.Case)
+	}
+}
+
+func TestResolveRamadanDay(t *testing.T) {
+	now := libtime.Date(2026, 2, 24, 12, 0, 0, 0, libtime.UTC)
+	r := &Ramadan{}
+
+	ramadanData := ramadanData{
+		Date: ramadanDate{
+			Hijri: ramadanHijriDate{
+				Day:   "5",
+				Month: ramadanHijriMonth{Number: 9},
+			},
+		},
+	}
+	nonRamadanData := ramadanData
+	nonRamadanData.Date.Hijri.Month.Number = 7
+
+	// via hijri month
+	inRamadan, roza := r.resolveRamadanDay(now, ramadanData, "")
+	assert.True(t, inRamadan)
+	assert.Equal(t, 5, roza)
+
+	// not Ramadan month
+	inRamadan, roza = r.resolveRamadanDay(now, nonRamadanData, "")
+	assert.False(t, inRamadan)
+	assert.Equal(t, 0, roza)
+
+	// first_roza_date override — today is day 6 (2026-02-24, first roza 2026-02-19)
+	inRamadan, roza = r.resolveRamadanDay(now, nonRamadanData, "2026-02-19")
+	assert.True(t, inRamadan)
+	assert.Equal(t, 6, roza)
+
+	// first_roza_date override — date before start
+	beforeStart := libtime.Date(2026, 2, 18, 12, 0, 0, 0, libtime.UTC)
+	inRamadan, _ = r.resolveRamadanDay(beforeStart, nonRamadanData, "2026-02-19")
+	assert.False(t, inRamadan)
+
+	// first_roza_date override — past 30 days
+	afterEnd := libtime.Date(2026, 3, 22, 12, 0, 0, 0, libtime.UTC)
+	inRamadan, _ = r.resolveRamadanDay(afterEnd, nonRamadanData, "2026-02-19")
+	assert.False(t, inRamadan)
+}
+
+func TestRamadanComputeNextEvent(t *testing.T) {
+	fajr := libtime.Date(2026, 3, 10, 5, 15, 0, 0, libtime.UTC)
+	iftar := libtime.Date(2026, 3, 10, 18, 30, 0, 0, libtime.UTC)
+
+	cases := []struct {
+		Case              string
+		Now               libtime.Time
+		ExpectedNextEvent string
+		ExpectedFasting   bool
+	}{
+		{
+			Case:              "before Fajr",
+			Now:               libtime.Date(2026, 3, 10, 4, 0, 0, 0, libtime.UTC),
+			ExpectedNextEvent: "Sehar",
+			ExpectedFasting:   false,
+		},
+		{
+			Case:              "during fasting window",
+			Now:               libtime.Date(2026, 3, 10, 12, 0, 0, 0, libtime.UTC),
+			ExpectedNextEvent: "Iftar",
+			ExpectedFasting:   true,
+		},
+		{
+			Case:              "after Iftar",
+			Now:               libtime.Date(2026, 3, 10, 20, 0, 0, 0, libtime.UTC),
+			ExpectedNextEvent: "Sehar",
+			ExpectedFasting:   false,
+		},
+	}
+
+	nextDay := fajr.AddDate(0, 0, 1)
+	tomorrowFajr := libtime.Date(nextDay.Year(), nextDay.Month(), nextDay.Day(), fajr.Hour(), fajr.Minute(), 0, 0, fajr.Location())
+
+	for _, tc := range cases {
+		r := &Ramadan{}
+		r.computeNextEvent(tc.Now, fajr, iftar, tomorrowFajr)
+		assert.Equal(t, tc.ExpectedNextEvent, r.NextEvent, tc.Case)
+		assert.Equal(t, tc.ExpectedFasting, r.Fasting, tc.Case)
+		assert.NotEmpty(t, r.TimeRemaining, tc.Case)
+	}
+}

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -437,6 +437,7 @@
             "python",
             "quasar",
             "r",
+            "ramadan",
             "react",
             "root",
             "ruby",
@@ -2714,6 +2715,80 @@
                     "title": "Headers",
                     "description": "A key, value map of Headers to send with the request",
                     "default": {}
+                  }
+                },
+                "unevaluatedProperties": false
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "ramadan"
+              }
+            }
+          },
+          "then": {
+            "title": "Ramadan Segment",
+            "description": "https://ohmyposh.dev/docs/segments/health/ramadan",
+            "properties": {
+              "options": {
+                "properties": {
+                  "latitude": {
+                    "type": "number",
+                    "title": "Latitude",
+                    "description": "Latitude for prayer time calculation",
+                    "default": 0
+                  },
+                  "longitude": {
+                    "type": "number",
+                    "title": "Longitude",
+                    "description": "Longitude for prayer time calculation",
+                    "default": 0
+                  },
+                  "city": {
+                    "type": "string",
+                    "title": "City",
+                    "description": "City name for location lookup (takes precedence over latitude/longitude)",
+                    "default": ""
+                  },
+                  "country": {
+                    "type": "string",
+                    "title": "Country",
+                    "description": "Country name or ISO 3166 alpha-2 code (required when using city)",
+                    "default": ""
+                  },
+                  "method": {
+                    "type": "integer",
+                    "title": "Calculation Method",
+                    "description": "Prayer calculation method ID (0-23). See https://aladhan.com/calculation-methods",
+                    "default": 3
+                  },
+                  "school": {
+                    "type": "integer",
+                    "title": "Madhab School",
+                    "description": "0 = Shafi (standard), 1 = Hanafi",
+                    "default": 0
+                  },
+                  "hide_outside_ramadan": {
+                    "type": "boolean",
+                    "title": "Hide Outside Ramadan",
+                    "description": "Hide the segment when not in Ramadan",
+                    "default": true
+                  },
+                  "first_roza_date": {
+                    "type": "string",
+                    "title": "First Roza Date",
+                    "description": "Override first day of Ramadan as YYYY-MM-DD for local moon sighting",
+                    "default": ""
+                  },
+                  "http_timeout": {
+                    "type": "integer",
+                    "title": "HTTP request timeout",
+                    "description": "Milliseconds to use for HTTP request timeouts",
+                    "default": 20
                   }
                 },
                 "unevaluatedProperties": false

--- a/website/docs/segments/health/ramadan.mdx
+++ b/website/docs/segments/health/ramadan.mdx
@@ -1,0 +1,114 @@
+---
+id: ramadan
+title: Ramadan
+sidebar_label: Ramadan
+---
+
+## What
+
+Displays Sehar (Fajr) and Iftar (Maghrib) prayer times along with a countdown to the next
+event during Ramadan. Powered by the free [Aladhan Prayer Times API][aladhan]. The segment
+auto-hides when it is not Ramadan (configurable via `hide_outside_ramadan`).
+
+## Sample Configuration
+
+import Config from "@site/src/components/Config.js";
+
+<Config
+  data={{
+    type: "ramadan",
+    style: "diamond",
+    foreground: "#ffffff",
+    background: "#1a472a",
+    leading_diamond: "\ue0b6",
+    trailing_diamond: "\ue0b0",
+    template:
+      "\U0001F319 Roza {{.RozaNumber}} \u00b7 {{.NextEvent}} in {{.TimeRemaining}}",
+    options: {
+      city: "Lahore",
+      country: "PK",
+      method: 1,
+      school: 1
+    }
+  }}
+/>
+
+## Options
+
+| Name                   |   Type    | Default | Description                                                                  |
+| ---------------------- | :-------: | :-----: | ---------------------------------------------------------------------------- |
+| `latitude`             | `float64` |   `0`   | Latitude for prayer time calculation (use with `longitude`)                  |
+| `longitude`            | `float64` |   `0`   | Longitude for prayer time calculation (use with `latitude`)                  |
+| `city`                 | `string`  |  `""`   | City name for location lookup — takes precedence over `latitude`/`longitude` |
+| `country`              | `string`  |  `""`   | Country name or ISO 3166 alpha-2 code — required when using `city`           |
+| `method`               |   `int`   |   `3`   | Prayer calculation method (0–23, 99). See [Aladhan methods][methods] for details |
+| `school`               |   `int`   |   `0`   | Madhab school: `0` = Shafi (standard), `1` = Hanafi                          |
+| `hide_outside_ramadan` |  `bool`   | `true`  | Hide the segment when not in Ramadan                                         |
+| `first_roza_date`      | `string`  |  `""`   | Override first day of Ramadan as `YYYY-MM-DD` for local moon sighting        |
+| `http_timeout`         |   `int`   |  `20`   | HTTP request timeout in milliseconds                                         |
+
+:::info
+Either **city + country** or **latitude + longitude** must be configured. If both are
+provided, `city` + `country` takes precedence.
+:::
+
+:::tip Prayer calculation methods
+
+Use the method associated with the issuing authority closest to your location.
+The full ID→authority mapping is:
+
+| ID  | Authority                                                      |
+| --- | -------------------------------------------------------------- |
+| 0   | Shia Ithna-Ashari, Leva Institute, Qum                         |
+| 1   | University of Islamic Sciences, Karachi                        |
+| 2   | Islamic Society of North America (ISNA)                        |
+| 3   | Muslim World League (**default**)                              |
+| 4   | Umm Al-Qura University, Makkah                                 |
+| 5   | Egyptian General Authority of Survey                           |
+| 7   | Institute of Geophysics, University of Tehran                  |
+| 8   | Gulf Region                                                    |
+| 9   | Kuwait                                                         |
+| 10  | Qatar                                                          |
+| 11  | Majlis Ugama Islam Singapura, Singapore                        |
+| 12  | Union Organisation Islamique de France                         |
+| 13  | Diyanet İşleri Başkanlığı, Turkey *(experimental)*             |
+| 14  | Spiritual Administration of Muslims of Russia                  |
+| 15  | Moonsighting Committee Worldwide                               |
+| 16  | Dubai *(experimental)*                                         |
+| 17  | Jabatan Kemajuan Islam Malaysia (JAKIM)                        |
+| 18  | Tunisia                                                        |
+| 19  | Algeria                                                        |
+| 20  | Kementerian Agama Republik Indonesia                           |
+| 21  | Morocco                                                        |
+| 22  | Comunidade Islâmica de Lisboa, Portugal                        |
+| 23  | Ministry of Awqaf, Islamic Affairs and Holy Places, Jordan     |
+| 99  | Custom (use `methodSettings` via the API)                      |
+
+Note: ID 6 is not assigned.
+:::
+
+## Template ([info][templates])
+
+:::note default template
+
+```template
+ 🌙 Roza {{.RozaNumber}} · {{.NextEvent}} in {{.TimeRemaining}}
+```
+
+:::
+
+### Properties
+
+| Name             | Type     | Description                                                     |
+| ---------------- | -------- | --------------------------------------------------------------- |
+| `.Fajr`          | `string` | Sehar (Fajr) time in `HH:MM` format                             |
+| `.Iftar`         | `string` | Iftar (Maghrib) time in `HH:MM` format                          |
+| `.Imsak`         | `string` | Imsak time in `HH:MM` format (~10 min before Fajr)              |
+| `.RozaNumber`    | `int`    | Day number within Ramadan (1–30)                                |
+| `.NextEvent`     | `string` | Name of the next event: `Sehar` or `Iftar`                      |
+| `.TimeRemaining` | `string` | Countdown to the next event, e.g. `3h 42m`                      |
+| `.Fasting`       | `bool`   | `true` when currently between Fajr and Maghrib (fasting window) |
+
+[templates]: /docs/configuration/templates
+[aladhan]: https://aladhan.com/prayer-times-api
+[methods]: https://aladhan.com/calculation-methods

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -111,6 +111,7 @@ export default {
           collapsed: true,
           items: [
             "segments/health/nightscout",
+            "segments/health/ramadan",
             "segments/health/strava",
             "segments/health/withings",
           ]


### PR DESCRIPTION
## Summary

Adds a new **Ramadan** segment that displays Sehar (Fajr) and Iftar (Maghrib) prayer times
along with a countdown to the next event during the holy month of Ramadan.

## Features

- Fetches prayer times from the free [Aladhan Prayer Times API](https://aladhan.com/prayer-times-api) — no API key required
- Supports location by **city + country** or **latitude + longitude**
- Configurable prayer calculation **method** (0–23) and **Madhab school** (Shafi/Hanafi)
- Auto-hides outside Ramadan (`hide_outside_ramadan`, default `true`)
- `first_roza_date` override for local moon sighting (`YYYY-MM-DD`)
- Template exposes: `.Fajr`, `.Iftar`, `.Imsak`, `.RozaNumber`, `.NextEvent`, `.TimeRemaining`, `.IsFasting`

## Default template

```
🌙 Roza {{.RozaNumber}} · {{.NextEvent}} in {{.TimeRemaining}}
```

## Inspired by

[ahmadawais/ramadan-cli](https://github.com/ahmadawais/ramadan-cli)