### PR TITLE
chore(schema): add missing formats to executiontime segment and Zorin os icon to os segment

### DIFF
--- a/themes/schema.json
+++ b/themes/schema.json
@@ -1682,7 +1682,9 @@
                       "houston",
                       "amarillo",
                       "round",
-                      "lucky7"
+                      "lucky7",
+                      "iso8601",
+                      "iso8601ms"
                     ],
                     "default": "austin"
                   }
@@ -3287,6 +3289,12 @@
                     "title": "Void Icon",
                     "description": "The icon to use for Void",
                     "default": "\uf32e"
+                  },
+                  "zorin": {
+                    "type": "string",
+                    "title": "Zorin Icon",
+                    "description": "The icon to use for Zorin OS",
+                    "default": "\uf32f"
                   }
                 },
                 "unevaluatedProperties": false


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

Updated schema with changes introduced in  #7298 and #7333 

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
