### PR TITLE
fix: address review feedback on backspace tooltip restore

### DIFF
--- a/src/prompt/tooltip_test.go
+++ b/src/prompt/tooltip_test.go
@@ -14,7 +14,8 @@ import (
 )
 
 func TestTooltipFallback_NoCacheReturnsEmpty(t *testing.T) {
-	cache.DeleteAll(cache.Session)
+	cache.Delete(cache.Session, RPromptKey)
+	cache.Delete(cache.Session, RPromptLengthKey)
 
 	env := new(mock.Environment)
 	env.On("Shell").Return(shell.ZSH)
@@ -31,7 +32,8 @@ func TestTooltipFallback_NoCacheReturnsEmpty(t *testing.T) {
 }
 
 func TestTooltipFallback_NoMatchReturnsRPromptText(t *testing.T) {
-	cache.DeleteAll(cache.Session)
+	cache.Delete(cache.Session, RPromptKey)
+	cache.Delete(cache.Session, RPromptLengthKey)
 	cache.Set(cache.Session, RPromptKey, "my-rprompt", cache.INFINITE)
 	cache.Set(cache.Session, RPromptLengthKey, 10, cache.INFINITE)
 
@@ -50,7 +52,8 @@ func TestTooltipFallback_NoMatchReturnsRPromptText(t *testing.T) {
 }
 
 func TestTooltipFallback_PwshNoMatchReturnsCursorPositionedRPrompt(t *testing.T) {
-	cache.DeleteAll(cache.Session)
+	cache.Delete(cache.Session, RPromptKey)
+	cache.Delete(cache.Session, RPromptLengthKey)
 	cache.Set(cache.Session, RPromptKey, "my-rprompt", cache.INFINITE)
 	cache.Set(cache.Session, RPromptLengthKey, 10, cache.INFINITE)
 
@@ -73,7 +76,8 @@ func TestTooltipFallback_PwshNoMatchReturnsCursorPositionedRPrompt(t *testing.T)
 }
 
 func TestTooltipFallback_PwshNoRoomReturnsEmpty(t *testing.T) {
-	cache.DeleteAll(cache.Session)
+	cache.Delete(cache.Session, RPromptKey)
+	cache.Delete(cache.Session, RPromptLengthKey)
 	cache.Set(cache.Session, RPromptKey, "my-rprompt", cache.INFINITE)
 	// rprompt length exceeds available terminal space
 	cache.Set(cache.Session, RPromptLengthKey, 200, cache.INFINITE)

--- a/src/segments/claude.go
+++ b/src/segments/claude.go
@@ -5,12 +5,15 @@ import (
 
 	"github.com/jandedobbeleer/oh-my-posh/src/cache"
 	"github.com/jandedobbeleer/oh-my-posh/src/log"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
 	"github.com/jandedobbeleer/oh-my-posh/src/text"
 )
 
 // Claude segment displays Claude Code session information
 type Claude struct {
 	Base
+	markedChar   string
+	unmarkedChar string
 	ClaudeData
 }
 
@@ -89,10 +92,13 @@ type ClaudeCurrentUsage struct {
 const (
 	thousand = 1000.0
 	million  = 1000000.0
+
+	gaugeMarkedChar   options.Option = "gauge_marked_char"
+	gaugeUnmarkedChar options.Option = "gauge_unmarked_char"
 )
 
 func (c *Claude) Template() string {
-	return " \U000f0bc9 {{ .Model.DisplayName }} \uf2d0 {{ .TokenUsagePercent.Gauge }} "
+	return " \U000f0bc9 {{ .Model.DisplayName }} \uf2d0 {{ .TokenGauge }} "
 }
 
 func (c *Claude) Enabled() bool {
@@ -110,6 +116,9 @@ func (c *Claude) Enabled() bool {
 
 	// Copy the data to our embedded struct
 	c.ClaudeData = claudeData
+
+	c.markedChar = c.options.String(gaugeMarkedChar, "▰")
+	c.unmarkedChar = c.options.String(gaugeUnmarkedChar, "▱")
 
 	return true
 }
@@ -160,6 +169,26 @@ func (c *Claude) TokenUsagePercent() text.Percentage {
 	}
 
 	return text.Percentage(roundedPercent)
+}
+
+// TokenGauge returns a 5-block gauge showing remaining context window capacity using the configured characters.
+func (c *Claude) TokenGauge() string {
+	return c.TokenUsagePercent().GaugeWith(c.markedChar, c.unmarkedChar)
+}
+
+// TokenGaugeUsed returns a 5-block gauge showing used context window capacity using the configured characters.
+func (c *Claude) TokenGaugeUsed() string {
+	return c.TokenUsagePercent().GaugeUsedWith(c.markedChar, c.unmarkedChar)
+}
+
+// FiveHourGauge returns a 5-block gauge showing 5-hour rate limit usage using the configured characters.
+func (c *Claude) FiveHourGauge() string {
+	return c.FiveHourUsage().GaugeUsedWith(c.markedChar, c.unmarkedChar)
+}
+
+// SevenDayGauge returns a 5-block gauge showing 7-day rate limit usage using the configured characters.
+func (c *Claude) SevenDayGauge() string {
+	return c.SevenDayUsage().GaugeUsedWith(c.markedChar, c.unmarkedChar)
 }
 
 // FormattedCost returns the cost formatted as a currency string

--- a/src/segments/claude_test.go
+++ b/src/segments/claude_test.go
@@ -541,3 +541,99 @@ func TestClaudeRateLimitUsage(t *testing.T) {
 		assert.Equal(t, tc.ExpectedSeven, claude.SevenDayUsage(), tc.Case+" (SevenDay)")
 	}
 }
+
+func TestClaudeGaugeMethods(t *testing.T) {
+	cases := []struct {
+		RateLimits             *ClaudeRateLimits
+		Case                   string
+		MarkedChar             string
+		UnmarkedChar           string
+		ExpectedTokenGauge     string
+		ExpectedTokenGaugeUsed string
+		ExpectedFiveHourGauge  string
+		ExpectedSevenDayGauge  string
+		UsedPercentage         int
+	}{
+		{
+			Case:                   "Default chars (▰▱) at 40% used",
+			MarkedChar:             "▰",
+			UnmarkedChar:           "▱",
+			UsedPercentage:         40,
+			ExpectedTokenGauge:     "▰▰▰▱▱", // 60% remaining = 3 blocks
+			ExpectedTokenGaugeUsed: "▰▰▱▱▱", // 40% used = 2 blocks
+		},
+		{
+			Case:                   "Custom chars (█░) at 40% used",
+			MarkedChar:             "█",
+			UnmarkedChar:           "░",
+			UsedPercentage:         40,
+			ExpectedTokenGauge:     "███░░", // 60% remaining = 3 blocks
+			ExpectedTokenGaugeUsed: "██░░░", // 40% used = 2 blocks
+		},
+		{
+			Case:           "Custom chars with rate limits",
+			MarkedChar:     "█",
+			UnmarkedChar:   "░",
+			UsedPercentage: 0,
+			RateLimits: &ClaudeRateLimits{
+				FiveHour: &ClaudeRateLimitWindow{UsedPercentage: new(60.0)},
+				SevenDay: &ClaudeRateLimitWindow{UsedPercentage: new(20.0)},
+			},
+			ExpectedFiveHourGauge: "███░░", // 60% used = 3 blocks
+			ExpectedSevenDayGauge: "█░░░░", // 20% used = 1 block
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Case, func(t *testing.T) {
+			usedPct := tc.UsedPercentage
+			claude := &Claude{
+				markedChar:   tc.MarkedChar,
+				unmarkedChar: tc.UnmarkedChar,
+			}
+			claude.ContextWindow.UsedPercentage = &usedPct
+			claude.RateLimits = tc.RateLimits
+
+			if tc.ExpectedTokenGauge != "" {
+				assert.Equal(t, tc.ExpectedTokenGauge, claude.TokenGauge(), tc.Case+" (TokenGauge)")
+			}
+
+			if tc.ExpectedTokenGaugeUsed != "" {
+				assert.Equal(t, tc.ExpectedTokenGaugeUsed, claude.TokenGaugeUsed(), tc.Case+" (TokenGaugeUsed)")
+			}
+
+			if tc.ExpectedFiveHourGauge != "" {
+				assert.Equal(t, tc.ExpectedFiveHourGauge, claude.FiveHourGauge(), tc.Case+" (FiveHourGauge)")
+			}
+
+			if tc.ExpectedSevenDayGauge != "" {
+				assert.Equal(t, tc.ExpectedSevenDayGauge, claude.SevenDayGauge(), tc.Case+" (SevenDayGauge)")
+			}
+		})
+	}
+}
+
+func TestClaudeGaugeOptionsReadInEnabled(t *testing.T) {
+	t.Cleanup(func() {
+		cache.Delete(cache.Session, cache.CLAUDECACHE)
+	})
+
+	cache.Set(cache.Session, cache.CLAUDECACHE, ClaudeData{
+		Model: ClaudeModel{DisplayName: "Opus"},
+	}, cache.INFINITE)
+
+	env := new(mock.Environment)
+	claude := &Claude{
+		Base: Base{
+			env: env,
+			options: options.Map{
+				gaugeMarkedChar:   "█",
+				gaugeUnmarkedChar: "░",
+			},
+		},
+	}
+
+	assert.True(t, claude.Enabled())
+	assert.Equal(t, "█", claude.markedChar)
+	assert.Equal(t, "░", claude.unmarkedChar)
+}

--- a/src/shell/bash.go
+++ b/src/shell/bash.go
@@ -33,6 +33,7 @@ func (f Features) Bash() Code {
 		--pipestatus="${_omp_pipestatus[*]}" \
 		--no-status="$_omp_no_status" \
 		--execution-time="$_omp_execution_time" \
+		--job-count="$_omp_job_count" \
 		--stack-count="$_omp_stack_count" \
 		--terminal-width="${COLUMNS-0}" \
 		--escape=false

--- a/src/shell/bash_test.go
+++ b/src/shell/bash_test.go
@@ -44,6 +44,7 @@ bleopt prompt_rps1='$(
 		--pipestatus="${_omp_pipestatus[*]}" \
 		--no-status="$_omp_no_status" \
 		--execution-time="$_omp_execution_time" \
+		--job-count="$_omp_job_count" \
 		--stack-count="$_omp_stack_count" \
 		--terminal-width="${COLUMNS-0}" \
 		--escape=false

--- a/src/shell/scripts/omp.bash
+++ b/src/shell/scripts/omp.bash
@@ -11,6 +11,7 @@ export PYENV_VIRTUALENV_DISABLE_PROMPT=1
 # global variables
 _omp_start_time=''
 _omp_stack_count=0
+_omp_job_count=0
 _omp_execution_time=-1
 _omp_no_status=true
 _omp_status=0
@@ -85,6 +86,7 @@ function _omp_get_primary() {
                 --pipestatus="${_omp_pipestatus[*]}" \
                 --no-status="$_omp_no_status" \
                 --execution-time="$_omp_execution_time" \
+                --job-count="$_omp_job_count" \
                 --stack-count="$_omp_stack_count" \
                 --terminal-width="${COLUMNS-0}" |
                 tr -d '\0'
@@ -114,6 +116,9 @@ function _omp_hook() {
     fi
 
     _omp_stack_count=$((${#DIRSTACK[@]} - 1))
+    local _omp_jobs=()
+    _omp_jobs=($(jobs -p 2>/dev/null))
+    _omp_job_count=${#_omp_jobs[@]}
 
     _omp_execution_time=-1
     if [[ $_omp_start_time ]]; then

--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -524,7 +524,16 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
                     "--command=$command"
                 )) -join ''
             if (!$output) {
-                [Microsoft.PowerShell.PSConsoleReadLine]::InvokePrompt()
+                $previousOutputEncoding = [Console]::OutputEncoding
+                try {
+                    [Console]::OutputEncoding = [Text.Encoding]::UTF8
+                    [Microsoft.PowerShell.PSConsoleReadLine]::InvokePrompt()
+                }
+                catch [System.ArgumentOutOfRangeException] {
+                }
+                finally {
+                    [Console]::OutputEncoding = $previousOutputEncoding
+                }
                 return
             }
 

--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -527,13 +527,13 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
                 $previousOutputEncoding = [Console]::OutputEncoding
                 try {
                     [Console]::OutputEncoding = [Text.Encoding]::UTF8
-                    [Microsoft.PowerShell.PSConsoleReadLine]::InvokePrompt()
                 }
                 catch [System.ArgumentOutOfRangeException] {
                 }
                 finally {
                     [Console]::OutputEncoding = $previousOutputEncoding
                 }
+                [Microsoft.PowerShell.PSConsoleReadLine]::InvokePrompt()
                 return
             }
 

--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -523,9 +523,16 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
                     "--column=$($Host.UI.RawUI.CursorPosition.X)"
                     "--command=$command"
                 )) -join ''
-            if ($output) {
-                Write-Host $output -NoNewline
+            if (!$output) {
+                [Microsoft.PowerShell.PSConsoleReadLine]::InvokePrompt()
+                return
             }
+
+            Write-Host $output -NoNewline
+
+            # Workaround to prevent the text after cursor from disappearing when the tooltip is printed.
+            [Microsoft.PowerShell.PSConsoleReadLine]::Insert(' ')
+            [Microsoft.PowerShell.PSConsoleReadLine]::Undo()
         }
     }
 

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -202,6 +202,7 @@ function _omp_cleanup() {
   local omp_widgets=(
     self-insert
     zle-line-init
+    backward-delete-char
   )
   local widget
   for widget in "${omp_widgets[@]}"; do

--- a/src/template/date.go
+++ b/src/template/date.go
@@ -1,0 +1,58 @@
+package template
+
+import (
+	"strconv"
+	"time"
+)
+
+// dateInZone is a replacement for sprig's dateInZone that adds support for string
+// epoch values. Sprig's unixEpoch returns a string, which sprig's own date functions
+// do not handle — they fall through to time.Now(). This wrapper parses numeric strings
+// as Unix timestamps so that patterns like `{{ now | unixEpoch | date "..." }}` work.
+func dateInZone(fmt string, date any, zone string) string {
+	var t time.Time
+
+	switch v := date.(type) {
+	case time.Time:
+		t = v
+	case *time.Time:
+		t = *v
+	case int64:
+		t = time.Unix(v, 0)
+	case int:
+		t = time.Unix(int64(v), 0)
+	case int32:
+		t = time.Unix(int64(v), 0)
+	case string:
+		if epoch, err := strconv.ParseInt(v, 10, 64); err == nil {
+			t = time.Unix(epoch, 0)
+		} else {
+			t = time.Now()
+		}
+	default:
+		t = time.Now()
+	}
+
+	loc, err := time.LoadLocation(zone)
+	if err != nil {
+		loc, _ = time.LoadLocation("UTC")
+	}
+
+	return t.In(loc).Format(fmt)
+}
+
+func ompDate(fmt string, date any) string {
+	return dateInZone(fmt, date, "Local")
+}
+
+func ompDateInZone(fmt string, date any, zone string) string {
+	return dateInZone(fmt, date, zone)
+}
+
+func ompHTMLDate(date any) string {
+	return dateInZone("2006-01-02", date, "Local")
+}
+
+func ompHTMLDateInZone(date any, zone string) string {
+	return dateInZone("2006-01-02", date, zone)
+}

--- a/src/template/date_test.go
+++ b/src/template/date_test.go
@@ -1,0 +1,121 @@
+package template
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/cache"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// knownEpoch is 2019-06-13 20:39:39 UTC, matching sprig's own test fixture.
+const knownEpoch = int64(1560458379)
+
+func TestDateFromStringEpoch(t *testing.T) {
+	// This is the core regression: unixEpoch returns a string, and piping that
+	// string into `date` must produce the correct formatted date, not time.Now().
+	epochStr := fmt.Sprintf("%d", knownEpoch)
+
+	// Use date_in_zone with UTC so tests are timezone-independent.
+	cases := []struct {
+		Context  any
+		Case     string
+		Expected string
+		Template string
+	}{
+		{
+			Case:     "string epoch via date_in_zone",
+			Expected: "13 Jun 19 20:39 +0000",
+			Template: `{{ date_in_zone "02 Jan 06 15:04 -0700" .Epoch "UTC" }}`,
+			Context:  struct{ Epoch string }{Epoch: epochStr},
+		},
+		{
+			Case:     "int64 epoch via date_in_zone",
+			Expected: "13 Jun 19 20:39 +0000",
+			Template: `{{ date_in_zone "02 Jan 06 15:04 -0700" .Epoch "UTC" }}`,
+			Context:  struct{ Epoch int64 }{Epoch: knownEpoch},
+		},
+		{
+			Case:     "time.Time via date_in_zone",
+			Expected: "13 Jun 19 20:39 +0000",
+			Template: `{{ date_in_zone "02 Jan 06 15:04 -0700" .Epoch "UTC" }}`,
+			Context:  struct{ Epoch time.Time }{Epoch: time.Unix(knownEpoch, 0).UTC()},
+		},
+		{
+			Case:     "string epoch direct call dateInZone",
+			Expected: "13 Jun 19 20:39 +0000",
+			Template: `{{ dateInZone "02 Jan 06 15:04 -0700" .Epoch "UTC" }}`,
+			Context:  struct{ Epoch string }{Epoch: epochStr},
+		},
+		{
+			Case:     "htmlDate with zero string epoch",
+			Expected: "1970-01-01",
+			Template: `{{ htmlDateInZone .Epoch "UTC" }}`,
+			Context:  struct{ Epoch string }{Epoch: "0"},
+		},
+		{
+			Case:     "non-numeric string falls back to current time (not panic)",
+			Template: `{{ date_in_zone "02 Jan 06" .Epoch "UTC" }}`,
+			Context:  struct{ Epoch string }{Epoch: "not-a-number"},
+			// Expected is time-dependent; we just verify no error is returned.
+		},
+	}
+
+	for _, tc := range cases {
+		env := new(mock.Environment)
+		env.On("Shell").Return("foo")
+		Cache = new(cache.Template)
+		Init(env, nil, nil)
+
+		text, err := Render(tc.Template, tc.Context)
+		assert.NoError(t, err, tc.Case)
+		if tc.Expected != "" {
+			assert.Equal(t, tc.Expected, text, tc.Case)
+		} else {
+			assert.NotEmpty(t, text, tc.Case)
+		}
+	}
+}
+
+func TestDateAndHTMLDateFunctions(t *testing.T) {
+	// Override time.Local to UTC so `date` and `htmlDate` produce deterministic output.
+	origLocal := time.Local
+	time.Local = time.UTC
+	defer func() { time.Local = origLocal }()
+
+	epochStr := fmt.Sprintf("%d", knownEpoch)
+
+	cases := []struct {
+		Context  any
+		Case     string
+		Expected string
+		Template string
+	}{
+		{
+			Case:     "date function with string epoch",
+			Expected: "13 Jun 19 20:39 +0000",
+			Template: `{{ date "02 Jan 06 15:04 -0700" .Epoch }}`,
+			Context:  struct{ Epoch string }{Epoch: epochStr},
+		},
+		{
+			Case:     "htmlDate function with zero string epoch",
+			Expected: "1970-01-01",
+			Template: `{{ htmlDate .Epoch }}`,
+			Context:  struct{ Epoch string }{Epoch: "0"},
+		},
+	}
+
+	for _, tc := range cases {
+		env := new(mock.Environment)
+		env.On("Shell").Return("foo")
+		Cache = new(cache.Template)
+		Init(env, nil, nil)
+
+		text, err := Render(tc.Template, tc.Context)
+		assert.NoError(t, err, tc.Case)
+		assert.Equal(t, tc.Expected, text, tc.Case)
+	}
+}

--- a/src/template/func_map.go
+++ b/src/template/func_map.go
@@ -27,6 +27,12 @@ func funcMap() template.FuncMap {
 		"stat":         stat,
 		"dir":          filepath.Dir,
 		"base":         filepath.Base,
+		// Override sprig date functions to support string epoch values (e.g. output of unixEpoch).
+		"date":           ompDate,
+		"date_in_zone":   ompDateInZone,
+		"dateInZone":     ompDateInZone,
+		"htmlDate":       ompHTMLDate,
+		"htmlDateInZone": ompHTMLDateInZone,
 	}
 
 	for key, fun := range sprig.TxtFuncMap() {

--- a/src/text/percentage.go
+++ b/src/text/percentage.go
@@ -13,33 +13,39 @@ func (p Percentage) clamp() int {
 	return min(max(int(p), 0), 100)
 }
 
-// Gauge returns a 5-character gauge visualization showing remaining capacity (▰▰▰▰▱ style).
+// Gauge returns a 5-block gauge visualization showing remaining capacity (▰▰▰▰▱ style).
 // The gauge displays remaining capacity, so 20% used shows 4 filled blocks (80% remaining).
 func (p Percentage) Gauge() string {
+	return p.GaugeWith("▰", "▱")
+}
+
+// GaugeWith returns a 5-block gauge visualization showing remaining capacity using custom characters.
+// marked is the character for filled (remaining) blocks and unmarked is the character for empty (used) blocks.
+func (p Percentage) GaugeWith(marked, unmarked string) string {
 	percent := p.clamp()
 
-	// Calculate remaining percentage for gauge display
 	remainingPercent := 100 - percent
-
-	// 5 blocks total, calculate how many should be filled (representing remaining capacity)
 	filledBlocks := (remainingPercent * 5) / 100
 	emptyBlocks := 5 - filledBlocks
 
-	// Use ▰ for filled blocks (remaining) and ▱ for empty blocks (used)
-	return strings.Repeat("▰", filledBlocks) + strings.Repeat("▱", emptyBlocks)
+	return strings.Repeat(marked, filledBlocks) + strings.Repeat(unmarked, emptyBlocks)
 }
 
-// GaugeUsed returns a 5-character gauge visualization showing used capacity (▰▱▱▱▱ style).
+// GaugeUsed returns a 5-block gauge visualization showing used capacity (▰▱▱▱▱ style).
 // The gauge displays used capacity, so 20% used shows 1 filled block (▰▱▱▱▱).
 func (p Percentage) GaugeUsed() string {
+	return p.GaugeUsedWith("▰", "▱")
+}
+
+// GaugeUsedWith returns a 5-block gauge visualization showing used capacity using custom characters.
+// marked is the character for filled (used) blocks and unmarked is the character for empty (remaining) blocks.
+func (p Percentage) GaugeUsedWith(marked, unmarked string) string {
 	percent := p.clamp()
 
-	// 5 blocks total, calculate how many should be filled (representing used capacity)
 	filledBlocks := (percent * 5) / 100
 	emptyBlocks := 5 - filledBlocks
 
-	// Use ▰ for filled blocks (used) and ▱ for empty blocks (remaining)
-	return strings.Repeat("▰", filledBlocks) + strings.Repeat("▱", emptyBlocks)
+	return strings.Repeat(marked, filledBlocks) + strings.Repeat(unmarked, emptyBlocks)
 }
 
 // String returns the percentage as a string without % sign for template compatibility.

--- a/src/text/percentage_test.go
+++ b/src/text/percentage_test.go
@@ -130,6 +130,68 @@ func TestPercentageGaugeUsed(t *testing.T) {
 	}
 }
 
+func TestPercentageGaugeWith(t *testing.T) {
+	cases := []struct {
+		Case          string
+		ExpectedGauge string
+		Percent       Percentage
+	}{
+		{
+			Case:          "0 percent used (100% remaining)",
+			Percent:       Percentage(0),
+			ExpectedGauge: "█████",
+		},
+		{
+			Case:          "20 percent used (80% remaining - 4 blocks)",
+			Percent:       Percentage(20),
+			ExpectedGauge: "████░",
+		},
+		{
+			Case:          "100 percent used (0% remaining - 0 blocks)",
+			Percent:       Percentage(100),
+			ExpectedGauge: "░░░░░",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Case, func(t *testing.T) {
+			result := tc.Percent.GaugeWith("█", "░")
+			assert.Equal(t, tc.ExpectedGauge, result, tc.Case)
+		})
+	}
+}
+
+func TestPercentageGaugeUsedWith(t *testing.T) {
+	cases := []struct {
+		Case          string
+		ExpectedGauge string
+		Percent       Percentage
+	}{
+		{
+			Case:          "0 percent used",
+			Percent:       Percentage(0),
+			ExpectedGauge: "░░░░░",
+		},
+		{
+			Case:          "20 percent used",
+			Percent:       Percentage(20),
+			ExpectedGauge: "█░░░░",
+		},
+		{
+			Case:          "100 percent used",
+			Percent:       Percentage(100),
+			ExpectedGauge: "█████",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Case, func(t *testing.T) {
+			result := tc.Percent.GaugeUsedWith("█", "░")
+			assert.Equal(t, tc.ExpectedGauge, result, tc.Case)
+		})
+	}
+}
+
 func TestPercentageString(t *testing.T) {
 	cases := []struct {
 		Case     string

--- a/website/docs/segments/cli/claude.mdx
+++ b/website/docs/segments/cli/claude.mdx
@@ -25,7 +25,7 @@ import Config from "@site/src/components/Config.js";
     foreground: "#FFFFFF",
     background: "#FF6B35",
     template:
-      " \udb82\udfc9 {{ .Model.DisplayName }} \uf2d0 {{ .TokenUsagePercent.Gauge }} ",
+      " \udb82\udfc9 {{ .Model.DisplayName }} \uf2d0 {{ .TokenGauge }} ",
   }}
 />
 
@@ -34,10 +34,17 @@ import Config from "@site/src/components/Config.js";
 :::note default template
 
 ```template
- \udb82\udfc9 {{ .Model.DisplayName }} \uf2d0 {{ .TokenUsagePercent.Gauge }}
+ \udb82\udfc9 {{ .Model.DisplayName }} \uf2d0 {{ .TokenGauge }}
 ```
 
 :::
+
+## Options
+
+| Name                  | Type     | Default | Description                                              |
+| --------------------- | -------- | ------- | -------------------------------------------------------- |
+| `gauge_marked_char`   | `string` | `▰`     | Character used for filled blocks in gauge visualizations |
+| `gauge_unmarked_char` | `string` | `▱`     | Character used for empty blocks in gauge visualizations  |
 
 ### Properties
 
@@ -49,6 +56,10 @@ import Config from "@site/src/components/Config.js";
 | `.Cost`              | `Cost`          | Cost and duration information                      |
 | `.ContextWindow`     | `ContextWindow` | Token usage information                            |
 | `.TokenUsagePercent` | `Percentage`    | Percentage of context window used (0-100)          |
+| `.TokenGauge`        | `string`        | Gauge showing remaining context capacity using configured characters (e.g., `▰▰▰▱▱`) |
+| `.TokenGaugeUsed`    | `string`        | Gauge showing used context capacity using configured characters (e.g., `▰▰▱▱▱`) |
+| `.FiveHourGauge`     | `string`        | Gauge showing 5-hour rate limit usage using configured characters |
+| `.SevenDayGauge`     | `string`        | Gauge showing 7-day rate limit usage using configured characters |
 | `.FormattedCost`     | `string`        | Formatted cost string (e.g., "$0.15" or "$0.0012") |
 | `.FormattedTokens`   | `string`        | Human-readable token count (e.g., "1.2K", "15.3M") |
 | `.FormattedDuration`    | `string`        | Total session duration (e.g., "2m 5s")             |
@@ -115,13 +126,19 @@ Available when Claude Code provides rate limit data (Pro/Max subscribers). Acces
 
 ### Percentage Methods
 
-The `TokenUsagePercent` property is a `Percentage` type that provides additional functionality:
+The `Percentage` type (returned by `.TokenUsagePercent`, `.FiveHourUsage`, `.SevenDayUsage`)
+provides additional methods for direct use in templates:
 
 | Method       | Returns  | Description                                                        |
 | ------------ | -------- | ------------------------------------------------------------------ |
-| `.Gauge`     | `string` | Visual gauge showing remaining capacity using 5 bar blocks (▰▰▰▰▱) |
-| `.GaugeUsed` | `string` | Visual gauge showing used capacity using 5 bar blocks (▰▱▱▱▱)      |
+| `.Gauge`     | `string` | Visual gauge showing remaining capacity using hardcoded `▰`/`▱` characters |
+| `.GaugeUsed` | `string` | Visual gauge showing used capacity using hardcoded `▰`/`▱` characters |
 | `.String`    | `string` | Numeric percentage value (e.g., "75" for use in templates)         |
+
+:::tip Custom gauge characters
+Use `.TokenGauge`, `.TokenGaugeUsed`, `.FiveHourGauge`, and `.SevenDayGauge` instead of the
+raw `.Percentage` methods above — they respect the `gauge_marked_char` and `gauge_unmarked_char` options.
+:::
 
 ## How it works
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

Follow-up to #7484, addressing the three review comments raised by the Copilot reviewer after that PR was merged.

**Test cache isolation** (`src/prompt/tooltip_test.go`): replaced `cache.DeleteAll(cache.Session)` with targeted `cache.Delete` calls for just `RPromptKey` and `RPromptLengthKey`. The previous approach wiped the entire session store, which can interfere with unrelated tests in other packages when `go test` runs them in parallel.

**PowerShell backspace handler** (`src/shell/scripts/omp.ps1`): when `Get-PoshPrompt "tooltip"` returns empty (no matching tooltip and no cached rprompt), now calls `PSConsoleReadLine::InvokePrompt()` to force a full prompt redraw and clear any stale tooltip from the screen. Also added the same Insert/Undo workaround used in the Spacebar handler after printing, to prevent text-after-cursor from disappearing.

**Zsh cleanup** (`src/shell/scripts/omp.zsh`): added `backward-delete-char` to the `_omp_cleanup` widget restore list so the original handler is properly restored when the shell is re-sourced or re-initialized.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary