### PR TITLE
fix(zsh): prevent stream process from inheriting parent stdin

### DIFF
--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -83,7 +83,8 @@ function _omp_start_streaming() {
 
   # start process substitution — no PID tracking needed
   # closing fd sends SIGPIPE which terminates oh-my-posh
-  exec {_omp_stream_fd}< <(exec "${stream_cmd[@]}") 2>/dev/null
+  # redirect stream process stdin to prevent it from interfering with command output
+  exec {_omp_stream_fd}< <(exec "${stream_cmd[@]}" </dev/null 2>/dev/null)
 
   if [[ $_omp_stream_fd -lt 0 ]]; then
     return 1
@@ -146,7 +147,7 @@ function _omp_precmd() {
   _omp_no_status=true
   _omp_tooltip_command=''
 
-  if [ $_omp_start_time ]; then
+  if [[ -n $_omp_start_time ]]; then
     local omp_now=$($_omp_executable get millis)
     _omp_execution_time=$(($omp_now - $_omp_start_time))
     _omp_no_status=false


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

Fixes #7357 

The stream process was inheriting the parent shell's stdin file descriptor,
which could interfere with command output when using process substitution.
This caused stdout from commands to not display correctly when streaming
was enabled.

Redirect the stream process stdin to /dev/null to isolate it from the
parent shell's stdin. This ensures command output is not consumed or
blocked by the streaming process.

Also improved variable check from [ ] to [[ -n ]] for better safety.

I've tested this fixes the issue for me, but I think it should be reviewed and tested by more people.

<!---

Tips:

If you're not comfortable with working with Git,
we're working on a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D)
as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
