### PR TITLE
feat(project): resolve TargetFramework from subdirs for .sln/.slnx

### DIFF
--- a/src/segments/project.go
+++ b/src/segments/project.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"io/fs"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -304,11 +305,10 @@ func (n *Project) getDotnetProject(item ProjectItem) *ProjectData {
 		target = values["TFM"]
 	}
 
-	// When a .sln/.slnx is matched and no TFM was found, scan subdirectories
 	if target == "" && (extension == ".sln" || extension == ".slnx") {
 		if n.options.Bool(ResolveTargetFromSolution, true) {
 			maxDepth := n.options.Int(SolutionSearchDepth, 2)
-			projContent := n.findProjectFileInSubdirs(maxDepth)
+			projContent := n.findProjectFileInSubdirs(files, maxDepth)
 			if projContent != "" {
 				values = regex.FindNamedRegexMatch(tag, projContent)
 				if len(values) != 0 {
@@ -328,48 +328,48 @@ func (n *Project) getDotnetProject(item ProjectItem) *ProjectData {
 	}
 }
 
-func (n *Project) findProjectFileInSubdirs(maxDepth int) string {
+func (n *Project) findProjectFileInSubdirs(rootEntries []fs.DirEntry, maxDepth int) string {
 	projectExts := []string{".csproj", ".fsproj", ".vbproj"}
 	pwd := n.env.Pwd()
 
-	type dirEntry struct {
-		path  string // absolute path for LsDir
-		depth int
+	type queueItem struct {
+		absPath string
+		relPath string
+		depth   int
 	}
 
-	queue := []dirEntry{{path: pwd, depth: 0}}
+	var queue []queueItem
+	for _, entry := range rootEntries {
+		if entry.IsDir() {
+			queue = append(queue, queueItem{
+				absPath: filepath.Join(pwd, entry.Name()),
+				relPath: entry.Name(),
+				depth:   1,
+			})
+		}
+	}
 
 	for len(queue) > 0 {
 		current := queue[0]
 		queue = queue[1:]
 
-		entries := n.env.LsDir(current.path)
+		entries := n.env.LsDir(current.absPath)
 		for _, entry := range entries {
 			if entry.IsDir() {
 				if current.depth < maxDepth {
-					queue = append(queue, dirEntry{
-						path:  filepath.Join(current.path, entry.Name()),
-						depth: current.depth + 1,
+					queue = append(queue, queueItem{
+						absPath: filepath.Join(current.absPath, entry.Name()),
+						relPath: filepath.Join(current.relPath, entry.Name()),
+						depth:   current.depth + 1,
 					})
 				}
 
 				continue
 			}
 
-			// Only check for project files in subdirectories (depth > 0)
-			if current.depth == 0 {
-				continue
-			}
-
 			ext := filepath.Ext(entry.Name())
 			if slices.Contains(projectExts, ext) {
-				relPath, err := filepath.Rel(pwd, filepath.Join(current.path, entry.Name()))
-				if err != nil {
-					log.Error(err)
-					continue
-				}
-
-				return n.env.FileContent(relPath)
+				return n.env.FileContent(filepath.Join(current.relPath, entry.Name()))
 			}
 		}
 	}

--- a/src/segments/project.go
+++ b/src/segments/project.go
@@ -17,6 +17,11 @@ import (
 	yaml "go.yaml.in/yaml/v3"
 )
 
+const (
+	ResolveTargetFromSolution options.Option = "resolve_target_from_solution"
+	SolutionSearchDepth       options.Option = "solution_search_depth"
+)
+
 type ProjectItem struct {
 	Fetcher func(item ProjectItem) *ProjectData
 	Name    string
@@ -299,6 +304,20 @@ func (n *Project) getDotnetProject(item ProjectItem) *ProjectData {
 		target = values["TFM"]
 	}
 
+	// When a .sln/.slnx is matched and no TFM was found, scan subdirectories
+	if target == "" && (extension == ".sln" || extension == ".slnx") {
+		if n.options.Bool(ResolveTargetFromSolution, true) {
+			maxDepth := n.options.Int(SolutionSearchDepth, 2)
+			projContent := n.findProjectFileInSubdirs(maxDepth)
+			if projContent != "" {
+				values = regex.FindNamedRegexMatch(tag, projContent)
+				if len(values) != 0 {
+					target = values["TFM"]
+				}
+			}
+		}
+	}
+
 	if target == "" {
 		log.Error(fmt.Errorf("cannot extract TFM from %s project file", name))
 	}
@@ -307,6 +326,55 @@ func (n *Project) getDotnetProject(item ProjectItem) *ProjectData {
 		Target: target,
 		Name:   name,
 	}
+}
+
+func (n *Project) findProjectFileInSubdirs(maxDepth int) string {
+	projectExts := []string{".csproj", ".fsproj", ".vbproj"}
+	pwd := n.env.Pwd()
+
+	type dirEntry struct {
+		path  string // absolute path for LsDir
+		depth int
+	}
+
+	queue := []dirEntry{{path: pwd, depth: 0}}
+
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+
+		entries := n.env.LsDir(current.path)
+		for _, entry := range entries {
+			if entry.IsDir() {
+				if current.depth < maxDepth {
+					queue = append(queue, dirEntry{
+						path:  filepath.Join(current.path, entry.Name()),
+						depth: current.depth + 1,
+					})
+				}
+
+				continue
+			}
+
+			// Only check for project files in subdirectories (depth > 0)
+			if current.depth == 0 {
+				continue
+			}
+
+			ext := filepath.Ext(entry.Name())
+			if slices.Contains(projectExts, ext) {
+				relPath, err := filepath.Rel(pwd, filepath.Join(current.path, entry.Name()))
+				if err != nil {
+					log.Error(err)
+					continue
+				}
+
+				return n.env.FileContent(relPath)
+			}
+		}
+	}
+
+	return ""
 }
 
 func (n *Project) getPowerShellModuleData(_ ProjectItem) *ProjectData {

--- a/src/segments/project.go
+++ b/src/segments/project.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"io/fs"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -15,6 +16,11 @@ import (
 
 	toml "github.com/pelletier/go-toml/v2"
 	yaml "go.yaml.in/yaml/v3"
+)
+
+const (
+	ResolveTargetFromSolution options.Option = "resolve_target_from_solution"
+	SolutionSearchDepth       options.Option = "solution_search_depth"
 )
 
 type ProjectItem struct {
@@ -309,6 +315,16 @@ func (n *Project) getDotnetProject(item ProjectItem) *ProjectData {
 		target = values["TFM"]
 	}
 
+	if target == "" && (extension == ".sln" || extension == ".slnx") && n.options.Bool(ResolveTargetFromSolution, true) {
+		maxDepth := n.options.Int(SolutionSearchDepth, 2)
+		if projContent := n.findProjectFileInSubdirs(files, maxDepth); projContent != "" {
+			values = regex.FindNamedRegexMatch(tag, projContent)
+			if len(values) != 0 {
+				target = values["TFM"]
+			}
+		}
+	}
+
 	if target == "" {
 		log.Error(fmt.Errorf("cannot extract TFM from %s project file", name))
 	}
@@ -317,6 +333,43 @@ func (n *Project) getDotnetProject(item ProjectItem) *ProjectData {
 		Target: target,
 		Name:   name,
 	}
+}
+
+// findProjectFileInSubdirs scans the subdirectories in rootEntries breadth-first,
+// up to maxDepth levels deep, and returns the content of the first
+// .csproj/.fsproj/.vbproj file found. Paths are kept relative to pwd so
+// FileContent resolves them the same way the caller does.
+func (n *Project) findProjectFileInSubdirs(rootEntries []fs.DirEntry, maxDepth int) string {
+	projectExts := []string{".csproj", ".fsproj", ".vbproj"}
+	pwd := n.env.Pwd()
+
+	var dirs []string
+	for _, entry := range rootEntries {
+		if entry.IsDir() {
+			dirs = append(dirs, entry.Name())
+		}
+	}
+
+	for depth := 1; depth <= maxDepth && len(dirs) > 0; depth++ {
+		var next []string
+
+		for _, dir := range dirs {
+			for _, entry := range n.env.LsDir(filepath.Join(pwd, dir)) {
+				if entry.IsDir() {
+					next = append(next, filepath.Join(dir, entry.Name()))
+					continue
+				}
+
+				if slices.Contains(projectExts, filepath.Ext(entry.Name())) {
+					return n.env.FileContent(filepath.Join(dir, entry.Name()))
+				}
+			}
+		}
+
+		dirs = next
+	}
+
+	return ""
 }
 
 func (n *Project) getPowerShellModuleData(_ ProjectItem) *ProjectData {

--- a/src/segments/project_test.go
+++ b/src/segments/project_test.go
@@ -605,6 +605,188 @@ func TestDotnetProject(t *testing.T) {
 	}
 }
 
+func TestDotnetSolutionResolvesTargetFramework(t *testing.T) {
+	cases := []struct {
+		Case            string
+		SolutionFile    string
+		SubDirs         map[string][]fs.DirEntry // path -> entries returned by LsDir
+		FileContents    map[string]string         // path -> file content
+		Options         options.Map
+		ExpectedString  string
+		ExpectedEnabled bool
+	}{
+		{
+			Case:         ".sln with .csproj one level deep",
+			SolutionFile: "MyApp.sln",
+			SubDirs: map[string][]fs.DirEntry{
+				"posh": {
+					&MockDirEntry{name: "MyApp.sln"},
+					&MockDirEntry{name: "App", isDir: true},
+				},
+				filepath.Join("posh", "App"): {
+					&MockDirEntry{name: "App.csproj"},
+				},
+			},
+			FileContents: map[string]string{
+				"MyApp.sln":                              "",
+				filepath.Join("App", "App.csproj"):       "<Project><PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>",
+			},
+			ExpectedEnabled: true,
+			ExpectedString:  "MyApp \uf4de net8.0",
+		},
+		{
+			Case:         ".sln with .csproj at depth 2",
+			SolutionFile: "MyApp.sln",
+			SubDirs: map[string][]fs.DirEntry{
+				"posh": {
+					&MockDirEntry{name: "MyApp.sln"},
+					&MockDirEntry{name: "src", isDir: true},
+				},
+				filepath.Join("posh", "src"): {
+					&MockDirEntry{name: "App", isDir: true},
+				},
+				filepath.Join("posh", "src", "App"): {
+					&MockDirEntry{name: "App.csproj"},
+				},
+			},
+			FileContents: map[string]string{
+				"MyApp.sln":                                          "",
+				filepath.Join("src", "App", "App.csproj"):            "<Project><PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>",
+			},
+			ExpectedEnabled: true,
+			ExpectedString:  "MyApp \uf4de net8.0",
+		},
+		{
+			Case:         "depth limit exceeded - .csproj at depth 3, max depth 2",
+			SolutionFile: "MyApp.sln",
+			SubDirs: map[string][]fs.DirEntry{
+				"posh": {
+					&MockDirEntry{name: "MyApp.sln"},
+					&MockDirEntry{name: "src", isDir: true},
+				},
+				filepath.Join("posh", "src"): {
+					&MockDirEntry{name: "nested", isDir: true},
+				},
+				filepath.Join("posh", "src", "nested"): {
+					&MockDirEntry{name: "deep", isDir: true},
+				},
+				filepath.Join("posh", "src", "nested", "deep"): {
+					&MockDirEntry{name: "App.csproj"},
+				},
+			},
+			FileContents: map[string]string{
+				"MyApp.sln": "",
+			},
+			Options:         options.Map{SolutionSearchDepth: 2},
+			ExpectedEnabled: true,
+			ExpectedString:  "MyApp",
+		},
+		{
+			Case:         "opt-out with resolve_target_from_solution=false",
+			SolutionFile: "MyApp.sln",
+			SubDirs: map[string][]fs.DirEntry{
+				"posh": {
+					&MockDirEntry{name: "MyApp.sln"},
+					&MockDirEntry{name: "App", isDir: true},
+				},
+			},
+			FileContents: map[string]string{
+				"MyApp.sln": "",
+			},
+			Options:         options.Map{ResolveTargetFromSolution: false},
+			ExpectedEnabled: true,
+			ExpectedString:  "MyApp",
+		},
+		{
+			Case:         ".slnx triggers scanning - resolves TFM from .fsproj",
+			SolutionFile: "MyApp.slnx",
+			SubDirs: map[string][]fs.DirEntry{
+				"posh": {
+					&MockDirEntry{name: "MyApp.slnx"},
+					&MockDirEntry{name: "Lib", isDir: true},
+				},
+				filepath.Join("posh", "Lib"): {
+					&MockDirEntry{name: "Lib.fsproj"},
+				},
+			},
+			FileContents: map[string]string{
+				"MyApp.slnx":                              "",
+				filepath.Join("Lib", "Lib.fsproj"):        "<Project><PropertyGroup><TargetFramework>net9.0</TargetFramework></PropertyGroup></Project>",
+			},
+			ExpectedEnabled: true,
+			ExpectedString:  "MyApp \uf4de net9.0",
+		},
+		{
+			Case:         ".slnf does NOT trigger scanning",
+			SolutionFile: "MyApp.slnf",
+			SubDirs: map[string][]fs.DirEntry{
+				"posh": {
+					&MockDirEntry{name: "MyApp.slnf"},
+					&MockDirEntry{name: "App", isDir: true},
+				},
+			},
+			FileContents: map[string]string{
+				"MyApp.slnf": "",
+			},
+			ExpectedEnabled: true,
+			ExpectedString:  "MyApp",
+		},
+		{
+			Case:         "no project files in subdirs",
+			SolutionFile: "MyApp.sln",
+			SubDirs: map[string][]fs.DirEntry{
+				"posh": {
+					&MockDirEntry{name: "MyApp.sln"},
+					&MockDirEntry{name: "docs", isDir: true},
+				},
+				filepath.Join("posh", "docs"): {
+					&MockDirEntry{name: "README.md"},
+				},
+			},
+			FileContents: map[string]string{
+				"MyApp.sln": "",
+			},
+			ExpectedEnabled: true,
+			ExpectedString:  "MyApp",
+		},
+	}
+
+	for _, tc := range cases {
+		env := new(mock.Environment)
+		env.On(hasFiles, testify_.Anything).Run(func(args testify_.Arguments) {
+			for _, c := range env.ExpectedCalls {
+				if c.Method == hasFiles {
+					pattern := "*" + filepath.Ext(tc.SolutionFile)
+					c.ReturnArguments = testify_.Arguments{args.Get(0).(string) == pattern}
+				}
+			}
+		})
+		env.On("Pwd").Return("posh")
+
+		// Set up LsDir mocks for all paths
+		for path, entries := range tc.SubDirs {
+			env.On("LsDir", path).Return(entries)
+		}
+
+		// Set up FileContent mocks
+		for path, content := range tc.FileContents {
+			env.On("FileContent", path).Return(content)
+		}
+
+		opts := tc.Options
+		if opts == nil {
+			opts = options.Map{}
+		}
+
+		pkg := &Project{}
+		pkg.Init(opts, env)
+		assert.Equal(t, tc.ExpectedEnabled, pkg.Enabled(), tc.Case)
+		if tc.ExpectedEnabled {
+			assert.Equal(t, tc.ExpectedString, renderTemplate(env, pkg.Template(), pkg), tc.Case)
+		}
+	}
+}
+
 func TestPowerShellModuleProject(t *testing.T) {
 	cases := []struct {
 		Case            string

--- a/src/segments/project_test.go
+++ b/src/segments/project_test.go
@@ -610,7 +610,7 @@ func TestDotnetSolutionResolvesTargetFramework(t *testing.T) {
 		Case            string
 		SolutionFile    string
 		SubDirs         map[string][]fs.DirEntry // path -> entries returned by LsDir
-		FileContents    map[string]string         // path -> file content
+		FileContents    map[string]string        // path -> file content
 		Options         options.Map
 		ExpectedString  string
 		ExpectedEnabled bool
@@ -628,8 +628,8 @@ func TestDotnetSolutionResolvesTargetFramework(t *testing.T) {
 				},
 			},
 			FileContents: map[string]string{
-				"MyApp.sln":                              "",
-				filepath.Join("App", "App.csproj"):       "<Project><PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>",
+				"MyApp.sln":                        "",
+				filepath.Join("App", "App.csproj"): "<Project><PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>",
 			},
 			ExpectedEnabled: true,
 			ExpectedString:  "MyApp \uf4de net8.0",
@@ -650,8 +650,8 @@ func TestDotnetSolutionResolvesTargetFramework(t *testing.T) {
 				},
 			},
 			FileContents: map[string]string{
-				"MyApp.sln":                                          "",
-				filepath.Join("src", "App", "App.csproj"):            "<Project><PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>",
+				"MyApp.sln": "",
+				filepath.Join("src", "App", "App.csproj"): "<Project><PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>",
 			},
 			ExpectedEnabled: true,
 			ExpectedString:  "MyApp \uf4de net8.0",
@@ -710,8 +710,8 @@ func TestDotnetSolutionResolvesTargetFramework(t *testing.T) {
 				},
 			},
 			FileContents: map[string]string{
-				"MyApp.slnx":                              "",
-				filepath.Join("Lib", "Lib.fsproj"):        "<Project><PropertyGroup><TargetFramework>net9.0</TargetFramework></PropertyGroup></Project>",
+				"MyApp.slnx":                       "",
+				filepath.Join("Lib", "Lib.fsproj"): "<Project><PropertyGroup><TargetFramework>net9.0</TargetFramework></PropertyGroup></Project>",
 			},
 			ExpectedEnabled: true,
 			ExpectedString:  "MyApp \uf4de net9.0",

--- a/src/segments/project_test.go
+++ b/src/segments/project_test.go
@@ -651,6 +651,188 @@ func TestDotnetProject(t *testing.T) {
 	}
 }
 
+func TestDotnetSolutionResolvesTargetFramework(t *testing.T) {
+	cases := []struct {
+		Case            string
+		SolutionFile    string
+		SubDirs         map[string][]fs.DirEntry // path -> entries returned by LsDir
+		FileContents    map[string]string        // path -> file content
+		Options         options.Map
+		ExpectedString  string
+		ExpectedEnabled bool
+	}{
+		{
+			Case:         ".sln with .csproj one level deep",
+			SolutionFile: "MyApp.sln",
+			SubDirs: map[string][]fs.DirEntry{
+				"posh": {
+					&MockDirEntry{name: "MyApp.sln"},
+					&MockDirEntry{name: "App", isDir: true},
+				},
+				filepath.Join("posh", "App"): {
+					&MockDirEntry{name: "App.csproj"},
+				},
+			},
+			FileContents: map[string]string{
+				"MyApp.sln":                        "",
+				filepath.Join("App", "App.csproj"): "<Project><PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>",
+			},
+			ExpectedEnabled: true,
+			ExpectedString:  "MyApp \uf4de net8.0",
+		},
+		{
+			Case:         ".sln with .csproj at depth 2",
+			SolutionFile: "MyApp.sln",
+			SubDirs: map[string][]fs.DirEntry{
+				"posh": {
+					&MockDirEntry{name: "MyApp.sln"},
+					&MockDirEntry{name: "src", isDir: true},
+				},
+				filepath.Join("posh", "src"): {
+					&MockDirEntry{name: "App", isDir: true},
+				},
+				filepath.Join("posh", "src", "App"): {
+					&MockDirEntry{name: "App.csproj"},
+				},
+			},
+			FileContents: map[string]string{
+				"MyApp.sln": "",
+				filepath.Join("src", "App", "App.csproj"): "<Project><PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>",
+			},
+			ExpectedEnabled: true,
+			ExpectedString:  "MyApp \uf4de net8.0",
+		},
+		{
+			Case:         "depth limit exceeded - .csproj at depth 3, max depth 2",
+			SolutionFile: "MyApp.sln",
+			SubDirs: map[string][]fs.DirEntry{
+				"posh": {
+					&MockDirEntry{name: "MyApp.sln"},
+					&MockDirEntry{name: "src", isDir: true},
+				},
+				filepath.Join("posh", "src"): {
+					&MockDirEntry{name: "nested", isDir: true},
+				},
+				filepath.Join("posh", "src", "nested"): {
+					&MockDirEntry{name: "deep", isDir: true},
+				},
+				filepath.Join("posh", "src", "nested", "deep"): {
+					&MockDirEntry{name: "App.csproj"},
+				},
+			},
+			FileContents: map[string]string{
+				"MyApp.sln": "",
+			},
+			Options:         options.Map{SolutionSearchDepth: 2},
+			ExpectedEnabled: true,
+			ExpectedString:  "MyApp",
+		},
+		{
+			Case:         "opt-out with resolve_target_from_solution=false",
+			SolutionFile: "MyApp.sln",
+			SubDirs: map[string][]fs.DirEntry{
+				"posh": {
+					&MockDirEntry{name: "MyApp.sln"},
+					&MockDirEntry{name: "App", isDir: true},
+				},
+			},
+			FileContents: map[string]string{
+				"MyApp.sln": "",
+			},
+			Options:         options.Map{ResolveTargetFromSolution: false},
+			ExpectedEnabled: true,
+			ExpectedString:  "MyApp",
+		},
+		{
+			Case:         ".slnx triggers scanning - resolves TFM from .fsproj",
+			SolutionFile: "MyApp.slnx",
+			SubDirs: map[string][]fs.DirEntry{
+				"posh": {
+					&MockDirEntry{name: "MyApp.slnx"},
+					&MockDirEntry{name: "Lib", isDir: true},
+				},
+				filepath.Join("posh", "Lib"): {
+					&MockDirEntry{name: "Lib.fsproj"},
+				},
+			},
+			FileContents: map[string]string{
+				"MyApp.slnx":                       "",
+				filepath.Join("Lib", "Lib.fsproj"): "<Project><PropertyGroup><TargetFramework>net9.0</TargetFramework></PropertyGroup></Project>",
+			},
+			ExpectedEnabled: true,
+			ExpectedString:  "MyApp \uf4de net9.0",
+		},
+		{
+			Case:         ".slnf does NOT trigger scanning",
+			SolutionFile: "MyApp.slnf",
+			SubDirs: map[string][]fs.DirEntry{
+				"posh": {
+					&MockDirEntry{name: "MyApp.slnf"},
+					&MockDirEntry{name: "App", isDir: true},
+				},
+			},
+			FileContents: map[string]string{
+				"MyApp.slnf": "",
+			},
+			ExpectedEnabled: true,
+			ExpectedString:  "MyApp",
+		},
+		{
+			Case:         "no project files in subdirs",
+			SolutionFile: "MyApp.sln",
+			SubDirs: map[string][]fs.DirEntry{
+				"posh": {
+					&MockDirEntry{name: "MyApp.sln"},
+					&MockDirEntry{name: "docs", isDir: true},
+				},
+				filepath.Join("posh", "docs"): {
+					&MockDirEntry{name: "README.md"},
+				},
+			},
+			FileContents: map[string]string{
+				"MyApp.sln": "",
+			},
+			ExpectedEnabled: true,
+			ExpectedString:  "MyApp",
+		},
+	}
+
+	for _, tc := range cases {
+		env := new(mock.Environment)
+		env.On(hasFiles, testify_.Anything).Run(func(args testify_.Arguments) {
+			for _, c := range env.ExpectedCalls {
+				if c.Method == hasFiles {
+					pattern := "*" + filepath.Ext(tc.SolutionFile)
+					c.ReturnArguments = testify_.Arguments{args.Get(0).(string) == pattern}
+				}
+			}
+		})
+		env.On("Pwd").Return("posh")
+
+		// Set up LsDir mocks for all paths
+		for path, entries := range tc.SubDirs {
+			env.On("LsDir", path).Return(entries)
+		}
+
+		// Set up FileContent mocks
+		for path, content := range tc.FileContents {
+			env.On("FileContent", path).Return(content)
+		}
+
+		opts := tc.Options
+		if opts == nil {
+			opts = options.Map{}
+		}
+
+		pkg := &Project{}
+		pkg.Init(opts, env)
+		assert.Equal(t, tc.ExpectedEnabled, pkg.Enabled(), tc.Case)
+		if tc.ExpectedEnabled {
+			assert.Equal(t, tc.ExpectedString, renderTemplate(env, pkg.Template(), pkg), tc.Case)
+		}
+	}
+}
+
 func TestPowerShellModuleProject(t *testing.T) {
 	cases := []struct {
 		Case            string

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -3740,6 +3740,19 @@
                     "title": "Always Enabled",
                     "description": "Always show the segment",
                     "default": false
+                  },
+                  "resolve_target_from_solution": {
+                    "type": "boolean",
+                    "title": "Resolve Target from Solution",
+                    "description": "When a .sln/.slnx is matched, scan subdirectories for project files to extract TargetFramework",
+                    "default": true
+                  },
+                  "solution_search_depth": {
+                    "type": "integer",
+                    "title": "Solution Search Depth",
+                    "description": "Maximum directory depth to scan for project files when resolving from a solution",
+                    "default": 2,
+                    "minimum": 1
                   }
                 }
               }

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -3871,6 +3871,19 @@
                     "title": "Always Enabled",
                     "description": "Always show the segment",
                     "default": false
+                  },
+                  "resolve_target_from_solution": {
+                    "type": "boolean",
+                    "title": "Resolve Target from Solution",
+                    "description": "When a .sln/.slnx is matched, scan subdirectories for project files to extract TargetFramework",
+                    "default": true
+                  },
+                  "solution_search_depth": {
+                    "type": "integer",
+                    "title": "Solution Search Depth",
+                    "description": "Maximum directory depth to scan for project files when resolving from a solution",
+                    "default": 2,
+                    "minimum": 1
                   }
                 }
               }

--- a/website/docs/segments/system/project.mdx
+++ b/website/docs/segments/system/project.mdx
@@ -41,10 +41,12 @@ import Config from "@site/src/components/Config.js";
 
 ## Options
 
-| Name             |   Type    | Default | Description                                                                                                         |
-| ---------------- | :-------: | :-----: | ------------------------------------------------------------------------------------------------------------------- |
-| `always_enabled` | `boolean` | `false` | always show the segment                                                                                             |
-| `<type>_files`   |  `array`  |  `[]`   | override the project's files to validate for. Use the `.Type` values listed below to override (e.g. `dotnet_files`) |
+| Name                            |   Type    | Default | Description                                                                                                         |
+| ------------------------------- | :-------: | :-----: | ------------------------------------------------------------------------------------------------------------------- |
+| `always_enabled`                | `boolean` | `false` | always show the segment                                                                                             |
+| `<type>_files`                  |  `array`  |  `[]`   | override the project's files to validate for. Use the `.Type` values listed below to override (e.g. `dotnet_files`) |
+| `resolve_target_from_solution`  | `boolean` | `true`  | when a `.sln`/`.slnx` is matched, scan subdirectories for project files to extract `TargetFramework`               |
+| `solution_search_depth`         |   `int`   |  `2`    | maximum directory depth to scan for project files when resolving from a solution                                    |
 
 ## Template ([info][templates])
 

--- a/website/docs/segments/system/project.mdx
+++ b/website/docs/segments/system/project.mdx
@@ -42,10 +42,12 @@ import Config from "@site/src/components/Config.js";
 
 ## Options
 
-| Name             |   Type    | Default | Description                                                                                                         |
-| ---------------- | :-------: | :-----: | ------------------------------------------------------------------------------------------------------------------- |
-| `always_enabled` | `boolean` | `false` | always show the segment                                                                                             |
-| `<type>_files`   |  `array`  |  `[]`   | override the project's files to validate for. Use the `.Type` values listed below to override (e.g. `dotnet_files`) |
+| Name                            |   Type    | Default | Description                                                                                                         |
+| ------------------------------- | :-------: | :-----: | ------------------------------------------------------------------------------------------------------------------- |
+| `always_enabled`                | `boolean` | `false` | always show the segment                                                                                             |
+| `<type>_files`                  |  `array`  |  `[]`   | override the project's files to validate for. Use the `.Type` values listed below to override (e.g. `dotnet_files`) |
+| `resolve_target_from_solution`  | `boolean` | `true`  | when a `.sln`/`.slnx` is matched, scan subdirectories for project files to extract `TargetFramework`               |
+| `solution_search_depth`         |   `int`   |  `2`    | maximum directory depth to scan for project files when resolving from a solution                                    |
 
 ## Template ([info][templates])
 


### PR DESCRIPTION
Closes #7399

## Summary

- When the `project` segment matches a `.sln`/`.slnx` file that has no `TargetFramework`, scan subdirectories for `.csproj`/`.fsproj`/`.vbproj` files and extract the TFM from the first match
- Two new segment options: `resolve_target_from_solution` (default `true`) to opt out, and `solution_search_depth` (default `2`) to control BFS depth
- `.slnf` files are intentionally excluded from scanning

## Test plan

- [x] 7 table-driven test cases covering: depth 1 resolution, depth 2 resolution, depth limit exceeded, opt-out flag, `.slnx` trigger, `.slnf` exclusion, no project files found
- [x] Existing `TestDotnetProject` tests pass (no regressions)
- [x] Full test suite passes
- [x] `go vet` clean
- [x] Build succeeds