### PR TITLE
feat(template): add localeShortDate and localeShortTime functions

### DIFF
--- a/apm.lock
+++ b/apm.lock
@@ -1,0 +1,44 @@
+lockfile_version: '1'
+generated_at: '2026-04-28T06:19:02.309773+00:00'
+apm_version: 0.7.7
+dependencies:
+- repo_url: JanDeDobbeleer/agentic
+  host: github.com
+  resolved_commit: b4e8062eaeef93582bf4cbb86ad4816f37630bb2
+  virtual_path: skills/conventional-commit
+  is_virtual: true
+  package_type: claude_skill
+  deployed_files:
+  - .github/skills/conventional-commit
+- repo_url: JanDeDobbeleer/agentic
+  host: github.com
+  resolved_commit: b4e8062eaeef93582bf4cbb86ad4816f37630bb2
+  virtual_path: skills/golang
+  is_virtual: true
+  package_type: claude_skill
+  deployed_files:
+  - .github/skills/golang
+- repo_url: JanDeDobbeleer/agentic
+  host: github.com
+  resolved_commit: b4e8062eaeef93582bf4cbb86ad4816f37630bb2
+  virtual_path: skills/markdown
+  is_virtual: true
+  package_type: claude_skill
+  deployed_files:
+  - .github/skills/markdown
+- repo_url: JanDeDobbeleer/agentic
+  host: github.com
+  resolved_commit: b4e8062eaeef93582bf4cbb86ad4816f37630bb2
+  virtual_path: skills/powershell
+  is_virtual: true
+  package_type: claude_skill
+  deployed_files:
+  - .github/skills/powershell
+- repo_url: JanDeDobbeleer/agentic
+  host: github.com
+  resolved_commit: b4e8062eaeef93582bf4cbb86ad4816f37630bb2
+  virtual_path: skills/vale-user-facing-text
+  is_virtual: true
+  package_type: claude_skill
+  deployed_files:
+  - .github/skills/vale-user-facing-text

--- a/src/template/func_map.go
+++ b/src/template/func_map.go
@@ -27,6 +27,9 @@ func funcMap() template.FuncMap {
 		"stat":         stat,
 		"dir":          filepath.Dir,
 		"base":         filepath.Base,
+		// Locale-aware date/time formatting using OS regional settings.
+		"localeShortDate": localeShortDate,
+		"localeShortTime": localeShortTime,
 		// Override sprig date functions to support string epoch values (e.g. output of unixEpoch).
 		"date":           ompDate,
 		"date_in_zone":   ompDateInZone,

--- a/src/template/locale.go
+++ b/src/template/locale.go
@@ -5,6 +5,11 @@ import (
 	"sync"
 )
 
+const (
+	defaultDateLayout = "2006-01-02"
+	defaultTimeLayout = "15:04"
+)
+
 var (
 	localeOnce       sync.Once
 	localeDateLayout string
@@ -29,12 +34,12 @@ func getLocaleLayouts() (string, string) {
 
 	dateLayout := localeDateLayout
 	if dateLayout == "" {
-		dateLayout = "2006-01-02"
+		dateLayout = defaultDateLayout
 	}
 
 	timeLayout := localeTimeLayout
 	if timeLayout == "" {
-		timeLayout = "15:04"
+		timeLayout = defaultTimeLayout
 	}
 
 	return dateLayout, timeLayout
@@ -127,7 +132,7 @@ func posixPatternToGoLayout(pattern string) string {
 		"%y": "06",
 		"%m": "01",
 		"%d": "02",
-		"%e": "2",  // space-padded day; Go has no space padding — use unpadded
+		"%e": "2", // space-padded day; Go has no space padding — use unpadded
 		"%H": "15",
 		"%I": "03",
 		"%M": "04",

--- a/src/template/locale.go
+++ b/src/template/locale.go
@@ -2,45 +2,73 @@ package template
 
 import (
 	"strings"
-	"sync"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/cache"
 )
 
 const (
 	defaultDateLayout = "2006-01-02"
 	defaultTimeLayout = "15:04"
+
+	localeDateCacheKey = "locale_date_layout"
+	localeTimeCacheKey = "locale_time_layout"
 )
 
+// localeCache abstracts the persistent store used for locale layout strings.
+// The default implementation writes to cache.Device; tests inject a simple
+// in-memory map so they never touch the real device store.
+type localeCache interface {
+	get(key string) (string, bool)
+	set(key, val string)
+}
+
+type deviceLocaleCache struct{}
+
+func (deviceLocaleCache) get(key string) (string, bool) {
+	return cache.Get[string](cache.Device, key)
+}
+
+func (deviceLocaleCache) set(key, val string) {
+	cache.Set(cache.Device, key, val, cache.INFINITE)
+}
+
 var (
-	localeOnce       sync.Once
-	localeDateLayout string
-	localeTimeLayout string
+	// localeLayoutsStore is the backing store for cached layouts; replaced by a
+	// mock in tests.
+	localeLayoutsStore localeCache = deviceLocaleCache{}
 
 	// localeLayoutsResolver is set by init() in the platform-specific files
-	// (locale_windows.go / locale_unix.go). It is never called until the first
-	// time a template actually uses localeShortDate or localeShortTime, so the
-	// OS is not queried on every prompt render — only when these functions are
-	// needed, and then the results are cached for the lifetime of the process.
+	// (locale_windows.go / locale_unix.go). It is queried once at init time
+	// when the cache is empty, and the result is stored in the device cache so
+	// subsequent sessions do not need to query the OS again.
 	localeLayoutsResolver func() (dateLayout, timeLayout string)
 )
 
 // getLocaleLayouts returns the OS short-date and short-time layouts as Go
-// time format strings. The OS is queried at most once per process.
+// time format strings. Results are stored in the device cache (via
+// localeLayoutsStore) so the OS is queried at most once per device.
 func getLocaleLayouts() (string, string) {
-	localeOnce.Do(func() {
-		if localeLayoutsResolver != nil {
-			localeDateLayout, localeTimeLayout = localeLayoutsResolver()
-		}
-	})
+	dateLayout, dateOK := localeLayoutsStore.get(localeDateCacheKey)
+	timeLayout, timeOK := localeLayoutsStore.get(localeTimeCacheKey)
 
-	dateLayout := localeDateLayout
+	if dateOK && timeOK {
+		return dateLayout, timeLayout
+	}
+
+	if localeLayoutsResolver != nil {
+		dateLayout, timeLayout = localeLayoutsResolver()
+	}
+
 	if dateLayout == "" {
 		dateLayout = defaultDateLayout
 	}
 
-	timeLayout := localeTimeLayout
 	if timeLayout == "" {
 		timeLayout = defaultTimeLayout
 	}
+
+	localeLayoutsStore.set(localeDateCacheKey, dateLayout)
+	localeLayoutsStore.set(localeTimeCacheKey, timeLayout)
 
 	return dateLayout, timeLayout
 }

--- a/src/template/locale.go
+++ b/src/template/locale.go
@@ -1,0 +1,162 @@
+package template
+
+import (
+	"strings"
+	"sync"
+)
+
+var (
+	localeOnce       sync.Once
+	localeDateLayout string
+	localeTimeLayout string
+
+	// localeLayoutsResolver is set by init() in the platform-specific files
+	// (locale_windows.go / locale_unix.go). It is never called until the first
+	// time a template actually uses localeShortDate or localeShortTime, so the
+	// OS is not queried on every prompt render — only when these functions are
+	// needed, and then the results are cached for the lifetime of the process.
+	localeLayoutsResolver func() (dateLayout, timeLayout string)
+)
+
+// getLocaleLayouts returns the OS short-date and short-time layouts as Go
+// time format strings. The OS is queried at most once per process.
+func getLocaleLayouts() (string, string) {
+	localeOnce.Do(func() {
+		if localeLayoutsResolver != nil {
+			localeDateLayout, localeTimeLayout = localeLayoutsResolver()
+		}
+	})
+
+	dateLayout := localeDateLayout
+	if dateLayout == "" {
+		dateLayout = "2006-01-02"
+	}
+
+	timeLayout := localeTimeLayout
+	if timeLayout == "" {
+		timeLayout = "15:04"
+	}
+
+	return dateLayout, timeLayout
+}
+
+// localeShortDate formats date using the OS short-date regional setting.
+//
+// Example:
+//
+//	{{ localeShortDate .SomeTime }}
+func localeShortDate(date any) string {
+	layout, _ := getLocaleLayouts()
+	return dateInZone(layout, date, "Local")
+}
+
+// localeShortTime formats date using the OS short-time regional setting.
+//
+// Example:
+//
+//	{{ localeShortTime .SomeTime }}
+func localeShortTime(date any) string {
+	_, layout := getLocaleLayouts()
+	return dateInZone(layout, date, "Local")
+}
+
+// windowsPatternToGoLayout converts a Windows date/time format string
+// (as stored in HKCU\Control Panel\International) to a Go time layout string.
+//
+// Tokens are replaced longest-match-first so that e.g. "yyyy" is not
+// partially consumed as "yy".
+func windowsPatternToGoLayout(pattern string) string {
+	// Order matters: longer tokens must be replaced before shorter ones.
+	replacements := []struct{ from, to string }{
+		{"dddd", "Monday"},
+		{"ddd", "Mon"},
+		{"dd", "02"},
+		{"d", "2"},
+		{"MMMM", "January"},
+		{"MMM", "Jan"},
+		{"MM", "01"},
+		{"M", "1"},
+		{"yyyy", "2006"},
+		{"yy", "06"},
+		// 24-hour (H/HH) — Go has no unpadded 24-hour; both map to "15".
+		{"HH", "15"},
+		{"H", "15"},
+		// 12-hour
+		{"hh", "03"},
+		{"h", "3"},
+		// Minutes
+		{"mm", "04"},
+		{"m", "4"},
+		// Seconds
+		{"ss", "05"},
+		{"s", "5"},
+		// AM/PM
+		{"tt", "PM"},
+		{"t", "PM"},
+	}
+
+	// Walk through the pattern rune-by-rune, matching the longest token at
+	// each position so that literal characters (separators like "/" and ":")
+	// are passed through unchanged.
+	var out strings.Builder
+	i := 0
+	for i < len(pattern) {
+		matched := false
+		for _, r := range replacements {
+			if strings.HasPrefix(pattern[i:], r.from) {
+				out.WriteString(r.to)
+				i += len(r.from)
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			out.WriteByte(pattern[i])
+			i++
+		}
+	}
+
+	return out.String()
+}
+
+// posixPatternToGoLayout converts a POSIX strftime format string (as returned
+// by `locale -k LC_TIME` d_fmt / t_fmt) to a Go time layout string.
+func posixPatternToGoLayout(pattern string) string {
+	replacements := map[string]string{
+		"%Y": "2006",
+		"%y": "06",
+		"%m": "01",
+		"%d": "02",
+		"%e": "2",  // space-padded day; Go has no space padding — use unpadded
+		"%H": "15",
+		"%I": "03",
+		"%M": "04",
+		"%S": "05",
+		"%p": "PM",
+		"%P": "pm",
+		"%A": "Monday",
+		"%a": "Mon",
+		"%B": "January",
+		"%b": "Jan",
+		"%Z": "MST",
+		"%z": "-0700",
+		"%%": "%",
+	}
+
+	var out strings.Builder
+	i := 0
+	for i < len(pattern) {
+		if i+1 < len(pattern) && pattern[i] == '%' {
+			token := pattern[i : i+2]
+			if rep, ok := replacements[token]; ok {
+				out.WriteString(rep)
+				i += 2
+				continue
+			}
+		}
+		out.WriteByte(pattern[i])
+		i++
+	}
+
+	return out.String()
+}

--- a/src/template/locale.go
+++ b/src/template/locale.go
@@ -2,6 +2,7 @@ package template
 
 import (
 	"strings"
+	"sync"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/cache"
 )
@@ -42,6 +43,8 @@ var (
 	// when the cache is empty, and the result is stored in the device cache so
 	// subsequent sessions do not need to query the OS again.
 	localeLayoutsResolver func() (dateLayout, timeLayout string)
+
+	localeResolveOnce = &sync.Once{}
 )
 
 // getLocaleLayouts returns the OS short-date and short-time layouts as Go
@@ -55,20 +58,26 @@ func getLocaleLayouts() (string, string) {
 		return dateLayout, timeLayout
 	}
 
-	if localeLayoutsResolver != nil {
-		dateLayout, timeLayout = localeLayoutsResolver()
-	}
+	localeResolveOnce.Do(func() {
+		date, t := "", ""
+		if localeLayoutsResolver != nil {
+			date, t = localeLayoutsResolver()
+		}
 
-	if dateLayout == "" {
-		dateLayout = defaultDateLayout
-	}
+		if date == "" {
+			date = defaultDateLayout
+		}
 
-	if timeLayout == "" {
-		timeLayout = defaultTimeLayout
-	}
+		if t == "" {
+			t = defaultTimeLayout
+		}
 
-	localeLayoutsStore.set(localeDateCacheKey, dateLayout)
-	localeLayoutsStore.set(localeTimeCacheKey, timeLayout)
+		localeLayoutsStore.set(localeDateCacheKey, date)
+		localeLayoutsStore.set(localeTimeCacheKey, t)
+	})
+
+	dateLayout, _ = localeLayoutsStore.get(localeDateCacheKey)
+	timeLayout, _ = localeLayoutsStore.get(localeTimeCacheKey)
 
 	return dateLayout, timeLayout
 }

--- a/src/template/locale.go
+++ b/src/template/locale.go
@@ -55,7 +55,7 @@ func localeShortDate(date any) string {
 	return dateInZone(layout, date, "Local")
 }
 
-// localeShortTime formats date using the OS short-time regional setting.
+// localeShortTime formats time using the OS short-time regional setting.
 //
 // Example:
 //
@@ -95,7 +95,8 @@ func windowsPatternToGoLayout(pattern string) string {
 		// Seconds
 		{"ss", "05"},
 		{"s", "5"},
-		// AM/PM
+		// AM/PM — Go has no single-character AM/PM token; both "t" and "tt" map to "PM".
+		// "t" will always render as two characters ("AM"/"PM"), matching "tt" behaviour.
 		{"tt", "PM"},
 		{"t", "PM"},
 	}

--- a/src/template/locale_test.go
+++ b/src/template/locale_test.go
@@ -1,6 +1,7 @@
 package template
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -29,19 +30,22 @@ func (m *mockLocaleCache) set(key, val string) {
 	m.data[key] = val
 }
 
-// setupLocaleTest wires up a fresh mock cache and returns a cleanup function
-// that restores both the store and the resolver to their original values.
+// setupLocaleTest wires up a fresh mock cache and registers cleanup via
+// t.Cleanup to restore both the store and the resolver to their original values.
 func setupLocaleTest(t *testing.T) {
 	t.Helper()
 
 	origStore := localeLayoutsStore
 	origResolver := localeLayoutsResolver
+	origOnce := localeResolveOnce
 
 	localeLayoutsStore = newMockLocaleCache()
+	localeResolveOnce = &sync.Once{}
 
 	t.Cleanup(func() {
 		localeLayoutsStore = origStore
 		localeLayoutsResolver = origResolver
+		localeResolveOnce = origOnce
 	})
 }
 

--- a/src/template/locale_test.go
+++ b/src/template/locale_test.go
@@ -82,11 +82,14 @@ func TestLocaleShortDateFallback(t *testing.T) {
 	Init(mockEnv, nil, nil)
 
 	// Override the resolver to return empty strings (simulates resolver failure).
+	prevResolver := localeLayoutsResolver
 	localeLayoutsResolver = func() (string, string) { return "", "" }
+	t.Cleanup(func() { localeLayoutsResolver = prevResolver })
 	resetLocaleCache("", "")
 
+	origLocal := time.Local
 	time.Local = time.UTC
-	defer func() { time.Local = time.FixedZone("UTC", 0) }()
+	t.Cleanup(func() { time.Local = origLocal })
 
 	tmpl := `{{ localeShortDate .T }}`
 	ctx := struct{ T time.Time }{T: time.Unix(0, 0).UTC()}
@@ -103,11 +106,14 @@ func TestLocaleShortTimeFallback(t *testing.T) {
 	Cache = new(cache.Template)
 	Init(mockEnv, nil, nil)
 
+	prevResolver := localeLayoutsResolver
 	localeLayoutsResolver = func() (string, string) { return "", "" }
+	t.Cleanup(func() { localeLayoutsResolver = prevResolver })
 	resetLocaleCache("", "")
 
+	origLocal := time.Local
 	time.Local = time.UTC
-	defer func() { time.Local = time.FixedZone("UTC", 0) }()
+	t.Cleanup(func() { time.Local = origLocal })
 
 	tmpl := `{{ localeShortTime .T }}`
 	ctx := struct{ T time.Time }{T: time.Unix(0, 0).UTC()}
@@ -124,11 +130,14 @@ func TestLocaleShortDateWithISOLayout(t *testing.T) {
 	Cache = new(cache.Template)
 	Init(mockEnv, nil, nil)
 
+	prevResolver := localeLayoutsResolver
 	localeLayoutsResolver = func() (string, string) { return defaultDateLayout, defaultTimeLayout }
+	t.Cleanup(func() { localeLayoutsResolver = prevResolver })
 	resetLocaleCache("", "")
 
+	origLocal := time.Local
 	time.Local = time.UTC
-	defer func() { time.Local = time.FixedZone("UTC", 0) }()
+	t.Cleanup(func() { time.Local = origLocal })
 
 	// knownEpoch = 2019-06-13 20:39:39 UTC (from date_test.go)
 	tmpl := `{{ localeShortDate .T }}`
@@ -145,11 +154,14 @@ func TestLocaleShortTimeWith24hLayout(t *testing.T) {
 	Cache = new(cache.Template)
 	Init(mockEnv, nil, nil)
 
+	prevResolver := localeLayoutsResolver
 	localeLayoutsResolver = func() (string, string) { return defaultDateLayout, defaultTimeLayout }
+	t.Cleanup(func() { localeLayoutsResolver = prevResolver })
 	resetLocaleCache("", "")
 
+	origLocal := time.Local
 	time.Local = time.UTC
-	defer func() { time.Local = time.FixedZone("UTC", 0) }()
+	t.Cleanup(func() { time.Local = origLocal })
 
 	tmpl := `{{ localeShortTime .T }}`
 	ctx := struct{ T time.Time }{T: time.Unix(knownEpoch, 0).UTC()}
@@ -165,11 +177,14 @@ func TestLocaleShortDateWith12hUSLayout(t *testing.T) {
 	Cache = new(cache.Template)
 	Init(mockEnv, nil, nil)
 
+	prevResolver := localeLayoutsResolver
 	localeLayoutsResolver = func() (string, string) { return "1/2/2006", "3:04 PM" }
+	t.Cleanup(func() { localeLayoutsResolver = prevResolver })
 	resetLocaleCache("", "")
 
+	origLocal := time.Local
 	time.Local = time.UTC
-	defer func() { time.Local = time.FixedZone("UTC", 0) }()
+	t.Cleanup(func() { time.Local = origLocal })
 
 	tmpl := `{{ localeShortDate .T }} {{ localeShortTime .T }}`
 	ctx := struct{ T time.Time }{T: time.Unix(knownEpoch, 0).UTC()}

--- a/src/template/locale_test.go
+++ b/src/template/locale_test.go
@@ -1,7 +1,6 @@
 package template
 
 import (
-	"sync"
 	"testing"
 	"time"
 
@@ -11,12 +10,39 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// resetLocaleCache resets the locale sync.Once so individual test cases can
-// inject their own layouts without cross-contamination.
-func resetLocaleCache(dateLayout, timeLayout string) {
-	localeOnce = sync.Once{}
-	localeDateLayout = dateLayout
-	localeTimeLayout = timeLayout
+// mockLocaleCache is a simple in-memory localeCache implementation used in
+// tests to avoid touching the real device cache store.
+type mockLocaleCache struct {
+	data map[string]string
+}
+
+func newMockLocaleCache() *mockLocaleCache {
+	return &mockLocaleCache{data: make(map[string]string)}
+}
+
+func (m *mockLocaleCache) get(key string) (string, bool) {
+	v, ok := m.data[key]
+	return v, ok
+}
+
+func (m *mockLocaleCache) set(key, val string) {
+	m.data[key] = val
+}
+
+// setupLocaleTest wires up a fresh mock cache and returns a cleanup function
+// that restores both the store and the resolver to their original values.
+func setupLocaleTest(t *testing.T) {
+	t.Helper()
+
+	origStore := localeLayoutsStore
+	origResolver := localeLayoutsResolver
+
+	localeLayoutsStore = newMockLocaleCache()
+
+	t.Cleanup(func() {
+		localeLayoutsStore = origStore
+		localeLayoutsResolver = origResolver
+	})
 }
 
 // TestWindowsPatternToGoLayout verifies the Windows date/time format → Go layout converter.
@@ -81,11 +107,8 @@ func TestLocaleShortDateFallback(t *testing.T) {
 	Cache = new(cache.Template)
 	Init(mockEnv, nil, nil)
 
-	// Override the resolver to return empty strings (simulates resolver failure).
-	prevResolver := localeLayoutsResolver
+	setupLocaleTest(t)
 	localeLayoutsResolver = func() (string, string) { return "", "" }
-	t.Cleanup(func() { localeLayoutsResolver = prevResolver })
-	resetLocaleCache("", "")
 
 	origLocal := time.Local
 	time.Local = time.UTC
@@ -106,10 +129,8 @@ func TestLocaleShortTimeFallback(t *testing.T) {
 	Cache = new(cache.Template)
 	Init(mockEnv, nil, nil)
 
-	prevResolver := localeLayoutsResolver
+	setupLocaleTest(t)
 	localeLayoutsResolver = func() (string, string) { return "", "" }
-	t.Cleanup(func() { localeLayoutsResolver = prevResolver })
-	resetLocaleCache("", "")
 
 	origLocal := time.Local
 	time.Local = time.UTC
@@ -130,10 +151,8 @@ func TestLocaleShortDateWithISOLayout(t *testing.T) {
 	Cache = new(cache.Template)
 	Init(mockEnv, nil, nil)
 
-	prevResolver := localeLayoutsResolver
+	setupLocaleTest(t)
 	localeLayoutsResolver = func() (string, string) { return defaultDateLayout, defaultTimeLayout }
-	t.Cleanup(func() { localeLayoutsResolver = prevResolver })
-	resetLocaleCache("", "")
 
 	origLocal := time.Local
 	time.Local = time.UTC
@@ -154,10 +173,8 @@ func TestLocaleShortTimeWith24hLayout(t *testing.T) {
 	Cache = new(cache.Template)
 	Init(mockEnv, nil, nil)
 
-	prevResolver := localeLayoutsResolver
+	setupLocaleTest(t)
 	localeLayoutsResolver = func() (string, string) { return defaultDateLayout, defaultTimeLayout }
-	t.Cleanup(func() { localeLayoutsResolver = prevResolver })
-	resetLocaleCache("", "")
 
 	origLocal := time.Local
 	time.Local = time.UTC
@@ -177,10 +194,8 @@ func TestLocaleShortDateWith12hUSLayout(t *testing.T) {
 	Cache = new(cache.Template)
 	Init(mockEnv, nil, nil)
 
-	prevResolver := localeLayoutsResolver
+	setupLocaleTest(t)
 	localeLayoutsResolver = func() (string, string) { return "1/2/2006", "3:04 PM" }
-	t.Cleanup(func() { localeLayoutsResolver = prevResolver })
-	resetLocaleCache("", "")
 
 	origLocal := time.Local
 	time.Local = time.UTC

--- a/src/template/locale_test.go
+++ b/src/template/locale_test.go
@@ -1,0 +1,175 @@
+package template
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/cache"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// resetLocaleCache resets the locale sync.Once so individual test cases can
+// inject their own layouts without cross-contamination.
+func resetLocaleCache(dateLayout, timeLayout string) {
+	localeOnce = sync.Once{}
+	localeDateLayout = dateLayout
+	localeTimeLayout = timeLayout
+}
+
+// TestWindowsPatternToGoLayout verifies the Windows date/time format → Go layout converter.
+func TestWindowsPatternToGoLayout(t *testing.T) {
+	cases := []struct {
+		Case     string
+		Input    string
+		Expected string
+	}{
+		{Case: "ISO-style date", Input: "yyyy-MM-dd", Expected: "2006-01-02"},
+		{Case: "US short date", Input: "M/d/yyyy", Expected: "1/2/2006"},
+		{Case: "EU date with dots", Input: "dd.MM.yyyy", Expected: "02.01.2006"},
+		{Case: "24-hour time", Input: "HH:mm", Expected: "15:04"},
+		{Case: "12-hour time with AM/PM", Input: "h:mm tt", Expected: "3:04 PM"},
+		{Case: "zero-padded 12-hour", Input: "hh:mm tt", Expected: "03:04 PM"},
+		{Case: "abbreviated day name", Input: "ddd, MMM d yyyy", Expected: "Mon, Jan 2 2006"},
+		{Case: "full day and month name", Input: "dddd, MMMM d, yyyy", Expected: "Monday, January 2, 2006"},
+		{Case: "2-digit year", Input: "dd/MM/yy", Expected: "02/01/06"},
+		{Case: "with seconds", Input: "HH:mm:ss", Expected: "15:04:05"},
+	}
+
+	for _, tc := range cases {
+		got := windowsPatternToGoLayout(tc.Input)
+		assert.Equal(t, tc.Expected, got, tc.Case)
+	}
+}
+
+// TestPosixPatternToGoLayout verifies the POSIX strftime → Go layout converter.
+func TestPosixPatternToGoLayout(t *testing.T) {
+	cases := []struct {
+		Case     string
+		Input    string
+		Expected string
+	}{
+		{Case: "ISO date", Input: "%Y-%m-%d", Expected: "2006-01-02"},
+		{Case: "US date", Input: "%m/%d/%Y", Expected: "01/02/2006"},
+		{Case: "EU date with dots", Input: "%d.%m.%Y", Expected: "02.01.2006"},
+		{Case: "24-hour time", Input: "%H:%M", Expected: "15:04"},
+		{Case: "12-hour with AM/PM", Input: "%I:%M %p", Expected: "03:04 PM"},
+		{Case: "abbreviated month", Input: "%b %e, %Y", Expected: "Jan 2, 2006"},
+		{Case: "full day and month", Input: "%A, %B %e, %Y", Expected: "Monday, January 2, 2006"},
+		{Case: "escaped percent", Input: "100%%", Expected: "100%"},
+		{Case: "lowercase am/pm", Input: "%I:%M %P", Expected: "03:04 pm"},
+		{Case: "with seconds", Input: "%H:%M:%S", Expected: "15:04:05"},
+	}
+
+	for _, tc := range cases {
+		got := posixPatternToGoLayout(tc.Input)
+		assert.Equal(t, tc.Expected, got, tc.Case)
+	}
+}
+
+// TestLocaleShortDateFallback verifies that a zero-value resolver still
+// produces ISO 8601 output rather than an empty string.
+func TestLocaleShortDateFallback(t *testing.T) {
+	mockEnv := new(mock.Environment)
+	mockEnv.On("Shell").Return("foo")
+	Cache = new(cache.Template)
+	Init(mockEnv, nil, nil)
+
+	// Override the resolver to return empty strings (simulates resolver failure).
+	localeLayoutsResolver = func() (string, string) { return "", "" }
+	resetLocaleCache("", "")
+
+	time.Local = time.UTC
+	defer func() { time.Local = time.FixedZone("UTC", 0) }()
+
+	tmpl := `{{ localeShortDate .T }}`
+	ctx := struct{ T time.Time }{T: time.Unix(0, 0).UTC()}
+	got, err := Render(tmpl, ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, "1970-01-01", got)
+}
+
+// TestLocaleShortTimeFallback verifies that a zero-value resolver still
+// produces 24-hour output rather than an empty string.
+func TestLocaleShortTimeFallback(t *testing.T) {
+	mockEnv := new(mock.Environment)
+	mockEnv.On("Shell").Return("foo")
+	Cache = new(cache.Template)
+	Init(mockEnv, nil, nil)
+
+	localeLayoutsResolver = func() (string, string) { return "", "" }
+	resetLocaleCache("", "")
+
+	time.Local = time.UTC
+	defer func() { time.Local = time.FixedZone("UTC", 0) }()
+
+	tmpl := `{{ localeShortTime .T }}`
+	ctx := struct{ T time.Time }{T: time.Unix(0, 0).UTC()}
+	got, err := Render(tmpl, ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, "00:00", got)
+}
+
+// TestLocaleShortDateWithISOLayout exercises the full template stack with a
+// known locale layout so we can verify the output without touching the OS.
+func TestLocaleShortDateWithISOLayout(t *testing.T) {
+	mockEnv := new(mock.Environment)
+	mockEnv.On("Shell").Return("foo")
+	Cache = new(cache.Template)
+	Init(mockEnv, nil, nil)
+
+	localeLayoutsResolver = func() (string, string) { return "2006-01-02", "15:04" }
+	resetLocaleCache("", "")
+
+	time.Local = time.UTC
+	defer func() { time.Local = time.FixedZone("UTC", 0) }()
+
+	// knownEpoch = 2019-06-13 20:39:39 UTC (from date_test.go)
+	tmpl := `{{ localeShortDate .T }}`
+	ctx := struct{ T time.Time }{T: time.Unix(knownEpoch, 0).UTC()}
+	got, err := Render(tmpl, ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, "2019-06-13", got)
+}
+
+// TestLocaleShortTimeWith24hLayout exercises the time function with a known layout.
+func TestLocaleShortTimeWith24hLayout(t *testing.T) {
+	mockEnv := new(mock.Environment)
+	mockEnv.On("Shell").Return("foo")
+	Cache = new(cache.Template)
+	Init(mockEnv, nil, nil)
+
+	localeLayoutsResolver = func() (string, string) { return "2006-01-02", "15:04" }
+	resetLocaleCache("", "")
+
+	time.Local = time.UTC
+	defer func() { time.Local = time.FixedZone("UTC", 0) }()
+
+	tmpl := `{{ localeShortTime .T }}`
+	ctx := struct{ T time.Time }{T: time.Unix(knownEpoch, 0).UTC()}
+	got, err := Render(tmpl, ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, "20:39", got)
+}
+
+// TestLocaleShortDateWith12hUSLayout verifies a US-style locale layout.
+func TestLocaleShortDateWith12hUSLayout(t *testing.T) {
+	mockEnv := new(mock.Environment)
+	mockEnv.On("Shell").Return("foo")
+	Cache = new(cache.Template)
+	Init(mockEnv, nil, nil)
+
+	localeLayoutsResolver = func() (string, string) { return "1/2/2006", "3:04 PM" }
+	resetLocaleCache("", "")
+
+	time.Local = time.UTC
+	defer func() { time.Local = time.FixedZone("UTC", 0) }()
+
+	tmpl := `{{ localeShortDate .T }} {{ localeShortTime .T }}`
+	ctx := struct{ T time.Time }{T: time.Unix(knownEpoch, 0).UTC()}
+	got, err := Render(tmpl, ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, "6/13/2019 8:39 PM", got)
+}

--- a/src/template/locale_test.go
+++ b/src/template/locale_test.go
@@ -20,16 +20,18 @@ func resetLocaleCache(dateLayout, timeLayout string) {
 }
 
 // TestWindowsPatternToGoLayout verifies the Windows date/time format → Go layout converter.
+//
+//nolint:dupl
 func TestWindowsPatternToGoLayout(t *testing.T) {
 	cases := []struct {
 		Case     string
 		Input    string
 		Expected string
 	}{
-		{Case: "ISO-style date", Input: "yyyy-MM-dd", Expected: "2006-01-02"},
+		{Case: "ISO-style date", Input: "yyyy-MM-dd", Expected: defaultDateLayout},
 		{Case: "US short date", Input: "M/d/yyyy", Expected: "1/2/2006"},
 		{Case: "EU date with dots", Input: "dd.MM.yyyy", Expected: "02.01.2006"},
-		{Case: "24-hour time", Input: "HH:mm", Expected: "15:04"},
+		{Case: "24-hour time", Input: "HH:mm", Expected: defaultTimeLayout},
 		{Case: "12-hour time with AM/PM", Input: "h:mm tt", Expected: "3:04 PM"},
 		{Case: "zero-padded 12-hour", Input: "hh:mm tt", Expected: "03:04 PM"},
 		{Case: "abbreviated day name", Input: "ddd, MMM d yyyy", Expected: "Mon, Jan 2 2006"},
@@ -45,16 +47,18 @@ func TestWindowsPatternToGoLayout(t *testing.T) {
 }
 
 // TestPosixPatternToGoLayout verifies the POSIX strftime → Go layout converter.
+//
+//nolint:dupl
 func TestPosixPatternToGoLayout(t *testing.T) {
 	cases := []struct {
 		Case     string
 		Input    string
 		Expected string
 	}{
-		{Case: "ISO date", Input: "%Y-%m-%d", Expected: "2006-01-02"},
+		{Case: "ISO date", Input: "%Y-%m-%d", Expected: defaultDateLayout},
 		{Case: "US date", Input: "%m/%d/%Y", Expected: "01/02/2006"},
 		{Case: "EU date with dots", Input: "%d.%m.%Y", Expected: "02.01.2006"},
-		{Case: "24-hour time", Input: "%H:%M", Expected: "15:04"},
+		{Case: "24-hour time", Input: "%H:%M", Expected: defaultTimeLayout},
 		{Case: "12-hour with AM/PM", Input: "%I:%M %p", Expected: "03:04 PM"},
 		{Case: "abbreviated month", Input: "%b %e, %Y", Expected: "Jan 2, 2006"},
 		{Case: "full day and month", Input: "%A, %B %e, %Y", Expected: "Monday, January 2, 2006"},
@@ -120,7 +124,7 @@ func TestLocaleShortDateWithISOLayout(t *testing.T) {
 	Cache = new(cache.Template)
 	Init(mockEnv, nil, nil)
 
-	localeLayoutsResolver = func() (string, string) { return "2006-01-02", "15:04" }
+	localeLayoutsResolver = func() (string, string) { return defaultDateLayout, defaultTimeLayout }
 	resetLocaleCache("", "")
 
 	time.Local = time.UTC
@@ -141,7 +145,7 @@ func TestLocaleShortTimeWith24hLayout(t *testing.T) {
 	Cache = new(cache.Template)
 	Init(mockEnv, nil, nil)
 
-	localeLayoutsResolver = func() (string, string) { return "2006-01-02", "15:04" }
+	localeLayoutsResolver = func() (string, string) { return defaultDateLayout, defaultTimeLayout }
 	resetLocaleCache("", "")
 
 	time.Local = time.UTC

--- a/src/template/locale_unix.go
+++ b/src/template/locale_unix.go
@@ -1,0 +1,44 @@
+//go:build !windows
+
+package template
+
+import (
+	"strings"
+)
+
+func init() {
+	localeLayoutsResolver = resolveUnixLocale
+}
+
+// resolveUnixLocale runs `locale -k LC_TIME` and extracts the d_fmt and t_fmt
+// values, converting them from POSIX strftime format to Go time layout strings.
+func resolveUnixLocale() (dateLayout, timeLayout string) {
+	output, err := env.RunCommand("locale", "-k", "LC_TIME")
+	if err != nil {
+		return "", ""
+	}
+
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+
+		value = strings.Trim(value, `"`)
+
+		switch key {
+		case "d_fmt":
+			if value != "" {
+				dateLayout = posixPatternToGoLayout(value)
+			}
+		case "t_fmt":
+			if value != "" {
+				timeLayout = posixPatternToGoLayout(value)
+			}
+		}
+	}
+
+	return dateLayout, timeLayout
+}

--- a/src/template/locale_unix.go
+++ b/src/template/locale_unix.go
@@ -18,7 +18,7 @@ func resolveUnixLocale() (dateLayout, timeLayout string) {
 		return "", ""
 	}
 
-	for _, line := range strings.Split(output, "\n") {
+	for line := range strings.SplitSeq(output, "\n") {
 		line = strings.TrimSpace(line)
 
 		key, value, ok := strings.Cut(line, "=")

--- a/src/template/locale_windows.go
+++ b/src/template/locale_windows.go
@@ -1,0 +1,36 @@
+package template
+
+import (
+	"strings"
+)
+
+func init() {
+	localeLayoutsResolver = resolveWindowsLocale
+}
+
+// resolveWindowsLocale reads the user's short-date and short-time patterns
+// from the Windows registry and converts them to Go time layout strings.
+//
+// Registry keys read:
+//
+//	HKCU\Control Panel\International\sShortDate
+//	HKCU\Control Panel\International\sShortTime
+func resolveWindowsLocale() (dateLayout, timeLayout string) {
+	const keyBase = `HKCU\Control Panel\International\`
+
+	if v, err := env.WindowsRegistryKeyValue(keyBase + "sShortDate"); err == nil && v != nil {
+		raw := strings.TrimSpace(v.String)
+		if raw != "" {
+			dateLayout = windowsPatternToGoLayout(raw)
+		}
+	}
+
+	if v, err := env.WindowsRegistryKeyValue(keyBase + "sShortTime"); err == nil && v != nil {
+		raw := strings.TrimSpace(v.String)
+		if raw != "" {
+			timeLayout = windowsPatternToGoLayout(raw)
+		}
+	}
+
+	return dateLayout, timeLayout
+}

--- a/website/docs/configuration/templates.mdx
+++ b/website/docs/configuration/templates.mdx
@@ -190,6 +190,8 @@ use them.
 | <code>\{\{ .Code &vert; hresult \}\}</code>                        | Transform a status code to its HRESULT value for easy troubleshooting. For example `-1978335212` becomes `0x8A150014`.     |
 | `{{ readFile ".version.json" }}`                                   | Read a file in the current directory. Returns a string.                                                                    |
 | `{{ random (list \"a\" 2 .MyThirdItem) }}`                         | Selects a random element from a list. The list can be an array or slice containing any types (use sprig's `list`).         |
+| `{{ localeShortDate .SomeTime }}`                                  | Format a `time.Time` value using the OS short-date regional setting (e.g. `2026-04-25`). Falls back to `2006-01-02`.       |
+| `{{ localeShortTime .SomeTime }}`                                  | Format a `time.Time` value using the OS short-time regional setting (e.g. `17:59`). Falls back to `15:04`.                 |
 
 ## Cross segment template properties
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Closes #7481

OMP templates use Go time layout strings that are fixed at config-write time and don't adapt to the user's OS locale. A user whose Windows short-date is `yyyy-MM-dd` and short-time is `HH:mm` sees `Apr 25, 5:59pm` where they expect `2026-04-25 17:59`. Sharing a theme across users with different regional preferences requires either hard-coding the author's format or per-user wrapper scripts.

This PR adds two new template functions that format a `time.Time` value using the user's actual OS regional settings:

```
{{ localeShortDate .SomeTime }}  ->  "2026-04-25"  (per OS short-date setting)
{{ localeShortTime .SomeTime }}  ->  "17:59"        (per OS short-time setting)
```

**How it works:**

- **Windows**: reads `HKCU\Control Panel\International\sShortDate` and `sShortTime` via the existing `env.WindowsRegistryKeyValue()` API and translates the Windows format tokens (`yyyy`, `MM`, `dd`, `HH`, `tt`, etc.) to a Go time layout string.
- **Unix/macOS**: runs `locale -k LC_TIME` and parses `d_fmt` / `t_fmt`, translating POSIX `strftime` tokens (`%Y`, `%m`, `%d`, `%H`, `%M`, etc.) to a Go time layout string.

**Performance:** the OS is queried at most once per process lifetime. The resolver function is called lazily via `sync.Once` -- only when a template actually uses one of these functions. If neither function is ever used, the OS is never touched at all. If the resolver fails or returns an empty value, the functions fall back to ISO 8601 date (`2006-01-02`) and 24-hour time (`15:04`).

**Testing:** the resolver function is a package-level variable that tests can override, keeping all tests deterministic and OS-independent. 7 new tests cover the conversion tables and the full template stack.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary