### PR TITLE
feat(bash): support global .Jobs by passing --job-count

### DIFF
--- a/src/shell/bash.go
+++ b/src/shell/bash.go
@@ -33,6 +33,7 @@ func (f Features) Bash() Code {
 		--pipestatus="${_omp_pipestatus[*]}" \
 		--no-status="$_omp_no_status" \
 		--execution-time="$_omp_execution_time" \
+		--job-count="$_omp_job_count" \
 		--stack-count="$_omp_stack_count" \
 		--terminal-width="${COLUMNS-0}" \
 		--escape=false

--- a/src/shell/bash_test.go
+++ b/src/shell/bash_test.go
@@ -1,4 +1,4 @@
-﻿package shell
+package shell
 
 import (
 	"fmt"

--- a/src/shell/bash_test.go
+++ b/src/shell/bash_test.go
@@ -1,4 +1,4 @@
-package shell
+﻿package shell
 
 import (
 	"fmt"
@@ -44,6 +44,7 @@ bleopt prompt_rps1='$(
 		--pipestatus="${_omp_pipestatus[*]}" \
 		--no-status="$_omp_no_status" \
 		--execution-time="$_omp_execution_time" \
+		--job-count="$_omp_job_count" \
 		--stack-count="$_omp_stack_count" \
 		--terminal-width="${COLUMNS-0}" \
 		--escape=false

--- a/src/shell/scripts/omp.bash
+++ b/src/shell/scripts/omp.bash
@@ -116,7 +116,9 @@ function _omp_hook() {
     fi
 
     _omp_stack_count=$((${#DIRSTACK[@]} - 1))
-    _omp_job_count=$(( $(jobs -p 2>/dev/null | wc -l) ))
+    local _omp_jobs=()
+    _omp_jobs=($(jobs -p 2>/dev/null))
+    _omp_job_count=${#_omp_jobs[@]}
 
     _omp_execution_time=-1
     if [[ $_omp_start_time ]]; then

--- a/src/shell/scripts/omp.bash
+++ b/src/shell/scripts/omp.bash
@@ -11,6 +11,7 @@ export PYENV_VIRTUALENV_DISABLE_PROMPT=1
 # global variables
 _omp_start_time=''
 _omp_stack_count=0
+_omp_job_count=0
 _omp_execution_time=-1
 _omp_no_status=true
 _omp_status=0
@@ -85,6 +86,7 @@ function _omp_get_primary() {
                 --pipestatus="${_omp_pipestatus[*]}" \
                 --no-status="$_omp_no_status" \
                 --execution-time="$_omp_execution_time" \
+                --job-count="$_omp_job_count" \
                 --stack-count="$_omp_stack_count" \
                 --terminal-width="${COLUMNS-0}" |
                 tr -d '\0'
@@ -114,6 +116,7 @@ function _omp_hook() {
     fi
 
     _omp_stack_count=$((${#DIRSTACK[@]} - 1))
+    _omp_job_count=$(( $(jobs -p 2>/dev/null | wc -l) ))
 
     _omp_execution_time=-1
     if [[ $_omp_start_time ]]; then


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

Fixes #7463.

The global template property `.Jobs` was not available in bash because the bash init script never counted background jobs or passed `--job-count` to the `oh-my-posh` executable. Zsh already does this via `_omp_job_count=${#jobstates}`. This PR brings bash to parity.

**Changes:**

- `omp.bash`: adds `_omp_job_count=0` as a global variable, counts background jobs in `_omp_hook` using `$(( $(jobs -p 2>/dev/null | wc -l) ))`, and passes `--job-count="$_omp_job_count"` to `omp print primary`.
- `bash.go`: adds `--job-count="$_omp_job_count"` to the BLE session `RPrompt` heredoc so the right-prompt also has access to `.Jobs`.
- `bash_test.go`: updates `TestBashFeaturesWithBLE` to include the new flag in the expected output.

The arithmetic expansion `$(( ... ))` ensures the value is always a plain integer regardless of whether `wc -l` pads with leading spaces (as it does on BSD/macOS).

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary