### PR TITLE
refactor(theme): add support for bun runtime and rust language in multiverse-neon

### DIFF
--- a/themes/multiverse-neon.omp.json
+++ b/themes/multiverse-neon.omp.json
@@ -2,8 +2,9 @@
   "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
   "blocks": [
     {
+      "type": "prompt",
       "alignment": "left",
-     "segments": [
+      "segments": [
         {
           "background": "#29315A",
           "foreground": "#3EC669",
@@ -36,19 +37,38 @@
           "trailing_diamond": "\ue0b4",
           "type": "git"
         },
-
         {
           "foreground": "#C94A16",
           "style": "plain",
           "template": "x ",
           "type": "status"
         }
-      ],
-      "type": "prompt"
+      ]
     },
-     {
+    {
+      "type": "prompt",
       "alignment": "right",
       "segments": [
+        {
+          "type": "bun",
+          "style": "plain",
+          "foreground": "#e5dbcc",
+          "options": {
+            "display_mode": "files",
+            "fetch_version": true
+          },
+          "template": " \ue76f {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }}"
+        },
+        {
+          "type": "crystal",
+          "style": "plain",
+          "foreground": "#e5e5e5",
+          "options": {
+            "display_mode": "files",
+            "fetch_version": true
+          },
+          "template": " \ue7ac {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }}"
+        },
         {
           "type": "node",
           "style": "plain",
@@ -62,42 +82,42 @@
             "pnpm_icon": "<#e5a100>\ue865 pnpm</> ",
             "yarn_icon": "<#37aee5>\ue6a7 yarn</> "
           },
-          "template": "{{ if .PackageManagerIcon }}{{ .PackageManagerIcon }} {{ end }}\ue718 {{ .Full }}"
+          "template": "{{ if ne .PackageManagerName \"bun\" }}{{ if .PackageManagerIcon }}{{ .PackageManagerIcon }}{{ end }}\ue718 {{ .Full }}{{ end }}"
         },
         {
-          "foreground": "#4063D8",
-          "options": {
-            "display_mode": "files",
-            "fetch_version": true
-          },
+          "type": "python",
           "style": "plain",
-          "template": " {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }}",
-          "type": "crystal"
-        },
-        {
-          "foreground": "#DE3F24",
-          "options": {
-            "display_mode": "files",
-            "fetch_version": true
-          },
-          "style": "plain",
-          "template": " {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }}",
-          "type": "ruby"
-        },
-        {
-          "foreground": "#FED142",
+          "foreground": "#e5c949",
           "options": {
             "display_mode": "context",
             "fetch_virtual_env": false
           },
+          "template": " \ue73c {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }}"
+        },
+        {
+          "type": "ruby",
           "style": "plain",
-          "template": " {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }}",
-          "type": "python"
+          "foreground": "#e5252b",
+          "options": {
+            "display_mode": "files",
+            "fetch_version": true
+          },
+          "template": " \ue791 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }}"
+        },
+        {
+          "type": "rust",
+          "style": "plain",
+          "foreground": "#e58a55",
+          "options": {
+            "display_mode": "files",
+            "fetch_version": true
+          },
+          "template": " \ue7a8 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }}"
         }
-      ],
-      "type": "prompt"
+      ]
     },
     {
+      "type": "prompt",
       "alignment": "left",
       "newline": true,
       "segments": [
@@ -107,8 +127,7 @@
           "template": "\u279c ",
           "type": "text"
         }
-      ],
-      "type": "prompt"
+      ]
     }
   ],
   "version": 4


### PR DESCRIPTION
…tiverse-neon

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

- Added support for [Rust](https://ohmyposh.dev/docs/segments/languages/rust) language version display
- Added support for [Bun](https://ohmyposh.dev/docs/segments/cli/bun) CLI version display
- Reorganized the JSON so that the OMP segments are in alphabetical order

Note: Bun can be used either as a package manager alongside the Node runtime, or as both the runtime and package manager. This theme update ensures the prompt shows only the Bun version when Bun is used as the runtime, and the Node version with the Bun package manager icon when Bun is used solely as the package manager.

Tips:

If you're not comfortable with working with Git,
we're working on a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D)
as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
