### PR TITLE
Feat/transient show interrupt

### DIFF
--- a/src/cache/template.go
+++ b/src/cache/template.go
@@ -28,6 +28,7 @@ type SimpleTemplate struct {
 	Code          int
 	WSL           bool
 	Root          bool
+	Interrupted   bool
 }
 
 func (t *Template) AddSegmentData(key string, value any) {

--- a/src/cli/data.go
+++ b/src/cli/data.go
@@ -54,5 +54,9 @@ func applyDataFile(flags *runtime.Flags, changed func(name string) bool) error {
 		flags.PipeStatus = *envFlags.PipeStatus
 	}
 
+	if envFlags.Interrupted != nil && !changed("interrupted") {
+		flags.Interrupted = *envFlags.Interrupted
+	}
+
 	return nil
 }

--- a/src/cli/data_test.go
+++ b/src/cli/data_test.go
@@ -52,7 +52,7 @@ func changedSet(names ...string) func(string) bool {
 func TestApplyDataFile_EmptyPathIsNoop(t *testing.T) {
 	withDataPath(t, "")
 
-	flags := &runtime.Flags{PWD: "/live/pwd", ErrorCode: 1, ExecutionTime: 2.5, PipeStatus: "0"}
+	flags := &runtime.Flags{PWD: "/live/pwd", ErrorCode: 1, ExecutionTime: 2.5, PipeStatus: "0", Interrupted: true}
 
 	err := applyDataFile(flags, noneChanged)
 	require.NoError(t, err)
@@ -61,6 +61,7 @@ func TestApplyDataFile_EmptyPathIsNoop(t *testing.T) {
 	assert.Equal(t, 1, flags.ErrorCode)
 	assert.InDelta(t, 2.5, flags.ExecutionTime, 0)
 	assert.Equal(t, "0", flags.PipeStatus)
+	assert.True(t, flags.Interrupted)
 	assert.Nil(t, flags.EnvData)
 	assert.Nil(t, flags.SegmentData)
 }
@@ -85,9 +86,9 @@ func TestApplyDataFile_UnsupportedExtensionErrors(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestApplyDataFile_RoutesAllFourKeysWhenNoFlagsChanged(t *testing.T) {
+func TestApplyDataFile_RoutesEveryKeyWhenNoFlagsChanged(t *testing.T) {
 	path := writeDataFile(t, `{
-		"env": {"PWD": "/data/pwd", "Code": 3, "ExecutionTime": 12.5, "PipeStatus": "0 1"},
+		"env": {"PWD": "/data/pwd", "Code": 3, "ExecutionTime": 12.5, "PipeStatus": "0 1", "Interrupted": true},
 		"segments": {"az": {"Name": "my-sub"}}
 	}`)
 	withDataPath(t, path)
@@ -101,6 +102,7 @@ func TestApplyDataFile_RoutesAllFourKeysWhenNoFlagsChanged(t *testing.T) {
 	assert.Equal(t, 3, flags.ErrorCode)
 	assert.InDelta(t, 12.5, flags.ExecutionTime, 0)
 	assert.Equal(t, "0 1", flags.PipeStatus)
+	assert.True(t, flags.Interrupted)
 
 	require.NotNil(t, flags.SegmentData)
 	assert.JSONEq(t, `{"Name": "my-sub"}`, string(flags.SegmentData["az"]))
@@ -114,33 +116,34 @@ func TestApplyDataFile_RoutesAllFourKeysWhenNoFlagsChanged(t *testing.T) {
 
 func TestApplyDataFile_ExplicitCLIFlagWinsOverDataFile(t *testing.T) {
 	path := writeDataFile(t, `{
-		"env": {"PWD": "/data/pwd", "Code": 3, "ExecutionTime": 12.5, "PipeStatus": "0 1"}
+		"env": {"PWD": "/data/pwd", "Code": 3, "ExecutionTime": 12.5, "PipeStatus": "0 1", "Interrupted": true}
 	}`)
 	withDataPath(t, path)
 
 	flags := &runtime.Flags{PWD: "/live/pwd", ErrorCode: 1, ExecutionTime: 2.5, PipeStatus: "0"}
 
-	err := applyDataFile(flags, changedSet("pwd", "status", "execution-time", "pipestatus"))
+	err := applyDataFile(flags, changedSet("pwd", "status", "execution-time", "pipestatus", "interrupted"))
 	require.NoError(t, err)
 
 	// Every routed key was explicitly set on the CLI, so the live/flag
-	// value must survive untouched despite the data file providing all four.
+	// value must survive untouched despite the data file providing them all.
 	assert.Equal(t, "/live/pwd", flags.PWD)
 	assert.Equal(t, 1, flags.ErrorCode)
 	assert.InDelta(t, 2.5, flags.ExecutionTime, 0)
 	assert.Equal(t, "0", flags.PipeStatus)
+	assert.False(t, flags.Interrupted)
 }
 
 func TestApplyDataFile_PerKeyPrecedence(t *testing.T) {
 	path := writeDataFile(t, `{
-		"env": {"PWD": "/data/pwd", "Code": 3, "ExecutionTime": 12.5, "PipeStatus": "0 1"}
+		"env": {"PWD": "/data/pwd", "Code": 3, "ExecutionTime": 12.5, "PipeStatus": "0 1", "Interrupted": true}
 	}`)
 	withDataPath(t, path)
 
 	flags := &runtime.Flags{PWD: "/live/pwd", ErrorCode: 1, ExecutionTime: 2.5, PipeStatus: "0"}
 
-	// Only "status" is explicitly set on the CLI; the other three keys
-	// should still be routed from the data file.
+	// Only "status" is explicitly set on the CLI; the remaining keys should
+	// still be routed from the data file.
 	err := applyDataFile(flags, changedSet("status"))
 	require.NoError(t, err)
 
@@ -148,13 +151,28 @@ func TestApplyDataFile_PerKeyPrecedence(t *testing.T) {
 	assert.Equal(t, 1, flags.ErrorCode, "status explicitly set, so it must keep the live/flag value")
 	assert.InDelta(t, 12.5, flags.ExecutionTime, 0, "execution-time not explicitly set, so the data file value should apply")
 	assert.Equal(t, "0 1", flags.PipeStatus, "pipestatus not explicitly set, so the data file value should apply")
+	assert.True(t, flags.Interrupted, "interrupted not explicitly set, so the data file value should apply")
+}
+
+func TestApplyDataFile_InterruptedFalseIsRoutedNotTreatedAsAbsent(t *testing.T) {
+	path := writeDataFile(t, `{"env": {"Interrupted": false}}`)
+	withDataPath(t, path)
+
+	// EnvData holds a *bool so an explicit false is distinguishable from a
+	// missing key: it must overwrite the live true rather than be skipped.
+	flags := &runtime.Flags{Interrupted: true}
+
+	err := applyDataFile(flags, noneChanged)
+	require.NoError(t, err)
+
+	assert.False(t, flags.Interrupted)
 }
 
 func TestApplyDataFile_MissingEnvKeysLeaveFlagsUntouched(t *testing.T) {
 	path := writeDataFile(t, `{"segments": {"az": {"Name": "my-sub"}}}`)
 	withDataPath(t, path)
 
-	flags := &runtime.Flags{PWD: "/live/pwd", ErrorCode: 1, ExecutionTime: 2.5, PipeStatus: "0"}
+	flags := &runtime.Flags{PWD: "/live/pwd", ErrorCode: 1, ExecutionTime: 2.5, PipeStatus: "0", Interrupted: true}
 
 	err := applyDataFile(flags, noneChanged)
 	require.NoError(t, err)
@@ -163,4 +181,5 @@ func TestApplyDataFile_MissingEnvKeysLeaveFlagsUntouched(t *testing.T) {
 	assert.Equal(t, 1, flags.ErrorCode)
 	assert.InDelta(t, 2.5, flags.ExecutionTime, 0)
 	assert.Equal(t, "0", flags.PipeStatus)
+	assert.True(t, flags.Interrupted)
 }

--- a/src/cli/print.go
+++ b/src/cli/print.go
@@ -31,6 +31,7 @@ var (
 	noStatus     bool
 	column       int
 	escape       bool
+	interrupted  bool
 )
 
 // printCmd represents the print command
@@ -88,6 +89,7 @@ func createPrintCmd() *cobra.Command {
 				IsPrimary:     args[0] == prompt.PRIMARY,
 				Escape:        escape,
 				Force:         force,
+				Interrupted:   interrupted,
 			}
 
 			if err := applyDataFile(flags, cmd.Flags().Changed); err != nil {
@@ -154,6 +156,7 @@ func createPrintCmd() *cobra.Command {
 	printCmd.Flags().BoolVar(&escape, "escape", true, "escape the ANSI sequences for the shell")
 	printCmd.Flags().BoolVarP(&force, "force", "f", false, "force rendering the segments")
 	printCmd.Flags().StringVar(&dataPath, "data", "", "path to a template data file (json/yaml/toml) to render with")
+	printCmd.Flags().BoolVar(&interrupted, "interrupted", false, "the command was interrupted")
 
 	// Hide flags that are for internal use only.
 	_ = printCmd.Flags().MarkHidden("save-cache")

--- a/src/config/data.go
+++ b/src/config/data.go
@@ -27,6 +27,7 @@ type EnvData struct {
 	Code          *int
 	ExecutionTime *float64
 	PipeStatus    *string
+	Interrupted   *bool
 }
 
 // LoadData reads and parses a template data file. The format is derived

--- a/src/config/data_test.go
+++ b/src/config/data_test.go
@@ -134,6 +134,7 @@ func TestEnvFlagsPresence(t *testing.T) {
 	assert.Nil(t, envFlags.PWD)
 	assert.Nil(t, envFlags.ExecutionTime)
 	assert.Nil(t, envFlags.PipeStatus)
+	assert.Nil(t, envFlags.Interrupted)
 }
 
 func TestEnvFlagsAbsent(t *testing.T) {
@@ -146,6 +147,7 @@ func TestEnvFlagsAbsent(t *testing.T) {
 	assert.Nil(t, envFlags.Code)
 	assert.Nil(t, envFlags.ExecutionTime)
 	assert.Nil(t, envFlags.PipeStatus)
+	assert.Nil(t, envFlags.Interrupted)
 }
 
 func TestLoadDataUnsupportedExtension(t *testing.T) {

--- a/src/runtime/environment.go
+++ b/src/runtime/environment.go
@@ -114,6 +114,7 @@ type Flags struct {
 	Plain         bool
 	Force         bool
 	Streaming     bool
+	Interrupted   bool
 }
 
 type CommandError struct {

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -566,7 +566,12 @@ function _omp_zle-line-init() {
   _omp_cleanup_stream
   _omp_serve_abort
 
-  if [[ -n $_omp_transient_prompt ]]; then
+  if ((ret)); then
+    # interrupted (e.g. Ctrl-C): a pre-rendered transient prompt was built
+    # before the interrupt and can't carry .Interrupted, so always re-render
+    # through the CLI with the flag set
+    eval "$(_omp_get_prompt transient --eval $terminal_width_option --interrupted)"
+  elif [[ -n $_omp_transient_prompt ]]; then
     # rendered ahead of time by the streaming process (one column narrower,
     # mirroring the empty-buffer workaround above), saves a CLI call
     PS1=$_omp_transient_prompt

--- a/src/template/cache.go
+++ b/src/template/cache.go
@@ -22,14 +22,20 @@ var (
 	// time loadCache runs, env.Pwd()/StatusCodes()/ExecutionTime() already
 	// reflect the flag-precedence-resolved value (CLI flag > data file >
 	// live). They must never be applied a second time here, or a raw file
-	// value could clobber that resolved value.
-	routedEnvDataKeys = []string{"PWD", "Code", "ExecutionTime", "PipeStatus"}
+	// value could clobber that resolved value. A key belongs here if and only
+	// if applyDataFile routes it - listing one it does not route would instead
+	// make that key unsettable from a data file.
+	routedEnvDataKeys = []string{"PWD", "Code", "ExecutionTime", "PipeStatus", "Interrupted"}
 )
 
 func loadCache(vars maps.Simple[any], aliases *maps.Config) {
 	if !env.Flags().IsPrimary {
 		// Load the template cache for a non-primary prompt before rendering any templates.
 		if OK := restoreCache(); OK {
+			// Interrupted is a per-invocation flag, never a cached value: the
+			// restored blob was saved by the primary prompt (never interrupted),
+			// so it must be refreshed from the current flags.
+			Cache.Interrupted = env.Flags().Interrupted
 			return
 		}
 	}
@@ -43,6 +49,7 @@ func loadCache(vars maps.Simple[any], aliases *maps.Config) {
 	tmpl.Shell = env.Shell()
 	tmpl.ShellVersion = env.Flags().ShellVersion
 	tmpl.Code, _ = env.StatusCodes()
+	tmpl.Interrupted = env.Flags().Interrupted
 	tmpl.WSL = env.IsWsl()
 	tmpl.Segments = maps.NewConcurrent[any]()
 	tmpl.PromptCount = env.Flags().PromptCount

--- a/src/template/cache_test.go
+++ b/src/template/cache_test.go
@@ -55,18 +55,19 @@ func TestLoadCacheEnvDataOverlay(t *testing.T) {
 
 func TestLoadCacheEnvDataIgnoresRoutedKeys(t *testing.T) {
 	flags := &runtime.Flags{
-		EnvData: json.RawMessage(`{"PWD":"/bogus/path","Code":99,"ExecutionTime":42.5,"PipeStatus":"1 0"}`),
+		EnvData: json.RawMessage(`{"PWD":"/bogus/path","Code":99,"ExecutionTime":42.5,"PipeStatus":"1 0","Interrupted":true}`),
 	}
 
 	env = newLoadCacheMockEnv(flags)
 
 	loadCache(nil, &maps.Config{})
 
-	// The routed keys must be ignored by the overlay: PWD/Code keep the
-	// value already resolved by the CLI layer (here, the live mock values),
+	// The routed keys must be ignored by the overlay: PWD/Code/Interrupted keep
+	// the value already resolved by the CLI layer (here, the live mock values),
 	// never the raw file value.
 	assert.Equal(t, "/tmp/omp-test/project", Cache.PWD)
 	assert.Equal(t, 0, Cache.Code)
+	assert.False(t, Cache.Interrupted)
 }
 
 func TestLoadCacheEnvDataAliasAppliesToOverlaidValue(t *testing.T) {

--- a/website/docs/configuration/transient.mdx
+++ b/website/docs/configuration/transient.mdx
@@ -51,6 +51,28 @@ You need to extend or create a custom theme with your transient prompt. For exam
 | `filler`               | `string`  | when you want to create a line with a repeated set of characters spanning the width of the terminal. Will be added _after_ the `template` text |
 | `newline`              | `boolean` | add a newline before the prompt. The newline will not be printed under the same conditions as for primary prompt [newlines][block-newline].    |
 
+## Template ([info][templates])
+
+On top of the [global template properties][templates], the transient prompt exposes:
+
+| Name           | Type      | Description                                                       |
+| -------------- | --------- | ---------------------------------------------------------------- |
+| `.Interrupted` | `boolean` | whether the previous command was interrupted (e.g. via `Ctrl-C`) |
+
+:::caution
+`.Interrupted` is only set in `zsh`. Every other shell reports `false`, even after a real `Ctrl-C`.
+:::
+
+For example, to show a red `^C` in front of the transient prompt when a command was interrupted:
+
+```json
+{
+  "transient_prompt": {
+    "template": "{{ if .Interrupted }}<red>^C </>{{ end }}{{ .Shell }}> "
+  }
+}
+```
+
 ## Enable the feature
 
 Oh My posh handles enabling the feature automatically for all shells except `cmd` when the config contains a


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

This is the 2nd feature on top of the Feat/zsh transient multiline #7360 PR 

This feature adds a new status flag .Interrupted that can be used e.g. in transient_template:

I have a transient command that shows the command and the return code if it is non-zero:

```
[00:06:47]❯ return 1
✘ 1
[00:06:48]❯ return 1
✘ 1
```

The problem is that in quick typing I sometimes interrupt the command with Ctrl-C, which then sometimes can not be differentiated from the submitted but failed commands. To be able to differentiate them, I'm adding a new state which then can be used in the transient_template for this reason, e.g.:

```
[transient_prompt]
  template = "{{ if .Interrupted }}<red>^C </>{{ end }}"
```

With this, you can easily see which commands were interrupted:

```
[00:15:08]❯ return 1
✘ 1
[00:15:10]❯ ^C return 1
✘ 1
```

Note: the reason of the status flag and template usage showing ^C in front of the command instead of having ^C in the position where it was pressed is because sometimes in lazy mode - especially with long multi-line commands - I prefer to be able to copy part of the previously interrupted command, which would be hard if the ^C would be in the middle of the command messing it up



<!---

Tips:

If you're not comfortable with working with Git,
we're working on a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D)
as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
