### PR TITLE
fix(zsh): streaming placeholder not updated when async is enabled

### DIFF
--- a/src/shell/init.go
+++ b/src/shell/init.go
@@ -123,10 +123,7 @@ func recurseInitCommand(env runtime.Environment) string {
 
 // generateAndSourceScript writes the init script to the cache and returns a source command.
 func generateAndSourceScript(env runtime.Environment, feats Features) string {
-	// Streaming provides its own async update mechanism via oh-my-posh stream;
-	// combining it with async sourcing (precmd re-source) causes the old stream's
-	// EOF handler to close the new stream's fd, so skip async sourcing when streaming is active.
-	async := feats&Async != 0 && feats&Streaming == 0
+	async := feats&Async != 0
 
 	if scriptPath, ok := hasScript(env); ok {
 		return sourceCommand(env, scriptPath, async)

--- a/src/shell/init.go
+++ b/src/shell/init.go
@@ -123,7 +123,10 @@ func recurseInitCommand(env runtime.Environment) string {
 
 // generateAndSourceScript writes the init script to the cache and returns a source command.
 func generateAndSourceScript(env runtime.Environment, feats Features) string {
-	async := feats&Async != 0
+	// Streaming provides its own async update mechanism via oh-my-posh stream;
+	// combining it with async sourcing (precmd re-source) causes the old stream's
+	// EOF handler to close the new stream's fd, so skip async sourcing when streaming is active.
+	async := feats&Async != 0 && feats&Streaming == 0
 
 	if scriptPath, ok := hasScript(env); ok {
 		return sourceCommand(env, scriptPath, async)

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -17,7 +17,7 @@ _omp_cursor_positioning=0
 _omp_ftcs_marks=0
 
 # streaming support variables
-# Use := to preserve the current fd value if the script is re-sourced mid-session.
+# Preserve the current fd value if the script is re-sourced mid-session; default to -1 when unset or empty.
 _omp_stream_fd=${_omp_stream_fd:--1}
 _omp_enable_streaming=0
 _omp_primary_prompt=""

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -17,7 +17,8 @@ _omp_cursor_positioning=0
 _omp_ftcs_marks=0
 
 # streaming support variables
-_omp_stream_fd=-1
+# Use := to preserve the current fd value if the script is re-sourced mid-session.
+_omp_stream_fd=${_omp_stream_fd:--1}
 _omp_enable_streaming=0
 _omp_primary_prompt=""
 _omp_streaming_supported=""
@@ -110,8 +111,11 @@ function _omp_async_handler() {
   IFS= read -r -u $fd -d $'\0' _omp_primary_prompt
   if [[ $? -ne 0 ]]; then
     if [[ -z "$_omp_primary_prompt" ]]; then
-      # EOF — stream closed normally
-      _omp_cleanup_stream
+      # EOF — unregister and close only this specific fd so that a stale handler
+      # from a previous prompt cycle cannot close the current stream's fd.
+      zle -F $fd 2>/dev/null
+      eval "exec ${fd}<&-" 2>/dev/null
+      [[ $_omp_stream_fd -eq $fd ]] && _omp_stream_fd=-1
       return 0
     fi
   fi

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -111,11 +111,9 @@ function _omp_async_handler() {
   IFS= read -r -u $fd -d $'\0' _omp_primary_prompt
   if [[ $? -ne 0 ]]; then
     if [[ -z "$_omp_primary_prompt" ]]; then
-      # EOF — unregister and close only this specific fd so that a stale handler
-      # from a previous prompt cycle cannot close the current stream's fd.
-      zle -F $fd 2>/dev/null
-      eval "exec ${fd}<&-" 2>/dev/null
-      [[ $_omp_stream_fd -eq $fd ]] && _omp_stream_fd=-1
+      # EOF — only clean up if this is still the active stream fd.
+      # A stale handler from a previous prompt cycle must not close the current stream.
+      [[ $_omp_stream_fd -eq $fd ]] && _omp_cleanup_stream
       return 0
     fi
   fi


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Fixes #7313.

When both `async` and `streaming` are configured in ZSH, the streaming placeholder (`...`) would display but never get replaced with the actual prompt content.

**Root cause:** The ZSH async init mechanism works by emitting `precmd() { source <script> }`, which re-sources the entire `omp.zsh` script before every prompt cycle. Top-level variable assignments run unconditionally on each re-source, so `_omp_stream_fd=-1` was overwriting the live fd value mid-flight. This broke fd lifecycle management in two ways:

1. `_omp_cleanup_stream` saw fd `-1` and skipped cleanup before starting the new stream, leaking the old fd and its ZLE handler.
2. The stale EOF handler from the previous prompt cycle later fired, found `_omp_stream_fd` pointing at the *new* stream, and closed it — so the placeholder was never replaced.

**Fix — two minimal changes to `omp.zsh`:**

- `_omp_stream_fd=${_omp_stream_fd:--1}` — the ZSH `:=` modifier preserves the current fd value when the script is re-sourced, initialising to `-1` only on the very first source at shell startup.
- In `_omp_async_handler`, guard the EOF cleanup with `[[ $_omp_stream_fd -eq $fd ]]` so a stale handler from a previous prompt cycle can never close the current stream's fd.

No changes to `init.go` or any Go code are required.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary