### PR TITLE
feat(segment): add `vimode` segment for ZSH Vi mode (#5438)

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -203,6 +203,11 @@ func (cfg *Config) Features(env runtime.Environment) shell.Features {
 					feats |= shell.PoshGit
 				}
 			}
+
+			if segment.Type == VIMODE && env.Shell() == shell.ZSH {
+				log.Debug("vi mode tracking enabled")
+				feats |= shell.VIMode
+			}
 		}
 	}
 

--- a/src/config/segment_types.go
+++ b/src/config/segment_types.go
@@ -142,6 +142,7 @@ func init() {
 	gob.Register(&segments.UpgradeCache{})
 	gob.Register(&segments.V{})
 	gob.Register(&segments.Vala{})
+	gob.Register(&segments.VIMode{})
 	gob.Register(&segments.Wakatime{})
 	gob.Register(&segments.WinGet{})
 	gob.Register(&segments.WinGetPackage{})
@@ -367,6 +368,8 @@ const (
 	V SegmentType = "v"
 	// VALA writes the active vala version
 	VALA SegmentType = "vala"
+	// VIMODE writes the active ZSH Vi mode (insert/normal/visual)
+	VIMODE SegmentType = "vimode"
 	// WAKATIME writes tracked time spend in dev editors
 	WAKATIME SegmentType = "wakatime"
 	// WINGET writes the number of available WinGet package updates
@@ -490,6 +493,7 @@ var Segments = map[SegmentType]func() SegmentWriter{
 	UPGRADE:         func() SegmentWriter { return &segments.Upgrade{} },
 	V:               func() SegmentWriter { return &segments.V{} },
 	VALA:            func() SegmentWriter { return &segments.Vala{} },
+	VIMODE:          func() SegmentWriter { return &segments.VIMode{} },
 	WAKATIME:        func() SegmentWriter { return &segments.Wakatime{} },
 	WINGET:          func() SegmentWriter { return &segments.WinGet{} },
 	WINREG:          func() SegmentWriter { return &segments.WindowsRegistry{} },

--- a/src/segments/vimode.go
+++ b/src/segments/vimode.go
@@ -1,0 +1,43 @@
+package segments
+
+const (
+	poshVIModeEnv = "POSH_VI_MODE"
+)
+
+type VIMode struct {
+	Base
+
+	Mode   string
+	Keymap string
+}
+
+func (v *VIMode) Template() string {
+	return " {{ .Mode }} "
+}
+
+func (v *VIMode) Enabled() bool {
+	v.Keymap = v.env.Getenv(poshVIModeEnv)
+	if v.Keymap == "" {
+		return false
+	}
+
+	v.Mode = mapVIModeKeymap(v.Keymap)
+	return true
+}
+
+func mapVIModeKeymap(keymap string) string {
+	switch keymap {
+	case "main", "viins", "emacs":
+		return "insert"
+	case "vicmd":
+		return "normal"
+	case "visual":
+		return "visual"
+	case "viopp":
+		return "viopp"
+	case "replace":
+		return "replace"
+	default:
+		return keymap
+	}
+}

--- a/src/segments/vimode_test.go
+++ b/src/segments/vimode_test.go
@@ -1,0 +1,47 @@
+package segments
+
+import (
+	"testing"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVIMode(t *testing.T) {
+	cases := []struct {
+		Case            string
+		Env             string
+		ExpectedMode    string
+		ExpectedKeymap  string
+		ExpectedEnabled bool
+	}{
+		{Case: "main keymap maps to insert", Env: "main", ExpectedMode: "insert", ExpectedKeymap: "main", ExpectedEnabled: true},
+		{Case: "viins keymap maps to insert", Env: "viins", ExpectedMode: "insert", ExpectedKeymap: "viins", ExpectedEnabled: true},
+		{Case: "emacs keymap maps to insert", Env: "emacs", ExpectedMode: "insert", ExpectedKeymap: "emacs", ExpectedEnabled: true},
+		{Case: "vicmd keymap maps to normal", Env: "vicmd", ExpectedMode: "normal", ExpectedKeymap: "vicmd", ExpectedEnabled: true},
+		{Case: "visual keymap is preserved", Env: "visual", ExpectedMode: "visual", ExpectedKeymap: "visual", ExpectedEnabled: true},
+		{Case: "viopp keymap is preserved", Env: "viopp", ExpectedMode: "viopp", ExpectedKeymap: "viopp", ExpectedEnabled: true},
+		{Case: "replace keymap is preserved", Env: "replace", ExpectedMode: "replace", ExpectedKeymap: "replace", ExpectedEnabled: true},
+		{Case: "unknown keymap falls through", Env: "custom", ExpectedMode: "custom", ExpectedKeymap: "custom", ExpectedEnabled: true},
+		{Case: "empty env disables segment", Env: "", ExpectedEnabled: false},
+	}
+
+	for _, tc := range cases {
+		env := new(mock.Environment)
+		env.On("Getenv", poshVIModeEnv).Return(tc.Env)
+
+		v := &VIMode{}
+		v.Init(options.Map{}, env)
+
+		assert.Equal(t, tc.ExpectedEnabled, v.Enabled(), tc.Case)
+
+		if !tc.ExpectedEnabled {
+			continue
+		}
+
+		assert.Equal(t, tc.ExpectedKeymap, v.Keymap, tc.Case)
+		assert.Equal(t, tc.ExpectedMode, renderTemplate(env, v.Template(), v), tc.Case)
+	}
+}

--- a/src/shell/bash.go
+++ b/src/shell/bash.go
@@ -50,7 +50,7 @@ bleopt prompt_ps1_final='$(
         --shell-version="$BASH_VERSION" \
         --escape=false
 )'`
-	case PromptMark, PoshGit, Azure, LineError, Jobs, Tooltips, Async, Streaming, KeyHandlers:
+	case PromptMark, PoshGit, Azure, LineError, Jobs, Tooltips, Async, Streaming, KeyHandlers, VIMode:
 		fallthrough
 	default:
 		return ""

--- a/src/shell/cmd.go
+++ b/src/shell/cmd.go
@@ -32,7 +32,7 @@ func (f Features) Cmd() Code {
 else
     os.execute(string.format('"%s" notice', omp_executable))
 end`
-	case PromptMark, PoshGit, Azure, LineError, Jobs, CursorPositioning, Async, Streaming, KeyHandlers:
+	case PromptMark, PoshGit, Azure, LineError, Jobs, CursorPositioning, Async, Streaming, KeyHandlers, VIMode:
 		fallthrough
 	default:
 		return ""

--- a/src/shell/elvish.go
+++ b/src/shell/elvish.go
@@ -13,7 +13,7 @@ func (f Features) Elvish() Code {
 		return "$_omp_executable upgrade --auto"
 	case Notice:
 		return "$_omp_executable notice"
-	case PromptMark, RPrompt, PoshGit, Azure, LineError, Jobs, CursorPositioning, Tooltips, Transient, FTCSMarks, Async, Streaming, KeyHandlers:
+	case PromptMark, RPrompt, PoshGit, Azure, LineError, Jobs, CursorPositioning, Tooltips, Transient, FTCSMarks, Async, Streaming, KeyHandlers, VIMode:
 		fallthrough
 	default:
 		return ""

--- a/src/shell/features.go
+++ b/src/shell/features.go
@@ -20,6 +20,7 @@ const (
 	Async
 	Streaming
 	KeyHandlers
+	VIMode
 )
 
 // getAllFeatures returns all defined feature flags by iterating through bit positions
@@ -31,7 +32,7 @@ func getAllFeatures() []Features {
 		feature := Features(1 << i)
 
 		// Stop when we reach a power of 2 greater than our highest defined feature
-		if feature > KeyHandlers*2 {
+		if feature > VIMode*2 {
 			break
 		}
 

--- a/src/shell/fish.go
+++ b/src/shell/fish.go
@@ -27,7 +27,7 @@ func (f Features) Fish() Code {
 		return unixUpgrade
 	case Notice:
 		return unixNotice
-	case RPrompt, PoshGit, Azure, LineError, Jobs, Async, KeyHandlers:
+	case RPrompt, PoshGit, Azure, LineError, Jobs, Async, KeyHandlers, VIMode:
 		fallthrough
 	default:
 		return ""

--- a/src/shell/nu.go
+++ b/src/shell/nu.go
@@ -17,7 +17,7 @@ func (f Features) Nu() Code {
 		return "^$_omp_executable upgrade --auto"
 	case Notice:
 		return "^$_omp_executable notice"
-	case PromptMark, RPrompt, PoshGit, Azure, LineError, Jobs, Tooltips, FTCSMarks, CursorPositioning, Async, Streaming, KeyHandlers:
+	case PromptMark, RPrompt, PoshGit, Azure, LineError, Jobs, Tooltips, FTCSMarks, CursorPositioning, Async, Streaming, KeyHandlers, VIMode:
 		fallthrough
 	default:
 		return ""

--- a/src/shell/pwsh.go
+++ b/src/shell/pwsh.go
@@ -33,7 +33,7 @@ func (f Features) Pwsh() Code {
 		return "$global:_ompStreaming = $true"
 	case KeyHandlers:
 		return "Enable-KeyHandlers"
-	case PromptMark, RPrompt, CursorPositioning, Async:
+	case PromptMark, RPrompt, CursorPositioning, Async, VIMode:
 		fallthrough
 	default:
 		return ""

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -362,5 +362,17 @@ function enable_poshtooltips() {
   _omp_create_widget backward-delete-char _omp_restore_rprompt
 }
 
+# vi mode tracking — re-render the prompt whenever the active keymap changes
+function _omp_render_vimode() {
+  export POSH_VI_MODE=${KEYMAP:-main}
+  eval "$(_omp_get_prompt primary --eval)"
+  zle .reset-prompt
+}
+
+function _omp_enable_vimode() {
+  export POSH_VI_MODE=${POSH_VI_MODE:-main}
+  _omp_create_widget zle-keymap-select _omp_render_vimode
+}
+
 # legacy functions
 function enable_poshtransientprompt() {}

--- a/src/shell/xonsh.go
+++ b/src/shell/xonsh.go
@@ -15,7 +15,7 @@ func (f Features) Xonsh() Code {
 		return "@(_omp_executable) upgrade --auto"
 	case Notice:
 		return "@(_omp_executable) notice"
-	case PromptMark, RPrompt, PoshGit, Azure, LineError, Jobs, Tooltips, Transient, CursorPositioning, FTCSMarks, Async, Streaming, KeyHandlers:
+	case PromptMark, RPrompt, PoshGit, Azure, LineError, Jobs, Tooltips, Transient, CursorPositioning, FTCSMarks, Async, Streaming, KeyHandlers, VIMode:
 		fallthrough
 	default:
 		return ""

--- a/src/shell/zsh.go
+++ b/src/shell/zsh.go
@@ -23,6 +23,8 @@ func (f Features) Zsh() Code {
 		return unixNotice
 	case Streaming:
 		return "_omp_enable_streaming=1"
+	case VIMode:
+		return "_omp_enable_vimode"
 	case PromptMark, RPrompt, PoshGit, Azure, LineError, Jobs, Async, KeyHandlers:
 		fallthrough
 	default:

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -467,6 +467,7 @@
             "upgrade",
             "v",
             "vala",
+            "vimode",
             "wakatime",
             "winget",
             "winreg",
@@ -4843,6 +4844,19 @@
                 }
               }
             }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "vimode"
+              }
+            }
+          },
+          "then": {
+            "title": "Vi mode",
+            "description": "https://ohmyposh.dev/docs/segments/system/vimode"
           }
         },
         {

--- a/website/docs/segments/system/vimode.mdx
+++ b/website/docs/segments/system/vimode.mdx
@@ -1,0 +1,52 @@
+---
+id: vimode
+title: Vi mode
+sidebar_label: Vi mode
+---
+
+## What
+
+Display the current ZSH [Vi mode][zsh-vi-mode] (insert / normal / visual …) in
+the prompt. Useful when using `bindkey -v` so you can tell at a glance which
+mode you are in.
+
+:::caution
+This segment is currently only supported in **ZSH**. Adding it to your
+configuration will automatically register a `zle-keymap-select` hook that
+re-renders the prompt every time the keymap changes.
+:::
+
+## Sample Configuration
+
+import Config from "@site/src/components/Config.js";
+
+<Config
+  data={{
+    type: "vimode",
+    style: "plain",
+    foreground: "#ffffff",
+    background: "#0077c2",
+    template: " {{ if eq .Mode \"normal\" }} NORMAL{{ else if eq .Mode \"visual\" }} VISUAL{{ else }} INSERT{{ end }} ",
+  }}
+/>
+
+## Template ([info][templates])
+
+:::note default template
+
+```template
+ {{ .Mode }}
+```
+
+:::
+
+### Properties
+
+| Name      |   Type   | Description                                                                                              |
+| --------- | :------: | -------------------------------------------------------------------------------------------------------- |
+| `.Mode`   | `string` | the normalized mode: `insert`, `normal`, `visual`, `viopp`, `replace`, or the raw keymap when unmapped   |
+| `.Keymap` | `string` | the raw [`$KEYMAP`][zsh-keymap] value reported by ZSH (e.g. `main`, `viins`, `vicmd`, `visual`, `viopp`) |
+
+[templates]: /docs/configuration/templates
+[zsh-vi-mode]: https://zsh.sourceforge.io/Doc/Release/Zsh-Line-Editor.html#Keymaps
+[zsh-keymap]: https://zsh.sourceforge.io/Doc/Release/Zsh-Line-Editor.html#index-KEYMAP

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -194,6 +194,7 @@ export default {
             "segments/system/text",
             "segments/system/time",
             "segments/system/upgrade",
+            "segments/system/vimode",
             "segments/system/winget",
             "segments/system/winreg",
           ]


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Closes #5438.

Adds a new `vimode` segment that displays the active ZSH vi keymap
(`insert` / `normal` / `visual` / `viopp` / `replace`) in the prompt.
This is useful for users running `bindkey -v` who want to see their
current editor mode at a glance.

#### How it works

- A new `VIMode` feature flag is introduced in `src/shell/features.go`. The
  flag is turned on in `src/config/config.go` whenever a configuration
  contains a `vimode` segment **and** the active shell is ZSH.
- When the flag is set, `src/shell/zsh.go` emits `_omp_enable_vimode` into
  the generated init script. That function (defined in
  `src/shell/scripts/omp.zsh`) registers a `zle-keymap-select` widget which
  updates `POSH_VI_MODE=${KEYMAP:-main}` and calls `zle .reset-prompt`
  every time the keymap changes, so the prompt is re-rendered immediately
  on mode transitions.
- The segment itself (`src/segments/vimode.go`) reads `POSH_VI_MODE` and
  exposes two template properties:
  - `.Mode` &mdash; normalized to `insert` (for `main`/`viins`/`emacs`),
    `normal` (for `vicmd`), `visual`, `viopp`, `replace`, or the raw
    keymap when unmapped.
  - `.Keymap` &mdash; the raw `$KEYMAP` value reported by ZSH.
- The segment returns `Enabled() == false` when `POSH_VI_MODE` is empty,
  so it is silently skipped on shells other than ZSH (or in ZSH sessions
  that have not enabled vi mode).

#### Default template

```template
 {{ .Mode }}
```

#### Sample configuration

```json
{
  "type": "vimode",
  "style": "plain",
  "foreground": "#ffffff",
  "background": "#0077c2",
  "template": " {{ if eq .Mode \"normal\" }} NORMAL{{ else if eq .Mode \"visual\" }} VISUAL{{ else }} INSERT{{ end }} "
}
```

#### Limitations

- ZSH only. The feature-flag gate in `src/config/config.go` ensures the
  init-script hook is emitted exclusively for ZSH sessions, and the
  segment's `Enabled()` check guards against rendering on other shells.

#### Files changed

| File | Purpose |
| ---- | ------- |
| `src/segments/vimode.go` | Segment implementation and keymap normalization |
| `src/segments/vimode_test.go` | Table-driven tests covering every keymap mapping plus the disabled path |
| `src/config/segment_types.go` | `gob.Register`, `VIMODE` type constant, and writer-map entry |
| `src/config/config.go` | Enables `shell.VIMode` feature when a `vimode` segment is configured in ZSH |
| `src/shell/features.go` | New `VIMode` feature flag |
| `src/shell/zsh.go` | Maps the `VIMode` flag to `_omp_enable_vimode` |
| `src/shell/scripts/omp.zsh` | `_omp_render_vimode` and `_omp_enable_vimode` widget definitions |
| `website/docs/segments/system/vimode.mdx` | Segment documentation |
| `website/sidebars.js` | Sidebar entry under the *system* category |
| `themes/schema.json` | Adds `vimode` to the segment-type enum and an `allOf` entry for the new type |

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary