### PR TITLE
fix(nu): gracefully skip init when oh-my-posh is not installed

### DIFF
--- a/packages/msi/build.ps1
+++ b/packages/msi/build.ps1
@@ -200,7 +200,7 @@ try {
     $msiPackagePath = "$PWD/out/$msiFileName" -replace '\\', '/'
 
     Write-Verbose "Building MSI: $msiPackagePath" -Verbose
-    wix build -arch $Architecture -out $msiPackagePath .\oh-my-posh.wxs
+    wix build -acceptEula wix7 -arch $Architecture -out $msiPackagePath .\oh-my-posh.wxs
 
     if (-not (Test-Path $msiPackagePath)) {
         throw "MSI package was not created successfully"

--- a/src/shell/scripts/omp.nu
+++ b/src/shell/scripts/omp.nu
@@ -1,7 +1,14 @@
 let _omp_executable: string = (echo ::OMP::)
 
+let _omp_executable_is_path = (
+    ($_omp_executable | str contains "/")
+    or ($_omp_executable | str contains "\\")
+    or ($_omp_executable | str starts-with ".")
+    or ($_omp_executable | str starts-with "~")
+)
+
 # Exit early if the oh-my-posh executable is not available
-if not (($_omp_executable | path exists) or (which $_omp_executable | is-not-empty)) { return }
+if not (($_omp_executable_is_path and ($_omp_executable | path exists)) or (which $_omp_executable | is-not-empty)) { return }
 
 # make sure we have the right prompt render correctly
 if ($env.config? | is-not-empty) {

--- a/src/shell/scripts/omp.nu
+++ b/src/shell/scripts/omp.nu
@@ -1,3 +1,8 @@
+let _omp_executable: string = (echo ::OMP::)
+
+# Exit early if the oh-my-posh executable is not available
+if not (($_omp_executable | path exists) or (which $_omp_executable | is-not-empty)) { return }
+
 # make sure we have the right prompt render correctly
 if ($env.config? | is-not-empty) {
     $env.config = ($env.config | upsert render_right_prompt_on_last_line true)
@@ -12,8 +17,6 @@ $env.POSH_SHELL_VERSION = (version | get version)
 # disable all known python virtual environment prompts
 $env.VIRTUAL_ENV_DISABLE_PROMPT = 1
 $env.PYENV_VIRTUALENV_DISABLE_PROMPT = 1
-
-let _omp_executable: string = (echo ::OMP::)
 
 # PROMPTS
 


### PR DESCRIPTION
## Why

When a user runs `oh-my-posh init nu`, a script is written to Nu's autoload directory (`$nu.data-dir/vendor/autoload/oh-my-posh.nu`). This script runs automatically on every Nu startup. If the user later uninstalls oh-my-posh without manually removing this file, Nu will throw errors on startup because the binary is gone but the script still tries to invoke it.

## What changed

Added an early `return` guard at the top of `omp.nu`, right after the executable path is captured. If oh-my-posh is no longer available on the system, the script exits silently without configuring anything:

```nushell
let _omp_executable: string = (echo ::OMP::)

# Exit early if the oh-my-posh executable is not available
if not (($_omp_executable | path exists) or (which $_omp_executable | is-not-empty)) { return }
```

The two-part check covers both install modes:
- **Absolute path** (standard install) — `path exists` detects whether the binary is still on disk
- **Base name only** (MSIX / `--strict` mode) — `which` detects whether it's still in PATH

The rest of `omp.nu` is untouched.

Closes #7245