### PR TITLE
feat(docker): add environment display mode with container listing and filter support

### DIFF
--- a/src/segments/docker.go
+++ b/src/segments/docker.go
@@ -15,7 +15,7 @@ const (
 	FetchContext options.Option = "fetch_context"
 	// DockerCommand is the property used to specify the docker command to use
 	DockerCommand options.Option = "docker_command"
-	// Filter is the property used to specify a filter to apply when fetching the current docker context, see https://docs.docker.com/reference/cli/docker/container/ls/#filter
+	// Filter is the property used to specify a filter to apply to docker ps results in environment mode, see https://docs.docker.com/reference/cli/docker/container/ls/#filter
 	Filter options.Option = "filter"
 )
 

--- a/src/segments/docker.go
+++ b/src/segments/docker.go
@@ -3,6 +3,7 @@ package segments
 import (
 	"encoding/json"
 	"path/filepath"
+	"strings"
 
 	"slices"
 
@@ -12,16 +13,35 @@ import (
 const (
 	// FetchContext is the property used to fetch the current docker context
 	FetchContext options.Option = "fetch_context"
+	// DockerCommand is the property used to specify the docker command to use
+	DockerCommand options.Option = "docker_command"
+	// Filter is the property used to specify a filter to apply when fetching the current docker context, see https://docs.docker.com/reference/cli/docker/container/ls/#filter
+	Filter options.Option = "filter"
 )
 
 type DockerConfig struct {
 	CurrentContext string `json:"currentContext"`
+	DockerCommand  string
+	Filter         string
 }
 
 type Docker struct {
 	Base
 
-	Context string
+	Context    string
+	Containers []Container
+
+	command *cmd
+}
+
+type Container struct {
+	ID      string
+	Image   string
+	Command string
+	Created string
+	Status  string
+	Ports   string
+	Names   string
 }
 
 func (d *Docker) Template() string {
@@ -57,6 +77,7 @@ func (d *Docker) Enabled() bool {
 	extensions = d.options.StringArray(LanguageExtensions, extensions)
 
 	displayMode := d.options.String(DisplayMode, DisplayModeContext)
+
 	switch displayMode {
 	case DisplayModeContext:
 		return d.fetchContext()
@@ -71,6 +92,36 @@ func (d *Docker) Enabled() bool {
 		}
 
 		return true
+	case DisplayModeEnvironment:
+		// always fetch context first
+		hasContext := d.fetchContext()
+
+		dockerCommand := d.options.String(DockerCommand, "docker")
+		if !d.env.HasCommand(dockerCommand) {
+			return hasContext
+		}
+
+		filter := d.options.String(Filter, "")
+		// Use Go template formatting with tab separation
+		format := `{{.ID}}\t{{.Image}}\t{{.Command}}\t{{.CreatedAt}}\t{{.Status}}\t{{.Ports}}\t{{.Names}}`
+		args := []string{"ps", "--format", format}
+		if len(filter) > 0 {
+			args = append(args, "--filter", filter)
+		}
+
+		d.command = &cmd{
+			executable: dockerCommand,
+			args:       args,
+		}
+
+		containers, err := d.fetchContainers()
+		if err != nil {
+			return hasContext
+		}
+
+		d.Containers = containers
+
+		return hasContext || len(d.Containers) > 0
 	}
 
 	return false
@@ -108,4 +159,39 @@ func (d *Docker) fetchContext() bool {
 	}
 
 	return false
+}
+
+func (d *Docker) fetchContainers() ([]Container, error) {
+	if d.command == nil {
+		return nil, nil
+	}
+
+	output, err := d.env.RunCommand(d.command.executable, d.command.args...)
+	if err != nil {
+		return nil, err
+	}
+
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) == 0 || (len(lines) == 1 && lines[0] == "") {
+		return nil, nil
+	}
+
+	containers := make([]Container, len(lines))
+	for i, line := range lines {
+		fields := strings.Split(line, "\t")
+		if len(fields) != 7 {
+			continue // Or handle error for malformed line
+		}
+		containers[i] = Container{
+			ID:      fields[0],
+			Image:   fields[1],
+			Command: fields[2],
+			Created: fields[3],
+			Status:  fields[4],
+			Ports:   fields[5],
+			Names:   fields[6],
+		}
+	}
+
+	return containers, nil
 }

--- a/src/segments/docker.go
+++ b/src/segments/docker.go
@@ -2,6 +2,7 @@ package segments
 
 import (
 	"encoding/json"
+	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -94,11 +95,11 @@ func (d *Docker) Enabled() bool {
 		return true
 	case DisplayModeEnvironment:
 		// always fetch context first
-		hasContext := d.fetchContext()
+		_ = d.fetchContext()
 
 		dockerCommand := d.options.String(DockerCommand, "docker")
 		if !d.env.HasCommand(dockerCommand) {
-			return hasContext
+			return false
 		}
 
 		filter := d.options.String(Filter, "")
@@ -116,12 +117,12 @@ func (d *Docker) Enabled() bool {
 
 		containers, err := d.fetchContainers()
 		if err != nil {
-			return hasContext
+			return false
 		}
 
 		d.Containers = containers
 
-		return hasContext || len(d.Containers) > 0
+		return len(d.Containers) > 0
 	}
 
 	return false
@@ -176,13 +177,14 @@ func (d *Docker) fetchContainers() ([]Container, error) {
 		return nil, nil
 	}
 
-	containers := make([]Container, len(lines))
+	containers := make([]Container, 0, len(lines))
 	for i, line := range lines {
+		line = strings.TrimRight(line, "\r")
 		fields := strings.Split(line, "\t")
 		if len(fields) != 7 {
-			continue // Or handle error for malformed line
+			return nil, fmt.Errorf("invalid docker ps output on line %d: expected 7 fields, got %d", i+1, len(fields))
 		}
-		containers[i] = Container{
+		containers = append(containers, Container{
 			ID:      fields[0],
 			Image:   fields[1],
 			Command: fields[2],
@@ -190,7 +192,7 @@ func (d *Docker) fetchContainers() ([]Container, error) {
 			Status:  fields[4],
 			Ports:   fields[5],
 			Names:   fields[6],
-		}
+		})
 	}
 
 	return containers, nil

--- a/src/segments/docker_test.go
+++ b/src/segments/docker_test.go
@@ -90,3 +90,98 @@ func TestDockerFiles(t *testing.T) {
 		assert.Equal(t, tc.ExpectedEnabled, docker.Enabled(), tc.Case)
 	}
 }
+
+func TestDockerEnvironment(t *testing.T) {
+	cases := []struct {
+		Case            string
+		ExpectedEnabled bool
+		ExpectedContext string
+		Filter          string
+		DockerCommand   string
+		CommandOutput   string
+		HasCommand      bool
+	}{
+		{
+			Case:            "Docker command not found",
+			ExpectedEnabled: false,
+			HasCommand:      false,
+		},
+		{
+			Case:            "No running containers",
+			ExpectedEnabled: false,
+			HasCommand:      true,
+			CommandOutput:   "",
+		},
+		{
+			Case:            "One running container",
+			ExpectedEnabled: true,
+			HasCommand:      true,
+			CommandOutput:   "c1\timage1\tcmd1\tcreated1\tstatus1\tports1\tnames1",
+			ExpectedContext: "1 running (c1)",
+		},
+		{
+			Case:            "Multiple running containers",
+			ExpectedEnabled: true,
+			HasCommand:      true,
+			CommandOutput:   "c1\timage1\tcmd1\tcreated1\tstatus1\tports1\tnames1\nc2\timage2\tcmd2\tcreated2\tstatus2\tports2\tnames2",
+			ExpectedContext: "2 running (c1)",
+		},
+		{
+			Case:            "Filter applied",
+			ExpectedEnabled: true,
+			HasCommand:      true,
+			Filter:          "name=service1",
+			CommandOutput:   "c1\timage1\tcmd1\tcreated1\tstatus1\tports1\tnames1",
+			ExpectedContext: "1 running (c1)",
+		},
+		{
+			Case:            "Custom docker command",
+			ExpectedEnabled: true,
+			HasCommand:      true,
+			DockerCommand:   "podman",
+			CommandOutput:   "c1\timage1\tcmd1\tcreated1\tstatus1\tports1\tnames1",
+			ExpectedContext: "1 running (c1)",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Case, func(t *testing.T) {
+			env := new(mock.Environment)
+			env.On("Getenv", mock_.Anything).Return("")
+			env.On("Home").Return("")
+			env.On("FileContent", mock_.Anything).Return("")
+
+			dockerCommand := "docker"
+			if len(tc.DockerCommand) > 0 {
+				dockerCommand = tc.DockerCommand
+			}
+
+			env.On("HasCommand", dockerCommand).Return(tc.HasCommand)
+
+			format := `{{.ID}}\t{{.Image}}\t{{.Command}}\t{{.CreatedAt}}\t{{.Status}}\t{{.Ports}}\t{{.Names}}`
+			args := []string{"ps", "--format", format}
+			if len(tc.Filter) > 0 {
+				args = append(args, "--filter", tc.Filter)
+			}
+
+			env.On("RunCommand", dockerCommand, args).Return(tc.CommandOutput, nil)
+
+			props := options.Map{
+				DisplayMode: DisplayModeEnvironment,
+				Filter:      tc.Filter,
+			}
+			if len(tc.DockerCommand) > 0 {
+				props[DockerCommand] = tc.DockerCommand
+			}
+
+			docker := &Docker{}
+			docker.Init(props, env)
+
+			assert.Equal(t, tc.ExpectedEnabled, docker.Enabled())
+			if tc.ExpectedEnabled {
+				template := `{{ len .Containers }} running ({{ (index .Containers 0).ID }})`
+				assert.Equal(t, tc.ExpectedContext, renderTemplate(env, template, docker))
+			}
+		})
+	}
+}

--- a/src/segments/docker_test.go
+++ b/src/segments/docker_test.go
@@ -127,6 +127,19 @@ func TestDockerEnvironment(t *testing.T) {
 			ExpectedContext: "2 running (c1)",
 		},
 		{
+			Case:            "Multiple running containers with windows line endings",
+			ExpectedEnabled: true,
+			HasCommand:      true,
+			CommandOutput:   "c1\timage1\tcmd1\tcreated1\tstatus1\tports1\tnames1\r\nc2\timage2\tcmd2\tcreated2\tstatus2\tports2\tnames2\r\n",
+			ExpectedContext: "2 running (c1)",
+		},
+		{
+			Case:            "Output with empty line",
+			ExpectedEnabled: false,
+			HasCommand:      true,
+			CommandOutput:   "c1\timage1\tcmd1\tcreated1\tstatus1\tports1\tnames1\n\nc2\timage2\tcmd2\tcreated2\tstatus2\tports2\tnames2",
+		},
+		{
 			Case:            "Filter applied",
 			ExpectedEnabled: true,
 			HasCommand:      true,

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -1532,7 +1532,8 @@
                     "$ref": "#/definitions/display_mode",
                     "enum": [
                       "files",
-                      "context"
+                      "context",
+                      "environment"
                     ]
                   },
                   "extensions": {
@@ -1549,6 +1550,18 @@
                     "title": "Fetch Context",
                     "description": "Fetch the Docker context",
                     "default": true
+                  },
+                  "docker_command": {
+                    "type": "string",
+                    "title": "Docker Command",
+                    "description": "Command used to call Docker",
+                    "default": "docker"
+                  },
+                  "filter": {
+                    "type": "string",
+                    "title": "Filter",
+                    "description": "Filter passed to docker ps. See https://docs.docker.com/reference/cli/docker/container/ls/#filter",
+                    "default": ""
                   }
                 },
                 "unevaluatedProperties": false

--- a/website/docs/segments/cli/docker.mdx
+++ b/website/docs/segments/cli/docker.mdx
@@ -6,7 +6,7 @@ sidebar_label: Docker
 
 ## What
 
-Display the current [Docker][docker] context, or container stats when `display_mode` is set to `environment`.
+Display the current [Docker][docker] context, or a list of running containers when `display_mode` is set to `environment`.
 
 ## Sample Configuration
 

--- a/website/docs/segments/cli/docker.mdx
+++ b/website/docs/segments/cli/docker.mdx
@@ -6,7 +6,7 @@ sidebar_label: Docker
 
 ## What
 
-Display the current [Docker][docker] context. Will not be active when using the default context.
+Display the current [Docker][docker] context, or container stats when `display_mode` is set to `environment`.
 
 ## Sample Configuration
 
@@ -20,16 +20,23 @@ import Config from "@site/src/components/Config.js";
     foreground: "#000000",
     background: "#0B59E7",
     template: " \uf308 {{ .Context }} ",
+    options: {
+      display_mode: "environment",
+      docker_command: "docker",
+      filter: "name=oh-my-posh-db-1"
+    }
   }}
 />
 
 ## Options
 
-| Name            |    Type    |                                      Default                                     | Description                                                                                                                                                              |
-| --------------- | :--------: | :------------------------------------------------------------------------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `display_mode`  |  `string`  |                                     `context`                                    | <ul><li>`files`: the segment is only displayed when a file `extensions` listed is present</li><li>`context`: displays the segment when a Docker context active</li></ul> |
-| `fetch_context` | `boolean`  |                                      `true`                                      | also fetch the current active Docker context when in the `files` display mode                                                                                            |
-| `extensions`    | `[]string` | `compose.yml, compose.yaml, docker-compose.yml, docker-compose.yaml, Dockerfile` | allows to override the default list of file extensions to validate                                                                                                       |
+| Name             | Type       | Default                      | Description                                                                                                               |
+| ---------------- | ---------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `display_mode`   | `string`   | `context`                    | `files`, `context`, or `environment`                                                                                      |
+| `fetch_context`  | `boolean`  | `true`                       | fetch context in `files` mode                                                                                             |
+| `docker_command` | `string`   | `docker`                     | command used in `environment` mode                                                                                        |
+| `filter`         | `string`   | empty                        | passed to `docker ps`, see [the filter documentation](https://docs.docker.com/engine/reference/commandline/ps/#filtering) |
+| `extensions`     | `[]string` | compose files and Dockerfile | overrides the file checks                                                                                                 |
 
 ## Template ([info][templates])
 
@@ -43,10 +50,22 @@ import Config from "@site/src/components/Config.js";
 
 ### Properties
 
-| Name       | Type     | Description                |
-| ---------- | -------- | -------------------------- |
-| `.Context` | `string` | the current active context |
+| Name          | Type          | Description                         |
+| ------------- | ------------- | ----------------------------------- |
+| `.Context`    | `string`      | current active context              |
+| `.Containers` | `[]Container` | running containers from `docker ps` |
+
+#### Container
+
+| Name       | Type     | Description       |
+| ---------- | -------- | ----------------- |
+| `.ID`      | `string` | container ID      |
+| `.Image`   | `string` | container image   |
+| `.Command` | `string` | container command |
+| `.Created` | `string` | created time      |
+| `.Status`  | `string` | container status  |
+| `.Ports`   | `string` | published ports   |
+| `.Names`   | `string` | container name    |
 
 [docker]: https://www.docker.com/
-[go-text-template]: https://golang.org/pkg/text/template/
 [templates]: /docs/configuration/templates


### PR DESCRIPTION
### Prerequisites

- [✅ ] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [ ✅] The commit message follows the [conventional commits][cc] guidelines.
- [ ✅] Tests for the changes have been added (for bug fixes / features).
- [ ✅] Docs have been added/updated (for bug fixes / features).

### Description

Added display_mode environment to the docker segment. When this displaymode is used, the block is active as long as the docker command exists. 
If this display mode is chosen, docker ps is executed and the output is parsed and supplied in a list. 
The user can add filters according to [cli-spec](https://docs.docker.com/reference/cli/docker/container/ls/#filter).
The user can also provide an alias for the docker command

I did not change code for the other display_modes and did not change the template, to not break existing configs.

<!---

Tips:

If you're not comfortable with working with Git,
we're working on a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D)
as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
