### PR TITLE
Feat/zsh transient multiline

### DIFF
--- a/src/config/segment.go
+++ b/src/config/segment.go
@@ -81,12 +81,13 @@ type Segment struct {
 	Pending                bool           `json:"-" toml:"-" yaml:"-"`
 	// Killed is set by the engine when the segment's timeout expired and its
 	// child processes were killed; it blocks fallback_template rendering.
-	Killed             bool `json:"-" toml:"-" yaml:"-"`
-	Interactive        bool `json:"interactive,omitempty" toml:"interactive,omitempty" yaml:"interactive,omitempty"`
-	foregroundResolved bool
-	backgroundResolved bool
-	needsEvaluated     bool
-	evaluated          bool
+	Killed              bool `json:"-" toml:"-" yaml:"-"`
+	Interactive         bool `json:"interactive,omitempty" toml:"interactive,omitempty" yaml:"interactive,omitempty"`
+	MultilineKeepPrompt bool `json:"multiline_keepprompt,omitempty" toml:"multiline_keepprompt,omitempty" yaml:"multiline_keepprompt,omitempty"`
+	foregroundResolved  bool
+	backgroundResolved  bool
+	needsEvaluated      bool
+	evaluated           bool
 }
 
 // segmentAlias is used to avoid recursion during unmarshaling

--- a/src/prompt/extra.go
+++ b/src/prompt/extra.go
@@ -89,15 +89,21 @@ func (e *Engine) ExtraPrompt(promptType ExtraPromptType) string {
 
 	switch e.Env.Shell() {
 	case shell.ZSH:
-		if promptType == Transient {
-			if !e.Env.Flags().Eval {
-				break
-			}
+		if !e.Env.Flags().Eval {
+			break
+		}
 
-			prompt := fmt.Sprintf("PS1=%s", shell.QuotePosixStr(str))
+		if promptType == Transient {
+			evalOutput := fmt.Sprintf("PS1=%s", shell.QuotePosixStr(str))
 			// empty RPROMPT
-			prompt += "\nRPROMPT=''"
-			return prompt
+			evalOutput += "\nRPROMPT=''"
+			return evalOutput
+		}
+
+		if promptType == Secondary {
+			evalOutput := fmt.Sprintf("_omp_secondary_prompt=%s", shell.QuotePosixStr(str))
+			evalOutput += fmt.Sprintf("\nPOSH_MULTILINE_KEEPPROMPT=%t", prompt.MultilineKeepPrompt)
+			return evalOutput
 		}
 	case shell.PWSH:
 		if promptType == Transient {

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -37,8 +37,8 @@ _omp_serve_pid=${_omp_serve_pid:-0}
 _omp_serve_cycle=0
 _omp_serve_failures=0
 
-# set secondary prompt
-_omp_secondary_prompt=$($_omp_executable print secondary --shell=zsh)
+# set secondary prompt (also exports POSH_MULTILINE_KEEPPROMPT)
+eval "$($_omp_executable print secondary --shell=zsh --eval)"
 
 function _omp_set_cursor_position() {
   # not supported in Midnight Commander
@@ -544,13 +544,65 @@ function _omp_restore_rprompt() {
   zle .reset-prompt
 }
 
+# Returns 0 when the current buffer is a complete command, 1 when more input
+# is expected (used to keep the primary prompt while a multi-line command is
+# still being typed).
+function _omp_is_buffer_complete() {
+  local buf=$PREBUFFER$BUFFER
+
+  # 1. Syntax check. The buffer travels over a pipe rather than a here-document,
+  # so no delimiter word can collide with whatever the user happens to type.
+  if ! print -r -- "$buf" | zsh -n 2>/dev/null; then
+    return 1
+  fi
+
+  # 2. An unterminated here-document parses cleanly, because the parser simply
+  # ends the body at EOF. Step 1 therefore cannot see one. Re-parse with `;;`
+  # appended: outside a case branch that is a syntax error, but an open
+  # here-document swallows it as body text. A clean parse means the body was
+  # never closed. The `<<` test only skips the extra parse when no here-document
+  # can possibly be open.
+  if [[ $buf == *'<<'* ]] && print -r -- "$buf"$'\n;;' | zsh -n 2>/dev/null; then
+    return 1
+  fi
+
+  # 3. An odd number of trailing backslashes escapes the newline that follows the
+  # buffer, which parses as a line continuation rather than an incomplete command.
+  local trailing=${buf##*[^\\]}
+  (( ${#trailing} % 2 )) && return 1
+
+  return 0
+}
+
 function _omp_zle-line-init() {
   [[ $CONTEXT == start ]] || return 0
 
   # Start regular line editor.
   (( $+zle_bracketed_paste )) && print -r -n - $zle_bracketed_paste[1]
-  zle .recursive-edit
-  local -i ret=$?
+
+  local -i ret=0
+  if [[ $POSH_MULTILINE_KEEPPROMPT == "true" ]]; then
+    # Keep the full primary prompt while a multi-line command is still being
+    # typed: re-enter the editor until the buffer is a complete command.
+    while true; do
+      zle .recursive-edit
+      ret=$?
+
+      if ((ret)) || _omp_is_buffer_complete; then
+        break
+      fi
+
+      # Nothing may be prefixed to the continuation line. BUFFER is the command
+      # itself, so anything added here is executed. Even pure whitespace breaks a
+      # here-document, whose terminator only matches at the very start of a line.
+      BUFFER+=$'\n'
+      CURSOR=$#BUFFER
+    done
+  else
+    zle .recursive-edit
+    ret=$?
+  fi
+
   (( $+zle_bracketed_paste )) && print -r -n - $zle_bracketed_paste[2]
 
   # We need this workaround because when the `filler` is set,

--- a/src/shell/zsh_test.go
+++ b/src/shell/zsh_test.go
@@ -1,9 +1,13 @@
 package shell
 
 import (
+	"os"
+	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestZshFeatures(t *testing.T) {
@@ -20,4 +24,89 @@ _omp_enable_streaming=1
 _omp_enable_vimode`
 
 	assert.Equal(t, want, got)
+}
+
+// zshIsBufferComplete lifts _omp_is_buffer_complete out of the embedded init script,
+// so the test drives the code we ship rather than a copy of it that can drift.
+func zshIsBufferComplete(t *testing.T) string {
+	t.Helper()
+
+	const signature = "function _omp_is_buffer_complete() {"
+
+	_, body, found := strings.Cut(zshInit, signature)
+	require.True(t, found, "_omp_is_buffer_complete is missing from omp.zsh")
+
+	body, _, found = strings.Cut(body, "\n}\n")
+	require.True(t, found, "_omp_is_buffer_complete has no closing brace")
+
+	return signature + body + "\n}\n"
+}
+
+// TestZshIsBufferComplete covers the check that keeps the primary prompt in place while
+// a multi-line command is still being typed. Zsh reports an unterminated here-document
+// as syntactically fine, so the here-document cases below are the interesting ones.
+func TestZshIsBufferComplete(t *testing.T) {
+	if _, err := exec.LookPath("zsh"); err != nil {
+		t.Skip("zsh is not installed")
+	}
+
+	cases := []struct {
+		Case     string
+		Buffer   string
+		Expected bool
+	}{
+		{Case: "Empty buffer", Buffer: "", Expected: true},
+		{Case: "Single command", Buffer: "echo hi", Expected: true},
+		{Case: "Unterminated quote", Buffer: `echo "abc`, Expected: false},
+		{Case: "Trailing pipe", Buffer: "echo hi |", Expected: false},
+		{Case: "Open for loop", Buffer: "for i in 1 2; do", Expected: false},
+		{Case: "Closed for loop", Buffer: "for i in 1 2; do\necho $i\ndone", Expected: true},
+		{Case: "Open case", Buffer: "case x in a) echo 1", Expected: false},
+		{Case: "Closed case", Buffer: "case x in a) echo 1;; esac", Expected: true},
+		{Case: "Odd trailing backslash", Buffer: `echo a \`, Expected: false},
+		{Case: "Even trailing backslashes", Buffer: `echo a \\`, Expected: true},
+		{Case: "Open here-document", Buffer: "cat <<EOF", Expected: false},
+		{Case: "Open here-document with a body", Buffer: "cat <<EOF\nhello", Expected: false},
+		{Case: "Closed here-document", Buffer: "cat <<EOF\nhello\nEOF", Expected: true},
+		{Case: "Open here-document in a block", Buffer: "if true; then\ncat <<EOF\nhello\nEOF", Expected: false},
+		{Case: "Closed here-document in a block", Buffer: "if true; then\ncat <<EOF\nhello\nEOF\nfi", Expected: true},
+		{Case: "Open tab-stripped here-document", Buffer: "cat <<-EOF\n\thello", Expected: false},
+		{Case: "Closed tab-stripped here-document", Buffer: "cat <<-EOF\n\thello\n\tEOF", Expected: true},
+		{Case: "Two here-documents", Buffer: "cat <<EOF\nx\nEOF\ncat <<END\ny\nEND", Expected: true},
+		{Case: "Here-string is not a here-document", Buffer: `cat <<<"hi"`, Expected: true},
+		{Case: "Left shift is not a here-document", Buffer: "echo $((1 << 2))", Expected: true},
+		{Case: "Delimiter word used as a command", Buffer: "echo one\nEOF\necho two", Expected: true},
+		{Case: "Delimiter word before an open block", Buffer: "echo one\nEOF\nfor i in 1 2; do", Expected: false},
+		{Case: "Here-document operator inside a body", Buffer: "cat <<EOF\ncat <<END\nEOF", Expected: true},
+		{Case: "Case terminator in an open here-document", Buffer: "cat <<EOF\n;;", Expected: false},
+		{Case: "Case terminator in a closed here-document", Buffer: "cat <<EOF\n;;\nEOF", Expected: true},
+		{Case: "Case terminator as an open delimiter", Buffer: "cat <<';;'", Expected: false},
+		{Case: "Case terminator as a closed delimiter", Buffer: "cat <<';;'\nbody\n;;", Expected: true},
+	}
+
+	script := zshIsBufferComplete(t) + `
+PREBUFFER=''
+BUFFER=$1
+if _omp_is_buffer_complete; then print -r -- COMPLETE; else print -r -- INCOMPLETE; fi
+`
+
+	// -f plus an empty HOME keeps the startup files out of the parse: every zsh the
+	// function shells out to reads ~/.zshenv, and an option set there can change how
+	// a buffer parses.
+	home := t.TempDir()
+
+	for _, tc := range cases {
+		cmd := exec.CommandContext(t.Context(), "zsh", "-f", "-c", script, "omp", tc.Buffer)
+		cmd.Env = []string{"HOME=" + home, "PATH=" + os.Getenv("PATH")}
+
+		out, err := cmd.Output()
+		require.NoError(t, err, tc.Case)
+
+		want := "INCOMPLETE"
+		if tc.Expected {
+			want = "COMPLETE"
+		}
+
+		assert.Equal(t, want, strings.TrimSpace(string(out)), tc.Case)
+	}
 }

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -5445,9 +5445,23 @@
       "description": "https://ohmyposh.dev/docs/configuration/line-error"
     },
     "secondary_prompt": {
-      "$ref": "#/definitions/extra_prompt",
       "title": "Secondary Prompt Setting",
-      "description": "https://ohmyposh.dev/docs/configuration/secondary-prompt"
+      "description": "https://ohmyposh.dev/docs/configuration/secondary-prompt",
+      "allOf": [
+        {
+          "$ref": "#/definitions/extra_prompt"
+        },
+        {
+          "properties": {
+            "multiline_keepprompt": {
+              "type": "boolean",
+              "title": "Multiline Keep Prompt",
+              "description": "Treat multi-line commands as a single block to support transient prompts correctly",
+              "default": false
+            }
+          }
+        }
+      ]
     },
     "debug_prompt": {
       "$ref": "#/definitions/extra_prompt",

--- a/website/docs/configuration/secondary-prompt.mdx
+++ b/website/docs/configuration/secondary-prompt.mdx
@@ -31,11 +31,12 @@ You need to extend or create a custom theme with your secondary prompt override.
 
 ## Options
 
-| Name         | Type     | Description                                                                                                                    |
-| ------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `background` | `string` | [color][colors]                                                                                                                |
-| `foreground` | `string` | [color][colors]                                                                                                                |
-| `template`   | `string` | a go [text/template][go-text-template] template extended with [sprig][sprig] utilizing the properties below - defaults to `> ` |
+| Name                   | Type      | Description                                                                                                                                       |
+| ---------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `background`           | `string`  | [color][colors]                                                                                                                                 |
+| `foreground`           | `string`  | [color][colors]                                                                                                                                 |
+| `template`             | `string`  | a go [text/template][go-text-template] template extended with [sprig][sprig] utilizing the properties below - defaults to `> `                  |
+| `multiline_keepprompt` | `boolean` | when `true`, a multi-line command is kept in a single buffer so the primary prompt stays in place until the whole command is submitted (Zsh only). Continuation lines are part of that buffer and get no secondary prompt, so `template` is not rendered for them. Defaults to `false` |
 
 ## Template ([info][templates])
 

--- a/website/docs/configuration/transient.mdx
+++ b/website/docs/configuration/transient.mdx
@@ -25,6 +25,10 @@ By enabling Transient Prompt, you can replace the prompt with some other content
 
 ![After Transient](/img/transient-after.gif)
 
+:::tip
+In Zsh, enabling [`multiline_keepprompt`][secondary-prompt] on the secondary prompt keeps the full prompt in place while you type a multi-line command, so the transient prompt takes over once the whole command is submitted rather than on its first line.
+:::
+
 ## Configuration
 
 You need to extend or create a custom theme with your transient prompt. For example:
@@ -68,3 +72,4 @@ clink set prompt.transient always
 [color-templates]: /docs/configuration/colors#color-templates
 [cstp]: /docs/configuration/templates#cross-segment-template-properties
 [block-newline]: /docs/configuration/block#newline
+[secondary-prompt]: /docs/configuration/secondary-prompt


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Previously while multiline command was typed the prompt changed to transient_prompt. If a multiline prompt was used with e.g. a single line transient_prompt, that caused the prompt replaced with transient prompt right after the first enter was hit after "\\" in the multiline command.
With the changes the multiline prompt is kept until the multiline command is submitted.

   1. Code Change: Implemented multi-line command support for Zsh transient prompts in src/shell/scripts/omp.zsh.
   2. Conventional Commits: Verified and committed with the following messages:
       * feat(zsh): support transient prompt for multi-line commands
       * docs: update transient prompt documentation for Zsh multi-line support
   3. Tests: Ran go test ./... in the src directory, and all 23 tests passed. Manual verification confirmed the fix works for both
      multi-line entry and Ctrl-C interrupts.
   4. Documentation: Added a tip to website/docs/configuration/transient.mdx regarding the improved Zsh multi-line support. 


<!---

Tips:

If you're not comfortable with working with Git,
we're working on a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D)
as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
