### PR TITLE
fix: emit FTCS_COMMAND_EXECUTED (OSC 133;C) in PowerShell with shell integration

### DIFF
--- a/src/cli/upgrade/notice_test.go
+++ b/src/cli/upgrade/notice_test.go
@@ -1,16 +1,57 @@
 package upgrade
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"testing"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/build"
+	rhttp "github.com/jandedobbeleer/oh-my-posh/src/runtime/http"
 	"github.com/stretchr/testify/assert"
 )
 
+// testRoundTripper redirects all outbound requests to a local test server.
+type testRoundTripper struct {
+	target *url.URL
+}
+
+func (rt *testRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	cloned := req.Clone(req.Context())
+	cloned.URL = &url.URL{
+		Scheme: rt.target.Scheme,
+		Host:   rt.target.Host,
+		Path:   req.URL.Path,
+	}
+	return http.DefaultTransport.RoundTrip(cloned)
+}
+
 func TestCanUpgrade(t *testing.T) {
+	const fakeLatest = "99.99.99"
+
+	// Serve a fake version file locally so tests never hit GitHub.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintf(w, "v%s", fakeLatest)
+	}))
+	defer server.Close()
+
+	targetURL, _ := url.Parse(server.URL)
+
+	savedHTTPClient := rhttp.HTTPClient
+	rhttp.HTTPClient = &http.Client{Transport: &testRoundTripper{target: targetURL}}
+	defer func() { rhttp.HTTPClient = savedHTTPClient }()
+
+	savedIsConnected := rhttp.IsConnected
+	rhttp.IsConnected = func() bool { return true }
+	defer func() { rhttp.IsConnected = savedIsConnected }()
+
 	ugc := &Config{}
-	latest, _ := ugc.FetchLatest()
+	latest, err := ugc.FetchLatest()
+	if err != nil {
+		t.Fatalf("failed to fetch latest version: %v", err)
+	}
 
 	cases := []struct {
 		Case           string

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -149,6 +149,11 @@ func (cfg *Config) Features(env runtime.Environment) shell.Features {
 	if cfg.ShellIntegration {
 		log.Debug("shell integration enabled")
 		feats |= shell.FTCSMarks
+		// PowerShell emits FTCS_COMMAND_EXECUTED (OSC 133;C) inside the Enter key handler,
+		// so KeyHandlers must be enabled whenever shell integration is active.
+		if env.Shell() == shell.PWSH {
+			feats |= shell.KeyHandlers
+		}
 	}
 
 	// do not enable upgrade features when async is enabled

--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -111,6 +111,60 @@ func TestGetPalette(t *testing.T) {
 		assert.Equal(t, tc.ExpectedPalette, got, tc.Case)
 	}
 }
+func TestFeaturesShellIntegration(t *testing.T) {
+	cases := []struct {
+		Case             string
+		Shell            string
+		ShellIntegration bool
+		ExpectedFeats    shell.Features
+	}{
+		{
+			Case:             "pwsh with shell integration enables FTCSMarks and KeyHandlers",
+			Shell:            shell.PWSH,
+			ShellIntegration: true,
+			ExpectedFeats:    shell.FTCSMarks | shell.KeyHandlers,
+		},
+		{
+			Case:             "bash with shell integration enables FTCSMarks only",
+			Shell:            shell.BASH,
+			ShellIntegration: true,
+			ExpectedFeats:    shell.FTCSMarks,
+		},
+		{
+			Case:             "zsh with shell integration enables FTCSMarks only",
+			Shell:            shell.ZSH,
+			ShellIntegration: true,
+			ExpectedFeats:    shell.FTCSMarks,
+		},
+		{
+			Case:             "pwsh without shell integration enables nothing",
+			Shell:            shell.PWSH,
+			ShellIntegration: false,
+			ExpectedFeats:    0,
+		},
+	}
+
+	for _, tc := range cases {
+		env := &mock.Environment{}
+		env.On("Shell").Return(tc.Shell)
+
+		template.Cache = &cache.Template{
+			SimpleTemplate: cache.SimpleTemplate{
+				Shell: tc.Shell,
+			},
+		}
+		template.Init(env, nil, nil)
+
+		cfg := &Config{
+			ShellIntegration: tc.ShellIntegration,
+			Upgrade:          &upgrade.Config{},
+		}
+
+		got := cfg.Features(env)
+		assert.Equal(t, tc.ExpectedFeats, got, tc.Case)
+	}
+}
+
 func TestUpgradeFeatures(t *testing.T) {
 	cases := []struct {
 		Case                  string

--- a/src/runtime/http/connection.go
+++ b/src/runtime/http/connection.go
@@ -7,9 +7,9 @@ import (
 	"time"
 )
 
-// IsConnected checks if we can connect to ohmyposh within 200ms
-// If we can connect, we are connected; otherwise, let's consider being offline
-func IsConnected() bool {
+// IsConnected checks if we can connect to ohmyposh within 200ms.
+// Exposed as a variable so it can be replaced in tests.
+var IsConnected = func() bool {
 	timeout := 200 * time.Millisecond
 	dialer := &net.Dialer{
 		Timeout: timeout,


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

Fixes #7377.

Ghostty 1.3.0 (and other terminals) use the `FTCS_COMMAND_EXECUTED` sequence (`\e]133;C\a`) to mark the moment a command begins executing, which is the start of their execution-time measurement window. Without it, terminals that rely on the `C`→`D` interval can't calculate execution time.

**Root cause:** When `shell_integration: true` is set in the OMP config without `transient` or `streaming`, the `KeyHandlers` feature was never enabled for PowerShell. The `\e]133;C\a` emission lives inside `New-EnterKeyHandler` (which is only registered when `Enable-KeyHandlers` is called), so the marker was silently dropped.

**Fix:** In `config.go`, when `ShellIntegration` is active and the shell is PowerShell, also enable `KeyHandlers`. The existing Enter key handler already guards the emission correctly with `$global:_ompFTCSMarks`, so no changes to `omp.ps1` were needed.

Bash, Zsh, and Fish are unaffected — they emit `FTCS_C` via `preexec`/`PS0` hooks independently.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary