### PR TITLE
fix(python): strip quotes from pipenv pyvenv.cfg prompt

### DIFF
--- a/src/segments/python.go
+++ b/src/segments/python.go
@@ -214,7 +214,7 @@ func (p *Python) pyvenvCfgPrompt() string {
 		key = strings.TrimSpace(key)
 		if key == "prompt" {
 			value := strings.TrimSpace(value)
-			return value
+			return strings.Trim(value, "\"")
 		}
 	}
 

--- a/src/segments/python_test.go
+++ b/src/segments/python_test.go
@@ -89,6 +89,15 @@ func TestPythonTemplate(t *testing.T) {
 			PyvenvCfg:      "home = /usr/bin/\nprompt = pyvenvCfgPrompt\n",
 			Expected:       "pyvenvCfgPrompt 3.8",
 		},
+		{
+			Case:           "pyvenv.cfg prompt with quotes (pipenv)",
+			FetchVersion:   true,
+			VirtualEnvName: "VENV",
+			PythonPath:     "/home/user/.pyenv/shims/python",
+			Template:       "{{ if .Venv }}{{ .Venv }} {{ end }}{{ .Major }}.{{ .Minor }}",
+			PyvenvCfg:      "home = /usr/bin/\nprompt = \"myproject\"\n",
+			Expected:       "myproject 3.8",
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

  - `pipenv` writes the `prompt` field in `pyvenv.cfg` with surrounding double quotes (e.g. `prompt = "myproject"`), whereas `uv` and the standard `venv` module do not
  - This caused `{{ .Venv }}` to render as `"myproject"` instead of `myproject` when using pipenv
  - Fix strips surrounding double quotes from the prompt value in `pyvenvCfgPrompt()`

## Test plan

  - Added test case `pyvenv.cfg prompt with quotes (pipenv)` to `TestPythonTemplate` covering the quoted prompt scenario
  - Validated manually in devcontainer: `oh-my-posh print primary` renders `myproject` without quotes
  - All tests pass: `go test "./..."`

Fixes #7409 