### PR TITLE
perf: string splitting avoidance/improvements

### DIFF
--- a/src/color/colors.go
+++ b/src/color/colors.go
@@ -49,7 +49,7 @@ func (c *Set) String() string {
 }
 
 func (c *Set) ParseString(colors string) {
-	parts := strings.Split(colors, "|")
+	parts := strings.SplitN(colors, "|", 3)
 	if len(parts) != 2 {
 		return
 	}

--- a/src/segments/aws.go
+++ b/src/segments/aws.go
@@ -80,7 +80,7 @@ func (a *Aws) getConfigFileInfo() {
 		}
 
 		if sectionActive && strings.HasPrefix(line, "region") {
-			splitted := strings.Split(line, "=")
+			splitted := strings.SplitN(line, "=", 3)
 			if len(splitted) >= 2 {
 				a.Region = strings.TrimSpace(splitted[1])
 				break

--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -785,7 +785,7 @@ func (g *Git) setStatus() {
 
 		if strings.HasPrefix(line, BRANCHSTATUS) && len(line) > len(BRANCHSTATUS) {
 			status := line[len(BRANCHSTATUS):]
-			splitted := strings.Split(status, " ")
+			splitted := strings.SplitN(status, " ", 3)
 			if len(splitted) >= 2 {
 				g.Ahead, _ = strconv.Atoi(splitted[0])
 				behind, _ := strconv.Atoi(splitted[1])

--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -312,8 +312,7 @@ func (g *Git) StashCount() int {
 		return 0
 	}
 
-	lines := strings.Split(stashContent, "\n")
-	g.stashCount = len(lines)
+	g.stashCount = strings.Count(stashContent, "\n") + 1 // +1: fileContent() trims
 	return g.stashCount
 }
 

--- a/src/segments/jujutsu.go
+++ b/src/segments/jujutsu.go
@@ -79,14 +79,14 @@ func (jj *Jujutsu) ClosestBookmarks() string {
 		return ""
 	}
 
-	lines := strings.Split(statusString, "\n")
+	line, _, _ := strings.Cut(statusString, "\n")
 
-	if !jj.options.Bool(FetchAhead, false) || len(lines[0]) == 0 {
-		return lines[0]
+	if !jj.options.Bool(FetchAhead, false) || len(line) == 0 {
+		return line
 	}
 
 	aheadIcon := jj.options.String(AheadIcon, "\u21e1")
-	marks := strings.Split(lines[0], " ")
+	marks := strings.Split(line, " ")
 	// String to return for status
 	var endString strings.Builder
 
@@ -97,7 +97,7 @@ func (jj *Jujutsu) ClosestBookmarks() string {
 
 	aheadString, err := jj.getJujutsuCommandOutput("log", "--no-graph", "-T", "'.'", "-r", rangeString)
 	if err != nil {
-		return lines[0]
+		return line
 	}
 
 	aheadCounter := len(aheadString)

--- a/src/segments/mercurial.go
+++ b/src/segments/mercurial.go
@@ -107,7 +107,7 @@ func (hg *Mercurial) setMercurialStatus() {
 		return
 	}
 
-	idSplit := strings.Split(idString, "|")
+	idSplit := strings.SplitN(idString, "|", 6)
 	if len(idSplit) != 5 {
 		return
 	}

--- a/src/segments/python.go
+++ b/src/segments/python.go
@@ -177,7 +177,7 @@ func (p *Python) pyenvVersion() (string, error) {
 	}
 
 	// override virtualenv if pyenv set one
-	parts := strings.Split(shortPath, string(filepath.Separator))
+	parts := strings.SplitN(shortPath, string(filepath.Separator), 4)
 	if len(parts) > 2 && p.canUseVenvName(parts[2]) {
 		p.Venv = parts[2]
 	}


### PR DESCRIPTION
### Prerequisites

- [ ] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

<!---

Tips:

If you're not comfortable with working with Git,
we're working on a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D)
as your preferred cross platform Git GUI power tool.

-->

Replace uses of strings.Split with strings.Count, strings.Cut, and strings.SplitN as appropriate to avoid throwaway splitting.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
