### PR TITLE
feat(claude): add configurable gauge characters

### DIFF
--- a/src/segments/claude.go
+++ b/src/segments/claude.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/jandedobbeleer/oh-my-posh/src/cache"
 	"github.com/jandedobbeleer/oh-my-posh/src/log"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
 	"github.com/jandedobbeleer/oh-my-posh/src/text"
 )
 
@@ -12,6 +13,8 @@ import (
 type Claude struct {
 	Base
 	ClaudeData
+	markedChar   string
+	unmarkedChar string
 }
 
 // ClaudeData represents the parsed Claude JSON data
@@ -89,10 +92,13 @@ type ClaudeCurrentUsage struct {
 const (
 	thousand = 1000.0
 	million  = 1000000.0
+
+	gaugeMarkedChar   options.Option = "gauge_marked_char"
+	gaugeUnmarkedChar options.Option = "gauge_unmarked_char"
 )
 
 func (c *Claude) Template() string {
-	return " \U000f0bc9 {{ .Model.DisplayName }} \uf2d0 {{ .TokenUsagePercent.Gauge }} "
+	return " \U000f0bc9 {{ .Model.DisplayName }} \uf2d0 {{ .TokenGauge }} "
 }
 
 func (c *Claude) Enabled() bool {
@@ -110,6 +116,9 @@ func (c *Claude) Enabled() bool {
 
 	// Copy the data to our embedded struct
 	c.ClaudeData = claudeData
+
+	c.markedChar = c.options.String(gaugeMarkedChar, "▰")
+	c.unmarkedChar = c.options.String(gaugeUnmarkedChar, "▱")
 
 	return true
 }
@@ -160,6 +169,26 @@ func (c *Claude) TokenUsagePercent() text.Percentage {
 	}
 
 	return text.Percentage(roundedPercent)
+}
+
+// TokenGauge returns a 5-block gauge showing remaining context window capacity using the configured characters.
+func (c *Claude) TokenGauge() string {
+	return c.TokenUsagePercent().GaugeWith(c.markedChar, c.unmarkedChar)
+}
+
+// TokenGaugeUsed returns a 5-block gauge showing used context window capacity using the configured characters.
+func (c *Claude) TokenGaugeUsed() string {
+	return c.TokenUsagePercent().GaugeUsedWith(c.markedChar, c.unmarkedChar)
+}
+
+// FiveHourGauge returns a 5-block gauge showing 5-hour rate limit usage using the configured characters.
+func (c *Claude) FiveHourGauge() string {
+	return c.FiveHourUsage().GaugeUsedWith(c.markedChar, c.unmarkedChar)
+}
+
+// SevenDayGauge returns a 5-block gauge showing 7-day rate limit usage using the configured characters.
+func (c *Claude) SevenDayGauge() string {
+	return c.SevenDayUsage().GaugeUsedWith(c.markedChar, c.unmarkedChar)
 }
 
 // FormattedCost returns the cost formatted as a currency string

--- a/src/segments/claude.go
+++ b/src/segments/claude.go
@@ -12,9 +12,9 @@ import (
 // Claude segment displays Claude Code session information
 type Claude struct {
 	Base
-	ClaudeData
 	markedChar   string
 	unmarkedChar string
+	ClaudeData
 }
 
 // ClaudeData represents the parsed Claude JSON data

--- a/src/segments/claude_test.go
+++ b/src/segments/claude_test.go
@@ -573,9 +573,9 @@ func TestClaudeGaugeMethods(t *testing.T) {
 			ExpectedTokenGaugeUsed: "██░░░", // 40% used = 2 blocks
 		},
 		{
-			Case:         "Custom chars with rate limits",
-			MarkedChar:   "█",
-			UnmarkedChar: "░",
+			Case:           "Custom chars with rate limits",
+			MarkedChar:     "█",
+			UnmarkedChar:   "░",
 			UsedPercentage: 0,
 			RateLimits: &ClaudeRateLimits{
 				FiveHour: &ClaudeRateLimitWindow{UsedPercentage: new(60.0)},

--- a/src/segments/claude_test.go
+++ b/src/segments/claude_test.go
@@ -541,3 +541,101 @@ func TestClaudeRateLimitUsage(t *testing.T) {
 		assert.Equal(t, tc.ExpectedSeven, claude.SevenDayUsage(), tc.Case+" (SevenDay)")
 	}
 }
+
+func TestClaudeGaugeMethods(t *testing.T) {
+	cases := []struct {
+		RateLimits             *ClaudeRateLimits
+		Case                   string
+		MarkedChar             string
+		UnmarkedChar           string
+		ExpectedTokenGauge     string
+		ExpectedTokenGaugeUsed string
+		ExpectedFiveHourGauge  string
+		ExpectedSevenDayGauge  string
+		UsedPercentage         int
+		FiveHourPercent        float64
+		SevenDayPercent        float64
+	}{
+		{
+			Case:                   "Default chars (▰▱) at 40% used",
+			MarkedChar:             "▰",
+			UnmarkedChar:           "▱",
+			UsedPercentage:         40,
+			ExpectedTokenGauge:     "▰▰▰▱▱", // 60% remaining = 3 blocks
+			ExpectedTokenGaugeUsed: "▰▰▱▱▱", // 40% used = 2 blocks
+		},
+		{
+			Case:                   "Custom chars (█░) at 40% used",
+			MarkedChar:             "█",
+			UnmarkedChar:           "░",
+			UsedPercentage:         40,
+			ExpectedTokenGauge:     "███░░", // 60% remaining = 3 blocks
+			ExpectedTokenGaugeUsed: "██░░░", // 40% used = 2 blocks
+		},
+		{
+			Case:         "Custom chars with rate limits",
+			MarkedChar:   "█",
+			UnmarkedChar: "░",
+			UsedPercentage: 0,
+			RateLimits: &ClaudeRateLimits{
+				FiveHour: &ClaudeRateLimitWindow{UsedPercentage: new(60.0)},
+				SevenDay: &ClaudeRateLimitWindow{UsedPercentage: new(20.0)},
+			},
+			ExpectedFiveHourGauge: "███░░", // 60% used = 3 blocks
+			ExpectedSevenDayGauge: "█░░░░", // 20% used = 1 block
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Case, func(t *testing.T) {
+			usedPct := tc.UsedPercentage
+			claude := &Claude{
+				markedChar:   tc.MarkedChar,
+				unmarkedChar: tc.UnmarkedChar,
+			}
+			claude.ContextWindow.UsedPercentage = &usedPct
+			claude.RateLimits = tc.RateLimits
+
+			if tc.ExpectedTokenGauge != "" {
+				assert.Equal(t, tc.ExpectedTokenGauge, claude.TokenGauge(), tc.Case+" (TokenGauge)")
+			}
+
+			if tc.ExpectedTokenGaugeUsed != "" {
+				assert.Equal(t, tc.ExpectedTokenGaugeUsed, claude.TokenGaugeUsed(), tc.Case+" (TokenGaugeUsed)")
+			}
+
+			if tc.ExpectedFiveHourGauge != "" {
+				assert.Equal(t, tc.ExpectedFiveHourGauge, claude.FiveHourGauge(), tc.Case+" (FiveHourGauge)")
+			}
+
+			if tc.ExpectedSevenDayGauge != "" {
+				assert.Equal(t, tc.ExpectedSevenDayGauge, claude.SevenDayGauge(), tc.Case+" (SevenDayGauge)")
+			}
+		})
+	}
+}
+
+func TestClaudeGaugeOptionsReadInEnabled(t *testing.T) {
+	t.Cleanup(func() {
+		cache.Delete(cache.Session, cache.CLAUDECACHE)
+	})
+
+	cache.Set(cache.Session, cache.CLAUDECACHE, ClaudeData{
+		Model: ClaudeModel{DisplayName: "Opus"},
+	}, cache.INFINITE)
+
+	env := new(mock.Environment)
+	claude := &Claude{
+		Base: Base{
+			env: env,
+			options: options.Map{
+				gaugeMarkedChar:   "█",
+				gaugeUnmarkedChar: "░",
+			},
+		},
+	}
+
+	assert.True(t, claude.Enabled())
+	assert.Equal(t, "█", claude.markedChar)
+	assert.Equal(t, "░", claude.unmarkedChar)
+}

--- a/src/segments/claude_test.go
+++ b/src/segments/claude_test.go
@@ -553,8 +553,6 @@ func TestClaudeGaugeMethods(t *testing.T) {
 		ExpectedFiveHourGauge  string
 		ExpectedSevenDayGauge  string
 		UsedPercentage         int
-		FiveHourPercent        float64
-		SevenDayPercent        float64
 	}{
 		{
 			Case:                   "Default chars (▰▱) at 40% used",

--- a/src/text/percentage.go
+++ b/src/text/percentage.go
@@ -16,30 +16,36 @@ func (p Percentage) clamp() int {
 // Gauge returns a 5-character gauge visualization showing remaining capacity (▰▰▰▰▱ style).
 // The gauge displays remaining capacity, so 20% used shows 4 filled blocks (80% remaining).
 func (p Percentage) Gauge() string {
+	return p.GaugeWith("▰", "▱")
+}
+
+// GaugeWith returns a 5-character gauge visualization showing remaining capacity using custom characters.
+// marked is the character for filled (remaining) blocks and unmarked is the character for empty (used) blocks.
+func (p Percentage) GaugeWith(marked, unmarked string) string {
 	percent := p.clamp()
 
-	// Calculate remaining percentage for gauge display
 	remainingPercent := 100 - percent
-
-	// 5 blocks total, calculate how many should be filled (representing remaining capacity)
 	filledBlocks := (remainingPercent * 5) / 100
 	emptyBlocks := 5 - filledBlocks
 
-	// Use ▰ for filled blocks (remaining) and ▱ for empty blocks (used)
-	return strings.Repeat("▰", filledBlocks) + strings.Repeat("▱", emptyBlocks)
+	return strings.Repeat(marked, filledBlocks) + strings.Repeat(unmarked, emptyBlocks)
 }
 
 // GaugeUsed returns a 5-character gauge visualization showing used capacity (▰▱▱▱▱ style).
 // The gauge displays used capacity, so 20% used shows 1 filled block (▰▱▱▱▱).
 func (p Percentage) GaugeUsed() string {
+	return p.GaugeUsedWith("▰", "▱")
+}
+
+// GaugeUsedWith returns a 5-character gauge visualization showing used capacity using custom characters.
+// marked is the character for filled (used) blocks and unmarked is the character for empty (remaining) blocks.
+func (p Percentage) GaugeUsedWith(marked, unmarked string) string {
 	percent := p.clamp()
 
-	// 5 blocks total, calculate how many should be filled (representing used capacity)
 	filledBlocks := (percent * 5) / 100
 	emptyBlocks := 5 - filledBlocks
 
-	// Use ▰ for filled blocks (used) and ▱ for empty blocks (remaining)
-	return strings.Repeat("▰", filledBlocks) + strings.Repeat("▱", emptyBlocks)
+	return strings.Repeat(marked, filledBlocks) + strings.Repeat(unmarked, emptyBlocks)
 }
 
 // String returns the percentage as a string without % sign for template compatibility.

--- a/src/text/percentage.go
+++ b/src/text/percentage.go
@@ -13,13 +13,13 @@ func (p Percentage) clamp() int {
 	return min(max(int(p), 0), 100)
 }
 
-// Gauge returns a 5-character gauge visualization showing remaining capacity (▰▰▰▰▱ style).
+// Gauge returns a 5-block gauge visualization showing remaining capacity (▰▰▰▰▱ style).
 // The gauge displays remaining capacity, so 20% used shows 4 filled blocks (80% remaining).
 func (p Percentage) Gauge() string {
 	return p.GaugeWith("▰", "▱")
 }
 
-// GaugeWith returns a 5-character gauge visualization showing remaining capacity using custom characters.
+// GaugeWith returns a 5-block gauge visualization showing remaining capacity using custom characters.
 // marked is the character for filled (remaining) blocks and unmarked is the character for empty (used) blocks.
 func (p Percentage) GaugeWith(marked, unmarked string) string {
 	percent := p.clamp()
@@ -31,13 +31,13 @@ func (p Percentage) GaugeWith(marked, unmarked string) string {
 	return strings.Repeat(marked, filledBlocks) + strings.Repeat(unmarked, emptyBlocks)
 }
 
-// GaugeUsed returns a 5-character gauge visualization showing used capacity (▰▱▱▱▱ style).
+// GaugeUsed returns a 5-block gauge visualization showing used capacity (▰▱▱▱▱ style).
 // The gauge displays used capacity, so 20% used shows 1 filled block (▰▱▱▱▱).
 func (p Percentage) GaugeUsed() string {
 	return p.GaugeUsedWith("▰", "▱")
 }
 
-// GaugeUsedWith returns a 5-character gauge visualization showing used capacity using custom characters.
+// GaugeUsedWith returns a 5-block gauge visualization showing used capacity using custom characters.
 // marked is the character for filled (used) blocks and unmarked is the character for empty (remaining) blocks.
 func (p Percentage) GaugeUsedWith(marked, unmarked string) string {
 	percent := p.clamp()

--- a/src/text/percentage_test.go
+++ b/src/text/percentage_test.go
@@ -130,6 +130,68 @@ func TestPercentageGaugeUsed(t *testing.T) {
 	}
 }
 
+func TestPercentageGaugeWith(t *testing.T) {
+	cases := []struct {
+		Case          string
+		ExpectedGauge string
+		Percent       Percentage
+	}{
+		{
+			Case:          "0 percent used (100% remaining)",
+			Percent:       Percentage(0),
+			ExpectedGauge: "█████",
+		},
+		{
+			Case:          "20 percent used (80% remaining - 4 blocks)",
+			Percent:       Percentage(20),
+			ExpectedGauge: "████░",
+		},
+		{
+			Case:          "100 percent used (0% remaining - 0 blocks)",
+			Percent:       Percentage(100),
+			ExpectedGauge: "░░░░░",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Case, func(t *testing.T) {
+			result := tc.Percent.GaugeWith("█", "░")
+			assert.Equal(t, tc.ExpectedGauge, result, tc.Case)
+		})
+	}
+}
+
+func TestPercentageGaugeUsedWith(t *testing.T) {
+	cases := []struct {
+		Case          string
+		ExpectedGauge string
+		Percent       Percentage
+	}{
+		{
+			Case:          "0 percent used",
+			Percent:       Percentage(0),
+			ExpectedGauge: "░░░░░",
+		},
+		{
+			Case:          "20 percent used",
+			Percent:       Percentage(20),
+			ExpectedGauge: "█░░░░",
+		},
+		{
+			Case:          "100 percent used",
+			Percent:       Percentage(100),
+			ExpectedGauge: "█████",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Case, func(t *testing.T) {
+			result := tc.Percent.GaugeUsedWith("█", "░")
+			assert.Equal(t, tc.ExpectedGauge, result, tc.Case)
+		})
+	}
+}
+
 func TestPercentageString(t *testing.T) {
 	cases := []struct {
 		Case     string

--- a/website/docs/segments/cli/claude.mdx
+++ b/website/docs/segments/cli/claude.mdx
@@ -41,10 +41,10 @@ import Config from "@site/src/components/Config.js";
 
 ## Options
 
-| Option               | Default | Description                                              |
-| -------------------- | ------- | -------------------------------------------------------- |
-| `gauge_marked_char`  | `▰`     | Character used for filled blocks in gauge visualizations |
-| `gauge_unmarked_char`| `▱`     | Character used for empty blocks in gauge visualizations  |
+| Name                  | Type     | Default | Description                                              |
+| --------------------- | -------- | ------- | -------------------------------------------------------- |
+| `gauge_marked_char`   | `string` | `▰`     | Character used for filled blocks in gauge visualizations |
+| `gauge_unmarked_char` | `string` | `▱`     | Character used for empty blocks in gauge visualizations  |
 
 ### Properties
 

--- a/website/docs/segments/cli/claude.mdx
+++ b/website/docs/segments/cli/claude.mdx
@@ -25,7 +25,7 @@ import Config from "@site/src/components/Config.js";
     foreground: "#FFFFFF",
     background: "#FF6B35",
     template:
-      " \udb82\udfc9 {{ .Model.DisplayName }} \uf2d0 {{ .TokenUsagePercent.Gauge }} ",
+      " \udb82\udfc9 {{ .Model.DisplayName }} \uf2d0 {{ .TokenGauge }} ",
   }}
 />
 
@@ -34,10 +34,17 @@ import Config from "@site/src/components/Config.js";
 :::note default template
 
 ```template
- \udb82\udfc9 {{ .Model.DisplayName }} \uf2d0 {{ .TokenUsagePercent.Gauge }}
+ \udb82\udfc9 {{ .Model.DisplayName }} \uf2d0 {{ .TokenGauge }}
 ```
 
 :::
+
+## Options
+
+| Option               | Default | Description                                              |
+| -------------------- | ------- | -------------------------------------------------------- |
+| `gauge_marked_char`  | `▰`     | Character used for filled blocks in gauge visualizations |
+| `gauge_unmarked_char`| `▱`     | Character used for empty blocks in gauge visualizations  |
 
 ### Properties
 
@@ -49,6 +56,10 @@ import Config from "@site/src/components/Config.js";
 | `.Cost`              | `Cost`          | Cost and duration information                      |
 | `.ContextWindow`     | `ContextWindow` | Token usage information                            |
 | `.TokenUsagePercent` | `Percentage`    | Percentage of context window used (0-100)          |
+| `.TokenGauge`        | `string`        | Gauge showing remaining context capacity using configured characters (e.g., `▰▰▰▱▱`) |
+| `.TokenGaugeUsed`    | `string`        | Gauge showing used context capacity using configured characters (e.g., `▰▰▱▱▱`) |
+| `.FiveHourGauge`     | `string`        | Gauge showing 5-hour rate limit usage using configured characters |
+| `.SevenDayGauge`     | `string`        | Gauge showing 7-day rate limit usage using configured characters |
 | `.FormattedCost`     | `string`        | Formatted cost string (e.g., "$0.15" or "$0.0012") |
 | `.FormattedTokens`   | `string`        | Human-readable token count (e.g., "1.2K", "15.3M") |
 | `.FormattedDuration`    | `string`        | Total session duration (e.g., "2m 5s")             |
@@ -115,13 +126,19 @@ Available when Claude Code provides rate limit data (Pro/Max subscribers). Acces
 
 ### Percentage Methods
 
-The `TokenUsagePercent` property is a `Percentage` type that provides additional functionality:
+The `Percentage` type (returned by `.TokenUsagePercent`, `.FiveHourUsage`, `.SevenDayUsage`)
+provides additional methods for direct use in templates:
 
 | Method       | Returns  | Description                                                        |
 | ------------ | -------- | ------------------------------------------------------------------ |
-| `.Gauge`     | `string` | Visual gauge showing remaining capacity using 5 bar blocks (▰▰▰▰▱) |
-| `.GaugeUsed` | `string` | Visual gauge showing used capacity using 5 bar blocks (▰▱▱▱▱)      |
+| `.Gauge`     | `string` | Visual gauge showing remaining capacity using hardcoded `▰`/`▱` characters |
+| `.GaugeUsed` | `string` | Visual gauge showing used capacity using hardcoded `▰`/`▱` characters |
 | `.String`    | `string` | Numeric percentage value (e.g., "75" for use in templates)         |
+
+:::tip Custom gauge characters
+Use `.TokenGauge`, `.TokenGaugeUsed`, `.FiveHourGauge`, and `.SevenDayGauge` instead of the
+raw `.Percentage` methods above — they respect the `gauge_marked_char` and `gauge_unmarked_char` options.
+:::
 
 ## How it works
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Closes #7471.

The Claude Code segment hardcodes `▰`/`▱` for its gauge visualizations. On some systems these characters render with overlapping box sides, making the gauge look broken. This PR adds `gauge_marked_char` and `gauge_unmarked_char` options so users can substitute any characters they prefer (e.g. `█`/`░`).

**Approach:**

- `GaugeWith(marked, unmarked string)` and `GaugeUsedWith(marked, unmarked string)` are added to `text.Percentage`. The existing `Gauge()`/`GaugeUsed()` methods now delegate to these with the original defaults, so nothing changes for callers that don't opt in.
- The `Claude` segment reads the two new options in `Enabled()` and stores them as unexported fields.
- Four new template methods -- `TokenGauge`, `TokenGaugeUsed`, `FiveHourGauge`, `SevenDayGauge` -- build their gauges using the configured characters.
- The default template is updated from `{{ .TokenUsagePercent.Gauge }}` to `{{ .TokenGauge }}`. With default settings the output is identical, so existing prompts are unaffected.
- Old templates that reference `.TokenUsagePercent.Gauge`, `.FiveHourUsage.Gauge`, etc. still work -- they just always use the hardcoded characters.

**Example config:**

```toml
[blocks.segments.options]
gauge_marked_char = "█"
gauge_unmarked_char = "░"
```

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary