### PR TITLE
feat: restore rprompt on backspace when tooltip no longer matches

### DIFF
--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,6 +1,6 @@
 lockfile_version: '1'
-generated_at: '2026-03-24T19:20:00.231781+00:00'
-apm_version: 0.7.7
+generated_at: '2026-04-12T20:00:53.202813+00:00'
+apm_version: 0.8.11
 dependencies:
 - repo_url: JanDeDobbeleer/agentic
   host: github.com
@@ -9,8 +9,8 @@ dependencies:
   is_virtual: true
   package_type: claude_skill
   deployed_files:
-  - .claude/skills/conventional-commit
   - .github/skills/conventional-commit
+  content_hash: sha256:d842107e497b6fd51f24e2bfe74dbaf3f9e0e358bf5f95b9d79abbec5785e7af
 - repo_url: JanDeDobbeleer/agentic
   host: github.com
   resolved_commit: b4e8062eaeef93582bf4cbb86ad4816f37630bb2
@@ -18,8 +18,8 @@ dependencies:
   is_virtual: true
   package_type: claude_skill
   deployed_files:
-  - .claude/skills/golang
   - .github/skills/golang
+  content_hash: sha256:b0783cb13028c1b486aaffe7bce1b49294e92b22e1f8ce58895e61c639865f90
 - repo_url: JanDeDobbeleer/agentic
   host: github.com
   resolved_commit: b4e8062eaeef93582bf4cbb86ad4816f37630bb2
@@ -27,8 +27,8 @@ dependencies:
   is_virtual: true
   package_type: claude_skill
   deployed_files:
-  - .claude/skills/markdown
   - .github/skills/markdown
+  content_hash: sha256:fa25f4f36faa33fa51ec6e9a3b5bf7cde618d8d7dfb572dd8f55733dc1813265
 - repo_url: JanDeDobbeleer/agentic
   host: github.com
   resolved_commit: b4e8062eaeef93582bf4cbb86ad4816f37630bb2
@@ -36,8 +36,8 @@ dependencies:
   is_virtual: true
   package_type: claude_skill
   deployed_files:
-  - .claude/skills/powershell
   - .github/skills/powershell
+  content_hash: sha256:bc844acc1cf9ccc5d2d10e1c889b8b5b69b92f743e3bc11e0bc9a386770fc864
 - repo_url: JanDeDobbeleer/agentic
   host: github.com
   resolved_commit: b4e8062eaeef93582bf4cbb86ad4816f37630bb2
@@ -45,5 +45,5 @@ dependencies:
   is_virtual: true
   package_type: claude_skill
   deployed_files:
-  - .claude/skills/vale-user-facing-text
   - .github/skills/vale-user-facing-text
+  content_hash: sha256:7676bf19dc93149f469655ffb0b166db7c953fe0483b8a96e763ce024b1c8a59

--- a/src/prompt/tooltip.go
+++ b/src/prompt/tooltip.go
@@ -10,6 +10,37 @@ import (
 	"github.com/jandedobbeleer/oh-my-posh/src/terminal"
 )
 
+func (e *Engine) tooltipFallback() string {
+	rprompt, OK := cache.Get[string](cache.Session, RPromptKey)
+	if !OK {
+		return ""
+	}
+
+	rpromptLength, OK := cache.Get[int](cache.Session, RPromptLengthKey)
+	if !OK {
+		return rprompt
+	}
+
+	switch e.Env.Shell() {
+	case shell.PWSH:
+		e.rprompt = rprompt
+		e.currentLineLength = e.Env.Flags().Column
+
+		space, ok := e.canWriteRightBlock(rpromptLength, true)
+		if !ok {
+			return ""
+		}
+
+		e.write(terminal.SaveCursorPosition())
+		e.write(strings.Repeat(" ", space))
+		e.write(rprompt)
+		e.write(terminal.RestoreCursorPosition())
+		return e.string()
+	default:
+		return rprompt
+	}
+}
+
 func (e *Engine) Tooltip(tip string) string {
 	tip = strings.Trim(tip, " ")
 	tooltips := make([]*config.Segment, 0, 1)
@@ -29,7 +60,7 @@ func (e *Engine) Tooltip(tip string) string {
 	}
 
 	if len(tooltips) == 0 {
-		return ""
+		return e.tooltipFallback()
 	}
 
 	// little hack to reuse the current logic

--- a/src/prompt/tooltip_test.go
+++ b/src/prompt/tooltip_test.go
@@ -1,0 +1,95 @@
+package prompt
+
+import (
+	"testing"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/cache"
+	"github.com/jandedobbeleer/oh-my-posh/src/config"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+	"github.com/jandedobbeleer/oh-my-posh/src/shell"
+	"github.com/jandedobbeleer/oh-my-posh/src/terminal"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTooltipFallback_NoCacheReturnsEmpty(t *testing.T) {
+	cache.DeleteAll(cache.Session)
+
+	env := new(mock.Environment)
+	env.On("Shell").Return(shell.ZSH)
+
+	terminal.Init(shell.ZSH)
+
+	engine := &Engine{
+		Env:    env,
+		Config: &config.Config{},
+	}
+
+	got := engine.Tooltip("unknown-command")
+	assert.Empty(t, got)
+}
+
+func TestTooltipFallback_NoMatchReturnsRPromptText(t *testing.T) {
+	cache.DeleteAll(cache.Session)
+	cache.Set(cache.Session, RPromptKey, "my-rprompt", cache.INFINITE)
+	cache.Set(cache.Session, RPromptLengthKey, 10, cache.INFINITE)
+
+	env := new(mock.Environment)
+	env.On("Shell").Return(shell.ZSH)
+
+	terminal.Init(shell.ZSH)
+
+	engine := &Engine{
+		Env:    env,
+		Config: &config.Config{},
+	}
+
+	got := engine.Tooltip("unknown-command")
+	assert.Equal(t, "my-rprompt", got)
+}
+
+func TestTooltipFallback_PwshNoMatchReturnsCursorPositionedRPrompt(t *testing.T) {
+	cache.DeleteAll(cache.Session)
+	cache.Set(cache.Session, RPromptKey, "my-rprompt", cache.INFINITE)
+	cache.Set(cache.Session, RPromptLengthKey, 10, cache.INFINITE)
+
+	env := new(mock.Environment)
+	env.On("Shell").Return(shell.PWSH)
+	env.On("Flags").Return(&runtime.Flags{Column: 5})
+	env.On("TerminalWidth").Return(200, nil)
+
+	terminal.Init(shell.PWSH)
+
+	engine := &Engine{
+		Env:    env,
+		Config: &config.Config{},
+	}
+
+	got := engine.Tooltip("unknown-command")
+	assert.Contains(t, got, "my-rprompt")
+	assert.Contains(t, got, terminal.SaveCursorPosition())
+	assert.Contains(t, got, terminal.RestoreCursorPosition())
+}
+
+func TestTooltipFallback_PwshNoRoomReturnsEmpty(t *testing.T) {
+	cache.DeleteAll(cache.Session)
+	cache.Set(cache.Session, RPromptKey, "my-rprompt", cache.INFINITE)
+	// rprompt length exceeds available terminal space
+	cache.Set(cache.Session, RPromptLengthKey, 200, cache.INFINITE)
+
+	env := new(mock.Environment)
+	env.On("Shell").Return(shell.PWSH)
+	env.On("Flags").Return(&runtime.Flags{Column: 100})
+	env.On("TerminalWidth").Return(200, nil)
+
+	terminal.Init(shell.PWSH)
+
+	engine := &Engine{
+		Env:    env,
+		Config: &config.Config{},
+	}
+
+	got := engine.Tooltip("unknown-command")
+	assert.Empty(t, got)
+}

--- a/src/shell/scripts/omp.fish
+++ b/src/shell/scripts/omp.fish
@@ -333,6 +333,17 @@ end
 
 function _omp_enter_key_handler
     if commandline --paging-mode
+        set --global _omp_new_prompt 1
+        set --global _omp_tooltip_command ''
+
+        # cleanup streaming before executing command
+        _omp_cleanup_stream
+
+        if test $_omp_transient_prompt = 1
+            set --global _omp_transient 1
+            commandline --function repaint
+        end
+
         commandline --function execute
         return
     end

--- a/src/shell/scripts/omp.fish
+++ b/src/shell/scripts/omp.fish
@@ -304,9 +304,29 @@ function _omp_space_key_handler
     commandline --function repaint
 end
 
+function _omp_backspace_key_handler
+    commandline --function backward-delete-char
+
+    if test -z "$_omp_tooltip_command"
+        return
+    end
+
+    set --local current_command (commandline --current-buffer | string trim -l | string split --allow-empty -f1 ' ' | string collect)
+
+    if test "$current_command" = "$_omp_tooltip_command"
+        return
+    end
+
+    set _omp_tooltip_command "$current_command"
+    set _omp_current_rprompt (_omp_get_prompt tooltip --command="$current_command" | string join '')
+    commandline --function repaint
+end
+
 function enable_poshtooltips
     bind \x20 _omp_space_key_handler -M default
     bind \x20 _omp_space_key_handler -M insert
+    bind \x7f _omp_backspace_key_handler -M default
+    bind \x7f _omp_backspace_key_handler -M insert
 end
 
 # transient prompt

--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -506,6 +506,27 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
             finally {
             }
         }
+
+        Set-PSReadLineKeyHandler -Key Backspace -BriefDescription 'OhMyPoshBackspaceKeyHandler' -ScriptBlock {
+            [Microsoft.PowerShell.PSConsoleReadLine]::BackwardDeleteChar()
+            if (!$script:TooltipCommand) { return }
+
+            $command = ''
+            [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$command, [ref]$null)
+            $command = $command.TrimStart().Split(' ', 2) | Select-Object -First 1
+
+            if ($command -eq $script:TooltipCommand) { return }
+
+            $script:TooltipCommand = $command
+
+            $output = (Get-PoshPrompt "tooltip" @(
+                    "--column=$($Host.UI.RawUI.CursorPosition.X)"
+                    "--command=$command"
+                )) -join ''
+            if ($output) {
+                Write-Host $output -NoNewline
+            }
+        }
     }
 
     function Enable-KeyHandlers {

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -259,6 +259,24 @@ function _omp_render_tooltip() {
   zle .reset-prompt
 }
 
+function _omp_restore_rprompt() {
+  if [[ -z $_omp_tooltip_command ]]; then
+    return
+  fi
+
+  setopt local_options no_shwordsplit
+
+  local current_command=${${(MS)BUFFER##[[:graph:]]*}%%[[:space:]]*}
+
+  if [[ $current_command = "$_omp_tooltip_command" ]]; then
+    return
+  fi
+
+  _omp_tooltip_command="$current_command"
+  RPROMPT=$(_omp_get_prompt tooltip --command="$current_command")
+  zle .reset-prompt
+}
+
 function _omp_zle-line-init() {
   [[ $CONTEXT == start ]] || return 0
 
@@ -340,6 +358,7 @@ function enable_poshtooltips() {
   fi
 
   _omp_create_widget $widget _omp_render_tooltip
+  _omp_create_widget backward-delete-char _omp_restore_rprompt
 }
 
 # legacy functions


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

Closes #7458.

When tooltips are enabled and the user presses Backspace causing the first word of the buffer to change (or become empty), the tooltip is now cleared and the original right prompt is restored -- instead of leaving the stale tooltip visible.

**How it works:**

- `tooltipFallback()` is added to `prompt/tooltip.go`. When `Tooltip()` finds no matching segment for the current command, it reads `RPromptKey` and `RPromptLengthKey` from the session cache (already written there during the primary prompt render when tooltips are configured) and returns the cached rprompt. For PowerShell it applies the same save/space/restore cursor-positioning as a normal tooltip; for Zsh and Fish it returns the plain text.
- Shell scripts (Zsh, Fish, PowerShell) each get a backspace key handler that fires only when `_omp_tooltip_command` is set and the first word has changed. It calls `print tooltip --command="$new_command"` -- Go then decides whether to return a new matching tooltip, the cached rprompt, or an empty string.
- An early-return guard means repeated backspaces within the same first word (e.g. `git status` -> `git statu`) are free -- no oh-my-posh subprocess is spawned.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary