### PR TITLE
fix: handle named numeric types in gt/lt template functions

### DIFF
--- a/src/generics/convert.go
+++ b/src/generics/convert.go
@@ -2,6 +2,7 @@ package generics
 
 import (
 	"errors"
+	"reflect"
 	"strconv"
 )
 
@@ -31,6 +32,16 @@ func toNumeric[T Numeric](value any) (T, error) {
 		}
 		return T(0), nil
 	default:
+		// Handle named types with numeric underlying types (e.g. type Percentage int)
+		rv := reflect.ValueOf(value)
+		switch rv.Kind() { //nolint:exhaustive
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			return T(rv.Int()), nil
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			return T(rv.Uint()), nil
+		case reflect.Float32, reflect.Float64:
+			return T(rv.Float()), nil
+		}
 		return T(0), errors.New("invalid numeric type")
 	}
 }

--- a/src/template/compare.go
+++ b/src/template/compare.go
@@ -42,7 +42,14 @@ func gt(e1, e2 any) bool {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		return v.Int() > int64(toIntOrZero(e2))
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		return int64(v.Uint()) > int64(toIntOrZero(e2))
+		e2Int, err := toInt(e2)
+		if err != nil {
+			return v.Uint() > 0
+		}
+		if e2Int < 0 {
+			return true
+		}
+		return v.Uint() > uint64(e2Int)
 	case reflect.Float32, reflect.Float64:
 		return v.Float() > toFloat64(e2)
 	}

--- a/src/template/compare.go
+++ b/src/template/compare.go
@@ -1,6 +1,10 @@
 package template
 
-import "github.com/jandedobbeleer/oh-my-posh/src/generics"
+import (
+	"reflect"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/generics"
+)
 
 func toIntOrZero(e any) int {
 	if value, err := generics.TryParseInt[int](e); err == nil {
@@ -31,6 +35,18 @@ func gt(e1, e2 any) bool {
 	if val, OK := e1.(float64); OK {
 		return val > toFloat64(e2)
 	}
+
+	// Handle named types with numeric underlying types (e.g. type Percentage int)
+	v := reflect.ValueOf(e1)
+	switch v.Kind() { //nolint:exhaustive
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() > int64(toIntOrZero(e2))
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return int64(v.Uint()) > int64(toIntOrZero(e2))
+	case reflect.Float32, reflect.Float64:
+		return v.Float() > toFloat64(e2)
+	}
+
 	return false
 }
 

--- a/src/template/compare_test.go
+++ b/src/template/compare_test.go
@@ -3,6 +3,7 @@ package template
 import (
 	"testing"
 
+	"github.com/jandedobbeleer/oh-my-posh/src/text"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,6 +22,12 @@ func TestGt(t *testing.T) {
 		{Case: "Float vs String", Expected: true, E1: float64(3), E2: "test"},
 		{Case: "Int vs String", Expected: true, E1: 3, E2: "test"},
 		{Case: "String vs String", Expected: false, E1: "test", E2: "test"},
+		// Named int types (e.g. text.Percentage)
+		{Case: "Percentage(60) gt 50 = true", Expected: true, E1: text.Percentage(60), E2: 50},
+		{Case: "Percentage(40) gt 50 = false", Expected: false, E1: text.Percentage(40), E2: 50},
+		{Case: "Percentage(50) gt 50 = false", Expected: false, E1: text.Percentage(50), E2: 50},
+		{Case: "Int gt Percentage = true", Expected: true, E1: 60, E2: text.Percentage(50)},
+		{Case: "Int gt Percentage = false", Expected: false, E1: 40, E2: text.Percentage(50)},
 	}
 
 	for _, tc := range cases {
@@ -42,6 +49,11 @@ func TestLt(t *testing.T) {
 		{Case: "Float vs Float", Expected: true, E1: float64(3), E2: float64(4)},
 		{Case: "Float vs String", Expected: false, E1: float64(3), E2: "test"},
 		{Case: "String vs String", Expected: false, E1: "test", E2: "test"},
+		// Named int types (e.g. text.Percentage)
+		{Case: "Percentage(40) lt 50 = true", Expected: true, E1: text.Percentage(40), E2: 50},
+		{Case: "Percentage(60) lt 50 = false", Expected: false, E1: text.Percentage(60), E2: 50},
+		{Case: "Int lt Percentage = true", Expected: true, E1: 40, E2: text.Percentage(50)},
+		{Case: "Int lt Percentage = false", Expected: false, E1: 60, E2: text.Percentage(50)},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

Fixes #7299 — `{{ if gt .TokenUsagePercent 50 }}` in `background_templates` always evaluated to `false`.

The custom `gt` function used direct Go type assertions (`e1.(int)`, etc.). These silently fail for **named types** like `text.Percentage` (`type Percentage int`) because Go's type system distinguishes a named type from its underlying primitive at runtime. So `text.Percentage(60).(int)` returns `(0, false)`, and `gt` falls through to `return false` every time.

Fix adds a `reflect.Value.Kind()` fallback in `gt()` to handle any named type whose underlying kind is int, uint, or float. The same fallback is added to `toNumeric()` in `src/generics/convert.go` so the reverse case (`{{ if gt 50 .TokenUsagePercent }}`) also works correctly. Regression tests added for `text.Percentage` in `TestGt` and `TestLt`.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary