### PR TITLE
chore: update Go comment in Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # See here for image contents: https://github.com/devcontainers/images/blob/main/src/go/.devcontainer/Dockerfile
 
-# [Choice] Go version: 1, 1.24, 1.25, 1-trixie, 1.24-trixie, 1.25-trixie, 1-bookworm, 1.24-bookworm, 1.25-bookworm, 1-bullseye, 1.24-bullseye, 1.25-bullseye
+# [Choice] Go version: 1, 1.25, 1.26, 1-trixie, 1.25-trixie, 1.26-trixie, 1-bookworm, 1.25-bookworm, 1.26-bookworm, 1-bullseye, 1.25-bullseye, 1.26-bullseye
 ARG VARIANT=1-trixie
 FROM mcr.microsoft.com/vscode/devcontainers/go:${VARIANT}
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Update the Go version choices comment in the devcontainer Dockerfile.

### Changes

- Remove Go `1.24` from the version choices
- Add Go `1.26` to the version choices
- Reflect `1.25` / `1.26` based variants (trixie, bookworm, bullseye)

Follow up #7395

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
