### PR TITLE
feat(segment): add FiveHourResetsAt and SevenDayResetsAt template methods

### DIFF
--- a/src/segments/claude.go
+++ b/src/segments/claude.go
@@ -246,7 +246,7 @@ func (c *Claude) SevenDayUsage() text.Percentage {
 
 // rateLimitResetsAt extracts the reset time from a rate limit window with nil-safety.
 func rateLimitResetsAt(limits *ClaudeRateLimits, window func(*ClaudeRateLimits) *ClaudeRateLimitWindow) time.Time {
-	if limits == nil {
+	if limits == nil || window == nil {
 		return time.Time{}
 	}
 
@@ -272,7 +272,8 @@ func (c *Claude) SevenDayResetsAt() time.Time {
 	})
 }
 
-// rateLimitResetsIn returns the duration until a rate limit window resets.
+// rateLimitResetsIn returns the signed duration until a rate limit window resets.
+// Returns 0 when data is unavailable, a negative value when the window already reset, and a positive value otherwise.
 func rateLimitResetsIn(limits *ClaudeRateLimits, window func(*ClaudeRateLimits) *ClaudeRateLimitWindow) time.Duration {
 	t := rateLimitResetsAt(limits, window)
 	if t.IsZero() {
@@ -282,14 +283,16 @@ func rateLimitResetsIn(limits *ClaudeRateLimits, window func(*ClaudeRateLimits) 
 	return time.Until(t)
 }
 
-// FiveHourResetsIn returns the duration until the 5-hour rolling window resets, or 0 if unavailable.
+// FiveHourResetsIn returns the signed duration until the 5-hour rolling window resets.
+// Returns 0 when unavailable, negative when the window already reset.
 func (c *Claude) FiveHourResetsIn() time.Duration {
 	return rateLimitResetsIn(c.RateLimits, func(r *ClaudeRateLimits) *ClaudeRateLimitWindow {
 		return r.FiveHour
 	})
 }
 
-// SevenDayResetsIn returns the duration until the 7-day rolling window resets, or 0 if unavailable.
+// SevenDayResetsIn returns the signed duration until the 7-day rolling window resets.
+// Returns 0 when unavailable, negative when the window already reset.
 func (c *Claude) SevenDayResetsIn() time.Duration {
 	return rateLimitResetsIn(c.RateLimits, func(r *ClaudeRateLimits) *ClaudeRateLimitWindow {
 		return r.SevenDay

--- a/src/segments/claude.go
+++ b/src/segments/claude.go
@@ -2,6 +2,7 @@ package segments
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/cache"
 	"github.com/jandedobbeleer/oh-my-posh/src/log"
@@ -239,6 +240,58 @@ func (c *Claude) FiveHourUsage() text.Percentage {
 // SevenDayUsage returns the 7-day window rate limit usage as a Percentage.
 func (c *Claude) SevenDayUsage() text.Percentage {
 	return rateLimitPercentage(c.RateLimits, func(r *ClaudeRateLimits) *ClaudeRateLimitWindow {
+		return r.SevenDay
+	})
+}
+
+// rateLimitResetsAt extracts the reset time from a rate limit window with nil-safety.
+func rateLimitResetsAt(limits *ClaudeRateLimits, window func(*ClaudeRateLimits) *ClaudeRateLimitWindow) time.Time {
+	if limits == nil {
+		return time.Time{}
+	}
+
+	w := window(limits)
+	if w == nil || w.ResetsAt == nil {
+		return time.Time{}
+	}
+
+	return time.Unix(*w.ResetsAt, 0)
+}
+
+// FiveHourResetsAt returns the reset time for the 5-hour rolling window, or zero if unavailable.
+func (c *Claude) FiveHourResetsAt() time.Time {
+	return rateLimitResetsAt(c.RateLimits, func(r *ClaudeRateLimits) *ClaudeRateLimitWindow {
+		return r.FiveHour
+	})
+}
+
+// SevenDayResetsAt returns the reset time for the 7-day rolling window, or zero if unavailable.
+func (c *Claude) SevenDayResetsAt() time.Time {
+	return rateLimitResetsAt(c.RateLimits, func(r *ClaudeRateLimits) *ClaudeRateLimitWindow {
+		return r.SevenDay
+	})
+}
+
+// rateLimitResetsIn returns the duration until a rate limit window resets.
+func rateLimitResetsIn(limits *ClaudeRateLimits, window func(*ClaudeRateLimits) *ClaudeRateLimitWindow) time.Duration {
+	t := rateLimitResetsAt(limits, window)
+	if t.IsZero() {
+		return 0
+	}
+
+	return time.Until(t)
+}
+
+// FiveHourResetsIn returns the duration until the 5-hour rolling window resets, or 0 if unavailable.
+func (c *Claude) FiveHourResetsIn() time.Duration {
+	return rateLimitResetsIn(c.RateLimits, func(r *ClaudeRateLimits) *ClaudeRateLimitWindow {
+		return r.FiveHour
+	})
+}
+
+// SevenDayResetsIn returns the duration until the 7-day rolling window resets, or 0 if unavailable.
+func (c *Claude) SevenDayResetsIn() time.Duration {
+	return rateLimitResetsIn(c.RateLimits, func(r *ClaudeRateLimits) *ClaudeRateLimitWindow {
 		return r.SevenDay
 	})
 }

--- a/src/segments/claude_test.go
+++ b/src/segments/claude_test.go
@@ -705,10 +705,10 @@ func TestClaudeRateLimitResetsIn(t *testing.T) {
 	futureTS := libtime.Now().Add(24 * libtime.Hour).Unix()
 
 	cases := []struct {
-		RateLimits      *ClaudeRateLimits
-		Case            string
-		FiveHourSign    int // -1=negative, 0=zero, 1=positive
-		SevenDaySign    int
+		RateLimits   *ClaudeRateLimits
+		Case         string
+		FiveHourSign int // -1=negative, 0=zero, 1=positive
+		SevenDaySign int
 	}{
 		{
 			Case:         "Nil RateLimits",

--- a/src/segments/claude_test.go
+++ b/src/segments/claude_test.go
@@ -2,6 +2,7 @@ package segments
 
 import (
 	"testing"
+	libtime "time"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/cache"
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
@@ -636,4 +637,136 @@ func TestClaudeGaugeOptionsReadInEnabled(t *testing.T) {
 	assert.True(t, claude.Enabled())
 	assert.Equal(t, "█", claude.markedChar)
 	assert.Equal(t, "░", claude.unmarkedChar)
+}
+
+func TestClaudeRateLimitResetsAt(t *testing.T) {
+	fiveHourTS := int64(1711180800) // 2024-03-23 08:00:00 UTC
+	sevenDayTS := int64(1711612800) // 2024-03-28 08:00:00 UTC
+
+	cases := []struct {
+		ExpectedFiveHour libtime.Time
+		ExpectedSevenDay libtime.Time
+		RateLimits       *ClaudeRateLimits
+		Case             string
+	}{
+		{
+			Case:             "Nil RateLimits",
+			RateLimits:       nil,
+			ExpectedFiveHour: libtime.Time{},
+			ExpectedSevenDay: libtime.Time{},
+		},
+		{
+			Case: "Nil FiveHour window",
+			RateLimits: &ClaudeRateLimits{
+				SevenDay: &ClaudeRateLimitWindow{ResetsAt: &sevenDayTS},
+			},
+			ExpectedFiveHour: libtime.Time{},
+			ExpectedSevenDay: libtime.Unix(sevenDayTS, 0),
+		},
+		{
+			Case: "Nil SevenDay window",
+			RateLimits: &ClaudeRateLimits{
+				FiveHour: &ClaudeRateLimitWindow{ResetsAt: &fiveHourTS},
+			},
+			ExpectedFiveHour: libtime.Unix(fiveHourTS, 0),
+			ExpectedSevenDay: libtime.Time{},
+		},
+		{
+			Case: "Nil ResetsAt pointers",
+			RateLimits: &ClaudeRateLimits{
+				FiveHour: &ClaudeRateLimitWindow{ResetsAt: nil},
+				SevenDay: &ClaudeRateLimitWindow{ResetsAt: nil},
+			},
+			ExpectedFiveHour: libtime.Time{},
+			ExpectedSevenDay: libtime.Time{},
+		},
+		{
+			Case: "Valid timestamps for both windows",
+			RateLimits: &ClaudeRateLimits{
+				FiveHour: &ClaudeRateLimitWindow{ResetsAt: &fiveHourTS},
+				SevenDay: &ClaudeRateLimitWindow{ResetsAt: &sevenDayTS},
+			},
+			ExpectedFiveHour: libtime.Unix(fiveHourTS, 0),
+			ExpectedSevenDay: libtime.Unix(sevenDayTS, 0),
+		},
+	}
+
+	for _, tc := range cases {
+		claude := &Claude{}
+		claude.RateLimits = tc.RateLimits
+
+		assert.Equal(t, tc.ExpectedFiveHour, claude.FiveHourResetsAt(), tc.Case+" (FiveHour)")
+		assert.Equal(t, tc.ExpectedSevenDay, claude.SevenDayResetsAt(), tc.Case+" (SevenDay)")
+	}
+}
+
+func TestClaudeRateLimitResetsIn(t *testing.T) {
+	pastTS := libtime.Now().Add(-libtime.Hour).Unix()
+	futureTS := libtime.Now().Add(24 * libtime.Hour).Unix()
+
+	cases := []struct {
+		RateLimits      *ClaudeRateLimits
+		Case            string
+		FiveHourSign    int // -1=negative, 0=zero, 1=positive
+		SevenDaySign    int
+	}{
+		{
+			Case:         "Nil RateLimits",
+			RateLimits:   nil,
+			FiveHourSign: 0,
+			SevenDaySign: 0,
+		},
+		{
+			Case:         "Nil windows",
+			RateLimits:   &ClaudeRateLimits{},
+			FiveHourSign: 0,
+			SevenDaySign: 0,
+		},
+		{
+			Case: "Nil ResetsAt",
+			RateLimits: &ClaudeRateLimits{
+				FiveHour: &ClaudeRateLimitWindow{},
+				SevenDay: &ClaudeRateLimitWindow{},
+			},
+			FiveHourSign: 0,
+			SevenDaySign: 0,
+		},
+		{
+			Case: "Past timestamp",
+			RateLimits: &ClaudeRateLimits{
+				FiveHour: &ClaudeRateLimitWindow{ResetsAt: &pastTS},
+				SevenDay: &ClaudeRateLimitWindow{ResetsAt: &pastTS},
+			},
+			FiveHourSign: -1,
+			SevenDaySign: -1,
+		},
+		{
+			Case: "Future timestamp",
+			RateLimits: &ClaudeRateLimits{
+				FiveHour: &ClaudeRateLimitWindow{ResetsAt: &futureTS},
+				SevenDay: &ClaudeRateLimitWindow{ResetsAt: &futureTS},
+			},
+			FiveHourSign: 1,
+			SevenDaySign: 1,
+		},
+	}
+
+	assertSign := func(t *testing.T, d libtime.Duration, sign int, name string) {
+		t.Helper()
+		switch sign {
+		case 0:
+			assert.Equal(t, libtime.Duration(0), d, name)
+		case 1:
+			assert.Positive(t, d, name)
+		case -1:
+			assert.Negative(t, d, name)
+		}
+	}
+
+	for _, tc := range cases {
+		claude := &Claude{}
+		claude.RateLimits = tc.RateLimits
+		assertSign(t, claude.FiveHourResetsIn(), tc.FiveHourSign, tc.Case+" (FiveHour)")
+		assertSign(t, claude.SevenDayResetsIn(), tc.SevenDaySign, tc.Case+" (SevenDay)")
+	}
 }

--- a/website/docs/segments/cli/claude.mdx
+++ b/website/docs/segments/cli/claude.mdx
@@ -60,6 +60,10 @@ import Config from "@site/src/components/Config.js";
 | `.TokenGaugeUsed`    | `string`        | Gauge showing used context capacity using configured characters (e.g., `▰▰▱▱▱`) |
 | `.FiveHourGauge`     | `string`        | Gauge showing 5-hour rate limit usage using configured characters |
 | `.SevenDayGauge`     | `string`        | Gauge showing 7-day rate limit usage using configured characters |
+| `.FiveHourResetsAt`  | `time.Time`     | 5-hour rate limit window reset time                |
+| `.SevenDayResetsAt`  | `time.Time`     | 7-day rate limit window reset time                 |
+| `.FiveHourResetsIn`  | `time.Duration` | duration until 5-hour window resets                |
+| `.SevenDayResetsIn`  | `time.Duration` | duration until 7-day window resets                 |
 | `.FormattedCost`     | `string`        | Formatted cost string (e.g., "$0.15" or "$0.0012") |
 | `.FormattedTokens`   | `string`        | Human-readable token count (e.g., "1.2K", "15.3M") |
 | `.FormattedDuration`    | `string`        | Total session duration (e.g., "2m 5s")             |

--- a/website/docs/segments/cli/claude.mdx
+++ b/website/docs/segments/cli/claude.mdx
@@ -62,8 +62,8 @@ import Config from "@site/src/components/Config.js";
 | `.SevenDayGauge`     | `string`        | Gauge showing 7-day rate limit usage using configured characters |
 | `.FiveHourResetsAt`  | `time.Time`     | 5-hour rate limit window reset time                |
 | `.SevenDayResetsAt`  | `time.Time`     | 7-day rate limit window reset time                 |
-| `.FiveHourResetsIn`  | `time.Duration` | duration until 5-hour window resets                |
-| `.SevenDayResetsIn`  | `time.Duration` | duration until 7-day window resets                 |
+| `.FiveHourResetsIn`  | `time.Duration` | time until 5-hour resets; 0=unavailable, neg=past  |
+| `.SevenDayResetsIn`  | `time.Duration` | time until 7-day resets; 0=unavailable, neg=past   |
 | `.FormattedCost`     | `string`        | Formatted cost string (e.g., "$0.15" or "$0.0012") |
 | `.FormattedTokens`   | `string`        | Human-readable token count (e.g., "1.2K", "15.3M") |
 | `.FormattedDuration`    | `string`        | Total session duration (e.g., "2m 5s")             |


### PR DESCRIPTION
## What

Add two nil-safe template methods to the Claude segment that surface `ResetsAt` as a native `time.Time` value:

- `.FiveHourResetsAt()`  reset time for the 5-hour rolling rate limit window
- `.SevenDayResetsAt()`  reset time for the 7-day rate limit window

Returns `time.Time{}` (zero value) when data is absent, so templates can guard with `.IsZero`.

## Why

`ClaudeRateLimitWindow.ResetsAt` (`*int64`) was already parsed from Claude Code's JSON but had no template-friendly accessor. Users had to write shell wrappers to expose the value.

## Template usage

```
{{ if not .FiveHourResetsAt.IsZero }} resets {{ .FiveHourResetsAt.Format "15:04" }}{{ end }}
```

## Changes

- `src/segments/claude.go`  add `"time"` import, `rateLimitResetsAt` helper, and two methods
- `src/segments/claude_test.go`  `TestClaudeRateLimitResetsAt` covering nil inputs and valid timestamps
- `website/docs/segments/cli/claude.mdx`  document the two new properties

Closes #7480