### PR TITLE
feat(segments): Add Aspire segment

### DIFF
--- a/src/config/segment_types.go
+++ b/src/config/segment_types.go
@@ -27,6 +27,7 @@ func init() {
 	gob.Register(&segments.Angular{})
 	gob.Register(&segments.Version{})
 	gob.Register(&segments.Argocd{})
+	gob.Register(&segments.Aspire{})
 	gob.Register(&segments.Aurelia{})
 	gob.Register(&segments.Aws{})
 	gob.Register(&segments.Az{})
@@ -165,6 +166,8 @@ const (
 	ANGULAR SegmentType = "angular"
 	// ARGOCD writes the current argocd context
 	ARGOCD SegmentType = "argocd"
+	// ASPIRE writes the Aspire apphost status
+	ASPIRE SegmentType = "aspire"
 	// AURELIA writes which aurelia version is currently referenced in package.json
 	AURELIA SegmentType = "aurelia"
 	// AWS writes the active aws context
@@ -386,6 +389,7 @@ const (
 var Segments = map[SegmentType]func() SegmentWriter{
 	ANGULAR:         func() SegmentWriter { return &segments.Angular{} },
 	ARGOCD:          func() SegmentWriter { return &segments.Argocd{} },
+	ASPIRE:          func() SegmentWriter { return &segments.Aspire{} },
 	AURELIA:         func() SegmentWriter { return &segments.Aurelia{} },
 	AWS:             func() SegmentWriter { return &segments.Aws{} },
 	AZ:              func() SegmentWriter { return &segments.Az{} },

--- a/src/config/segment_types.go
+++ b/src/config/segment_types.go
@@ -27,6 +27,7 @@ func init() {
 	gob.Register(&segments.Angular{})
 	gob.Register(&segments.Version{})
 	gob.Register(&segments.Argocd{})
+	gob.Register(&segments.Aspire{})
 	gob.Register(&segments.Aurelia{})
 	gob.Register(&segments.Aws{})
 	gob.Register(&segments.Az{})
@@ -169,6 +170,8 @@ const (
 	ANGULAR SegmentType = "angular"
 	// ARGOCD writes the current argocd context
 	ARGOCD SegmentType = "argocd"
+	// ASPIRE writes the Aspire apphost status
+	ASPIRE SegmentType = "aspire"
 	// AURELIA writes which aurelia version is currently referenced in package.json
 	AURELIA SegmentType = "aurelia"
 	// AWS writes the active aws context
@@ -396,6 +399,7 @@ const (
 var Segments = map[SegmentType]func() SegmentWriter{
 	ANGULAR:         func() SegmentWriter { return &segments.Angular{} },
 	ARGOCD:          func() SegmentWriter { return &segments.Argocd{} },
+	ASPIRE:          func() SegmentWriter { return &segments.Aspire{} },
 	AURELIA:         func() SegmentWriter { return &segments.Aurelia{} },
 	AWS:             func() SegmentWriter { return &segments.Aws{} },
 	AZ:              func() SegmentWriter { return &segments.Az{} },

--- a/src/segments/aspire.go
+++ b/src/segments/aspire.go
@@ -1,0 +1,202 @@
+package segments
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+)
+
+type Aspire struct {
+	Base
+
+	AppHostPath string
+	Version     string
+	Name        string
+	Lang        string
+	Running     bool
+}
+
+var aspireAppHostFiles = []string{
+	"apphost.cs",
+	"apphost.ts",
+}
+
+const aspireCommand = "aspire"
+
+const (
+	// FetchRunning controls whether the segment should query aspire ps.
+	FetchRunning options.Option = "fetch_running"
+)
+
+type aspireAppHostSelection struct {
+	SelectedProjectFile      string   `json:"selected_project_file"`
+	AllProjectFileCandidates []string `json:"all_project_file_candidates"`
+}
+
+type aspireAppHostProcess struct {
+	AppHostPath string `json:"appHostPath"`
+}
+
+func (a *Aspire) Template() string {
+	return " \uf423 {{ .Name }}{{ if .Running }} \uf00c{{ end }} "
+}
+
+func (a *Aspire) Enabled() bool {
+	appHostPath := a.resolveAppHostPath()
+	if appHostPath == "" {
+		return false
+	}
+
+	a.AppHostPath = filepath.Clean(appHostPath)
+	a.Name = aspireDisplayName(a.AppHostPath)
+	a.Lang = aspireLanguage(a.AppHostPath)
+	a.resolveVersion()
+	a.Running = a.options.Bool(FetchRunning, true) && a.isRunning()
+
+	return true
+}
+
+func (a *Aspire) resolveAppHostPath() string {
+	if a.env.HasCommand(aspireCommand) {
+		appHostPath := a.resolveAppHostPathWithCLI()
+		if appHostPath != "" {
+			return appHostPath
+		}
+	}
+
+	for _, candidate := range aspireAppHostFiles {
+		file, err := a.env.HasParentFilePath(candidate, false)
+		if err == nil {
+			return file.Path
+		}
+	}
+
+	return ""
+}
+
+func (a *Aspire) resolveAppHostPathWithCLI() string {
+	output, err := a.env.RunCommand(aspireCommand, "extension", "get-apphosts")
+	if err != nil {
+		return ""
+	}
+
+	for _, line := range strings.Split(output, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+
+		var selection aspireAppHostSelection
+		if err := json.Unmarshal([]byte(trimmed), &selection); err != nil {
+			continue
+		}
+
+		if selection.SelectedProjectFile != "" {
+			return selection.SelectedProjectFile
+		}
+
+		if len(selection.AllProjectFileCandidates) == 1 {
+			return selection.AllProjectFileCandidates[0]
+		}
+	}
+
+	return ""
+}
+
+func (a *Aspire) isRunning() bool {
+	if !a.env.HasCommand(aspireCommand) || a.AppHostPath == "" {
+		return false
+	}
+
+	for _, args := range [][]string{{"ps", "--format", "json", "--resources"}, {"ps", "--format", "json"}} {
+		output, err := a.env.RunCommand(aspireCommand, args...)
+		if err != nil {
+			continue
+		}
+
+		running, parsed := a.parseRunningAppHosts(output)
+		if parsed {
+			return running
+		}
+	}
+
+	return false
+}
+
+func (a *Aspire) parseRunningAppHosts(output string) (bool, bool) {
+	var appHosts []aspireAppHostProcess
+	if err := json.Unmarshal([]byte(output), &appHosts); err != nil {
+		return false, false
+	}
+
+	for _, appHost := range appHosts {
+		if sameFilePath(appHost.AppHostPath, a.AppHostPath) {
+			return true, true
+		}
+	}
+
+	return false, true
+}
+
+func (a *Aspire) resolveVersion() {
+	file, err := a.env.HasParentFilePath("Directory.Packages.props", false)
+	if err != nil {
+		return
+	}
+
+	propsContent := a.env.FileContent(file.Path)
+	if propsContent == "" {
+		return
+	}
+
+	if idx := strings.Index(propsContent, "Aspire.Hosting.AppHost"); idx >= 0 {
+		a.Version = extractVersionAttribute(propsContent[idx:])
+	}
+}
+
+func extractVersionAttribute(s string) string {
+	versionKey := "Version=\""
+	idx := strings.Index(s, versionKey)
+	if idx < 0 {
+		return ""
+	}
+
+	start := idx + len(versionKey)
+	end := strings.Index(s[start:], "\"")
+	if end < 0 {
+		return ""
+	}
+
+	return s[start : start+end]
+}
+
+func aspireDisplayName(appHostPath string) string {
+	fileName := filepath.Base(appHostPath)
+	if fileName == "apphost.cs" || fileName == "apphost.ts" {
+		return filepath.Base(filepath.Dir(appHostPath))
+	}
+
+	return strings.TrimSuffix(fileName, filepath.Ext(fileName))
+}
+
+func aspireLanguage(appHostPath string) string {
+	switch strings.TrimPrefix(filepath.Ext(appHostPath), ".") {
+	case "cs", "ts":
+		return strings.TrimPrefix(filepath.Ext(appHostPath), ".")
+	default:
+		return ""
+	}
+}
+
+func sameFilePath(left, right string) bool {
+	cleanLeft := filepath.Clean(left)
+	cleanRight := filepath.Clean(right)
+
+	if cleanLeft == cleanRight {
+		return true
+	}
+
+	return strings.EqualFold(cleanLeft, cleanRight)
+}

--- a/src/segments/aspire_test.go
+++ b/src/segments/aspire_test.go
@@ -1,0 +1,152 @@
+package segments
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAspireSegment(t *testing.T) {
+	cases := []struct {
+		Case              string
+		HasAspire         bool
+		CLIOutput         string
+		CLIError          error
+		FallbackFile      string
+		PSResourcesOutput string
+		PSResourcesError  error
+		PSOutput          string
+		PSError           error
+		ExpectedName      string
+		ExpectedLang      string
+		ExpectedVersion   string
+		ExpectedEnabled   bool
+		ExpectedRunning   bool
+		FetchRunning      bool
+		HasProps          bool
+		PropsContent      string
+	}{
+		{
+			Case:            "no apphost file",
+			HasAspire:       false,
+			ExpectedEnabled: false,
+		},
+		{
+			Case:              "apphost resolved by aspire cli",
+			HasAspire:         true,
+			CLIOutput:         "{\"selected_project_file\":\"test/MyApp.AppHost/apphost.cs\",\"all_project_file_candidates\":[\"test/MyApp.AppHost/apphost.cs\"]}",
+			PSResourcesOutput: "[]",
+			ExpectedEnabled:   true,
+			ExpectedName:      "MyApp.AppHost",
+			ExpectedLang:      "cs",
+			FetchRunning:      true,
+		},
+		{
+			Case:              "apphost running from aspire ps resources",
+			HasAspire:         true,
+			CLIOutput:         "{\"selected_project_file\":\"test/MyApp.AppHost/apphost.cs\",\"all_project_file_candidates\":[\"test/MyApp.AppHost/apphost.cs\"]}",
+			PSResourcesOutput: "[{\"appHostPath\":\"test/MyApp.AppHost/apphost.cs\",\"appHostPid\":123}]",
+			ExpectedEnabled:   true,
+			ExpectedRunning:   true,
+			ExpectedName:      "MyApp.AppHost",
+			ExpectedLang:      "cs",
+			FetchRunning:      true,
+		},
+		{
+			Case:             "aspire ps falls back without resources",
+			HasAspire:        true,
+			CLIOutput:        "{\"selected_project_file\":\"test/MyApp.AppHost/apphost.cs\",\"all_project_file_candidates\":[\"test/MyApp.AppHost/apphost.cs\"]}",
+			PSResourcesError: errors.New("unknown flag: --resources"),
+			PSOutput:         "[{\"appHostPath\":\"test/MyApp.AppHost/apphost.cs\",\"appHostPid\":123}]",
+			ExpectedEnabled:  true,
+			ExpectedRunning:  true,
+			ExpectedName:     "MyApp.AppHost",
+			ExpectedLang:     "cs",
+			ExpectedVersion:  "9.0.0",
+			FetchRunning:     true,
+			HasProps:         true,
+			PropsContent:     `<PackageVersion Include="Aspire.Hosting.AppHost" Version="9.0.0" />`,
+		},
+		{
+			Case:            "running lookup can be disabled",
+			HasAspire:       true,
+			CLIOutput:       "{\"selected_project_file\":\"test/MyApp.AppHost/apphost.cs\",\"all_project_file_candidates\":[\"test/MyApp.AppHost/apphost.cs\"]}",
+			ExpectedEnabled: true,
+			ExpectedName:    "MyApp.AppHost",
+			ExpectedLang:    "cs",
+			FetchRunning:    false,
+		},
+		{
+			Case:            "fallback to parent apphost.ts when aspire cli unavailable",
+			HasAspire:       false,
+			FallbackFile:    "apphost.ts",
+			ExpectedEnabled: true,
+			ExpectedName:    "MyApp.AppHost",
+			ExpectedLang:    "ts",
+			FetchRunning:    true,
+		},
+	}
+
+	pwd := filepath.Join("test", "MyApp.AppHost", "nested")
+	appHostCS := filepath.Join("test", "MyApp.AppHost", "apphost.cs")
+	appHostTS := filepath.Join("test", "MyApp.AppHost", "apphost.ts")
+
+	for _, tc := range cases {
+		env := new(mock.Environment)
+		env.On("Flags").Return(&runtime.Flags{})
+		env.On("Pwd").Return(pwd)
+		env.On("HasCommand", aspireCommand).Return(tc.HasAspire)
+
+		if tc.HasAspire {
+			env.On("RunCommand", aspireCommand, []string{"extension", "get-apphosts"}).Return(tc.CLIOutput, tc.CLIError)
+			if tc.ExpectedEnabled && tc.FetchRunning {
+				env.On("RunCommand", aspireCommand, []string{"ps", "--format", "json", "--resources"}).Return(tc.PSResourcesOutput, tc.PSResourcesError)
+				if tc.PSResourcesError != nil {
+					env.On("RunCommand", aspireCommand, []string{"ps", "--format", "json"}).Return(tc.PSOutput, tc.PSError)
+				}
+			}
+		} else {
+			switch tc.FallbackFile {
+			case "apphost.cs":
+				env.On("HasParentFilePath", "apphost.cs", false).Return(&runtime.FileInfo{Path: appHostCS, ParentFolder: filepath.Dir(appHostCS)}, nil)
+			case "apphost.ts":
+				env.On("HasParentFilePath", "apphost.cs", false).Return(&runtime.FileInfo{}, errors.New("not found"))
+				env.On("HasParentFilePath", "apphost.ts", false).Return(&runtime.FileInfo{Path: appHostTS, ParentFolder: filepath.Dir(appHostTS)}, nil)
+			default:
+				env.On("HasParentFilePath", "apphost.cs", false).Return(&runtime.FileInfo{}, errors.New("not found"))
+				env.On("HasParentFilePath", "apphost.ts", false).Return(&runtime.FileInfo{}, errors.New("not found"))
+			}
+		}
+
+		if tc.HasProps {
+			fileInfo := &runtime.FileInfo{
+				Path:         filepath.Join("test", "Directory.Packages.props"),
+				ParentFolder: "test",
+			}
+			env.On("HasParentFilePath", "Directory.Packages.props", false).Return(fileInfo, nil)
+			env.On("FileContent", filepath.Join("test", "Directory.Packages.props")).Return(tc.PropsContent)
+		} else {
+			env.On("HasParentFilePath", "Directory.Packages.props", false).Return(&runtime.FileInfo{}, errors.New("not found"))
+		}
+
+		aspire := &Aspire{}
+		props := options.Map{FetchRunning: tc.FetchRunning}
+		aspire.Init(props, env)
+
+		assert.Equal(t, tc.ExpectedEnabled, aspire.Enabled(), tc.Case)
+
+		if tc.ExpectedEnabled {
+			assert.Equal(t, tc.ExpectedName, aspire.Name, tc.Case)
+			assert.Equal(t, tc.ExpectedLang, aspire.Lang, tc.Case)
+			assert.Equal(t, tc.ExpectedVersion, aspire.Version, tc.Case)
+			assert.Equal(t, tc.ExpectedRunning, aspire.Running, tc.Case)
+			assert.Equal(t, tc.ExpectedName, renderTemplate(env, "{{ .Name }}", aspire), tc.Case)
+			assert.Equal(t, tc.ExpectedRunning, renderTemplate(env, "{{ .Running }}", aspire) == "true", tc.Case)
+		}
+	}
+}

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -368,6 +368,7 @@
           "enum": [
             "angular",
             "argocd",
+            "aspire",
             "aurelia",
             "aws",
             "az",
@@ -653,6 +654,32 @@
           "then": {
             "title": "ArgoCD Segment",
             "description": "https://ohmyposh.dev/docs/segments/cli/argocd"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "aspire"
+              }
+            }
+          },
+          "then": {
+            "title": "Aspire Segment",
+            "description": "https://ohmyposh.dev/docs/segments/cli/aspire",
+            "properties": {
+              "options": {
+                "properties": {
+                  "fetch_running": {
+                    "type": "boolean",
+                    "title": "Fetch Running",
+                    "description": "Query aspire ps to determine whether the resolved AppHost is running",
+                    "default": true
+                  }
+                },
+                "unevaluatedProperties": false
+              }
+            }
           }
         },
         {

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -368,6 +368,7 @@
           "enum": [
             "angular",
             "argocd",
+            "aspire",
             "aurelia",
             "aws",
             "az",
@@ -656,6 +657,32 @@
           "then": {
             "title": "ArgoCD Segment",
             "description": "https://ohmyposh.dev/docs/segments/cli/argocd"
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "aspire"
+              }
+            }
+          },
+          "then": {
+            "title": "Aspire Segment",
+            "description": "https://ohmyposh.dev/docs/segments/cli/aspire",
+            "properties": {
+              "options": {
+                "properties": {
+                  "fetch_running": {
+                    "type": "boolean",
+                    "title": "Fetch Running",
+                    "description": "Query aspire ps to determine whether the resolved AppHost is running",
+                    "default": true
+                  }
+                },
+                "unevaluatedProperties": false
+              }
+            }
           }
         },
         {

--- a/website/docs/segments/cli/aspire.mdx
+++ b/website/docs/segments/cli/aspire.mdx
@@ -21,7 +21,7 @@ import Config from "@site/src/components/Config.js";
     powerline_symbol: "\uE0B0",
     foreground: "#193549",
     background: "#ffeb3b",
-    properties: {
+    options: {
       fetch_running: true,
     },
     template: " \uf423 {{ .Name }}{{ if .Running }} \uf00c{{ end }} ",

--- a/website/docs/segments/cli/aspire.mdx
+++ b/website/docs/segments/cli/aspire.mdx
@@ -1,0 +1,58 @@
+---
+id: aspire
+title: Aspire
+sidebar_label: Aspire
+---
+
+## What
+
+Status of your [Aspire][aspire] AppHost in the current repo and whether it is running.
+The segment uses the Aspire CLI to resolve the AppHost with `aspire extension get-apphosts`
+and checks running instances with `aspire ps --format json`.
+
+## Sample Configuration
+
+import Config from "@site/src/components/Config.js";
+
+<Config
+  data={{
+    type: "aspire",
+    style: "powerline",
+    powerline_symbol: "\uE0B0",
+    foreground: "#193549",
+    background: "#ffeb3b",
+    properties: {
+      fetch_running: true,
+    },
+    template: " \uf423 {{ .Name }}{{ if .Running }} \uf00c{{ end }} ",
+  }}
+/>
+
+## Options
+
+| Name            | Type      | Description                                                   | Default |
+| --------------- | --------- | ------------------------------------------------------------- | ------- |
+| `fetch_running` | `boolean` | query `aspire ps` to determine whether the resolved AppHost is running | `true` |
+
+## Template ([info][templates])
+
+:::note default template
+
+```template
+ \uf423 {{ .Name }}{{ if .Running }} \uf00c{{ end }}
+```
+
+:::
+
+### Properties
+
+| Name           | Type      | Description                                                         |
+| -------------- | --------- | ------------------------------------------------------------------- |
+| `.AppHostPath` | `string`  | the resolved AppHost path reported by the Aspire CLI or file search |
+| `.Name`        | `string`  | the Aspire AppHost display name                                     |
+| `.Version`     | `string`  | the Aspire Hosting version from `Directory.Packages.props`          |
+| `.Lang`        | `string`  | the detected single-file AppHost language (`cs` or `ts`)            |
+| `.Running`     | `boolean` | whether the resolved AppHost currently appears in `aspire ps`       |
+
+[templates]: /docs/configuration/templates
+[aspire]: https://aspire.dev/

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -55,6 +55,7 @@ export default {
           items: [
             "segments/cli/angular",
             "segments/cli/argocd",
+            "segments/cli/aspire",
             "segments/cli/aurelia",
             "segments/cli/bazel",
             "segments/cli/buf",


### PR DESCRIPTION
## Summary
- add a new [Aspire](aspire.dev) segment that resolves the apphost via Aspire CLI with file-based fallback
- detect running apphosts via `aspire ps` with optional `fetch_running` control
- document and register the segment in docs, sidebar, and schema

## Testing
- go test ./segments/ -run TestAspire -v
- go build -v