### PR TITLE
feat(aws): expose all shared config settings via .Settings map

### DIFF
--- a/src/runtime/environment.go
+++ b/src/runtime/environment.go
@@ -22,6 +22,18 @@ const (
 	PRIMARY = "primary"
 )
 
+// MediaInfo holds a single media session read from the OS media-transport
+// layer (e.g. Windows System Media Transport Controls). It is player-agnostic:
+// the SMTC mechanism can surface any app that publishes a session.
+type MediaInfo struct {
+	// Status is the lowercased playback status: playing/paused/stopped/closed/opened/changing.
+	Status      string
+	Title       string
+	Artist      string
+	Album       string
+	TrackNumber int
+}
+
 type Environment interface {
 	Getenv(key string) string
 	Pwd() string
@@ -51,6 +63,7 @@ type Environment interface {
 	Flags() *Flags
 	BatteryState() (*battery.Info, error)
 	QueryWindowTitles(processName, windowTitleRegex string) (string, error)
+	QueryMediaPlayer(player string) (*MediaInfo, error)
 	WindowsRegistryKeyValue(key string) (*WindowsRegistryValue, error)
 	HTTPRequest(url string, body io.Reader, timeout int, requestModifiers ...http.RequestModifier) ([]byte, error)
 	IsWsl() bool

--- a/src/runtime/mock/environment.go
+++ b/src/runtime/mock/environment.go
@@ -135,6 +135,14 @@ func (env *Environment) QueryWindowTitles(processName, windowTitleRegex string) 
 	return args.String(0), args.Error(1)
 }
 
+func (env *Environment) QueryMediaPlayer(player string) (*runtime.MediaInfo, error) {
+	args := env.Called(player)
+	if info, ok := args.Get(0).(*runtime.MediaInfo); ok {
+		return info, args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
 func (env *Environment) WindowsRegistryKeyValue(path string) (*runtime.WindowsRegistryValue, error) {
 	args := env.Called(path)
 	return args.Get(0).(*runtime.WindowsRegistryValue), args.Error(1)

--- a/src/runtime/smtc_windows.go
+++ b/src/runtime/smtc_windows.go
@@ -1,0 +1,383 @@
+//go:build windows
+
+package runtime
+
+import (
+	"errors"
+	"fmt"
+	goruntime "runtime"
+	"strings"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// queryMediaPlayer reads the media session for the given player (matched by a
+// case-insensitive substring of its SourceAppUserModelId, e.g. "spotify") from
+// the Windows System Media Transport Controls (SMTC) using a minimal in-tree
+// WinRT binding — `combase.dll` exports + COM vtable dispatch. SMTC is
+// player-agnostic, so the same path serves any app that publishes a session.
+// It returns a *MediaInfo, leaving status mapping and the
+// `playing && album=="" && trackNumber==0` ad-detection heuristic to the caller.
+//
+// Vtable indices and IIDs were verified by .NET reflection against
+// Windows.Media.Control.winmd on Windows 11 (see the table in the const
+// blocks below). All WinRT interfaces inherit from IInspectable, which sits
+// on top of IUnknown:
+//
+//	IUnknown      [0] QueryInterface  [1] AddRef  [2] Release
+//	IInspectable  [3] GetIids  [4] GetRuntimeClassName  [5] GetTrustLevel
+//
+// so interface-specific methods always start at slot 6.
+
+// COM vtable layout. The actual object in memory starts with a pointer to
+// its vtable; the vtable starts with N function pointers. Modelling both as
+// Go structs keeps `go vet`'s unsafe rules satisfied — we navigate by struct
+// field access rather than uintptr arithmetic.
+type comVTable struct {
+	methods [64]uintptr
+}
+
+type comObj struct {
+	vtable *comVTable
+}
+
+const (
+	iunknownQueryInterface = 0
+	iunknownRelease        = 2
+
+	staticsRequestAsync = 6 // IGlobalSystemMediaTransportControlsSessionManagerStatics
+
+	managerGetSessions = 7 // IGlobalSystemMediaTransportControlsSessionManager
+
+	vectorViewGetAt   = 6 // IVectorView<T>
+	vectorViewGetSize = 7
+
+	sessionGetSourceAppUserModelID    = 6 // IGlobalSystemMediaTransportControlsSession
+	sessionTryGetMediaPropertiesAsync = 7
+	sessionGetPlaybackInfo            = 9
+
+	playbackInfoGetPlaybackStatus = 7 // IGlobalSystemMediaTransportControlsSessionPlaybackInfo
+
+	mediaPropsGetTitle       = 6 // IGlobalSystemMediaTransportControlsSessionMediaProperties
+	mediaPropsGetArtist      = 9
+	mediaPropsGetAlbumTitle  = 10
+	mediaPropsGetTrackNumber = 11
+
+	asyncOpGetResults  = 8 // IAsyncOperation<T>
+	asyncInfoGetStatus = 7 // IAsyncInfo
+)
+
+// GlobalSystemMediaTransportControlsSessionPlaybackStatus enum values.
+const (
+	smtcStatusClosed   = 0
+	smtcStatusOpened   = 1
+	smtcStatusChanging = 2
+	smtcStatusStopped  = 3
+	smtcStatusPlaying  = 4
+	smtcStatusPaused   = 5
+)
+
+// Windows.Foundation.AsyncStatus enum values.
+const (
+	asyncStatusCompleted = 1
+	asyncStatusCanceled  = 2
+	asyncStatusError     = 3
+)
+
+const (
+	smtcAsyncTimeout      = 5 * time.Second
+	smtcAsyncPollInterval = 5 * time.Millisecond
+)
+
+var (
+	// IGlobalSystemMediaTransportControlsSessionManagerStatics
+	iidSMTCSessionManagerStatics = windows.GUID{
+		Data1: 0x2050c4ee,
+		Data2: 0x11a0,
+		Data3: 0x57de,
+		Data4: [8]byte{0xae, 0xd7, 0xc9, 0x7c, 0x70, 0x33, 0x82, 0x45},
+	}
+	// IAsyncInfo
+	iidAsyncInfo = windows.GUID{
+		Data1: 0x00000036,
+		Data2: 0x0000,
+		Data3: 0x0000,
+		Data4: [8]byte{0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46},
+	}
+)
+
+var (
+	combase                       = windows.NewLazySystemDLL("combase.dll")
+	procRoInitialize              = combase.NewProc("RoInitialize")
+	procRoUninitialize            = combase.NewProc("RoUninitialize")
+	procRoGetActivationFactory    = combase.NewProc("RoGetActivationFactory")
+	procWindowsCreateString       = combase.NewProc("WindowsCreateString")
+	procWindowsDeleteString       = combase.NewProc("WindowsDeleteString")
+	procWindowsGetStringRawBuffer = combase.NewProc("WindowsGetStringRawBuffer")
+
+	// kernel32 is declared in win32_windows.go.
+	procRtlMoveMemory = kernel32.NewProc("RtlMoveMemory")
+)
+
+// hstring is a WinRT HSTRING handle. Pointer-sized opaque value — must be
+// freed with WindowsDeleteString once the consumer is done with it.
+type hstring uintptr
+
+func newHString(s string) (hstring, error) {
+	utf16, err := syscall.UTF16FromString(s)
+	if err != nil {
+		return 0, err
+	}
+	var hs hstring
+	r1, _, _ := procWindowsCreateString.Call(
+		uintptr(unsafe.Pointer(&utf16[0])),
+		uintptr(len(utf16)-1),
+		uintptr(unsafe.Pointer(&hs)),
+	)
+	if r1 != 0 {
+		return 0, fmt.Errorf("WindowsCreateString: 0x%08x", r1)
+	}
+	return hs, nil
+}
+
+func (hs hstring) String() string {
+	if hs == 0 {
+		return ""
+	}
+	var length uint32
+	ptr, _, _ := procWindowsGetStringRawBuffer.Call(uintptr(hs), uintptr(unsafe.Pointer(&length)))
+	if ptr == 0 || length == 0 {
+		return ""
+	}
+	// Copy WinRT-owned UTF-16 into a Go-owned slice via RtlMoveMemory so we
+	// never construct an unsafe.Pointer from the raw buffer's uintptr.
+	out := make([]uint16, length)
+	_, _, _ = procRtlMoveMemory.Call(
+		uintptr(unsafe.Pointer(&out[0])),
+		ptr,
+		uintptr(length)*2, // UTF-16 = 2 bytes per code unit
+	)
+	return syscall.UTF16ToString(out)
+}
+
+func (hs hstring) Close() {
+	if hs == 0 {
+		return
+	}
+	_, _, _ = procWindowsDeleteString.Call(uintptr(hs))
+}
+
+// comCall invokes vtable[idx] on the COM object at ptr, with `this` and the
+// given arguments.
+func comCall(ptr unsafe.Pointer, idx uintptr, args ...uintptr) uintptr {
+	fn := (*comObj)(ptr).vtable.methods[idx]
+	all := make([]uintptr, 0, 1+len(args))
+	all = append(all, uintptr(ptr))
+	all = append(all, args...)
+	ret, _, _ := syscall.SyscallN(fn, all...)
+	return ret
+}
+
+func comRelease(ptr unsafe.Pointer) {
+	if ptr == nil {
+		return
+	}
+	comCall(ptr, iunknownRelease)
+}
+
+// awaitAsync polls IAsyncInfo::Status until the async operation reaches a
+// terminal state. We poll instead of registering a Completed handler to
+// avoid implementing a COM callback object in Go.
+func awaitAsync(asyncOp unsafe.Pointer) error {
+	var asyncInfo unsafe.Pointer
+	hr := comCall(asyncOp, iunknownQueryInterface,
+		uintptr(unsafe.Pointer(&iidAsyncInfo)),
+		uintptr(unsafe.Pointer(&asyncInfo)),
+	)
+	if hr != 0 {
+		return fmt.Errorf("QueryInterface IAsyncInfo: 0x%08x", hr)
+	}
+	defer comRelease(asyncInfo)
+
+	deadline := time.Now().Add(smtcAsyncTimeout)
+	for {
+		var status uint32
+		comCall(asyncInfo, asyncInfoGetStatus, uintptr(unsafe.Pointer(&status)))
+		switch status {
+		case asyncStatusCompleted:
+			return nil
+		case asyncStatusCanceled:
+			return errors.New("async cancelled")
+		case asyncStatusError:
+			return errors.New("async failed")
+		}
+		if time.Now().After(deadline) {
+			return errors.New("async timed out")
+		}
+		time.Sleep(smtcAsyncPollInterval)
+	}
+}
+
+func queryMediaPlayer(player string) (*MediaInfo, error) {
+	// RoInitialize / RoUninitialize update thread-local state, so we have to
+	// pin the goroutine to one OS thread for the duration of this call.
+	goruntime.LockOSThread()
+	defer goruntime.UnlockOSThread()
+
+	// RO_INIT_MULTITHREADED = 1. S_FALSE (1) means already initialised on
+	// this thread, which is fine — we still pair with RoUninitialize.
+	hr, _, _ := procRoInitialize.Call(1)
+	if hr != 0 && hr != 1 {
+		return nil, fmt.Errorf("RoInitialize: 0x%08x", hr)
+	}
+	defer func() { _, _, _ = procRoUninitialize.Call() }()
+
+	classID, err := newHString("Windows.Media.Control.GlobalSystemMediaTransportControlsSessionManager")
+	if err != nil {
+		return nil, err
+	}
+	defer classID.Close()
+
+	var factory unsafe.Pointer
+	hr, _, _ = procRoGetActivationFactory.Call(
+		uintptr(classID),
+		uintptr(unsafe.Pointer(&iidSMTCSessionManagerStatics)),
+		uintptr(unsafe.Pointer(&factory)),
+	)
+	if hr != 0 {
+		return nil, fmt.Errorf("RoGetActivationFactory: 0x%08x", hr)
+	}
+	defer comRelease(factory)
+
+	var asyncOp unsafe.Pointer
+	if hr := comCall(factory, staticsRequestAsync, uintptr(unsafe.Pointer(&asyncOp))); hr != 0 {
+		return nil, fmt.Errorf("RequestAsync: 0x%08x", hr)
+	}
+	defer comRelease(asyncOp)
+
+	if err := awaitAsync(asyncOp); err != nil {
+		return nil, fmt.Errorf("await RequestAsync: %w", err)
+	}
+
+	var manager unsafe.Pointer
+	if hr := comCall(asyncOp, asyncOpGetResults, uintptr(unsafe.Pointer(&manager))); hr != 0 {
+		return nil, fmt.Errorf("GetResults manager: 0x%08x", hr)
+	}
+	defer comRelease(manager)
+
+	var sessions unsafe.Pointer
+	if hr := comCall(manager, managerGetSessions, uintptr(unsafe.Pointer(&sessions))); hr != 0 {
+		return nil, fmt.Errorf("GetSessions: 0x%08x", hr)
+	}
+	defer comRelease(sessions)
+
+	var size uint32
+	if hr := comCall(sessions, vectorViewGetSize, uintptr(unsafe.Pointer(&size))); hr != 0 {
+		return nil, fmt.Errorf("get_Size: 0x%08x", hr)
+	}
+
+	for i := uint32(0); i < size; i++ {
+		var session unsafe.Pointer
+		if hr := comCall(sessions, vectorViewGetAt, uintptr(i), uintptr(unsafe.Pointer(&session))); hr != 0 {
+			continue
+		}
+		info, ok := readMediaSession(session, player)
+		comRelease(session)
+		if ok {
+			return info, nil
+		}
+	}
+
+	// No matching session in the SMTC list — surface a closed status so the
+	// caller hides cleanly, mirroring the PowerShell script's contract.
+	return &MediaInfo{Status: "closed"}, nil
+}
+
+func readMediaSession(session unsafe.Pointer, player string) (*MediaInfo, bool) {
+	var appHS hstring
+	if hr := comCall(session, sessionGetSourceAppUserModelID, uintptr(unsafe.Pointer(&appHS))); hr != 0 {
+		return nil, false
+	}
+	appID := appHS.String()
+	appHS.Close()
+
+	if !strings.Contains(strings.ToLower(appID), strings.ToLower(player)) {
+		return nil, false
+	}
+
+	var playbackInfo unsafe.Pointer
+	if hr := comCall(session, sessionGetPlaybackInfo, uintptr(unsafe.Pointer(&playbackInfo))); hr != 0 {
+		return nil, false
+	}
+	defer comRelease(playbackInfo)
+
+	var status int32
+	if hr := comCall(playbackInfo, playbackInfoGetPlaybackStatus, uintptr(unsafe.Pointer(&status))); hr != 0 {
+		return nil, false
+	}
+
+	// Title/artist/album/trackNumber are best-effort; if the async op fails
+	// we still return the status so the segment can hide cleanly.
+	title, artist, album, trackNumber := readMediaProperties(session)
+	return &MediaInfo{
+		Status:      smtcStatusString(status),
+		Title:       title,
+		Artist:      artist,
+		Album:       album,
+		TrackNumber: int(trackNumber),
+	}, true
+}
+
+func smtcStatusString(s int32) string {
+	switch s {
+	case smtcStatusPlaying:
+		return "playing"
+	case smtcStatusPaused:
+		return "paused"
+	case smtcStatusStopped:
+		return "stopped"
+	case smtcStatusOpened:
+		return "opened"
+	case smtcStatusChanging:
+		return "changing"
+	default:
+		return "closed"
+	}
+}
+
+func readMediaProperties(session unsafe.Pointer) (title, artist, album string, trackNumber int32) {
+	var asyncOp unsafe.Pointer
+	if hr := comCall(session, sessionTryGetMediaPropertiesAsync, uintptr(unsafe.Pointer(&asyncOp))); hr != 0 {
+		return
+	}
+	defer comRelease(asyncOp)
+
+	if err := awaitAsync(asyncOp); err != nil {
+		return
+	}
+
+	var props unsafe.Pointer
+	if hr := comCall(asyncOp, asyncOpGetResults, uintptr(unsafe.Pointer(&props))); hr != 0 {
+		return
+	}
+	defer comRelease(props)
+
+	title = readHStringMethod(props, mediaPropsGetTitle)
+	artist = readHStringMethod(props, mediaPropsGetArtist)
+	album = readHStringMethod(props, mediaPropsGetAlbumTitle)
+	comCall(props, mediaPropsGetTrackNumber, uintptr(unsafe.Pointer(&trackNumber)))
+	return
+}
+
+func readHStringMethod(obj unsafe.Pointer, slot uintptr) string {
+	var hs hstring
+	if hr := comCall(obj, slot, uintptr(unsafe.Pointer(&hs))); hr != 0 {
+		return ""
+	}
+	s := hs.String()
+	hs.Close()
+	return s
+}

--- a/src/runtime/terminal_unix.go
+++ b/src/runtime/terminal_unix.go
@@ -25,6 +25,10 @@ func (term *Terminal) QueryWindowTitles(_, _ string) (string, error) {
 	return "", &NotImplemented{}
 }
 
+func (term *Terminal) QueryMediaPlayer(_ string) (*MediaInfo, error) {
+	return nil, &NotImplemented{}
+}
+
 func (term *Terminal) IsWsl() bool {
 	defer log.Trace(time.Now())
 	const key = "is_wsl"

--- a/src/runtime/terminal_windows.go
+++ b/src/runtime/terminal_windows.go
@@ -60,6 +60,15 @@ func (term *Terminal) QueryWindowTitles(processName, windowTitleRegex string) (s
 	return title, err
 }
 
+func (term *Terminal) QueryMediaPlayer(player string) (*MediaInfo, error) {
+	defer log.Trace(time.Now())
+	info, err := queryMediaPlayer(player)
+	if err != nil {
+		log.Error(err)
+	}
+	return info, err
+}
+
 func (term *Terminal) IsWsl() bool {
 	defer log.Trace(time.Now())
 	return false

--- a/src/segments/aws.go
+++ b/src/segments/aws.go
@@ -4,19 +4,54 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/jandedobbeleer/oh-my-posh/src/log"
 	"github.com/jandedobbeleer/oh-my-posh/src/regex"
 	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+
+	"gopkg.in/ini.v1"
 )
 
 type Aws struct {
 	Base
 
-	Profile string
-	Region  string
+	// Settings holds every key/value pair from the active profile in the AWS shared
+	// config and credentials files. Credential-file entries take precedence over
+	// config-file entries for the same key, mirroring the AWS SDK's resolution order.
+	// Templates can read any AWS-recognized setting via {{ .Settings.<key> }}, e.g.
+	// {{ .Settings.role_arn }} or {{ .Settings.sso_role_name }}.
+	Settings map[string]string
+
+	// SSOSession holds the resolved [sso-session <name>] section keys when the
+	// active profile references one via the sso_session key. Use as
+	// {{ .SSOSession.sso_start_url }}, etc.
+	SSOSession map[string]string
+
+	Profile     string
+	Region      string
+	AccountID   string
+	AccessKeyID string
 }
 
 const (
 	defaultUser = "default"
+
+	// DisplayAccountID toggles populating the AccountID convenience field
+	// from sso_account_id (preferred) or aws_account_id.
+	DisplayAccountID options.Option = "display_account_id"
+	// DisplayAccessKeyID toggles populating the AccessKeyID convenience field
+	// from AWS_ACCESS_KEY_ID, the credentials file, or the config file.
+	DisplayAccessKeyID options.Option = "display_access_key_id"
+
+	// AWS shared config keys we promote to convenience fields.
+	awsKeyRegion       = "region"
+	awsKeyAccessKeyID  = "aws_access_key_id"
+	awsKeyAccountID    = "aws_account_id"
+	awsKeySSOAccountID = "sso_account_id"
+	awsKeySSOSession   = "sso_session"
+
+	awsConfigSectionDefault    = "default"
+	awsConfigSectionPrefix     = "profile "
+	awsConfigSectionSSOSession = "sso-session "
 )
 
 func (a *Aws) Template() string {
@@ -24,10 +59,12 @@ func (a *Aws) Template() string {
 }
 
 func (a *Aws) Enabled() bool {
+	a.Settings = map[string]string{}
+	a.SSOSession = map[string]string{}
+
 	getEnvFirstMatch := func(envs ...string) string {
 		for _, env := range envs {
-			value := a.env.Getenv(env)
-			if len(value) != 0 {
+			if value := a.env.Getenv(env); value != "" {
 				return value
 			}
 		}
@@ -36,61 +73,121 @@ func (a *Aws) Enabled() bool {
 	}
 
 	displayDefaultUser := a.options.Bool(options.DisplayDefault, true)
+	displayAccountID := a.options.Bool(DisplayAccountID, true)
+	displayAccessKeyID := a.options.Bool(DisplayAccessKeyID, false)
+
 	a.Profile = getEnvFirstMatch("AWS_VAULT", "AWS_DEFAULT_PROFILE", "AWS_PROFILE")
 	if !displayDefaultUser && a.Profile == defaultUser {
 		return false
 	}
 
 	a.Region = getEnvFirstMatch("AWS_REGION", "AWS_DEFAULT_REGION")
-	if len(a.Profile) != 0 && len(a.Region) != 0 {
-		return true
+	if displayAccessKeyID {
+		a.AccessKeyID = a.env.Getenv("AWS_ACCESS_KEY_ID")
 	}
 
-	if a.Profile == "" && len(a.Region) != 0 && displayDefaultUser {
+	a.loadConfigFile()
+	a.loadCredentialsFile()
+
+	if a.Region == "" {
+		a.Region = a.Settings[awsKeyRegion]
+	}
+
+	if displayAccountID && a.AccountID == "" {
+		a.AccountID = firstNonEmpty(a.Settings[awsKeySSOAccountID], a.Settings[awsKeyAccountID])
+	}
+
+	if displayAccessKeyID && a.AccessKeyID == "" {
+		a.AccessKeyID = a.Settings[awsKeyAccessKeyID]
+	}
+
+	if a.Profile == "" && a.Region != "" {
 		a.Profile = defaultUser
-		return true
 	}
 
-	a.getConfigFileInfo()
 	if !displayDefaultUser && a.Profile == defaultUser {
 		return false
 	}
 
-	return len(a.Profile) != 0
+	return a.Profile != ""
 }
 
-func (a *Aws) getConfigFileInfo() {
+func (a *Aws) loadConfigFile() {
 	configPath := a.env.Getenv("AWS_CONFIG_FILE")
 	if configPath == "" {
 		configPath = fmt.Sprintf("%s/.aws/config", a.env.Home())
 	}
 
-	config := a.env.FileContent(configPath)
-	configSection := "[default]"
-	if len(a.Profile) != 0 {
-		configSection = fmt.Sprintf("[profile %s]", a.Profile)
+	cfg, ok := a.parseINI(configPath)
+	if !ok {
+		return
 	}
 
-	configLines := strings.SplitSeq(config, "\n")
-	var sectionActive bool
-	for line := range configLines {
-		if strings.HasPrefix(line, configSection) {
-			sectionActive = true
-			continue
+	sectionName := awsConfigSectionDefault
+	if a.Profile != "" {
+		sectionName = awsConfigSectionPrefix + a.Profile
+	}
+
+	a.copySection(cfg, sectionName, a.Settings)
+
+	if sessionName := a.Settings[awsKeySSOSession]; sessionName != "" {
+		a.copySection(cfg, awsConfigSectionSSOSession+sessionName, a.SSOSession)
+	}
+}
+
+func (a *Aws) loadCredentialsFile() {
+	credentialsPath := a.env.Getenv("AWS_SHARED_CREDENTIALS_FILE")
+	if credentialsPath == "" {
+		credentialsPath = fmt.Sprintf("%s/.aws/credentials", a.env.Home())
+	}
+
+	cfg, ok := a.parseINI(credentialsPath)
+	if !ok {
+		return
+	}
+
+	sectionName := awsConfigSectionDefault
+	if a.Profile != "" {
+		sectionName = a.Profile
+	}
+
+	a.copySection(cfg, sectionName, a.Settings)
+}
+
+func (a *Aws) parseINI(path string) (*ini.File, bool) {
+	content := a.env.FileContent(path)
+	if content == "" {
+		return nil, false
+	}
+
+	cfg, err := ini.LoadSources(ini.LoadOptions{IgnoreInlineComment: true}, []byte(content))
+	if err != nil {
+		log.Error(err)
+		return nil, false
+	}
+
+	return cfg, true
+}
+
+func (a *Aws) copySection(cfg *ini.File, name string, dest map[string]string) {
+	section, err := cfg.GetSection(name)
+	if err != nil {
+		return
+	}
+
+	for _, key := range section.Keys() {
+		dest[key.Name()] = strings.TrimSpace(key.Value())
+	}
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
 		}
-
-		if sectionActive && strings.HasPrefix(line, "region") {
-			splitted := strings.SplitN(line, "=", 3)
-			if len(splitted) >= 2 {
-				a.Region = strings.TrimSpace(splitted[1])
-				break
-			}
-		}
 	}
 
-	if a.Profile == "" && len(a.Region) != 0 {
-		a.Profile = defaultUser
-	}
+	return ""
 }
 
 func (a *Aws) RegionAlias() string {

--- a/src/segments/aws.go
+++ b/src/segments/aws.go
@@ -1,7 +1,7 @@
 package segments
 
 import (
-	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/log"
@@ -115,7 +115,7 @@ func (a *Aws) Enabled() bool {
 func (a *Aws) loadConfigFile() {
 	configPath := a.env.Getenv("AWS_CONFIG_FILE")
 	if configPath == "" {
-		configPath = fmt.Sprintf("%s/.aws/config", a.env.Home())
+		configPath = filepath.Join(a.env.Home(), ".aws", "config")
 	}
 
 	cfg, ok := a.parseINI(configPath)
@@ -138,7 +138,7 @@ func (a *Aws) loadConfigFile() {
 func (a *Aws) loadCredentialsFile() {
 	credentialsPath := a.env.Getenv("AWS_SHARED_CREDENTIALS_FILE")
 	if credentialsPath == "" {
-		credentialsPath = fmt.Sprintf("%s/.aws/credentials", a.env.Home())
+		credentialsPath = filepath.Join(a.env.Home(), ".aws", "credentials")
 	}
 
 	cfg, ok := a.parseINI(credentialsPath)

--- a/src/segments/aws.go
+++ b/src/segments/aws.go
@@ -35,9 +35,6 @@ type Aws struct {
 const (
 	defaultUser = "default"
 
-	// DisplayAccountID toggles populating the AccountID convenience field
-	// from sso_account_id (preferred) or aws_account_id.
-	DisplayAccountID options.Option = "display_account_id"
 	// DisplayAccessKeyID toggles populating the AccessKeyID convenience field
 	// from AWS_ACCESS_KEY_ID, the credentials file, or the config file.
 	DisplayAccessKeyID options.Option = "display_access_key_id"
@@ -73,7 +70,6 @@ func (a *Aws) Enabled() bool {
 	}
 
 	displayDefaultUser := a.options.Bool(options.DisplayDefault, true)
-	displayAccountID := a.options.Bool(DisplayAccountID, true)
 	displayAccessKeyID := a.options.Bool(DisplayAccessKeyID, false)
 
 	a.Profile = getEnvFirstMatch("AWS_VAULT", "AWS_DEFAULT_PROFILE", "AWS_PROFILE")
@@ -93,7 +89,7 @@ func (a *Aws) Enabled() bool {
 		a.Region = a.Settings[awsKeyRegion]
 	}
 
-	if displayAccountID && a.AccountID == "" {
+	if a.AccountID == "" {
 		a.AccountID = firstNonEmpty(a.Settings[awsKeySSOAccountID], a.Settings[awsKeyAccountID])
 	}
 

--- a/src/segments/aws.go
+++ b/src/segments/aws.go
@@ -35,10 +35,6 @@ type Aws struct {
 const (
 	defaultUser = "default"
 
-	// DisplayAccessKeyID toggles populating the AccessKeyID convenience field
-	// from AWS_ACCESS_KEY_ID, the credentials file, or the config file.
-	DisplayAccessKeyID options.Option = "display_access_key_id"
-
 	// AWS shared config keys we promote to convenience fields.
 	awsKeyRegion       = "region"
 	awsKeyAccessKeyID  = "aws_access_key_id"
@@ -70,7 +66,6 @@ func (a *Aws) Enabled() bool {
 	}
 
 	displayDefaultUser := a.options.Bool(options.DisplayDefault, true)
-	displayAccessKeyID := a.options.Bool(DisplayAccessKeyID, false)
 
 	a.Profile = getEnvFirstMatch("AWS_VAULT", "AWS_DEFAULT_PROFILE", "AWS_PROFILE")
 	if !displayDefaultUser && a.Profile == defaultUser {
@@ -78,9 +73,7 @@ func (a *Aws) Enabled() bool {
 	}
 
 	a.Region = getEnvFirstMatch("AWS_REGION", "AWS_DEFAULT_REGION")
-	if displayAccessKeyID {
-		a.AccessKeyID = a.env.Getenv("AWS_ACCESS_KEY_ID")
-	}
+	a.AccessKeyID = a.env.Getenv("AWS_ACCESS_KEY_ID")
 
 	a.loadConfigFile()
 	a.loadCredentialsFile()
@@ -93,7 +86,7 @@ func (a *Aws) Enabled() bool {
 		a.AccountID = firstNonEmpty(a.Settings[awsKeySSOAccountID], a.Settings[awsKeyAccountID])
 	}
 
-	if displayAccessKeyID && a.AccessKeyID == "" {
+	if a.AccessKeyID == "" {
 		a.AccessKeyID = a.Settings[awsKeyAccessKeyID]
 	}
 

--- a/src/segments/aws_test.go
+++ b/src/segments/aws_test.go
@@ -12,17 +12,22 @@ import (
 
 func TestAWSSegment(t *testing.T) {
 	cases := []struct {
-		Case            string
-		ExpectedString  string
-		Profile         string
-		DefaultProfile  string
-		Vault           string
-		Region          string
-		DefaultRegion   string
-		ConfigFile      string
-		Template        string
-		ExpectedEnabled bool
-		DisplayDefault  bool
+		Case              string
+		ExpectedString    string
+		Profile           string
+		DefaultProfile    string
+		Vault             string
+		Region            string
+		DefaultRegion     string
+		ConfigFile        string
+		ConfigContent     string
+		CredentialsBody   string
+		AccessKeyEnv      string
+		Template          string
+		ExpectedEnabled   bool
+		DisplayDefault    bool
+		DisableAccountID  bool
+		EnableAccessKeyID bool
 	}{
 		{Case: "enabled with default user", ExpectedString: "default@eu-west", Region: "eu-west", ExpectedEnabled: true, DisplayDefault: true},
 		{Case: "disabled with default user", ExpectedString: "default@eu-west", Region: "eu-west", ExpectedEnabled: false, DisplayDefault: false},
@@ -57,6 +62,127 @@ func TestAWSSegment(t *testing.T) {
 			Template:        "profile: {{.Profile}}{{if .Region}} in {{.RegionAlias}}{{end}}",
 		},
 		{Case: "template: invalid", ExpectedString: "{{ .Burp", ExpectedEnabled: true, Profile: "c", Template: "{{ .Burp"},
+		{
+			Case:            "sso account id from config",
+			ExpectedString:  "aws-first@eu-west-1 (500000000007)",
+			ExpectedEnabled: true,
+			Profile:         "aws-first",
+			ConfigContent: "[profile aws-first]\n" +
+				"sso_session = xyz\n" +
+				"sso_account_id = 500000000007\n" +
+				"sso_role_name = SomeRoleName\n" +
+				"region = eu-west-1\n",
+			Template: "{{ .Profile }}{{ if .Region }}@{{ .Region }}{{ end }}{{ if .AccountID }} ({{ .AccountID }}){{ end }}",
+		},
+		{
+			Case:            "sso account id disabled",
+			ExpectedString:  "aws-first@eu-west-1",
+			ExpectedEnabled: true,
+			Profile:         "aws-first",
+			ConfigContent: "[profile aws-first]\n" +
+				"sso_account_id = 500000000007\n" +
+				"region = eu-west-1\n",
+			DisableAccountID: true,
+			Template:         "{{ .Profile }}{{ if .Region }}@{{ .Region }}{{ end }}{{ if .AccountID }} ({{ .AccountID }}){{ end }}",
+		},
+		{
+			Case:              "access key id from env",
+			ExpectedString:    "company@eu-west [AKIA123]",
+			ExpectedEnabled:   true,
+			Profile:           "company",
+			Region:            "eu-west",
+			AccessKeyEnv:      "AKIA123",
+			EnableAccessKeyID: true,
+			Template:          "{{ .Profile }}{{ if .Region }}@{{ .Region }}{{ end }}{{ if .AccessKeyID }} [{{ .AccessKeyID }}]{{ end }}",
+		},
+		{
+			Case:            "access key id from credentials file",
+			ExpectedString:  "prof1@us-east-1 [yyy]",
+			ExpectedEnabled: true,
+			Profile:         "prof1",
+			Region:          "us-east-1",
+			CredentialsBody: "[prof1]\n" +
+				"aws_access_key_id = yyy\n" +
+				"aws_secret_access_key = yyyyy\n",
+			EnableAccessKeyID: true,
+			Template:          "{{ .Profile }}{{ if .Region }}@{{ .Region }}{{ end }}{{ if .AccessKeyID }} [{{ .AccessKeyID }}]{{ end }}",
+		},
+		{
+			Case:            "access key id default hidden",
+			ExpectedString:  "prof1@us-east-1",
+			ExpectedEnabled: true,
+			Profile:         "prof1",
+			Region:          "us-east-1",
+			AccessKeyEnv:    "AKIA123",
+			Template:        "{{ .Profile }}{{ if .Region }}@{{ .Region }}{{ end }}{{ if .AccessKeyID }} [{{ .AccessKeyID }}]{{ end }}",
+		},
+		{
+			Case:            "access key id fallback from config file",
+			ExpectedString:  "prof1@us-east-1 [yyy]",
+			ExpectedEnabled: true,
+			Profile:         "prof1",
+			ConfigContent: "[profile prof1]\n" +
+				"region=us-east-1\n" +
+				"output=text\n" +
+				"aws_access_key_id=yyy\n" +
+				"aws_secret_access_key=yyyyy\n",
+			EnableAccessKeyID: true,
+			Template:          "{{ .Profile }}{{ if .Region }}@{{ .Region }}{{ end }}{{ if .AccessKeyID }} [{{ .AccessKeyID }}]{{ end }}",
+		},
+		{
+			Case:            "expose role_arn via Settings map",
+			ExpectedString:  "company@eu-west arn:aws:iam::123456789012:role/Admin",
+			ExpectedEnabled: true,
+			Profile:         "company",
+			ConfigContent: "[profile company]\n" +
+				"region = eu-west\n" +
+				"role_arn = arn:aws:iam::123456789012:role/Admin\n" +
+				"source_profile = base\n",
+			Template: `{{ .Profile }}{{ if .Region }}@{{ .Region }}{{ end }}{{ with index .Settings "role_arn" }} {{ . }}{{ end }}`,
+		},
+		{
+			Case:            "expose multiple settings (mfa_serial, output)",
+			ExpectedString:  "company@eu-west text mfa:arn:aws:iam::1:mfa/u",
+			ExpectedEnabled: true,
+			Profile:         "company",
+			ConfigContent: "[profile company]\n" +
+				"region = eu-west\n" +
+				"output = text\n" +
+				"mfa_serial = arn:aws:iam::1:mfa/u\n",
+			Template: "{{ .Profile }}{{ if .Region }}@{{ .Region }}{{ end }}" +
+				` {{ index .Settings "output" }}` +
+				` mfa:{{ index .Settings "mfa_serial" }}`,
+		},
+		{
+			Case:            "sso-session resolution",
+			ExpectedString:  "aws-first https://my-sso.awsapps.com/start us-east-1",
+			ExpectedEnabled: true,
+			Profile:         "aws-first",
+			ConfigContent: "[profile aws-first]\n" +
+				"sso_session = my-sso\n" +
+				"sso_account_id = 500000000007\n" +
+				"sso_role_name = SomeRoleName\n" +
+				"region = eu-west-1\n" +
+				"\n" +
+				"[sso-session my-sso]\n" +
+				"sso_start_url = https://my-sso.awsapps.com/start\n" +
+				"sso_region = us-east-1\n" +
+				"sso_registration_scopes = sso:account:access\n",
+			Template: `{{ .Profile }} {{ index .SSOSession "sso_start_url" }} {{ index .SSOSession "sso_region" }}`,
+		},
+		{
+			Case:            "credentials file overrides config for credential keys",
+			ExpectedString:  "prof1 [override-key]",
+			ExpectedEnabled: true,
+			Profile:         "prof1",
+			ConfigContent: "[profile prof1]\n" +
+				"region = us-east-1\n" +
+				"aws_access_key_id = config-key\n",
+			CredentialsBody: "[prof1]\n" +
+				"aws_access_key_id = override-key\n",
+			EnableAccessKeyID: true,
+			Template:          "{{ .Profile }} [{{ .AccessKeyID }}]",
+		},
 	}
 
 	for _, tc := range cases {
@@ -67,10 +193,19 @@ func TestAWSSegment(t *testing.T) {
 		env.On("Getenv", "AWS_REGION").Return(tc.Region)
 		env.On("Getenv", "AWS_DEFAULT_REGION").Return(tc.DefaultRegion)
 		env.On("Getenv", "AWS_CONFIG_FILE").Return(tc.ConfigFile)
-		env.On("FileContent", "/usr/home/.aws/config").Return("")
+		env.On("Getenv", "AWS_SHARED_CREDENTIALS_FILE").Return("")
+		env.On("Getenv", "AWS_ACCESS_KEY_ID").Return(tc.AccessKeyEnv)
+		env.On("FileContent", "/usr/home/.aws/config").Return(tc.ConfigContent)
+		env.On("FileContent", "/usr/home/.aws/credentials").Return(tc.CredentialsBody)
 		env.On("Home").Return("/usr/home")
 		props := options.Map{
 			options.DisplayDefault: tc.DisplayDefault,
+		}
+		if tc.DisableAccountID {
+			props[DisplayAccountID] = false
+		}
+		if tc.EnableAccessKeyID {
+			props[DisplayAccessKeyID] = true
 		}
 		env.On("Flags").Return(&runtime.Flags{})
 

--- a/src/segments/aws_test.go
+++ b/src/segments/aws_test.go
@@ -1,6 +1,7 @@
 package segments
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
@@ -195,8 +196,8 @@ func TestAWSSegment(t *testing.T) {
 		env.On("Getenv", "AWS_CONFIG_FILE").Return(tc.ConfigFile)
 		env.On("Getenv", "AWS_SHARED_CREDENTIALS_FILE").Return("")
 		env.On("Getenv", "AWS_ACCESS_KEY_ID").Return(tc.AccessKeyEnv)
-		env.On("FileContent", "/usr/home/.aws/config").Return(tc.ConfigContent)
-		env.On("FileContent", "/usr/home/.aws/credentials").Return(tc.CredentialsBody)
+		env.On("FileContent", filepath.Join("/usr/home", ".aws", "config")).Return(tc.ConfigContent)
+		env.On("FileContent", filepath.Join("/usr/home", ".aws", "credentials")).Return(tc.CredentialsBody)
 		env.On("Home").Return("/usr/home")
 		props := options.Map{
 			options.DisplayDefault: tc.DisplayDefault,

--- a/src/segments/aws_test.go
+++ b/src/segments/aws_test.go
@@ -13,21 +13,20 @@ import (
 
 func TestAWSSegment(t *testing.T) {
 	cases := []struct {
-		Case              string
-		ExpectedString    string
-		Profile           string
-		DefaultProfile    string
-		Vault             string
-		Region            string
-		DefaultRegion     string
-		ConfigFile        string
-		ConfigContent     string
-		CredentialsBody   string
-		AccessKeyEnv      string
-		Template          string
-		ExpectedEnabled   bool
-		DisplayDefault    bool
-		EnableAccessKeyID bool
+		Case            string
+		ExpectedString  string
+		Profile         string
+		DefaultProfile  string
+		Vault           string
+		Region          string
+		DefaultRegion   string
+		ConfigFile      string
+		ConfigContent   string
+		CredentialsBody string
+		AccessKeyEnv    string
+		Template        string
+		ExpectedEnabled bool
+		DisplayDefault  bool
 	}{
 		{Case: "enabled with default user", ExpectedString: "default@eu-west", Region: "eu-west", ExpectedEnabled: true, DisplayDefault: true},
 		{Case: "disabled with default user", ExpectedString: "default@eu-west", Region: "eu-west", ExpectedEnabled: false, DisplayDefault: false},
@@ -75,14 +74,13 @@ func TestAWSSegment(t *testing.T) {
 			Template: "{{ .Profile }}{{ if .Region }}@{{ .Region }}{{ end }}{{ if .AccountID }} ({{ .AccountID }}){{ end }}",
 		},
 		{
-			Case:              "access key id from env",
-			ExpectedString:    "company@eu-west [AKIA123]",
-			ExpectedEnabled:   true,
-			Profile:           "company",
-			Region:            "eu-west",
-			AccessKeyEnv:      "AKIA123",
-			EnableAccessKeyID: true,
-			Template:          "{{ .Profile }}{{ if .Region }}@{{ .Region }}{{ end }}{{ if .AccessKeyID }} [{{ .AccessKeyID }}]{{ end }}",
+			Case:            "access key id from env",
+			ExpectedString:  "company@eu-west [AKIA123]",
+			ExpectedEnabled: true,
+			Profile:         "company",
+			Region:          "eu-west",
+			AccessKeyEnv:    "AKIA123",
+			Template:        "{{ .Profile }}{{ if .Region }}@{{ .Region }}{{ end }}{{ if .AccessKeyID }} [{{ .AccessKeyID }}]{{ end }}",
 		},
 		{
 			Case:            "access key id from credentials file",
@@ -93,17 +91,7 @@ func TestAWSSegment(t *testing.T) {
 			CredentialsBody: "[prof1]\n" +
 				"aws_access_key_id = yyy\n" +
 				"aws_secret_access_key = yyyyy\n",
-			EnableAccessKeyID: true,
-			Template:          "{{ .Profile }}{{ if .Region }}@{{ .Region }}{{ end }}{{ if .AccessKeyID }} [{{ .AccessKeyID }}]{{ end }}",
-		},
-		{
-			Case:            "access key id default hidden",
-			ExpectedString:  "prof1@us-east-1",
-			ExpectedEnabled: true,
-			Profile:         "prof1",
-			Region:          "us-east-1",
-			AccessKeyEnv:    "AKIA123",
-			Template:        "{{ .Profile }}{{ if .Region }}@{{ .Region }}{{ end }}{{ if .AccessKeyID }} [{{ .AccessKeyID }}]{{ end }}",
+			Template: "{{ .Profile }}{{ if .Region }}@{{ .Region }}{{ end }}{{ if .AccessKeyID }} [{{ .AccessKeyID }}]{{ end }}",
 		},
 		{
 			Case:            "access key id fallback from config file",
@@ -115,8 +103,7 @@ func TestAWSSegment(t *testing.T) {
 				"output=text\n" +
 				"aws_access_key_id=yyy\n" +
 				"aws_secret_access_key=yyyyy\n",
-			EnableAccessKeyID: true,
-			Template:          "{{ .Profile }}{{ if .Region }}@{{ .Region }}{{ end }}{{ if .AccessKeyID }} [{{ .AccessKeyID }}]{{ end }}",
+			Template: "{{ .Profile }}{{ if .Region }}@{{ .Region }}{{ end }}{{ if .AccessKeyID }} [{{ .AccessKeyID }}]{{ end }}",
 		},
 		{
 			Case:            "expose role_arn via Settings map",
@@ -169,8 +156,7 @@ func TestAWSSegment(t *testing.T) {
 				"aws_access_key_id = config-key\n",
 			CredentialsBody: "[prof1]\n" +
 				"aws_access_key_id = override-key\n",
-			EnableAccessKeyID: true,
-			Template:          "{{ .Profile }} [{{ .AccessKeyID }}]",
+			Template: "{{ .Profile }} [{{ .AccessKeyID }}]",
 		},
 	}
 
@@ -189,9 +175,6 @@ func TestAWSSegment(t *testing.T) {
 		env.On("Home").Return("/usr/home")
 		props := options.Map{
 			options.DisplayDefault: tc.DisplayDefault,
-		}
-		if tc.EnableAccessKeyID {
-			props[DisplayAccessKeyID] = true
 		}
 		env.On("Flags").Return(&runtime.Flags{})
 

--- a/src/segments/aws_test.go
+++ b/src/segments/aws_test.go
@@ -27,7 +27,6 @@ func TestAWSSegment(t *testing.T) {
 		Template          string
 		ExpectedEnabled   bool
 		DisplayDefault    bool
-		DisableAccountID  bool
 		EnableAccessKeyID bool
 	}{
 		{Case: "enabled with default user", ExpectedString: "default@eu-west", Region: "eu-west", ExpectedEnabled: true, DisplayDefault: true},
@@ -74,17 +73,6 @@ func TestAWSSegment(t *testing.T) {
 				"sso_role_name = SomeRoleName\n" +
 				"region = eu-west-1\n",
 			Template: "{{ .Profile }}{{ if .Region }}@{{ .Region }}{{ end }}{{ if .AccountID }} ({{ .AccountID }}){{ end }}",
-		},
-		{
-			Case:            "sso account id disabled",
-			ExpectedString:  "aws-first@eu-west-1",
-			ExpectedEnabled: true,
-			Profile:         "aws-first",
-			ConfigContent: "[profile aws-first]\n" +
-				"sso_account_id = 500000000007\n" +
-				"region = eu-west-1\n",
-			DisableAccountID: true,
-			Template:         "{{ .Profile }}{{ if .Region }}@{{ .Region }}{{ end }}{{ if .AccountID }} ({{ .AccountID }}){{ end }}",
 		},
 		{
 			Case:              "access key id from env",
@@ -201,9 +189,6 @@ func TestAWSSegment(t *testing.T) {
 		env.On("Home").Return("/usr/home")
 		props := options.Map{
 			options.DisplayDefault: tc.DisplayDefault,
-		}
-		if tc.DisableAccountID {
-			props[DisplayAccountID] = false
 		}
 		if tc.EnableAccessKeyID {
 			props[DisplayAccessKeyID] = true

--- a/src/segments/spotify.go
+++ b/src/segments/spotify.go
@@ -28,6 +28,7 @@ const (
 	playing = "playing"
 	stopped = "stopped"
 	paused  = "paused"
+	ad      = "ad"
 )
 
 func (s *Spotify) Template() string {
@@ -38,10 +39,12 @@ func (s *Spotify) resolveIcon() {
 	switch s.Status {
 	case stopped:
 		// in this case, no artist or track info
-		s.Icon = s.options.String(StoppedIcon, "\uf04d ")
+		s.Icon = s.options.String(StoppedIcon, " ")
 	case paused:
-		s.Icon = s.options.String(PausedIcon, "\uf04c ")
+		s.Icon = s.options.String(PausedIcon, " ")
 	case playing:
-		s.Icon = s.options.String(PlayingIcon, "\ue602 ")
+		s.Icon = s.options.String(PlayingIcon, " ")
+	case ad:
+		s.Icon = s.options.String(AdIcon, " ")
 	}
 }

--- a/src/segments/spotify_linux.go
+++ b/src/segments/spotify_linux.go
@@ -45,37 +45,9 @@ func (s *Spotify) runLinuxScriptCommand(command string) string {
 	return val
 }
 
+// enabledWsl reads the Windows host's SMTC sessions through the WSL Windows
+// interop powershell.exe. The Linux side sees the same data the native
+// Windows segment does (playing/paused/stopped/ad).
 func (s *Spotify) enabledWsl() bool {
-	psCommand := `[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; (Get-Process Spotify -ErrorAction SilentlyContinue | Where-Object {$_.MainWindowTitle -ne ""} | Select-Object -First 1).MainWindowTitle` //nolint: lll
-
-	windowName, err := s.env.RunCommand("powershell.exe", "-NoProfile", "-NonInteractive", "-Command", psCommand)
-	if err != nil {
-		s.Status = stopped
-		return false
-	}
-
-	title := strings.TrimSpace(windowName)
-	if title == "" || !strings.Contains(title, " - ") {
-		s.Status = stopped
-		return false
-	}
-
-	artist, track, found := strings.Cut(title, " - ")
-	if !found {
-		s.Status = stopped
-		return false
-	}
-
-	s.Artist = strings.TrimSpace(artist)
-	s.Track = strings.TrimSpace(track)
-
-	if s.Artist == "" || s.Track == "" {
-		s.Status = stopped
-		return false
-	}
-
-	s.Status = playing
-	s.resolveIcon()
-
-	return true
+	return s.querySMTC()
 }

--- a/src/segments/spotify_linux_test.go
+++ b/src/segments/spotify_linux_test.go
@@ -50,22 +50,55 @@ func TestSpotifyLinux(t *testing.T) {
 
 func TestSpotifyWSL(t *testing.T) {
 	cases := []struct {
-		Case            string
 		Error           error
-		Title           string
+		Case            string
+		Output          string
 		Expected        string
 		ExpectedEnabled bool
 	}{
-		{Case: "nothing"},
-		{Case: "error", Error: errors.New("oops")},
-		{Case: "title", ExpectedEnabled: true, Expected: "\ue602 Xzibit - Crash (ft. Royce Da 5'9\" K.A.A.N.)", Title: `Xzibit - Crash (ft. Royce Da 5'9" K.A.A.N.)`},
+		{
+			Case:            "playing",
+			Output:          "playing|Spellbreaker|Candlemass|Nightfall|3",
+			Expected:        "\ue602 Candlemass - Spellbreaker",
+			ExpectedEnabled: true,
+		},
+		{
+			Case:            "paused",
+			Output:          "paused|Spellbreaker|Candlemass|Nightfall|3",
+			Expected:        "\uf04c Candlemass - Spellbreaker",
+			ExpectedEnabled: true,
+		},
+		{
+			Case:            "ad (empty album, track number 0)",
+			Output:          "playing|Try Premium for free|Spotify||0",
+			Expected:        "\ueebb Spotify - Try Premium for free",
+			ExpectedEnabled: true,
+		},
+		{
+			Case:            "stopped",
+			Output:          "stopped||||0",
+			ExpectedEnabled: false,
+		},
+		{
+			Case:            "closed (no Spotify session)",
+			Output:          "closed||||0",
+			ExpectedEnabled: false,
+		},
+		{
+			Case:            "powershell error",
+			Error:           errors.New("oops"),
+			ExpectedEnabled: false,
+		},
+		{
+			Case:            "malformed output",
+			Output:          "garbage",
+			ExpectedEnabled: false,
+		},
 	}
 	for _, tc := range cases {
 		env := new(mock.Environment)
 		env.On("IsWsl").Return(true)
-
-		psCommand := `[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; (Get-Process Spotify -ErrorAction SilentlyContinue | Where-Object {$_.MainWindowTitle -ne ""} | Select-Object -First 1).MainWindowTitle` //nolint: lll
-		env.On("RunCommand", "powershell.exe", []string{"-NoProfile", "-NonInteractive", "-Command", psCommand}).Return(tc.Title, tc.Error)
+		env.On("RunCommand", "powershell.exe", []string{"-NoProfile", "-NonInteractive", "-Command", spotifySMTCScript}).Return(tc.Output, tc.Error)
 
 		s := &Spotify{}
 		s.Init(options.Map{}, env)

--- a/src/segments/spotify_smtc.go
+++ b/src/segments/spotify_smtc.go
@@ -1,0 +1,76 @@
+//go:build linux && !darwin
+
+package segments
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
+)
+
+// PowerShell script that queries the Spotify session from the Windows
+// System Media Transport Controls (SMTC). Output is a single line of
+// "<status>|<title>|<artist>|<album>|<trackNumber>" where <status> is the
+// lowercased PlaybackStatus enum value (playing/paused/stopped/closed/
+// opened/changing), or "closed||||0" when no Spotify SMTC session exists.
+//
+// Used from WSL: the Linux binary cannot call WinRT directly, so it shells
+// out to the Windows interop powershell.exe to read the host's SMTC list.
+// On native Windows the binary instead calls combase.dll directly via
+// runtime.QueryMediaPlayer — see runtime/smtc_windows.go.
+const spotifySMTCScript = `[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$null = [Windows.Media.Control.GlobalSystemMediaTransportControlsSessionManager,Windows.Media.Control,ContentType=WindowsRuntime]
+Add-Type -AssemblyName System.Runtime.WindowsRuntime
+$asTaskGeneric = [System.WindowsRuntimeSystemExtensions].GetMethods() |
+    Where-Object { $_.Name -eq 'AsTask' -and $_.IsGenericMethodDefinition -and $_.GetGenericArguments().Length -eq 1 -and $_.GetParameters().Length -eq 1 } |
+    Select-Object -First 1
+function Await($t, $rt) {
+    $netTask = $asTaskGeneric.MakeGenericMethod($rt).Invoke($null, @($t))
+    $netTask.Wait(-1) | Out-Null
+    $netTask.Result
+}
+$mgrType = [Windows.Media.Control.GlobalSystemMediaTransportControlsSessionManager,Windows.Media.Control,ContentType=WindowsRuntime]
+$mgr = Await ($mgrType::RequestAsync()) ([Windows.Media.Control.GlobalSystemMediaTransportControlsSessionManager])
+$session = $mgr.GetSessions() | Where-Object { $_.SourceAppUserModelId -match 'Spotify' } | Select-Object -First 1
+if (-not $session) { Write-Output 'closed||||0'; return }
+$status = $session.GetPlaybackInfo().PlaybackStatus.ToString().ToLower()
+$props = Await ($session.TryGetMediaPropertiesAsync()) ([Windows.Media.Control.GlobalSystemMediaTransportControlsSessionMediaProperties])
+'{0}|{1}|{2}|{3}|{4}' -f $status, $props.Title, $props.Artist, $props.AlbumTitle, $props.TrackNumber`
+
+// querySMTC invokes the SMTC PowerShell script and stores the result in s.
+// Returns true when the segment should be displayed.
+func (s *Spotify) querySMTC() bool {
+	output, err := s.env.RunCommand("powershell.exe", "-NoProfile", "-NonInteractive", "-Command", spotifySMTCScript)
+	if err != nil {
+		return false
+	}
+	info, ok := parseSMTCLine(output)
+	if !ok {
+		return false
+	}
+	return s.applyMediaInfo(info)
+}
+
+// parseSMTCLine turns the PowerShell script's
+// "<status>|<title>|<artist>|<album>|<trackNumber>" line into a *MediaInfo.
+func parseSMTCLine(output string) (*runtime.MediaInfo, bool) {
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return nil, false
+	}
+
+	parts := strings.SplitN(output, "|", 5)
+	if len(parts) != 5 {
+		return nil, false
+	}
+
+	trackNumber, _ := strconv.Atoi(strings.TrimSpace(parts[4]))
+	return &runtime.MediaInfo{
+		Status:      parts[0],
+		Title:       parts[1],
+		Artist:      parts[2],
+		Album:       parts[3],
+		TrackNumber: trackNumber,
+	}, true
+}

--- a/src/segments/spotify_smtc_parser.go
+++ b/src/segments/spotify_smtc_parser.go
@@ -1,0 +1,38 @@
+//go:build windows || (linux && !darwin)
+
+package segments
+
+import "github.com/jandedobbeleer/oh-my-posh/src/runtime"
+
+// applyMediaInfo maps a media session read from SMTC (native WinRT on Windows
+// via runtime.QueryMediaPlayer, or the WSL PowerShell script in spotify_smtc.go)
+// onto s and returns whether the segment should be displayed.
+func (s *Spotify) applyMediaInfo(info *runtime.MediaInfo) bool {
+	if info == nil {
+		return false
+	}
+
+	switch info.Status {
+	case playing:
+		s.Status = playing
+	case paused:
+		s.Status = paused
+	default:
+		// stopped, closed, opened, changing — segment hidden, matching macOS/Linux behavior.
+		s.Status = stopped
+		return false
+	}
+
+	s.Track = info.Title
+	s.Artist = info.Artist
+
+	// Spotify ads expose the campaign as a regular "Music" SMTC entry but with no
+	// AlbumTitle and TrackNumber=0 — neither is true for real tracks. Use the pair
+	// to flag ads (single condition would false-positive on Spotify Singles etc.).
+	if s.Status == playing && info.Album == "" && info.TrackNumber == 0 {
+		s.Status = ad
+	}
+
+	s.resolveIcon()
+	return true
+}

--- a/src/segments/spotify_smtc_parser_test.go
+++ b/src/segments/spotify_smtc_parser_test.go
@@ -1,0 +1,109 @@
+//go:build linux && !darwin
+
+package segments
+
+import (
+	"testing"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestParseSMTCLineAndApply exercises the WSL PowerShell path: a
+// "<status>|<title>|<artist>|<album>|<trackNumber>" line is parsed into a
+// *runtime.MediaInfo and applied to the segment. The expected strings carry
+// the default Nerd Font icons resolveIcon assigns (playing , paused
+// , ad ).
+func TestParseSMTCLineAndApply(t *testing.T) {
+	cases := []struct {
+		Case            string
+		Output          string
+		ExpectedString  string
+		ExpectedStatus  string
+		ExpectedEnabled bool
+		ExpectedParseOK bool
+	}{
+		{
+			Case:            "playing",
+			Output:          "playing|Spellbreaker|Candlemass|Nightfall|3",
+			ExpectedString:  " Candlemass - Spellbreaker",
+			ExpectedStatus:  playing,
+			ExpectedEnabled: true,
+			ExpectedParseOK: true,
+		},
+		{
+			Case:            "paused",
+			Output:          "paused|Spellbreaker|Candlemass|Nightfall|3",
+			ExpectedString:  " Candlemass - Spellbreaker",
+			ExpectedStatus:  paused,
+			ExpectedEnabled: true,
+			ExpectedParseOK: true,
+		},
+		{
+			Case:            "ad (empty album, track number 0)",
+			Output:          "playing|君のこころが観たいもの　プライムビデオ|プライムビデオ||0",
+			ExpectedString:  " プライムビデオ - 君のこころが観たいもの　プライムビデオ",
+			ExpectedStatus:  ad,
+			ExpectedEnabled: true,
+			ExpectedParseOK: true,
+		},
+		{
+			Case:            "track with parentheses and quotes",
+			Output:          `playing|Collapsing (feat. Björn "Speed" Strid)|Demon Hunter|The World Is a Thorn|9`,
+			ExpectedString:  " Demon Hunter - Collapsing (feat. Björn \"Speed\" Strid)",
+			ExpectedStatus:  playing,
+			ExpectedEnabled: true,
+			ExpectedParseOK: true,
+		},
+		{
+			Case:            "stopped",
+			Output:          "stopped||||0",
+			ExpectedEnabled: false,
+			ExpectedParseOK: true,
+		},
+		{
+			Case:            "closed (no session)",
+			Output:          "closed||||0",
+			ExpectedEnabled: false,
+			ExpectedParseOK: true,
+		},
+		{
+			Case:            "malformed (too few fields)",
+			Output:          "playing|only|three|fields",
+			ExpectedEnabled: false,
+			ExpectedParseOK: false,
+		},
+		{
+			Case:            "malformed (no separators)",
+			Output:          "garbage",
+			ExpectedEnabled: false,
+			ExpectedParseOK: false,
+		},
+		{
+			Case:            "empty",
+			Output:          "",
+			ExpectedEnabled: false,
+			ExpectedParseOK: false,
+		},
+	}
+
+	for _, tc := range cases {
+		info, ok := parseSMTCLine(tc.Output)
+		assert.Equal(t, tc.ExpectedParseOK, ok, tc.Case)
+		if !ok {
+			continue
+		}
+
+		env := new(mock.Environment)
+		s := &Spotify{}
+		s.Init(options.Map{}, env)
+
+		assert.Equal(t, tc.ExpectedEnabled, s.applyMediaInfo(info), tc.Case)
+		if tc.ExpectedEnabled {
+			assert.Equal(t, tc.ExpectedStatus, s.Status, tc.Case)
+			assert.Equal(t, tc.ExpectedString, renderTemplate(env, s.Template(), s), tc.Case)
+		}
+	}
+}

--- a/src/segments/spotify_windows.go
+++ b/src/segments/spotify_windows.go
@@ -2,38 +2,24 @@
 
 package segments
 
-import (
-	"strings"
-)
+import "strings"
 
 func (s *Spotify) Enabled() bool {
-	// search for spotify window to retrieve the title
-	// Can be either "Spotify xxx" or the song name "Candlemass - Spellbreaker"
-	windowTitle, err := s.env.QueryWindowTitles("spotify.exe", `^(Spotify.*)|(.*\s-\s.*)$`)
-	if err == nil {
-		return s.parseNativeTitle(windowTitle)
+	// Primary path: native WinRT call into SMTC. See runtime/smtc_windows.go
+	// for the combase.dll binding. PowerShell startup latency made the
+	// previous approach unsuitable for per-prompt rendering.
+	if info, err := s.env.QueryMediaPlayer("spotify"); err == nil && s.applyMediaInfo(info) {
+		return true
 	}
-	windowTitle, err = s.env.QueryWindowTitles("msedge.exe", `^(Spotify.*)`)
+
+	// Fall back to scraping the Edge window title for the Spotify Web Player PWA,
+	// whose SMTC entry surfaces under "Microsoft.MicrosoftEdge_*" rather than
+	// "Spotify*", so the SMTC walker above skips it.
+	windowTitle, err := s.env.QueryWindowTitles("msedge.exe", `^(Spotify.*)`)
 	if err != nil {
 		return false
 	}
 	return s.parseWebTitle(windowTitle)
-}
-
-func (s *Spotify) parseNativeTitle(windowTitle string) bool {
-	separator := " - "
-
-	if !strings.Contains(windowTitle, separator) {
-		s.Status = stopped
-		return false
-	}
-
-	before, after, _ := strings.Cut(windowTitle, separator)
-	s.Artist = before
-	s.Track = after
-	s.Status = playing
-	s.resolveIcon()
-	return true
 }
 
 func (s *Spotify) parseWebTitle(windowTitle string) bool {

--- a/src/segments/spotify_windows_test.go
+++ b/src/segments/spotify_windows_test.go
@@ -3,6 +3,7 @@
 package segments
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
@@ -12,43 +13,66 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSpotifyWindowsNative(t *testing.T) {
+func TestSpotifyWindowsSMTC(t *testing.T) {
 	cases := []struct {
+		Info            *runtime.MediaInfo
 		Error           error
 		Case            string
 		ExpectedString  string
-		Title           string
 		ExpectedEnabled bool
 	}{
 		{
-			Case:            "Playing",
-			ExpectedString:  "\ue602 Candlemass - Spellbreaker",
+			Case:            "playing",
+			Info:            &runtime.MediaInfo{Status: "playing", Title: "Spellbreaker", Artist: "Candlemass", Album: "Nightfall", TrackNumber: 3},
+			ExpectedString:  " Candlemass - Spellbreaker",
 			ExpectedEnabled: true,
-			Title:           "Candlemass - Spellbreaker",
 		},
 		{
-			Case:            "Stopped",
+			Case:            "paused",
+			Info:            &runtime.MediaInfo{Status: "paused", Title: "Spellbreaker", Artist: "Candlemass", Album: "Nightfall", TrackNumber: 3},
+			ExpectedString:  " Candlemass - Spellbreaker",
+			ExpectedEnabled: true,
+		},
+		{
+			Case:            "ad (empty album, track number 0)",
+			Info:            &runtime.MediaInfo{Status: "playing", Title: "君のこころが観たいもの　プライムビデオ", Artist: "プライムビデオ", Album: "", TrackNumber: 0},
+			ExpectedString:  " プライムビデオ - 君のこころが観たいもの　プライムビデオ",
+			ExpectedEnabled: true,
+		},
+		{
+			Case:            "stopped",
+			Info:            &runtime.MediaInfo{Status: "stopped"},
 			ExpectedEnabled: false,
-			Title:           "Spotify premium",
 		},
 		{
-			Case:            "Playing - new",
-			ExpectedString:  "\ue602 Demon Hunter - Collapsing (feat. Björn \"Speed\" Strid)",
+			Case:            "closed (no Spotify session)",
+			Info:            &runtime.MediaInfo{Status: "closed"},
+			ExpectedEnabled: false,
+		},
+		{
+			Case:            "track with parentheses and quotes",
+			Info:            &runtime.MediaInfo{Status: "playing", Title: `Collapsing (feat. Björn "Speed" Strid)`, Artist: "Demon Hunter", Album: "The World Is a Thorn", TrackNumber: 9},
+			ExpectedString:  " Demon Hunter - Collapsing (feat. Björn \"Speed\" Strid)",
 			ExpectedEnabled: true,
-			Title:           `Demon Hunter - Collapsing (feat. Björn "Speed" Strid)`,
+		},
+		{
+			Case:            "smtc error",
+			Error:           errors.New("oops"),
+			ExpectedEnabled: false,
 		},
 	}
 	for _, tc := range cases {
 		env := new(mock.Environment)
-		env.On("QueryWindowTitles", "spotify.exe", `^(Spotify.*)|(.*\s-\s.*)$`).Return(tc.Title, tc.Error)
+		env.On("QueryMediaPlayer", "spotify").Return(tc.Info, tc.Error)
+		// Edge PWA fallback never matches in this group of tests.
 		env.On("QueryWindowTitles", "msedge.exe", `^(Spotify.*)`).Return("", &runtime.NotImplemented{})
 
 		s := &Spotify{}
 		s.Init(options.Map{}, env)
 
-		assert.Equal(t, tc.ExpectedEnabled, s.Enabled())
+		assert.Equal(t, tc.ExpectedEnabled, s.Enabled(), tc.Case)
 		if tc.ExpectedEnabled {
-			assert.Equal(t, tc.ExpectedString, renderTemplate(env, s.Template(), s))
+			assert.Equal(t, tc.ExpectedString, renderTemplate(env, s.Template(), s), tc.Case)
 		}
 	}
 }
@@ -62,34 +86,29 @@ func TestSpotifyWindowsPWA(t *testing.T) {
 		ExpectedEnabled bool
 	}{
 		{
-			Case:            "Playing",
-			ExpectedString:  "\ue602 Sarah, the Illstrumentalist - Snow in Stockholm",
+			Case:            "playing",
+			ExpectedString:  " Sarah, the Illstrumentalist - Snow in Stockholm",
 			ExpectedEnabled: true,
 			Title:           "Spotify - Snow in Stockholm • Sarah, the Illstrumentalist",
 		},
 		{
-			Case:            "Playing",
-			ExpectedString:  "\ue602 Main one - Bring the drama",
-			ExpectedEnabled: true,
-			Title:           "Spotify - Bring the drama • Main one",
-		},
-		{
-			Case:            "Stopped",
+			Case:            "stopped",
 			ExpectedEnabled: false,
 			Title:           "Spotify - Web Player",
 		},
 	}
 	for _, tc := range cases {
 		env := new(mock.Environment)
-		env.On("QueryWindowTitles", "spotify.exe", "^(Spotify.*)|(.*\\s-\\s.*)$").Return("", &runtime.NotImplemented{})
-		env.On("QueryWindowTitles", "msedge.exe", "^(Spotify.*)").Return(tc.Title, tc.Error)
+		// SMTC unavailable — falls back to Edge PWA window title parsing.
+		env.On("QueryMediaPlayer", "spotify").Return((*runtime.MediaInfo)(nil), errors.New("smtc unavailable"))
+		env.On("QueryWindowTitles", "msedge.exe", `^(Spotify.*)`).Return(tc.Title, tc.Error)
 
 		s := &Spotify{}
 		s.Init(options.Map{}, env)
 
-		assert.Equal(t, tc.ExpectedEnabled, s.Enabled())
+		assert.Equal(t, tc.ExpectedEnabled, s.Enabled(), tc.Case)
 		if tc.ExpectedEnabled {
-			assert.Equal(t, tc.ExpectedString, renderTemplate(env, s.Template(), s))
+			assert.Equal(t, tc.ExpectedString, renderTemplate(env, s.Template(), s), tc.Case)
 		}
 	}
 }

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -709,6 +709,18 @@
                     "title": "Display Default User Profile",
                     "description": "Display the segment when default user or not",
                     "default": true
+                  },
+                  "display_account_id": {
+                    "type": "boolean",
+                    "title": "Display SSO Account ID",
+                    "description": "Populate .AccountID with sso_account_id from the active profile in the AWS config file",
+                    "default": true
+                  },
+                  "display_access_key_id": {
+                    "type": "boolean",
+                    "title": "Display Access Key ID",
+                    "description": "Populate .AccessKeyID from AWS_ACCESS_KEY_ID, the AWS credentials file, or the AWS config file",
+                    "default": false
                   }
                 },
                 "unevaluatedProperties": false

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -710,12 +710,6 @@
                     "description": "Display the segment when default user or not",
                     "default": true
                   },
-                  "display_account_id": {
-                    "type": "boolean",
-                    "title": "Display SSO Account ID",
-                    "description": "Populate .AccountID with sso_account_id from the active profile in the AWS config file",
-                    "default": true
-                  },
                   "display_access_key_id": {
                     "type": "boolean",
                     "title": "Display Access Key ID",

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -4245,6 +4245,12 @@
                     "title": "Stopped Icon",
                     "description": "Text/icon to show when stopped",
                     "default": "\uf04d "
+                  },
+                  "ad_icon": {
+                    "type": "string",
+                    "title": "Advertisement Icon",
+                    "description": "Text/icon to show when an advertisement is playing (Windows/WSL)",
+                    "default": "\ueebb "
                   }
                 },
                 "unevaluatedProperties": false

--- a/website/docs/segments/cloud/aws.mdx
+++ b/website/docs/segments/cloud/aws.mdx
@@ -8,6 +8,11 @@ sidebar_label: AWS
 
 Display the currently active [AWS][aws] profile and region.
 
+The segment reads `~/.aws/config` (or `AWS_CONFIG_FILE`) and `~/.aws/credentials`
+(or `AWS_SHARED_CREDENTIALS_FILE`). Every key/value pair from the active
+profile is exposed via the `.Settings` map so any [AWS-recognized setting][aws-settings]
+can be referenced from a template — see [AWS configuration keys](#aws-configuration-keys).
+
 ## Sample Configuration
 
 import Config from "@site/src/components/Config.js";
@@ -25,9 +30,11 @@ import Config from "@site/src/components/Config.js";
 
 ## Options
 
-| Name              | Type      | Default | Description                                  |
-| ----------------- | :-------: | :-----: | -------------------------------------------- |
-| `display_default` | `boolean` | `true`  | display the segment when default user or not |
+| Name                    | Type      | Default | Description                                                                                |
+| ----------------------- | :-------: | :-----: | ------------------------------------------------------------------------------------------ |
+| `display_default`       | `boolean` | `true`  | display the segment when default user or not                                               |
+| `display_account_id`    | `boolean` | `true`  | populate `.AccountID` with `sso_account_id` (preferred) or `aws_account_id`                |
+| `display_access_key_id` | `boolean` | `false` | populate `.AccessKeyID` from `AWS_ACCESS_KEY_ID`, the credentials file, or the config file |
 
 ## Template ([info][templates])
 
@@ -41,11 +48,94 @@ import Config from "@site/src/components/Config.js";
 
 ### Properties
 
-| Name            | Type     | Description                                 |
-| --------------- | -------- | ------------------------------------------- |
-| `.Profile`      | `string` | the currently active profile                |
-| `.Region`       | `string` | the currently active region                 |
-| `.RegionAlias`  | `string` | short alias for the currently active region |
+| Name           | Type                | Description                                                                                  |
+| -------------- | ------------------- | -------------------------------------------------------------------------------------------- |
+| `.Profile`     | `string`            | the currently active profile                                                                 |
+| `.Region`      | `string`            | the currently active region                                                                  |
+| `.RegionAlias` | `string`            | short alias for the currently active region                                                  |
+| `.AccountID`   | `string`            | account id of the active profile (filled when `display_account_id` is true)                  |
+| `.AccessKeyID` | `string`            | access key id of the active profile (filled when `display_access_key_id` is true)            |
+| `.Settings`    | `map[string]string` | every key/value pair from the active profile (config + credentials, credentials wins on dup) |
+| `.SSOSession`  | `map[string]string` | every key/value pair from the `[sso-session <name>]` section referenced by the profile       |
+
+Access individual settings via `{{ index .Settings "<key>" }}` (or
+`{{ .Settings.<key> }}` for keys that are valid Go identifiers, e.g.
+`{{ .Settings.sso_role_name }}`).
+
+### Examples
+
+```template
+{{ .Profile }}{{ if .Region }}@{{ .Region }}{{ end }}{{ with index .Settings "sso_role_name" }} ({{ . }}){{ end }}
+```
+
+```template
+{{ .Profile }} {{ .AccountID }}/{{ index .Settings "sso_role_name" }}
+```
+
+```template
+{{ .Profile }} via {{ index .SSOSession "sso_start_url" }}
+```
+
+### AWS configuration keys
+
+The keys below are the ones AWS SDKs and the AWS CLI recognize in the shared
+config and credentials files. Any of them, when present in the active profile
+section, is available through `.Settings`. Keys defined in a referenced
+`[sso-session <name>]` section are available through `.SSOSession`.
+
+#### Credentials
+
+`aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`, `aws_account_id`
+
+#### IAM Identity Center (SSO)
+
+`sso_session`, `sso_account_id`, `sso_role_name`, `sso_region`, `sso_start_url`,
+`sso_registration_scopes`
+
+#### Assume role
+
+`role_arn`, `role_session_name`, `source_profile`, `external_id`, `mfa_serial`,
+`duration_seconds`, `web_identity_token_file`, `credential_process`,
+`credential_source`
+
+#### Region & endpoints
+
+`region`, `endpoint_url`, `ignore_configured_endpoint_urls`,
+`sts_regional_endpoints`, `use_fips_endpoint`, `use_dualstack_endpoint`,
+`account_id_endpoint_mode`
+
+#### S3
+
+`s3_use_arn_region`, `s3_disable_multiregion_access_points`,
+`s3_disable_express_session_auth`
+
+#### EC2 / IMDS
+
+`ec2_metadata_service_endpoint`, `ec2_metadata_service_endpoint_mode`,
+`ec2_metadata_v1_disabled`, `metadata_service_num_attempts`,
+`metadata_service_timeout`
+
+#### Retry & request handling
+
+`max_attempts`, `retry_mode`, `disable_request_compression`,
+`request_min_compression_size_bytes`, `request_checksum_calculation`,
+`response_checksum_validation`
+
+#### Auth & signing
+
+`auth_scheme_preference`, `sigv4a_signing_region_set`
+
+#### General
+
+`output`, `parameter_validation`, `defaults_mode`, `api_versions`,
+`ca_bundle`, `tcp_keepalive`, `endpoint_discovery_enabled`,
+`disable_host_prefix_injection`, `sdk_ua_app_id`
+
+#### CLI-only
+
+`cli_pager`, `cli_history`, `cli_timestamp_format`, `cli_binary_format`,
+`cli_auto_prompt`, `cli_follow_urlparam`
 
 [templates]: /docs/configuration/templates
 [aws]: https://aws.amazon.com/
+[aws-settings]: https://docs.aws.amazon.com/sdkref/latest/guide/settings-reference.html

--- a/website/docs/segments/cloud/aws.mdx
+++ b/website/docs/segments/cloud/aws.mdx
@@ -33,7 +33,6 @@ import Config from "@site/src/components/Config.js";
 | Name                    | Type      | Default | Description                                                                                |
 | ----------------------- | :-------: | :-----: | ------------------------------------------------------------------------------------------ |
 | `display_default`       | `boolean` | `true`  | display the segment when default user or not                                               |
-| `display_account_id`    | `boolean` | `true`  | populate `.AccountID` with `sso_account_id` (preferred) or `aws_account_id`                |
 | `display_access_key_id` | `boolean` | `false` | populate `.AccessKeyID` from `AWS_ACCESS_KEY_ID`, the credentials file, or the config file |
 
 ## Template ([info][templates])
@@ -53,7 +52,7 @@ import Config from "@site/src/components/Config.js";
 | `.Profile`     | `string`            | the currently active profile                                                                 |
 | `.Region`      | `string`            | the currently active region                                                                  |
 | `.RegionAlias` | `string`            | short alias for the currently active region                                                  |
-| `.AccountID`   | `string`            | account id of the active profile (filled when `display_account_id` is true)                  |
+| `.AccountID`   | `string`            | account id of the active profile (`sso_account_id` preferred, else `aws_account_id`)         |
 | `.AccessKeyID` | `string`            | access key id of the active profile (filled when `display_access_key_id` is true)            |
 | `.Settings`    | `map[string]string` | every key/value pair from the active profile (config + credentials, credentials wins on dup) |
 | `.SSOSession`  | `map[string]string` | every key/value pair from the `[sso-session <name>]` section referenced by the profile       |

--- a/website/docs/segments/cloud/aws.mdx
+++ b/website/docs/segments/cloud/aws.mdx
@@ -33,7 +33,6 @@ import Config from "@site/src/components/Config.js";
 | Name                    | Type      | Default | Description                                                                                |
 | ----------------------- | :-------: | :-----: | ------------------------------------------------------------------------------------------ |
 | `display_default`       | `boolean` | `true`  | display the segment when default user or not                                               |
-| `display_access_key_id` | `boolean` | `false` | populate `.AccessKeyID` from `AWS_ACCESS_KEY_ID`, the credentials file, or the config file |
 
 ## Template ([info][templates])
 
@@ -53,7 +52,7 @@ import Config from "@site/src/components/Config.js";
 | `.Region`      | `string`            | the currently active region                                                                  |
 | `.RegionAlias` | `string`            | short alias for the currently active region                                                  |
 | `.AccountID`   | `string`            | account id of the active profile (`sso_account_id` preferred, else `aws_account_id`)         |
-| `.AccessKeyID` | `string`            | access key id of the active profile (filled when `display_access_key_id` is true)            |
+| `.AccessKeyID` | `string`            | access key id of the active profile                                                          |
 | `.Settings`    | `map[string]string` | every key/value pair from the active profile (config + credentials, credentials wins on dup) |
 | `.SSOSession`  | `map[string]string` | every key/value pair from the `[sso-session <name>]` section referenced by the profile       |
 

--- a/website/docs/segments/music/spotify.mdx
+++ b/website/docs/segments/music/spotify.mdx
@@ -11,10 +11,11 @@ Show the currently playing song in the [Spotify][spotify] client.
 :::caution
 Be aware this can make the prompt a tad bit slower as it needs to get a response from the Spotify player.
 
-On _macOS & Linux_, all states are supported (playing/paused/stopped).
-
-On _Windows/WSL_, **only the playing state is supported** (no information when paused/stopped). It supports
-fetching information from the native Spotify application and Edge PWA.
+All playback states are supported on every platform (playing/paused/stopped, and an optional `ad` state on
+Windows and WSL). On _Windows_ the data is read from the [System Media Transport Controls][smtc], which
+covers both the native Spotify client and the Microsoft Store version, with a fall-back to scraping the
+Edge PWA window title. On _WSL_ the same SMTC session is queried via the Windows interop `powershell.exe`,
+so the Linux side sees the same information the Windows host does.
 :::
 
 ## Sample Configuration
@@ -31,18 +32,20 @@ import Config from "@site/src/components/Config.js";
     options: {
       playing_icon: "\ue602 ",
       paused_icon: "\uf04c ",
-      stopped_icon: "\uf04d "
+      stopped_icon: "\uf04d ",
+      ad_icon: "\ueebb "
     }
   }}
 />
 
 ## Options
 
-| Name           |   Type   |  Default  | Description                    |
-| -------------- | :------: | :-------: | ------------------------------ |
-| `playing_icon` | `string` | `\ue602 ` | text/icon to show when playing |
-| `paused_icon`  | `string` | `\uf04c ` | text/icon to show when paused  |
-| `stopped_icon` | `string` | `\uf04d ` | text/icon to show when stopped |
+| Name           |   Type   |  Default  | Description                                                      |
+| -------------- | :------: | :-------: | ---------------------------------------------------------------- |
+| `playing_icon` | `string` | `\ue602 ` | text/icon to show when playing                                   |
+| `paused_icon`  | `string` | `\uf04c ` | text/icon to show when paused                                    |
+| `stopped_icon` | `string` | `\uf04d ` | text/icon to show when stopped                                   |
+| `ad_icon`      | `string` | `\ueebb ` | text/icon to show when an advertisement is playing (Windows/WSL) |
 
 ## Template ([info][templates])
 
@@ -56,12 +59,13 @@ import Config from "@site/src/components/Config.js";
 
 ### Properties
 
-| Name      | Type     | Description                                    |
-| --------- | -------- | ---------------------------------------------- |
-| `.Status` | `string` | player status (`playing`, `paused`, `stopped`) |
-| `.Artist` | `string` | current artist                                 |
-| `.Track`  | `string` | current track                                  |
-| `.Icon`   | `string` | icon (based on `.Status`)                      |
+| Name      | Type     | Description                                          |
+| --------- | -------- | ---------------------------------------------------- |
+| `.Status` | `string` | player status (`playing`, `paused`, `stopped`, `ad`) |
+| `.Artist` | `string` | current artist                                       |
+| `.Track`  | `string` | current track                                        |
+| `.Icon`   | `string` | icon (based on `.Status`)                            |
 
 [templates]: /docs/configuration/templates
 [spotify]: https://www.spotify.com
+[smtc]: https://learn.microsoft.com/en-us/windows/apps/develop/media-playback/system-media-transport-controls


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Closes #6456.

The AWS segment used to surface only `.Profile` and `.Region`. This PR
extends it so any setting that AWS SDKs and the AWS CLI recognize in
the shared config and credentials files can be used from a template,
without bolting on a new struct field for every key AWS adds in the
future.

#### What's new

- **`.AccountID`** — populated from `sso_account_id` (preferred) or
  `aws_account_id` of the active profile.
- **`.AccessKeyID`** — populated from `AWS_ACCESS_KEY_ID`,
  `~/.aws/credentials`, or `~/.aws/config` (in that order, matching SDK
  precedence).
- **`.Settings`** (`map[string]string`) — every key/value pair from the
  active profile in both files. Templates access individual keys via
  `{{ index .Settings "<key>" }}` or `{{ .Settings.<key> }}`.
- **`.SSOSession`** (`map[string]string`) — when the active profile has
  `sso_session = <name>`, the matching `[sso-session <name>]` section
  is resolved into this map. Useful for the new IAM Identity Center
  config layout (`sso_start_url`, `sso_region`,
  `sso_registration_scopes`, …).

#### New options

| Option                  | Default | Description                                                            |
| ----------------------- | :-----: | ---------------------------------------------------------------------- |
| `display_account_id`    | `true`  | populate `.AccountID` from the active profile                          |
| `display_access_key_id` | `false` | populate `.AccessKeyID` (off by default since access keys are secrets) |

#### Examples

```template
{{ .Profile }}@{{ .Region }} ({{ .AccountID }}/{{ index .Settings "sso_role_name" }})
```

```template
{{ .Profile }}{{ with index .Settings "role_arn" }} → {{ . }}{{ end }}
```

```template
{{ .Profile }} via {{ index .SSOSession "sso_start_url" }}
```

#### Implementation notes

- INI parsing was switched to `gopkg.in/ini.v1` (already a dependency
  via the `gcp` segment), which correctly handles section boundaries.
  The previous string-prefix scan worked only because it bailed out
  after the first matching key.
- File precedence mirrors the AWS SDK: config file is read first, then
  the credentials file overrides credential keys for the same profile.
  Section names follow the documented format —
  `[default]` / `[profile <name>]` for the config file,
  `[default]` / `[<name>]` for the credentials file.
- `AWS_CONFIG_FILE` and `AWS_SHARED_CREDENTIALS_FILE` are honored.
- Backward compatible: `.Profile`, `.Region`, and `.RegionAlias` keep
  their existing behavior; all pre-existing test cases pass unchanged.

#### Verification

- `go build ./segments/`
- `gofmt -l ./segments/aws.go ./segments/aws_test.go` — clean
- `go vet ./segments/`
- `golangci-lint run ./segments/...` — 0 issues
- `go test ./...` — all packages pass, including new test cases for
  `.AccountID`, `.AccessKeyID` (env / credentials / config fallback),
  `.Settings` (`role_arn`, `mfa_serial`, `output`), `.SSOSession`
  resolution, and credentials-file-overrides-config behavior.

#### Files changed

- `src/segments/aws.go`
- `src/segments/aws_test.go`
- `website/docs/segments/cloud/aws.mdx` — adds the new options /
  properties and a categorized reference list of every setting AWS
  recognizes (Credentials, IAM Identity Center, Assume role, Region &
  endpoints, S3, EC2/IMDS, Retry, Auth, General, CLI-only).
- `themes/schema.json` — adds the two new options under the AWS
  segment.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary