### PR TITLE
fix(spotify): use correct D-Bus interface name on Linux

### DIFF
--- a/src/segments/spotify_linux.go
+++ b/src/segments/spotify_linux.go
@@ -40,7 +40,7 @@ func (s *Spotify) Enabled() bool {
 }
 
 func (s *Spotify) runLinuxScriptCommand(command string) string {
-	dbusCMD := "dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.options.Get string:org.mpris.MediaPlayer2.Player"
+	dbusCMD := "dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:org.mpris.MediaPlayer2.Player"
 	val := s.env.RunShellCommand(shell.BASH, dbusCMD+command)
 	return val
 }

--- a/src/segments/spotify_linux_test.go
+++ b/src/segments/spotify_linux_test.go
@@ -31,7 +31,7 @@ func TestSpotifyLinux(t *testing.T) {
 		env := new(mock.Environment)
 		env.On("IsWsl").Return(false)
 
-		dbusCMD := "dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.options.Get string:org.mpris.MediaPlayer2.Player"
+		dbusCMD := "dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:org.mpris.MediaPlayer2.Player"
 		env.On("RunShellCommand", shell.BASH, dbusCMD+" string:PlaybackStatus | awk -F '\"' '/string/ {print tolower($2)}'").Return(tc.Status)
 		env.On("RunShellCommand", shell.BASH, dbusCMD+" string:Metadata | awk -F '\"' 'BEGIN {RS=\"entry\"}; /'xesam:artist'/ {a=$4} END {print a}'").Return(tc.Artist)
 		env.On("RunShellCommand", shell.BASH, dbusCMD+" string:Metadata | awk -F '\"' 'BEGIN {RS=\"entry\"}; /'xesam:title'/ {t=$4} END {print t}'").Return(tc.Track)


### PR DESCRIPTION
## Summary

- The Spotify segment's D-Bus command uses `org.freedesktop.DBus.options.Get` instead of the correct `org.freedesktop.DBus.Properties.Get`, which causes the segment to silently fail on Linux
- This was likely introduced when the config key was renamed from `properties` to `options` — the D-Bus interface name was inadvertently changed along with it
- One-line fix in `spotify_linux.go` and the corresponding test

## Reproduction

With Spotify running on Linux:
```
# This fails (what oh-my-posh currently does):
dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.options.Get string:org.mpris.MediaPlayer2.Player string:PlaybackStatus
# Error: No such interface "org.freedesktop.DBus.options"

# This works (the fix):
dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:org.mpris.MediaPlayer2.Player string:PlaybackStatus
# Returns: variant string "Playing"
```

Fixes #7365