### PR TITLE
fix: handle string epoch in date template functions

### DIFF
--- a/src/template/date.go
+++ b/src/template/date.go
@@ -1,0 +1,58 @@
+package template
+
+import (
+	"strconv"
+	"time"
+)
+
+// dateInZone is a replacement for sprig's dateInZone that adds support for string
+// epoch values. Sprig's unixEpoch returns a string, which sprig's own date functions
+// do not handle — they fall through to time.Now(). This wrapper parses numeric strings
+// as Unix timestamps so that patterns like `{{ now | unixEpoch | date "..." }}` work.
+func dateInZone(fmt string, date interface{}, zone string) string {
+	var t time.Time
+
+	switch v := date.(type) {
+	case time.Time:
+		t = v
+	case *time.Time:
+		t = *v
+	case int64:
+		t = time.Unix(v, 0)
+	case int:
+		t = time.Unix(int64(v), 0)
+	case int32:
+		t = time.Unix(int64(v), 0)
+	case string:
+		if epoch, err := strconv.ParseInt(v, 10, 64); err == nil {
+			t = time.Unix(epoch, 0)
+		} else {
+			t = time.Now()
+		}
+	default:
+		t = time.Now()
+	}
+
+	loc, err := time.LoadLocation(zone)
+	if err != nil {
+		loc, _ = time.LoadLocation("UTC")
+	}
+
+	return t.In(loc).Format(fmt)
+}
+
+func ompDate(fmt string, date interface{}) string {
+	return dateInZone(fmt, date, "Local")
+}
+
+func ompDateInZone(fmt string, date interface{}, zone string) string {
+	return dateInZone(fmt, date, zone)
+}
+
+func ompHTMLDate(date interface{}) string {
+	return dateInZone("2006-01-02", date, "Local")
+}
+
+func ompHTMLDateInZone(date interface{}, zone string) string {
+	return dateInZone("2006-01-02", date, zone)
+}

--- a/src/template/date.go
+++ b/src/template/date.go
@@ -9,7 +9,7 @@ import (
 // epoch values. Sprig's unixEpoch returns a string, which sprig's own date functions
 // do not handle — they fall through to time.Now(). This wrapper parses numeric strings
 // as Unix timestamps so that patterns like `{{ now | unixEpoch | date "..." }}` work.
-func dateInZone(fmt string, date interface{}, zone string) string {
+func dateInZone(fmt string, date any, zone string) string {
 	var t time.Time
 
 	switch v := date.(type) {
@@ -41,18 +41,18 @@ func dateInZone(fmt string, date interface{}, zone string) string {
 	return t.In(loc).Format(fmt)
 }
 
-func ompDate(fmt string, date interface{}) string {
+func ompDate(fmt string, date any) string {
 	return dateInZone(fmt, date, "Local")
 }
 
-func ompDateInZone(fmt string, date interface{}, zone string) string {
+func ompDateInZone(fmt string, date any, zone string) string {
 	return dateInZone(fmt, date, zone)
 }
 
-func ompHTMLDate(date interface{}) string {
+func ompHTMLDate(date any) string {
 	return dateInZone("2006-01-02", date, "Local")
 }
 
-func ompHTMLDateInZone(date interface{}, zone string) string {
+func ompHTMLDateInZone(date any, zone string) string {
 	return dateInZone("2006-01-02", date, zone)
 }

--- a/src/template/date_test.go
+++ b/src/template/date_test.go
@@ -21,10 +21,10 @@ func TestDateFromStringEpoch(t *testing.T) {
 
 	// Use date_in_zone with UTC so tests are timezone-independent.
 	cases := []struct {
+		Context  any
 		Case     string
 		Expected string
 		Template string
-		Context  any
 	}{
 		{
 			Case:     "string epoch via date_in_zone",
@@ -89,10 +89,10 @@ func TestDateAndHTMLDateFunctions(t *testing.T) {
 	epochStr := fmt.Sprintf("%d", knownEpoch)
 
 	cases := []struct {
+		Context  any
 		Case     string
 		Expected string
 		Template string
-		Context  any
 	}{
 		{
 			Case:     "date function with string epoch",

--- a/src/template/date_test.go
+++ b/src/template/date_test.go
@@ -79,4 +79,3 @@ func TestDateFromStringEpoch(t *testing.T) {
 		}
 	}
 }
-

--- a/src/template/date_test.go
+++ b/src/template/date_test.go
@@ -79,3 +79,43 @@ func TestDateFromStringEpoch(t *testing.T) {
 		}
 	}
 }
+
+func TestDateAndHTMLDateFunctions(t *testing.T) {
+	// Override time.Local to UTC so `date` and `htmlDate` produce deterministic output.
+	origLocal := time.Local
+	time.Local = time.UTC
+	defer func() { time.Local = origLocal }()
+
+	epochStr := fmt.Sprintf("%d", knownEpoch)
+
+	cases := []struct {
+		Case     string
+		Expected string
+		Template string
+		Context  any
+	}{
+		{
+			Case:     "date function with string epoch",
+			Expected: "13 Jun 19 20:39 +0000",
+			Template: `{{ date "02 Jan 06 15:04 -0700" .Epoch }}`,
+			Context:  struct{ Epoch string }{Epoch: epochStr},
+		},
+		{
+			Case:     "htmlDate function with zero string epoch",
+			Expected: "1970-01-01",
+			Template: `{{ htmlDate .Epoch }}`,
+			Context:  struct{ Epoch string }{Epoch: "0"},
+		},
+	}
+
+	for _, tc := range cases {
+		env := new(mock.Environment)
+		env.On("Shell").Return("foo")
+		Cache = new(cache.Template)
+		Init(env, nil, nil)
+
+		text, err := Render(tc.Template, tc.Context)
+		assert.NoError(t, err, tc.Case)
+		assert.Equal(t, tc.Expected, text, tc.Case)
+	}
+}

--- a/src/template/date_test.go
+++ b/src/template/date_test.go
@@ -1,0 +1,82 @@
+package template
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/cache"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// knownEpoch is 2019-06-13 20:39:39 UTC, matching sprig's own test fixture.
+const knownEpoch = int64(1560458379)
+
+func TestDateFromStringEpoch(t *testing.T) {
+	// This is the core regression: unixEpoch returns a string, and piping that
+	// string into `date` must produce the correct formatted date, not time.Now().
+	epochStr := fmt.Sprintf("%d", knownEpoch)
+
+	// Use date_in_zone with UTC so tests are timezone-independent.
+	cases := []struct {
+		Case     string
+		Expected string
+		Template string
+		Context  any
+	}{
+		{
+			Case:     "string epoch via date_in_zone",
+			Expected: "13 Jun 19 20:39 +0000",
+			Template: `{{ date_in_zone "02 Jan 06 15:04 -0700" .Epoch "UTC" }}`,
+			Context:  struct{ Epoch string }{Epoch: epochStr},
+		},
+		{
+			Case:     "int64 epoch via date_in_zone",
+			Expected: "13 Jun 19 20:39 +0000",
+			Template: `{{ date_in_zone "02 Jan 06 15:04 -0700" .Epoch "UTC" }}`,
+			Context:  struct{ Epoch int64 }{Epoch: knownEpoch},
+		},
+		{
+			Case:     "time.Time via date_in_zone",
+			Expected: "13 Jun 19 20:39 +0000",
+			Template: `{{ date_in_zone "02 Jan 06 15:04 -0700" .Epoch "UTC" }}`,
+			Context:  struct{ Epoch time.Time }{Epoch: time.Unix(knownEpoch, 0).UTC()},
+		},
+		{
+			Case:     "string epoch direct call dateInZone",
+			Expected: "13 Jun 19 20:39 +0000",
+			Template: `{{ dateInZone "02 Jan 06 15:04 -0700" .Epoch "UTC" }}`,
+			Context:  struct{ Epoch string }{Epoch: epochStr},
+		},
+		{
+			Case:     "htmlDate with zero string epoch",
+			Expected: "1970-01-01",
+			Template: `{{ htmlDateInZone .Epoch "UTC" }}`,
+			Context:  struct{ Epoch string }{Epoch: "0"},
+		},
+		{
+			Case:     "non-numeric string falls back to current time (not panic)",
+			Template: `{{ date_in_zone "02 Jan 06" .Epoch "UTC" }}`,
+			Context:  struct{ Epoch string }{Epoch: "not-a-number"},
+			// Expected is time-dependent; we just verify no error is returned.
+		},
+	}
+
+	for _, tc := range cases {
+		env := new(mock.Environment)
+		env.On("Shell").Return("foo")
+		Cache = new(cache.Template)
+		Init(env, nil, nil)
+
+		text, err := Render(tc.Template, tc.Context)
+		assert.NoError(t, err, tc.Case)
+		if tc.Expected != "" {
+			assert.Equal(t, tc.Expected, text, tc.Case)
+		} else {
+			assert.NotEmpty(t, text, tc.Case)
+		}
+	}
+}
+

--- a/src/template/func_map.go
+++ b/src/template/func_map.go
@@ -27,6 +27,12 @@ func funcMap() template.FuncMap {
 		"stat":         stat,
 		"dir":          filepath.Dir,
 		"base":         filepath.Base,
+		// Override sprig date functions to support string epoch values (e.g. output of unixEpoch).
+		"date":           ompDate,
+		"date_in_zone":   ompDateInZone,
+		"dateInZone":     ompDateInZone,
+		"htmlDate":       ompHTMLDate,
+		"htmlDateInZone": ompHTMLDateInZone,
 	}
 
 	for key, fun := range sprig.TxtFuncMap() {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

Fixes #7470.

Templates like `{{ $n := (now|unixEpoch) }}{{ $n | date "Mon 2/Jan 15:04" }}` always rendered the current time instead of the time represented by `$n`.

**Root cause:** Sprig's `unixEpoch` returns a `string`. Sprig's `dateInZone` -- used internally by `date`, `date_in_zone`, `dateInZone`, `htmlDate`, and `htmlDateInZone` -- handles `time.Time`, `int64`, `int`, and `int32`, but has no `case string:` branch. Any string input falls through to `default: t = time.Now()`.

**Fix:** Override those five date-related sprig functions in OMP's `funcMap` with wrappers that parse a numeric string as a base-10 `int64` Unix epoch before delegating to the same formatting logic. All other input types retain existing sprig behavior.

Three files changed:
- `src/template/date.go` (new) -- local `dateInZone` with a `case string:` branch, plus thin wrapper helpers
- `src/template/func_map.go` -- registers the five overrides before the sprig merge loop so they shadow the originals
- `src/template/date_test.go` (new) -- table-driven tests covering string epoch, `int64` epoch, `time.Time`, and non-numeric fallback

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary