### PR TITLE
feat(claude): add cost sub-fields and rate limits

### DIFF
--- a/src/segments/claude.go
+++ b/src/segments/claude.go
@@ -36,13 +36,23 @@ type ClaudeWorkspace struct {
 	ProjectDir string `json:"project_dir"`
 }
 
+// DurationMS is a duration in milliseconds that formats as "Xm Ys".
+type DurationMS int64
+
+func (d DurationMS) String() string {
+	totalSeconds := int64(d) / 1000
+	minutes := totalSeconds / 60
+	seconds := totalSeconds % 60
+	return fmt.Sprintf("%dm %ds", minutes, seconds)
+}
+
 // ClaudeCost represents cost and duration information
 type ClaudeCost struct {
-	TotalCostUSD       float64 `json:"total_cost_usd"`
-	TotalDurationMS    int64   `json:"total_duration_ms"`
-	TotalAPIDurationMS int64   `json:"total_api_duration_ms"`
-	TotalLinesAdded    int     `json:"total_lines_added"`
-	TotalLinesRemoved  int     `json:"total_lines_removed"`
+	TotalCostUSD       float64    `json:"total_cost_usd"`
+	TotalDurationMS    DurationMS `json:"total_duration_ms"`
+	TotalAPIDurationMS DurationMS `json:"total_api_duration_ms"`
+	TotalLinesAdded    int        `json:"total_lines_added"`
+	TotalLinesRemoved  int        `json:"total_lines_removed"`
 }
 
 // ClaudeRateLimitWindow represents a single rate limit time window.
@@ -160,22 +170,14 @@ func (c *Claude) FormattedCost() string {
 	return fmt.Sprintf("$%.2f", c.Cost.TotalCostUSD)
 }
 
-// formatDurationMS converts milliseconds to "Xm Ys" format.
-func formatDurationMS(ms int64) string {
-	totalSeconds := ms / 1000
-	minutes := totalSeconds / 60
-	seconds := totalSeconds % 60
-	return fmt.Sprintf("%dm %ds", minutes, seconds)
-}
-
 // FormattedDuration returns total session duration as "Xm Ys".
 func (c *Claude) FormattedDuration() string {
-	return formatDurationMS(c.Cost.TotalDurationMS)
+	return c.Cost.TotalDurationMS.String()
 }
 
 // FormattedAPIDuration returns API wait time as "Xm Ys".
 func (c *Claude) FormattedAPIDuration() string {
-	return formatDurationMS(c.Cost.TotalAPIDurationMS)
+	return c.Cost.TotalAPIDurationMS.String()
 }
 
 // rateLimitPercentage extracts a percentage from a rate limit window with nil-safety.

--- a/src/segments/claude.go
+++ b/src/segments/claude.go
@@ -21,6 +21,7 @@ type ClaudeData struct {
 	SessionID     string              `json:"session_id"`
 	ContextWindow ClaudeContextWindow `json:"context_window"`
 	Cost          ClaudeCost          `json:"cost"`
+	RateLimits    *ClaudeRateLimits   `json:"rate_limits"`
 }
 
 // ClaudeModel represents the AI model information
@@ -42,6 +43,18 @@ type ClaudeCost struct {
 	TotalAPIDurationMS int64   `json:"total_api_duration_ms"`
 	TotalLinesAdded    int     `json:"total_lines_added"`
 	TotalLinesRemoved  int     `json:"total_lines_removed"`
+}
+
+// ClaudeRateLimitWindow represents a single rate limit time window.
+type ClaudeRateLimitWindow struct {
+	UsedPercentage *float64 `json:"used_percentage"`
+	ResetsAt       *int64   `json:"resets_at"`
+}
+
+// ClaudeRateLimits represents rate limit information across time windows.
+type ClaudeRateLimits struct {
+	FiveHour *ClaudeRateLimitWindow `json:"five_hour"`
+	SevenDay *ClaudeRateLimitWindow `json:"seven_day"`
 }
 
 // ClaudeContextWindow represents token usage information
@@ -163,6 +176,39 @@ func (c *Claude) FormattedDuration() string {
 // FormattedAPIDuration returns API wait time as "Xm Ys".
 func (c *Claude) FormattedAPIDuration() string {
 	return formatDurationMS(c.Cost.TotalAPIDurationMS)
+}
+
+// rateLimitPercentage extracts a percentage from a rate limit window with nil-safety.
+func rateLimitPercentage(limits *ClaudeRateLimits, window func(*ClaudeRateLimits) *ClaudeRateLimitWindow) text.Percentage {
+	if limits == nil {
+		return 0
+	}
+
+	w := window(limits)
+	if w == nil || w.UsedPercentage == nil {
+		return 0
+	}
+
+	percent := int(*w.UsedPercentage + 0.5)
+	if percent > 100 {
+		return 100
+	}
+
+	return text.Percentage(percent)
+}
+
+// FiveHourUsage returns the 5-hour rolling window rate limit usage as a Percentage.
+func (c *Claude) FiveHourUsage() text.Percentage {
+	return rateLimitPercentage(c.RateLimits, func(r *ClaudeRateLimits) *ClaudeRateLimitWindow {
+		return r.FiveHour
+	})
+}
+
+// SevenDayUsage returns the 7-day window rate limit usage as a Percentage.
+func (c *Claude) SevenDayUsage() text.Percentage {
+	return rateLimitPercentage(c.RateLimits, func(r *ClaudeRateLimits) *ClaudeRateLimitWindow {
+		return r.SevenDay
+	})
 }
 
 // FormattedTokens returns a human-readable string of current context tokens.

--- a/src/segments/claude.go
+++ b/src/segments/claude.go
@@ -37,8 +37,11 @@ type ClaudeWorkspace struct {
 
 // ClaudeCost represents cost and duration information
 type ClaudeCost struct {
-	TotalCostUSD    float64 `json:"total_cost_usd"`
-	TotalDurationMS int64   `json:"total_duration_ms"`
+	TotalCostUSD       float64 `json:"total_cost_usd"`
+	TotalDurationMS    int64   `json:"total_duration_ms"`
+	TotalAPIDurationMS int64   `json:"total_api_duration_ms"`
+	TotalLinesAdded    int     `json:"total_lines_added"`
+	TotalLinesRemoved  int     `json:"total_lines_removed"`
 }
 
 // ClaudeContextWindow represents token usage information
@@ -142,6 +145,24 @@ func (c *Claude) FormattedCost() string {
 	}
 
 	return fmt.Sprintf("$%.2f", c.Cost.TotalCostUSD)
+}
+
+// formatDurationMS converts milliseconds to "Xm Ys" format.
+func formatDurationMS(ms int64) string {
+	totalSeconds := ms / 1000
+	minutes := totalSeconds / 60
+	seconds := totalSeconds % 60
+	return fmt.Sprintf("%dm %ds", minutes, seconds)
+}
+
+// FormattedDuration returns total session duration as "Xm Ys".
+func (c *Claude) FormattedDuration() string {
+	return formatDurationMS(c.Cost.TotalDurationMS)
+}
+
+// FormattedAPIDuration returns API wait time as "Xm Ys".
+func (c *Claude) FormattedAPIDuration() string {
+	return formatDurationMS(c.Cost.TotalAPIDurationMS)
 }
 
 // FormattedTokens returns a human-readable string of current context tokens.

--- a/src/segments/claude.go
+++ b/src/segments/claude.go
@@ -16,12 +16,12 @@ type Claude struct {
 
 // ClaudeData represents the parsed Claude JSON data
 type ClaudeData struct {
+	RateLimits    *ClaudeRateLimits   `json:"rate_limits"`
 	Model         ClaudeModel         `json:"model"`
 	Workspace     ClaudeWorkspace     `json:"workspace"`
 	SessionID     string              `json:"session_id"`
 	ContextWindow ClaudeContextWindow `json:"context_window"`
 	Cost          ClaudeCost          `json:"cost"`
-	RateLimits    *ClaudeRateLimits   `json:"rate_limits"`
 }
 
 // ClaudeModel represents the AI model information

--- a/src/segments/claude_test.go
+++ b/src/segments/claude_test.go
@@ -284,8 +284,8 @@ func TestClaudeFormattedCost(t *testing.T) {
 func TestClaudeFormattedDuration(t *testing.T) {
 	cases := []struct {
 		Case     string
-		MS       DurationMS
 		Expected string
+		MS       DurationMS
 	}{
 		{Case: "Zero", MS: 0, Expected: "0m 0s"},
 		{Case: "Seconds only", MS: 45000, Expected: "0m 45s"},
@@ -303,8 +303,8 @@ func TestClaudeFormattedDuration(t *testing.T) {
 func TestClaudeFormattedAPIDuration(t *testing.T) {
 	cases := []struct {
 		Case     string
-		MS       DurationMS
 		Expected string
+		MS       DurationMS
 	}{
 		{Case: "Zero", MS: 0, Expected: "0m 0s"},
 		{Case: "Seconds only", MS: 30000, Expected: "0m 30s"},
@@ -419,8 +419,8 @@ func TestClaudeFormattedTokens(t *testing.T) {
 
 func TestClaudeRateLimitUsage(t *testing.T) {
 	cases := []struct {
-		Case          string
 		RateLimits    *ClaudeRateLimits
+		Case          string
 		ExpectedFive  text.Percentage
 		ExpectedSeven text.Percentage
 	}{

--- a/src/segments/claude_test.go
+++ b/src/segments/claude_test.go
@@ -268,6 +268,43 @@ func TestClaudeFormattedCost(t *testing.T) {
 	}
 }
 
+func TestClaudeFormattedDuration(t *testing.T) {
+	cases := []struct {
+		Case     string
+		MS       int64
+		Expected string
+	}{
+		{Case: "Zero", MS: 0, Expected: "0m 0s"},
+		{Case: "Seconds only", MS: 45000, Expected: "0m 45s"},
+		{Case: "Minutes and seconds", MS: 125000, Expected: "2m 5s"},
+		{Case: "Exact minute", MS: 60000, Expected: "1m 0s"},
+	}
+
+	for _, tc := range cases {
+		claude := &Claude{}
+		claude.Cost.TotalDurationMS = tc.MS
+		assert.Equal(t, tc.Expected, claude.FormattedDuration(), tc.Case)
+	}
+}
+
+func TestClaudeFormattedAPIDuration(t *testing.T) {
+	cases := []struct {
+		Case     string
+		MS       int64
+		Expected string
+	}{
+		{Case: "Zero", MS: 0, Expected: "0m 0s"},
+		{Case: "Seconds only", MS: 30000, Expected: "0m 30s"},
+		{Case: "Minutes and seconds", MS: 90000, Expected: "1m 30s"},
+	}
+
+	for _, tc := range cases {
+		claude := &Claude{}
+		claude.Cost.TotalAPIDurationMS = tc.MS
+		assert.Equal(t, tc.Expected, claude.FormattedAPIDuration(), tc.Case)
+	}
+}
+
 func TestClaudeFormattedTokens(t *testing.T) {
 	cases := []struct {
 		Case                     string

--- a/src/segments/claude_test.go
+++ b/src/segments/claude_test.go
@@ -284,7 +284,7 @@ func TestClaudeFormattedCost(t *testing.T) {
 func TestClaudeFormattedDuration(t *testing.T) {
 	cases := []struct {
 		Case     string
-		MS       int64
+		MS       DurationMS
 		Expected string
 	}{
 		{Case: "Zero", MS: 0, Expected: "0m 0s"},
@@ -303,7 +303,7 @@ func TestClaudeFormattedDuration(t *testing.T) {
 func TestClaudeFormattedAPIDuration(t *testing.T) {
 	cases := []struct {
 		Case     string
-		MS       int64
+		MS       DurationMS
 		Expected string
 	}{
 		{Case: "Zero", MS: 0, Expected: "0m 0s"},

--- a/src/segments/claude_test.go
+++ b/src/segments/claude_test.go
@@ -403,3 +403,79 @@ func TestClaudeFormattedTokens(t *testing.T) {
 		assert.Equal(t, tc.ExpectedFormat, formatted, tc.Case)
 	}
 }
+
+func TestClaudeRateLimitUsage(t *testing.T) {
+	cases := []struct {
+		Case          string
+		RateLimits    *ClaudeRateLimits
+		ExpectedFive  text.Percentage
+		ExpectedSeven text.Percentage
+	}{
+		{
+			Case:          "Nil RateLimits",
+			RateLimits:    nil,
+			ExpectedFive:  0,
+			ExpectedSeven: 0,
+		},
+		{
+			Case: "Nil FiveHour window",
+			RateLimits: &ClaudeRateLimits{
+				SevenDay: &ClaudeRateLimitWindow{UsedPercentage: new(50.0)},
+			},
+			ExpectedFive:  0,
+			ExpectedSeven: 50,
+		},
+		{
+			Case: "Nil SevenDay window",
+			RateLimits: &ClaudeRateLimits{
+				FiveHour: &ClaudeRateLimitWindow{UsedPercentage: new(25.0)},
+			},
+			ExpectedFive:  25,
+			ExpectedSeven: 0,
+		},
+		{
+			Case: "Nil UsedPercentage",
+			RateLimits: &ClaudeRateLimits{
+				FiveHour: &ClaudeRateLimitWindow{UsedPercentage: nil},
+				SevenDay: &ClaudeRateLimitWindow{UsedPercentage: nil},
+			},
+			ExpectedFive:  0,
+			ExpectedSeven: 0,
+		},
+		{
+			Case: "Valid percentages",
+			RateLimits: &ClaudeRateLimits{
+				FiveHour: &ClaudeRateLimitWindow{UsedPercentage: new(42.7)},
+				SevenDay: &ClaudeRateLimitWindow{UsedPercentage: new(75.3)},
+			},
+			ExpectedFive:  43,
+			ExpectedSeven: 75,
+		},
+		{
+			Case: "Value over 100 capped",
+			RateLimits: &ClaudeRateLimits{
+				FiveHour: &ClaudeRateLimitWindow{UsedPercentage: new(150.0)},
+				SevenDay: &ClaudeRateLimitWindow{UsedPercentage: new(200.0)},
+			},
+			ExpectedFive:  100,
+			ExpectedSeven: 100,
+		},
+		{
+			Case: "Zero percentages",
+			RateLimits: &ClaudeRateLimits{
+				FiveHour: &ClaudeRateLimitWindow{UsedPercentage: new(0.0)},
+				SevenDay: &ClaudeRateLimitWindow{UsedPercentage: new(0.0)},
+			},
+			ExpectedFive:  0,
+			ExpectedSeven: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		claude := &Claude{}
+		claude.RateLimits = tc.RateLimits
+
+		assert.Equal(t, tc.ExpectedFive, claude.FiveHourUsage(), tc.Case+" (FiveHour)")
+		assert.Equal(t, tc.ExpectedSeven, claude.SevenDayUsage(), tc.Case+" (SevenDay)")
+	}
+}

--- a/src/segments/claude_test.go
+++ b/src/segments/claude_test.go
@@ -37,8 +37,11 @@ func TestClaudeSegment(t *testing.T) {
 					ProjectDir: "/repo",
 				},
 				Cost: ClaudeCost{
-					TotalCostUSD:    0.01,
-					TotalDurationMS: 45000,
+					TotalCostUSD:       0.01,
+					TotalDurationMS:    45000,
+					TotalAPIDurationMS: 30000,
+					TotalLinesAdded:    156,
+					TotalLinesRemoved:  23,
 				},
 				ContextWindow: ClaudeContextWindow{
 					TotalInputTokens:  15234,
@@ -47,6 +50,16 @@ func TestClaudeSegment(t *testing.T) {
 					CurrentUsage: &ClaudeCurrentUsage{
 						InputTokens:  8500,
 						OutputTokens: 1200,
+					},
+				},
+				RateLimits: &ClaudeRateLimits{
+					FiveHour: &ClaudeRateLimitWindow{
+						UsedPercentage: new(24.5),
+						ResetsAt:       new(int64(1711180800)),
+					},
+					SevenDay: &ClaudeRateLimitWindow{
+						UsedPercentage: new(45.0),
+						ResetsAt:       new(int64(1711612800)),
 					},
 				},
 			},

--- a/website/docs/segments/cli/claude.mdx
+++ b/website/docs/segments/cli/claude.mdx
@@ -75,8 +75,8 @@ import Config from "@site/src/components/Config.js";
 | Name               | Type      | Description                            |
 | ------------------ | --------- | -------------------------------------- |
 | `.TotalCostUSD`       | `float64` | Total cost in USD                                 |
-| `.TotalDurationMS`    | `int64`   | Total session duration in milliseconds            |
-| `.TotalAPIDurationMS` | `int64`   | Time spent waiting for API responses (ms)         |
+| `.TotalDurationMS`    | `DurationMS` | Total session duration in milliseconds (formats as "Xm Ys") |
+| `.TotalAPIDurationMS` | `DurationMS` | Time spent waiting for API responses (formats as "Xm Ys")   |
 | `.TotalLinesAdded`    | `int`     | Lines of code added in the session                |
 | `.TotalLinesRemoved`  | `int`     | Lines of code removed in the session              |
 

--- a/website/docs/segments/cli/claude.mdx
+++ b/website/docs/segments/cli/claude.mdx
@@ -51,6 +51,10 @@ import Config from "@site/src/components/Config.js";
 | `.TokenUsagePercent` | `Percentage`    | Percentage of context window used (0-100)          |
 | `.FormattedCost`     | `string`        | Formatted cost string (e.g., "$0.15" or "$0.0012") |
 | `.FormattedTokens`   | `string`        | Human-readable token count (e.g., "1.2K", "15.3M") |
+| `.FormattedDuration`    | `string`        | Total session duration (e.g., "2m 5s")             |
+| `.FormattedAPIDuration` | `string`        | API wait time (e.g., "0m 45s")                     |
+| `.FiveHourUsage`        | `Percentage`    | 5-hour rolling rate limit usage (0-100)            |
+| `.SevenDayUsage`        | `Percentage`    | 7-day rate limit usage (0-100)                     |
 
 #### Model Properties
 
@@ -70,8 +74,11 @@ import Config from "@site/src/components/Config.js";
 
 | Name               | Type      | Description                            |
 | ------------------ | --------- | -------------------------------------- |
-| `.TotalCostUSD`    | `float64` | Total cost in USD                      |
-| `.TotalDurationMS` | `int64`   | Total session duration in milliseconds |
+| `.TotalCostUSD`       | `float64` | Total cost in USD                                 |
+| `.TotalDurationMS`    | `int64`   | Total session duration in milliseconds            |
+| `.TotalAPIDurationMS` | `int64`   | Time spent waiting for API responses (ms)         |
+| `.TotalLinesAdded`    | `int`     | Lines of code added in the session                |
+| `.TotalLinesRemoved`  | `int`     | Lines of code removed in the session              |
 
 #### ContextWindow Properties
 
@@ -88,6 +95,22 @@ import Config from "@site/src/components/Config.js";
 | --------------- | ----- | ------------------------------------- |
 | `.InputTokens`  | `int` | Input tokens for the current message  |
 | `.OutputTokens` | `int` | Output tokens for the current message |
+
+#### RateLimits Properties
+
+Available when Claude Code provides rate limit data (Pro/Max subscribers). Access via `.RateLimits`.
+
+| Name        | Type              | Description              |
+| ----------- | ----------------- | ------------------------ |
+| `.FiveHour` | `RateLimitWindow` | 5-hour rolling window    |
+| `.SevenDay` | `RateLimitWindow` | 7-day rolling window     |
+
+#### RateLimitWindow Properties
+
+| Name              | Type       | Description                              |
+| ----------------- | ---------- | ---------------------------------------- |
+| `.UsedPercentage` | `*float64` | Usage percentage (0-100), nil if unknown |
+| `.ResetsAt`       | `*int64`   | Unix epoch seconds when window resets    |
 
 ### Percentage Methods
 


### PR DESCRIPTION
## Summary

- Add `TotalAPIDurationMS`, `TotalLinesAdded`, `TotalLinesRemoved` fields to `ClaudeCost` struct
- Add `ClaudeRateLimits` and `ClaudeRateLimitWindow` structs with nil-safe `FiveHourUsage()` and `SevenDayUsage()` helpers returning `Percentage`
- Add `FormattedDuration()` and `FormattedAPIDuration()` methods for human-readable session/API duration
- Document all new properties in the Claude segment MDX docs

## Test plan

- [x] All 7 Claude tests pass (`TestClaudeSegment`, `TestClaudeTokenUsagePercent`, `TestClaudeFormattedCost`, `TestClaudeFormattedDuration`, `TestClaudeFormattedAPIDuration`, `TestClaudeFormattedTokens`, `TestClaudeRateLimitUsage`)
- [x] Rate limit tests cover nil limits, nil windows, nil percentages, rounding, and capping at 100
- [x] Duration tests cover zero, seconds-only, minutes+seconds, exact minute
- [x] Existing test fixture updated with new fields