### PR TITLE
feat(text): add Int() method to Percentage for template comparisons

### DIFF
--- a/src/text/percentage.go
+++ b/src/text/percentage.go
@@ -42,6 +42,11 @@ func (p Percentage) GaugeUsed() string {
 	return strings.Repeat("▰", filledBlocks) + strings.Repeat("▱", emptyBlocks)
 }
 
+// Int returns the percentage as an integer for template comparisons.
+func (p Percentage) Int() int {
+	return int(p)
+}
+
 // String returns the percentage as a string without % sign for template compatibility.
 func (p Percentage) String() string {
 	return fmt.Sprintf("%d", int(p))

--- a/src/text/percentage_test.go
+++ b/src/text/percentage_test.go
@@ -130,6 +130,25 @@ func TestPercentageGaugeUsed(t *testing.T) {
 	}
 }
 
+func TestPercentageInt(t *testing.T) {
+	cases := []struct {
+		Case     string
+		Expected int
+		Percent  Percentage
+	}{
+		{Case: "Zero percent", Percent: Percentage(0), Expected: 0},
+		{Case: "32 percent", Percent: Percentage(32), Expected: 32},
+		{Case: "100 percent", Percent: Percentage(100), Expected: 100},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Case, func(t *testing.T) {
+			result := tc.Percent.Int()
+			assert.Equal(t, tc.Expected, result, tc.Case)
+		})
+	}
+}
+
 func TestPercentageString(t *testing.T) {
 	cases := []struct {
 		Case     string


### PR DESCRIPTION
Possible fix for #7299.

## Summary

Adds an `Int()` method to the `Percentage` type, enabling numeric comparisons in oh-my-posh templates.

## Problem

When using `Percentage` in `background_templates` with `gt` comparisons (e.g. `{{ if gt .TokenUsagePercent 20 }}`), the comparison silently fails because the `String()` method is called implicitly, making the value a string instead of an integer.

## Solution

Add an `Int()` method that returns the raw `int` value, allowing template comparisons like:

```json
"background_templates": [
  "{{ if gt .TokenUsagePercent.Int 20 }}#ff6348{{ end }}"
]
```

## Test plan

- [x] Added `TestPercentageInt` unit tests covering 0%, 32%, and 100% cases
- [x] All existing percentage tests pass