### PR TITLE
docs/fix-typos-wakatime-brewfather

### DIFF
--- a/website/docs/segments/web/brewfather.mdx
+++ b/website/docs/segments/web/brewfather.mdx
@@ -150,7 +150,7 @@ to build your own. For reference, the built-in template looks like this:
 
 ### Unit conversion
 
-By default temperature readings are provided in degrees C, gravity readings in decimal Specific Gravity unts (X.XXX).
+By default temperature readings are provided in degrees C, gravity readings in decimal Specific Gravity units (X.XXX).
 
 The following conversion functions are available to the template to convert to other units:
 

--- a/website/docs/segments/web/wakatime.mdx
+++ b/website/docs/segments/web/wakatime.mdx
@@ -10,7 +10,7 @@ Shows the tracked time on [wakatime][wt] of the current day
 
 :::caution
 You **must** request an API key at the [wakatime][wt] website.
-The free tier for is sufficient. You'll find the API key in your profile settings page.
+The free tier is sufficient. You'll find the API key in your profile settings page.
 :::
 
 ## Sample Configuration


### PR DESCRIPTION
## Changes

- `wakatime.mdx`: Removed extra word "for" — "The free tier for is sufficient" → "The free tier is sufficient"
- `brewfather.mdx`: Fixed typo "unts" → "units" in unit conversion section

Small documentation fixes.