### PR TITLE
feat(segments): add gradle segment

### DIFF
--- a/src/config/segment_types.go
+++ b/src/config/segment_types.go
@@ -68,6 +68,7 @@ func init() {
 	gob.Register(&segments.Commit{})
 	gob.Register(&segments.GitVersion{})
 	gob.Register(&segments.Golang{})
+	gob.Register(&segments.Gradle{})
 	gob.Register(&segments.Haskell{})
 	gob.Register(&segments.Helm{})
 	gob.Register(&segments.IPify{})
@@ -235,6 +236,8 @@ const (
 	GITVERSION SegmentType = "gitversion"
 	// GOLANG writes which go version is currently active
 	GOLANG SegmentType = "go"
+	// GRADLE writes the active gradle version
+	GRADLE SegmentType = "gradle"
 	// HASKELL segment
 	HASKELL SegmentType = "haskell"
 	// HELM segment
@@ -421,6 +424,7 @@ var Segments = map[SegmentType]func() SegmentWriter{
 	GIT:             func() SegmentWriter { return &segments.Git{} },
 	GITVERSION:      func() SegmentWriter { return &segments.GitVersion{} },
 	GOLANG:          func() SegmentWriter { return &segments.Golang{} },
+	GRADLE:          func() SegmentWriter { return &segments.Gradle{} },
 	HASKELL:         func() SegmentWriter { return &segments.Haskell{} },
 	HELM:            func() SegmentWriter { return &segments.Helm{} },
 	IPIFY:           func() SegmentWriter { return &segments.IPify{} },

--- a/src/segments/gradle.go
+++ b/src/segments/gradle.go
@@ -5,11 +5,11 @@ import (
 )
 
 type Gradle struct {
-	Language
 	KotlinVersion string
 	GroovyVersion string
 	AntVersion    string
 	JVMVersion    string
+	Language
 }
 
 func (g *Gradle) Template() string {

--- a/src/segments/gradle.go
+++ b/src/segments/gradle.go
@@ -1,0 +1,66 @@
+package segments
+
+import (
+	"github.com/jandedobbeleer/oh-my-posh/src/regex"
+)
+
+type Gradle struct {
+	Language
+	KotlinVersion string
+	GroovyVersion string
+	AntVersion    string
+	JVMVersion    string
+}
+
+func (g *Gradle) Template() string {
+	return languageTemplate
+}
+
+func (g *Gradle) Enabled() bool {
+	g.extensions = []string{"*.gradle", "*.gradle.kts"}
+
+	executable := "gradle"
+	gradlew, err := g.env.HasParentFilePath("gradlew", false)
+	if err == nil {
+		executable = gradlew.Path
+	}
+
+	g.tooling = map[string]*cmd{
+		"gradle": {
+			executable: executable,
+			args:       []string{"--version"},
+			regex:      `Gradle (?P<version>(?P<major>\d+)\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?)`,
+			getVersion: g.buildGetVersion(executable),
+		},
+	}
+	g.defaultTooling = []string{"gradle"}
+	g.versionURLTemplate = "https://github.com/gradle/gradle/releases/tag/v{{ .Full }}"
+
+	return g.Language.Enabled()
+}
+
+func (g *Gradle) buildGetVersion(executable string) getVersion {
+	return func() (string, error) {
+		output, err := g.env.RunCommand(executable, "--version")
+		if err != nil {
+			return "", err
+		}
+		g.parseExtraVersions(output)
+		return output, nil
+	}
+}
+
+func (g *Gradle) parseExtraVersions(output string) {
+	if v := regex.FindNamedRegexMatch(`Kotlin:\s+(?P<version>\S+)`, output); len(v) > 0 {
+		g.KotlinVersion = v["version"]
+	}
+	if v := regex.FindNamedRegexMatch(`Groovy:\s+(?P<version>\S+)`, output); len(v) > 0 {
+		g.GroovyVersion = v["version"]
+	}
+	if v := regex.FindNamedRegexMatch(`Apache Ant.*version (?P<version>[\d.]+)`, output); len(v) > 0 {
+		g.AntVersion = v["version"]
+	}
+	if v := regex.FindNamedRegexMatch(`Launcher JVM:\s+(?P<version>[\d._]+)`, output); len(v) > 0 {
+		g.JVMVersion = v["version"]
+	}
+}

--- a/src/segments/gradle_test.go
+++ b/src/segments/gradle_test.go
@@ -34,11 +34,11 @@ func TestGradle(t *testing.T) {
 		ExpectedString string
 		GradleOutput   string
 		GradlewOutput  string
-		HasGradlew     bool
 		ExpectedKotlin string
 		ExpectedGroovy string
 		ExpectedAnt    string
 		ExpectedJVM    string
+		HasGradlew     bool
 	}{
 		{
 			Case:           "Global gradle binary",

--- a/src/segments/gradle_test.go
+++ b/src/segments/gradle_test.go
@@ -1,0 +1,138 @@
+package segments
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/cache"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+	"github.com/jandedobbeleer/oh-my-posh/src/template"
+
+	"github.com/alecthomas/assert"
+)
+
+const gradleVersionOutput = `------------------------------------------------------------
+Gradle 8.12.1
+------------------------------------------------------------
+
+Build time:    2025-01-24 12:55:12 UTC
+Revision:      0b1ee1ff81d1f4a26574ff4a362ac9180852b140
+
+Kotlin:        2.0.21
+Groovy:        3.0.22
+Ant:           Apache Ant(TM) version 1.10.15 compiled on August 25 2024
+Launcher JVM:  21.0.9 (Eclipse Adoptium 21.0.9+10-LTS)
+Daemon JVM:    C:\Users\trajano\scoop\apps\temurin21-jdk\current (no JDK specified, using current Java home)
+OS:            Windows 11 10.0 amd64`
+
+func TestGradle(t *testing.T) {
+	cases := []struct {
+		Case           string
+		ExpectedString string
+		GradleOutput   string
+		GradlewOutput  string
+		HasGradlew     bool
+		ExpectedKotlin string
+		ExpectedGroovy string
+		ExpectedAnt    string
+		ExpectedJVM    string
+	}{
+		{
+			Case:           "Global gradle binary",
+			ExpectedString: "8.12.1",
+			GradleOutput:   gradleVersionOutput,
+			HasGradlew:     false,
+			ExpectedKotlin: "2.0.21",
+			ExpectedGroovy: "3.0.22",
+			ExpectedAnt:    "1.10.15",
+			ExpectedJVM:    "21.0.9",
+		},
+		{
+			Case:           "Local gradlew wrapper takes priority",
+			ExpectedString: "8.12.1",
+			GradleOutput:   "",
+			GradlewOutput:  gradleVersionOutput,
+			HasGradlew:     true,
+			ExpectedKotlin: "2.0.21",
+			ExpectedGroovy: "3.0.22",
+			ExpectedAnt:    "1.10.15",
+			ExpectedJVM:    "21.0.9",
+		},
+		{
+			Case:           "Output missing extra version lines",
+			ExpectedString: "8.12.1",
+			GradleOutput:   "Gradle 8.12.1",
+			HasGradlew:     false,
+			ExpectedKotlin: "",
+			ExpectedGroovy: "",
+			ExpectedAnt:    "",
+			ExpectedJVM:    "",
+		},
+	}
+
+	// "No gradle files" — Enabled() returns false without calling gradle at all.
+	t.Run("No gradle files in directory", func(t *testing.T) {
+		env := new(mock.Environment)
+		env.On("HasFiles", "*.gradle").Return(false)
+		env.On("HasFiles", "*.gradle.kts").Return(false)
+		env.On("HasParentFilePath", "gradlew", false).Return(&runtime.FileInfo{}, errors.New("no match"))
+		env.On("Pwd").Return("/usr/home/project")
+		env.On("Home").Return("/usr/home")
+
+		props := options.Map{options.FetchVersion: true}
+		g := &Gradle{}
+		g.Init(props, env)
+		assert.False(t, g.Enabled())
+	})
+
+	for _, tc := range cases {
+		tc := tc // capture range variable
+		t.Run(tc.Case, func(t *testing.T) {
+			params := &mockedLanguageParams{
+				cmd:           "gradle",
+				versionParam:  "--version",
+				versionOutput: tc.GradleOutput,
+				extension:     "*.gradle",
+			}
+			env, props := getMockedLanguageEnv(params)
+
+			// getMockedLanguageEnv only registers HasFiles for "*.gradle"; also register "*.gradle.kts"
+			env.On("HasFiles", "*.gradle.kts").Return(false)
+			env.On("Shell").Return("bash")
+
+			fileInfo := &runtime.FileInfo{
+				Path:         "../gradlew",
+				ParentFolder: "./",
+				IsDir:        false,
+			}
+
+			var err error
+			if !tc.HasGradlew {
+				err = errors.New("no match")
+			}
+			env.On("HasParentFilePath", "gradlew", false).Return(fileInfo, err)
+
+			if tc.HasGradlew {
+				env.On("RunCommand", fileInfo.Path, []string{"--version"}).Return(tc.GradlewOutput, nil)
+			}
+
+			// Initialize template system so versionURLTemplate rendering doesn't panic.
+			if template.Cache == nil {
+				template.Cache = &cache.Template{}
+			}
+			template.Init(env, nil, nil)
+
+			g := &Gradle{}
+			g.Init(props, env)
+			assert.True(t, g.Enabled(), fmt.Sprintf("Failed in case: %s", tc.Case))
+			assert.Equal(t, tc.ExpectedString, renderTemplate(env, g.Template(), g), fmt.Sprintf("Failed in case: %s", tc.Case))
+			assert.Equal(t, tc.ExpectedKotlin, g.KotlinVersion, fmt.Sprintf("Kotlin in case: %s", tc.Case))
+			assert.Equal(t, tc.ExpectedGroovy, g.GroovyVersion, fmt.Sprintf("Groovy in case: %s", tc.Case))
+			assert.Equal(t, tc.ExpectedAnt, g.AntVersion, fmt.Sprintf("Ant in case: %s", tc.Case))
+			assert.Equal(t, tc.ExpectedJVM, g.JVMVersion, fmt.Sprintf("JVM in case: %s", tc.Case))
+		})
+	}
+}

--- a/src/segments/gradle_test.go
+++ b/src/segments/gradle_test.go
@@ -89,7 +89,6 @@ func TestGradle(t *testing.T) {
 	})
 
 	for _, tc := range cases {
-		tc := tc // capture range variable
 		t.Run(tc.Case, func(t *testing.T) {
 			params := &mockedLanguageParams{
 				cmd:           "gradle",

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -402,6 +402,7 @@
             "git",
             "gitversion",
             "go",
+            "gradle",
             "haskell",
             "helm",
             "http",
@@ -2102,6 +2103,41 @@
                     "default": [
                       "mod",
                       "go"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "gradle"
+              }
+            }
+          },
+          "then": {
+            "title": "Gradle Segment",
+            "description": "https://ohmyposh.dev/docs/segments/cli/gradle",
+            "properties": {
+              "options": {
+                "allOf": [
+                  {
+                    "$ref": "#/definitions/language_options"
+                  }
+                ],
+                "properties": {
+                  "extensions": {
+                    "default": [
+                      "*.gradle",
+                      "*.gradle.kts"
+                    ]
+                  },
+                  "tooling": {
+                    "default": [
+                      "gradle"
                     ]
                   }
                 }

--- a/website/docs/segments/cli/gradle.mdx
+++ b/website/docs/segments/cli/gradle.mdx
@@ -1,0 +1,69 @@
+---
+id: gradle
+title: Gradle
+sidebar_label: Gradle
+---
+
+## What
+
+Display the currently active [Gradle][gradle] version, along with the versions of its
+bundled components (Kotlin, Groovy, Ant, JVM).
+
+## Sample Configuration
+
+import Config from "@site/src/components/Config.js";
+
+<Config
+  data={{
+    type: "gradle",
+    style: "powerline",
+    powerline_symbol: "\uE0B0",
+    foreground: "#ffffff",
+    background: "#02303a",
+    template: " \uE70f {{ .Full }} ",
+  }}
+/>
+
+## Options
+
+| Name                   |    Type    |              Default               | Description                                                                                                                                                                                                                          |
+| ---------------------- | :--------: | :--------------------------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `home_enabled`         | `boolean`  |              `false`               | display the segment in the HOME folder or not                                                                                                                                                                                        |
+| `fetch_version`        | `boolean`  |               `true`               | fetch the Gradle version                                                                                                                                                                                                             |
+| `cache_duration`       |  `string`  |               `none`               | the duration for which the version will be cached. The duration is a string in the format `1h2m3s` and is parsed using the [time.ParseDuration] function from the Go standard library. To disable the cache, use `none`              |
+| `missing_command_text` |  `string`  |                                    | text to display when the command is missing                                                                                                                                                                                          |
+| `display_mode`         |  `string`  |            `context`               | <ul><li>`always`: the segment is always displayed</li><li>`files`: the segment is only displayed when file `extensions` listed are present</li><li>`context`: displays the segment when the environment or files is active</li></ul> |
+| `version_url_template` |  `string`  |                                    | a go [text/template][go-text-template] [template][templates] that creates the URL of the version info / release notes                                                                                                                |
+| `extensions`           | `[]string` | `*.gradle, *.gradle.kts`           | allows to override the default list of file extensions to validate                                                                                                                                                                   |
+| `folders`              | `[]string` |                                    | allows to override the list of folder names to validate                                                                                                                                                                              |
+| `tooling`              | `[]string` |             `gradle`               | the tooling to use for fetching the version                                                                                                                                                                                          |
+
+## Template ([info][templates])
+
+:::note default template
+
+```template
+{{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }}
+```
+
+:::
+
+### Properties
+
+| Name             | Type     | Description                                        |
+| ---------------- | -------- | -------------------------------------------------- |
+| `.Full`          | `string` | the full Gradle version                            |
+| `.Major`         | `string` | major number                                       |
+| `.Minor`         | `string` | minor number                                       |
+| `.Patch`         | `string` | patch number                                       |
+| `.KotlinVersion` | `string` | bundled Kotlin version                             |
+| `.GroovyVersion` | `string` | bundled Groovy version                             |
+| `.AntVersion`    | `string` | bundled Ant version                                |
+| `.JVMVersion`    | `string` | Launcher JVM version                               |
+| `.URL`           | `string` | URL of the release notes (from `version_url_template`) |
+| `.Error`         | `string` | error encountered when fetching the version string |
+
+[go-text-template]: https://golang.org/pkg/text/template/
+[templates]: /docs/configuration/templates
+[gradle]: https://gradle.org/
+[time.ParseDuration]: https://pkg.go.dev/time#ParseDuration

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -67,6 +67,7 @@ export default {
             "segments/cli/firebase",
             "segments/cli/flutter",
             "segments/cli/gitversion",
+            "segments/cli/gradle",
             "segments/cli/helm",
             "segments/cli/kubectl",
             "segments/cli/mvn",


### PR DESCRIPTION
Closes #7187

## Summary

- Adds a new `gradle` segment that displays the active Gradle version
- Exposes embedded component versions: Kotlin, Groovy, Ant, and Launcher JVM, parsed from `gradle --version` / `gradlew --version` output
- Automatically uses a `gradlew` wrapper when found in any parent directory

## Test Plan

- [x] `go test ./segments/ -run TestGradle -v` — 4 sub-tests pass (global binary, gradlew wrapper, minimal output, no gradle files)
- [x] `go build ./...` — full binary builds cleanly
- [x] JSON schema validated