### PR TITLE
feat(claude): add workspace.git_worktree support

### DIFF
--- a/src/segments/claude.go
+++ b/src/segments/claude.go
@@ -31,8 +31,9 @@ type ClaudeModel struct {
 
 // ClaudeWorkspace represents workspace directory information
 type ClaudeWorkspace struct {
-	CurrentDir string `json:"current_dir"`
-	ProjectDir string `json:"project_dir"`
+	CurrentDir  string `json:"current_dir"`
+	ProjectDir  string `json:"project_dir"`
+	GitWorktree string `json:"git_worktree"`
 }
 
 // ClaudeCost represents cost and duration information

--- a/src/segments/claude_test.go
+++ b/src/segments/claude_test.go
@@ -105,6 +105,10 @@ func TestClaudeSegment(t *testing.T) {
 }
 
 func TestClaudeWorkspaceGitWorktree(t *testing.T) {
+	t.Cleanup(func() {
+		cache.Delete(cache.Session, cache.CLAUDECACHE)
+	})
+
 	cases := []struct {
 		Case                string
 		Workspace           ClaudeWorkspace

--- a/src/segments/claude_test.go
+++ b/src/segments/claude_test.go
@@ -13,11 +13,12 @@ import (
 
 func TestClaudeSegment(t *testing.T) {
 	cases := []struct {
-		Case            string
-		ClaudeData      *ClaudeData
-		ExpectedModel   string
-		ExpectedSession string
-		ExpectedEnabled bool
+		Case                string
+		ClaudeData          *ClaudeData
+		ExpectedModel       string
+		ExpectedSession     string
+		ExpectedGitWorktree string
+		ExpectedEnabled     bool
 	}{
 		{
 			Case:            "No cache data",
@@ -33,8 +34,9 @@ func TestClaudeSegment(t *testing.T) {
 					DisplayName: "Opus",
 				},
 				Workspace: ClaudeWorkspace{
-					CurrentDir: "/repo/project",
-					ProjectDir: "/repo",
+					CurrentDir:  "/repo/project/.worktrees/feature",
+					ProjectDir:  "/repo/project",
+					GitWorktree: "/repo/project/.worktrees/feature",
 				},
 				Cost: ClaudeCost{
 					TotalCostUSD:    0.01,
@@ -50,9 +52,10 @@ func TestClaudeSegment(t *testing.T) {
 					},
 				},
 			},
-			ExpectedEnabled: true,
-			ExpectedModel:   "Opus",
-			ExpectedSession: "abc123",
+			ExpectedEnabled:     true,
+			ExpectedModel:       "Opus",
+			ExpectedSession:     "abc123",
+			ExpectedGitWorktree: "/repo/project/.worktrees/feature",
 		},
 		{
 			Case: "Valid cache data with partial fields",
@@ -96,7 +99,49 @@ func TestClaudeSegment(t *testing.T) {
 		if tc.ExpectedEnabled {
 			assert.Equal(t, tc.ExpectedModel, claude.Model.DisplayName, tc.Case)
 			assert.Equal(t, tc.ExpectedSession, claude.SessionID, tc.Case)
+			assert.Equal(t, tc.ExpectedGitWorktree, claude.Workspace.GitWorktree, tc.Case)
 		}
+	}
+}
+
+func TestClaudeWorkspaceGitWorktree(t *testing.T) {
+	cases := []struct {
+		Case                string
+		Workspace           ClaudeWorkspace
+		ExpectedGitWorktree string
+	}{
+		{
+			Case: "Inside a linked worktree",
+			Workspace: ClaudeWorkspace{
+				CurrentDir:  "/repo/project/.worktrees/feature",
+				ProjectDir:  "/repo/project",
+				GitWorktree: "/repo/project/.worktrees/feature",
+			},
+			ExpectedGitWorktree: "/repo/project/.worktrees/feature",
+		},
+		{
+			Case: "Outside a linked worktree",
+			Workspace: ClaudeWorkspace{
+				CurrentDir: "/repo/project",
+				ProjectDir: "/repo/project",
+			},
+			ExpectedGitWorktree: "",
+		},
+	}
+
+	for _, tc := range cases {
+		cache.Set(cache.Session, cache.CLAUDECACHE, ClaudeData{Workspace: tc.Workspace}, cache.INFINITE)
+
+		env := new(mock.Environment)
+		claude := &Claude{
+			Base: Base{
+				env:     env,
+				options: options.Map{},
+			},
+		}
+
+		assert.True(t, claude.Enabled(), tc.Case)
+		assert.Equal(t, tc.ExpectedGitWorktree, claude.Workspace.GitWorktree, tc.Case)
 	}
 }
 

--- a/website/docs/segments/cli/claude.mdx
+++ b/website/docs/segments/cli/claude.mdx
@@ -61,10 +61,11 @@ import Config from "@site/src/components/Config.js";
 
 #### Workspace Properties
 
-| Name          | Type     | Description               |
-| ------------- | -------- | ------------------------- |
-| `.CurrentDir` | `string` | Current working directory |
-| `.ProjectDir` | `string` | Root project directory    |
+| Name           | Type     | Description                                                           |
+| -------------- | -------- | --------------------------------------------------------------------- |
+| `.CurrentDir`  | `string` | Current working directory                                             |
+| `.ProjectDir`  | `string` | Root project directory                                                |
+| `.GitWorktree` | `string` | Path to the linked git worktree, empty when not inside a linked tree  |
 
 #### Cost Properties
 

--- a/website/docs/segments/cli/claude.mdx
+++ b/website/docs/segments/cli/claude.mdx
@@ -61,10 +61,10 @@ import Config from "@site/src/components/Config.js";
 
 #### Workspace Properties
 
-| Name           | Type     | Description                                                                |
-| -------------- | -------- | -------------------------------------------------------------------------- |
-| `.CurrentDir`  | `string` | Current working directory                                                  |
-| `.ProjectDir`  | `string` | Root project directory                                                     |
+| Name           | Type     | Description                                                                  |
+| -------------- | -------- | ---------------------------------------------------------------------------- |
+| `.CurrentDir`  | `string` | Current working directory                                                    |
+| `.ProjectDir`  | `string` | Root project directory                                                       |
 | `.GitWorktree` | `string` | Path to the linked git worktree, empty when not inside a linked git worktree |
 
 #### Cost Properties

--- a/website/docs/segments/cli/claude.mdx
+++ b/website/docs/segments/cli/claude.mdx
@@ -61,11 +61,11 @@ import Config from "@site/src/components/Config.js";
 
 #### Workspace Properties
 
-| Name           | Type     | Description                                                           |
-| -------------- | -------- | --------------------------------------------------------------------- |
-| `.CurrentDir`  | `string` | Current working directory                                             |
-| `.ProjectDir`  | `string` | Root project directory                                                |
-| `.GitWorktree` | `string` | Path to the linked git worktree, empty when not inside a linked tree  |
+| Name           | Type     | Description                                                                |
+| -------------- | -------- | -------------------------------------------------------------------------- |
+| `.CurrentDir`  | `string` | Current working directory                                                  |
+| `.ProjectDir`  | `string` | Root project directory                                                     |
+| `.GitWorktree` | `string` | Path to the linked git worktree, empty when not inside a linked git worktree |
 
 #### Cost Properties
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Claude Code 2.1.98 added a `git_worktree` field to the workspace block of the [status line JSON input][cc-statusline], set when the current directory is inside a linked git worktree. This PR wires it through the `claude` segment so templates can access it as `{{ .Workspace.GitWorktree }}`.

The field is an empty string when you're not inside a worktree, so the usual `{{ if .Workspace.GitWorktree }}...{{ end }}` pattern works.

Tests cover both the inside-a-worktree and outside-a-worktree cases, and the Workspace Properties table in the segment docs has a new row for the field.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[cc-statusline]: https://code.claude.com/docs/en/statusline
