### PR TITLE
chore(devcontainer): bump PowerShell from 7.5.4 to 7.6.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,9 +9,9 @@ ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 # Install powershell
-ARG PS_VERSION="7.5.4"
-# powershell-7.5.4-linux-x64.tar.gz
-# powershell-7.5.4-linux-arm64.tar.gz
+ARG PS_VERSION="7.6.0"
+# powershell-7.6.0-linux-x64.tar.gz
+# powershell-7.6.0-linux-arm64.tar.gz
 RUN ARCH="$(dpkg --print-architecture)"; \
     if [ "${ARCH}" = "amd64" ]; then \
         PS_BIN="v$PS_VERSION/powershell-$PS_VERSION-linux-x64.tar.gz"; \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
 
       "NODE_VERSION": "lts/*",
       //Powershell version
-      "PS_VERSION": "7.5.4"
+      "PS_VERSION": "7.6.0"
     }
   },
   "runArgs": [


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Bump the PowerShell version used in the devcontainer from 7.5.4 to [7.6.0](https://github.com/PowerShell/PowerShell/releases/tag/v7.6.0).

### Changes

- Update `PS_VERSION` from `7.5.4` to `7.6.0` in `.devcontainer/Dockerfile`
- Update `PS_VERSION` from `7.5.4` to `7.6.0` in `.devcontainer/devcontainer.json`
- Update corresponding archive filename comments in the Dockerfile


[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
