### PR TITLE
fix(dev): bump devcontainer Go version to 1.26

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
   "build": {
     "dockerfile": "Dockerfile",
     "args": {
-      // Update the VARIANT arg to pick a version of Go: 1, 1.24, 1.25
+      // Update the VARIANT arg to pick a version of Go: 1, 1.25, 1.26
       // Append -trixie, -bookworm or -bullseye to pin to an OS version.
       "VARIANT": "2-1.26-trixie",
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
     "args": {
       // Update the VARIANT arg to pick a version of Go: 1, 1.24, 1.25
       // Append -trixie, -bookworm or -bullseye to pin to an OS version.
-      "VARIANT": "2-1.25-trixie",
+      "VARIANT": "2-1.26-trixie",
 
       // Override me with your own timezone:
       "TZ": "UTC",


### PR DESCRIPTION
go.mod requires go >= 1.26.0, which causes the updateContentCommand to fail during container creation with Go 1.25.

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

<!---

Tips:

If you're not comfortable with working with Git,
we're working on a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D)
as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
