### PR TITLE
fix(theme): robbyrussell arrow turns red on command failure

### DIFF
--- a/themes/robbyrussell.omp.json
+++ b/themes/robbyrussell.omp.json
@@ -6,6 +6,7 @@
       "segments": [
         {
           "foreground": "#98C379",
+          "foreground_templates": ["{{ if gt .Code 0 }}#E06C75{{ end }}"],
           "style": "plain",
           "template": "\u279c",
           "type": "text"


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Fixes #7426

The `robbyrussell` theme's arrow (`➜`) was always green regardless of the previous command's exit code. In the original oh-my-zsh `robbyrussell` theme, the arrow turns red when the previous command fails.

Added `foreground_templates` to the arrow `text` segment — the same pattern already used by `1_shell` and `atomic` themes — so that:
- Exit code > 0 → arrow foreground overrides to red (`#E06C75`)
- Exit code == 0 → falls back to static green (`#98C379`)

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary