### PR TITLE
fix(bash): prepend hook in PROMPT_COMMAND for VS Code terminals

### DIFF
--- a/src/shell/scripts/omp.bash
+++ b/src/shell/scripts/omp.bash
@@ -158,7 +158,13 @@ function _omp_install_hook() {
         prompt_command+=("$cmd")
     done
 
-    PROMPT_COMMAND=("${prompt_command[@]}" _omp_hook)
+    # When VS Code shell integration is active, prepend so _omp_hook sets PS1 before
+    # VS Code's __vsc_prompt_cmd_original wraps it with A/B shell integration sequences.
+    if [[ "${TERM_PROGRAM-}" == "vscode" ]]; then
+        PROMPT_COMMAND=(_omp_hook "${prompt_command[@]}")
+    else
+        PROMPT_COMMAND=("${prompt_command[@]}" _omp_hook)
+    fi
 }
 
 _omp_install_hook


### PR DESCRIPTION
## Summary

Fixes #7029

In v28.1.1, `_omp_install_hook` was changed to **append** `_omp_hook` to `PROMPT_COMMAND` for better scalar compatibility. This broke VS Code's shell integration.

## Root Cause

VS Code's shell integration adds `__vsc_prompt_cmd_original` to `PROMPT_COMMAND`, which wraps `PS1` with A/B escape sequences (`\e]633;A\a` / `\e]633;B\a`) used to detect prompt start/end. With the append order:

1. `__vsc_prompt_cmd_original` runs → wraps PS1 with A/B sequences
2. `_omp_hook` runs **after** → overwrites PS1 **without** those sequences ❌

This causes VS Code and GitHub Copilot Agent to hang waiting for command completion because the prompt boundary markers are missing.

## Fix

Detect `TERM_PROGRAM=vscode` (set by VS Code in all its terminals) and **prepend** `_omp_hook` in that case so it sets PS1 before VS Code wraps it. All other environments retain the append behavior.

```bash
# When VS Code shell integration is active, prepend so _omp_hook sets PS1 before
# VS Code's __vsc_prompt_cmd_original wraps it with A/B shell integration sequences.
if [[ "${TERM_PROGRAM-}" == "vscode" ]]; then
    PROMPT_COMMAND=(_omp_hook "${prompt_command[@]}")
else
    PROMPT_COMMAND=("${prompt_command[@]}" _omp_hook)
fi
```

## Changes

- `src/shell/scripts/omp.bash` — conditional prepend/append in `_omp_install_hook`