### PR TITLE
fix(template): render unixEpoch strings in date helpers

### DIFF
--- a/src/template/date_test.go
+++ b/src/template/date_test.go
@@ -1,0 +1,82 @@
+package template
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/cache"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDateAcceptsUnixEpochStrings(t *testing.T) {
+	previousLocal := time.Local
+	time.Local = time.UTC
+	defer func() {
+		time.Local = previousLocal
+	}()
+
+	env := new(mock.Environment)
+	env.On("Shell").Return("foo")
+
+	Cache = new(cache.Template)
+	Init(env, nil, nil)
+
+	text, err := Render(`{{ "1776455769" | date "Mon 2/Jan 15:04" }} || {{ "1777060569" | date "Mon 2/Jan 15:04" }}`, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "Fri 17/Apr 19:56 || Fri 24/Apr 19:56", text)
+}
+
+func TestDateInZoneAcceptsUnixEpochStrings(t *testing.T) {
+	env := new(mock.Environment)
+	env.On("Shell").Return("foo")
+
+	Cache = new(cache.Template)
+	Init(env, nil, nil)
+
+	text, err := Render(`{{ date_in_zone "Mon 2/Jan 15:04" "1776455769" "UTC" }} || {{ dateInZone "Mon 2/Jan 15:04" "1777060569" "UTC" }}`, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "Fri 17/Apr 19:56 || Fri 24/Apr 19:56", text)
+}
+
+func TestHTMLDateAcceptsUnixEpochStrings(t *testing.T) {
+	previousLocal := time.Local
+	time.Local = time.UTC
+	defer func() {
+		time.Local = previousLocal
+	}()
+
+	env := new(mock.Environment)
+	env.On("Shell").Return("foo")
+
+	Cache = new(cache.Template)
+	Init(env, nil, nil)
+
+	text, err := Render(`{{ htmlDate "1776455769" }} || {{ htmlDateInZone "1777060569" "UTC" }}`, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "2026-04-17 || 2026-04-24", text)
+}
+
+func TestDatePipelineWithUnixEpochOutput(t *testing.T) {
+	previousLocal := time.Local
+	time.Local = time.UTC
+	defer func() {
+		time.Local = previousLocal
+	}()
+
+	env := new(mock.Environment)
+	env.On("Shell").Return("foo")
+
+	Cache = new(cache.Template)
+	Init(env, nil, nil)
+
+	text, err := Render(`{{ $n1 := (now|unixEpoch) }}{{ $n2 := (now|date_modify "+168h"|unixEpoch) }}{{ $n1 | date "2/Jan" }}||{{ $n2 | date "2/Jan" }}`, nil)
+	assert.NoError(t, err)
+
+	parts := strings.Split(text, "||")
+	if assert.Len(t, parts, 2) {
+		assert.NotEqual(t, parts[0], parts[1])
+	}
+}

--- a/src/template/func_map.go
+++ b/src/template/func_map.go
@@ -2,12 +2,33 @@ package template
 
 import (
 	"path/filepath"
+	"strconv"
 	"text/template"
 
 	"github.com/Masterminds/sprig/v3"
 )
 
+func normalizeUnixEpoch(value any) any {
+	text, ok := value.(string)
+	if !ok {
+		return value
+	}
+
+	epoch, err := strconv.ParseInt(text, 10, 64)
+	if err != nil {
+		return value
+	}
+
+	return epoch
+}
+
 func funcMap() template.FuncMap {
+	sprigFuncMap := sprig.TxtFuncMap()
+	sprigDate := sprigFuncMap["date"].(func(string, interface{}) string)
+	sprigDateInZone := sprigFuncMap["date_in_zone"].(func(string, interface{}, string) string)
+	sprigHTMLDate := sprigFuncMap["htmlDate"].(func(interface{}) string)
+	sprigHTMLDateInZone := sprigFuncMap["htmlDateInZone"].(func(interface{}, string) string)
+
 	funcMap := map[string]any{
 		"secondsRound": secondsRound,
 		"url":          url,
@@ -27,9 +48,24 @@ func funcMap() template.FuncMap {
 		"stat":         stat,
 		"dir":          filepath.Dir,
 		"base":         filepath.Base,
+		"date": func(layout string, value any) string {
+			return sprigDate(layout, normalizeUnixEpoch(value))
+		},
+		"date_in_zone": func(layout string, value any, zone string) string {
+			return sprigDateInZone(layout, normalizeUnixEpoch(value), zone)
+		},
+		"dateInZone": func(layout string, value any, zone string) string {
+			return sprigDateInZone(layout, normalizeUnixEpoch(value), zone)
+		},
+		"htmlDate": func(value any) string {
+			return sprigHTMLDate(normalizeUnixEpoch(value))
+		},
+		"htmlDateInZone": func(value any, zone string) string {
+			return sprigHTMLDateInZone(normalizeUnixEpoch(value), zone)
+		},
 	}
 
-	for key, fun := range sprig.TxtFuncMap() {
+	for key, fun := range sprigFuncMap {
 		if _, ok := funcMap[key]; !ok {
 			funcMap[key] = fun
 		}


### PR DESCRIPTION
Fixes #7470.

`unixEpoch` returns a numeric string, but sprig's date helpers only format `time.Time` and integer inputs. That meant templates like:

```gotemplate
{{ $n1 := (now|unixEpoch) }}{{ $n2 := (now|date_modify "+168h"|unixEpoch) }}
{{ $n1 | date "Mon 2/Jan 15:04" }} || {{ $n2 | date "Mon 2/Jan 15:04" }}
```

would render the current date for both values instead of the epoch timestamps.

This normalizes numeric epoch strings before calling the date-family helpers and adds regressions for:

- literal epoch strings with `date`
- `date_in_zone` / `dateInZone`
- `htmlDate` / `htmlDateInZone`
- the `now | unixEpoch | date` pipeline from the issue

Validation:

- `go test ./template/...`
- `go test ./...`
- `go run . print preview --config /tmp/omp-date.toml --plain`
