### PR TITLE
feat(http): add configurable timeout option

### DIFF
--- a/src/segments/http.go
+++ b/src/segments/http.go
@@ -16,8 +16,7 @@ type HTTP struct {
 }
 
 const (
-	METHOD  options.Option = "method"
-	TIMEOUT options.Option = "timeout"
+	METHOD options.Option = "method"
 )
 
 func (h *HTTP) Template() string {
@@ -31,7 +30,7 @@ func (h *HTTP) Enabled() bool {
 	}
 
 	method := h.options.String(METHOD, "GET")
-	timeout := h.options.Int(TIMEOUT, 10000)
+	timeout := h.options.Int(options.HTTPTimeout, 10000)
 
 	if resolved, err := template.Render(url, nil); err == nil {
 		url = resolved

--- a/src/segments/http.go
+++ b/src/segments/http.go
@@ -16,7 +16,8 @@ type HTTP struct {
 }
 
 const (
-	METHOD options.Option = "method"
+	METHOD  options.Option = "method"
+	TIMEOUT options.Option = "timeout"
 )
 
 func (h *HTTP) Template() string {
@@ -30,12 +31,13 @@ func (h *HTTP) Enabled() bool {
 	}
 
 	method := h.options.String(METHOD, "GET")
+	timeout := h.options.Int(TIMEOUT, 10000)
 
 	if resolved, err := template.Render(url, nil); err == nil {
 		url = resolved
 	}
 
-	result, err := h.getResult(url, method)
+	result, err := h.getResult(url, method, timeout)
 	if err != nil {
 		return false
 	}
@@ -44,12 +46,12 @@ func (h *HTTP) Enabled() bool {
 	return true
 }
 
-func (h *HTTP) getResult(url, method string) (map[string]any, error) {
+func (h *HTTP) getResult(url, method string, timeout int) (map[string]any, error) {
 	setMethod := func(request *http.Request) {
 		request.Method = method
 	}
 
-	resultBody, err := h.env.HTTPRequest(url, nil, 10000, setMethod)
+	resultBody, err := h.env.HTTPRequest(url, nil, timeout, setMethod)
 	if err != nil {
 		return nil, err
 	}

--- a/src/segments/http_test.go
+++ b/src/segments/http_test.go
@@ -73,7 +73,7 @@ func TestHTTPSegmentEnabled(t *testing.T) {
 			}
 
 			if tc.timeout > 0 {
-				props[TIMEOUT] = tc.timeout
+				props[options.HTTPTimeout] = tc.timeout
 			}
 
 			env.On("HTTPRequest", tc.url).Return([]byte(tc.response), func() error {

--- a/src/segments/http_test.go
+++ b/src/segments/http_test.go
@@ -17,6 +17,7 @@ func TestHTTPSegmentEnabled(t *testing.T) {
 		name        string
 		url         string
 		method      string
+		timeout     int
 		response    string
 		shouldError bool
 	}{
@@ -24,6 +25,7 @@ func TestHTTPSegmentEnabled(t *testing.T) {
 			name:        "Valid URL with GET response",
 			url:         "https://jsonplaceholder.typicode.com/posts/1",
 			method:      "GET",
+			timeout:     0,
 			response:    `{"id": "1"}`,
 			expected:    "1",
 			shouldError: false,
@@ -32,6 +34,7 @@ func TestHTTPSegmentEnabled(t *testing.T) {
 			name:        "Valid URL with POST response",
 			url:         "https://jsonplaceholder.typicode.com/posts",
 			method:      "POST",
+			timeout:     0,
 			response:    `{"id": "101"}`,
 			expected:    "101",
 			shouldError: false,
@@ -40,12 +43,23 @@ func TestHTTPSegmentEnabled(t *testing.T) {
 			name:        "Valid URL with error response",
 			url:         "https://api.example.com/data",
 			method:      "GET",
+			timeout:     0,
 			shouldError: true,
 		},
 		{
 			name:        "Empty URL",
 			url:         "",
 			method:      "GET",
+			timeout:     0,
+			shouldError: false,
+		},
+		{
+			name:        "Custom timeout",
+			url:         "https://jsonplaceholder.typicode.com/posts/1",
+			method:      "GET",
+			timeout:     5000,
+			response:    `{"id": "2"}`,
+			expected:    "2",
 			shouldError: false,
 		},
 	}
@@ -56,6 +70,10 @@ func TestHTTPSegmentEnabled(t *testing.T) {
 			props := options.Map{
 				URL:    tc.url,
 				METHOD: tc.method,
+			}
+
+			if tc.timeout > 0 {
+				props[TIMEOUT] = tc.timeout
 			}
 
 			env.On("HTTPRequest", tc.url).Return([]byte(tc.response), func() error {

--- a/src/segments/http_test.go
+++ b/src/segments/http_test.go
@@ -3,13 +3,27 @@ package segments
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"testing"
 
+	runtimehttp "github.com/jandedobbeleer/oh-my-posh/src/runtime/http"
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
 	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// timeoutCapturingEnv wraps the mock environment to record the timeout argument
+// passed to HTTPRequest, so tests can assert it flows through correctly.
+type timeoutCapturingEnv struct {
+	*mock.Environment
+	capturedTimeout int
+}
+
+func (e *timeoutCapturingEnv) HTTPRequest(url string, body io.Reader, timeout int, modifiers ...runtimehttp.RequestModifier) ([]byte, error) {
+	e.capturedTimeout = timeout
+	return e.Environment.HTTPRequest(url, body, timeout, modifiers...)
+}
 
 func TestHTTPSegmentEnabled(t *testing.T) {
 	cases := []struct {
@@ -66,7 +80,7 @@ func TestHTTPSegmentEnabled(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			env := new(mock.Environment)
+			inner := new(mock.Environment)
 			props := options.Map{
 				URL:    tc.url,
 				METHOD: tc.method,
@@ -76,22 +90,27 @@ func TestHTTPSegmentEnabled(t *testing.T) {
 				props[options.HTTPTimeout] = tc.timeout
 			}
 
-			env.On("HTTPRequest", tc.url).Return([]byte(tc.response), func() error {
+			inner.On("HTTPRequest", tc.url).Return([]byte(tc.response), func() error {
 				if tc.shouldError {
 					return errors.New("error")
 				}
 				return nil
 			}())
 
+			capturing := &timeoutCapturingEnv{Environment: inner}
+
 			cs := &HTTP{
 				Base: Base{
-					env:     env,
+					env:     capturing,
 					options: props,
 				},
 			}
 
 			_ = cs.Enabled()
 			assert.Equal(t, tc.expected, cs.Body["id"], tc.name)
+			if tc.timeout > 0 {
+				assert.Equal(t, tc.timeout, capturing.capturedTimeout, "expected custom timeout to be passed to HTTPRequest")
+			}
 		})
 	}
 }

--- a/src/segments/http_test.go
+++ b/src/segments/http_test.go
@@ -17,8 +17,8 @@ func TestHTTPSegmentEnabled(t *testing.T) {
 		name        string
 		url         string
 		method      string
-		timeout     int
 		response    string
+		timeout     int
 		shouldError bool
 	}{
 		{

--- a/website/docs/segments/web/http.mdx
+++ b/website/docs/segments/web/http.mdx
@@ -30,10 +30,11 @@ import Config from "@site/src/components/Config.js";
 
 ## Options
 
-| Name     |   Type   | Default | Description                                         |
-| -------- | :------: | :-----: | --------------------------------------------------- |
-| `url`    | `string` |   ``    | The HTTP URL you want to call, supports [templates] |
-| `method` | `string` |  `GET`  | The HTTP method to use, `GET` or `POST`             |
+| Name      |   Type   |  Default  | Description                                         |
+| --------- | :------: | :-------: | --------------------------------------------------- |
+| `url`     | `string` |    ``     | The HTTP URL you want to call, supports [templates] |
+| `method`  | `string` |   `GET`   | The HTTP method to use, `GET` or `POST`             |
+| `timeout` |  `int`   | `10000`   | The timeout in milliseconds for the HTTP request    |
 
 ## Template ([info][templates])
 

--- a/website/docs/segments/web/http.mdx
+++ b/website/docs/segments/web/http.mdx
@@ -34,7 +34,7 @@ import Config from "@site/src/components/Config.js";
 | --------- | :------: | :-------: | --------------------------------------------------- |
 | `url`     | `string` |    ``     | The HTTP URL you want to call, supports [templates] |
 | `method`  | `string` |   `GET`   | The HTTP method to use, `GET` or `POST`             |
-| `timeout` |  `int`   | `10000`   | The timeout in milliseconds for the HTTP request    |
+| `http_timeout` |  `int`   | `10000`   | The timeout in milliseconds for the HTTP request    |
 
 ## Template ([info][templates])
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Fixes #7476.

The HTTP segment had its request timeout hardcoded at 10 000 ms. On slower networks or endpoints (common on Windows where proxy/DNS resolution can add latency) this makes the segment silently fail with no way to increase the limit.

This PR adds an `http_timeout` option so users can tune the value per segment. The default remains 10 000 ms to preserve existing behaviour.

**Changes:**
- `src/segments/http.go`: Use `options.HTTPTimeout` (`http_timeout`) to read the configurable timeout (default 10000ms) and pass it to `HTTPRequest`.
- `src/segments/http_test.go`: Added `timeout` field to the test struct and a new "Custom timeout" test case.
- `website/docs/segments/web/http.mdx`: Added `http_timeout` row to the Options table.

Example configuration to raise the timeout to 30 seconds:

```json
{
  "type": "http",
  "options": {
    "url": "https://slow-api.example.com/data",
    "http_timeout": 30000
  }
}
```

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
