### PR TITLE
feat(claude): add missing statusline fields

### DIFF
--- a/src/segments/claude.go
+++ b/src/segments/claude.go
@@ -20,14 +20,24 @@ type Claude struct {
 
 // ClaudeData represents the parsed Claude JSON data
 type ClaudeData struct {
-	RateLimits    *ClaudeRateLimits   `json:"rate_limits"`
-	Model         ClaudeModel         `json:"model"`
-	Workspace     ClaudeWorkspace     `json:"workspace"`
-	SessionID     string              `json:"session_id"`
-	Effort        ClaudeEffort        `json:"effort"`
-	ContextWindow ClaudeContextWindow `json:"context_window"`
-	Cost          ClaudeCost          `json:"cost"`
-	Thinking      ClaudeThinking      `json:"thinking"`
+	RateLimits        *ClaudeRateLimits   `json:"rate_limits"`
+	Worktree          ClaudeWorktree      `json:"worktree"`
+	Model             ClaudeModel         `json:"model"`
+	OutputStyle       ClaudeOutputStyle   `json:"output_style"`
+	Vim               ClaudeVim           `json:"vim"`
+	TranscriptPath    string              `json:"transcript_path"`
+	CWD               string              `json:"cwd"`
+	Version           string              `json:"version"`
+	SessionID         string              `json:"session_id"`
+	Effort            ClaudeEffort        `json:"effort"`
+	SessionName       string              `json:"session_name"`
+	Agent             ClaudeAgent         `json:"agent"`
+	Workspace         ClaudeWorkspace     `json:"workspace"`
+	ContextWindow     ClaudeContextWindow `json:"context_window"`
+	Cost              ClaudeCost          `json:"cost"`
+	Exceeds200KTokens bool                `json:"exceeds_200k_tokens"`
+	Thinking          ClaudeThinking      `json:"thinking"`
+	FastMode          bool                `json:"fast_mode"`
 }
 
 // ClaudeModel represents the AI model information
@@ -38,9 +48,15 @@ type ClaudeModel struct {
 
 // ClaudeWorkspace represents workspace directory information
 type ClaudeWorkspace struct {
-	CurrentDir  string `json:"current_dir"`
-	ProjectDir  string `json:"project_dir"`
-	GitWorktree string `json:"git_worktree"`
+	CurrentDir  string   `json:"current_dir"`
+	ProjectDir  string   `json:"project_dir"`
+	GitWorktree string   `json:"git_worktree"`
+	AddedDirs   []string `json:"added_dirs"`
+}
+
+// ClaudeOutputStyle represents the current output style.
+type ClaudeOutputStyle struct {
+	Name string `json:"name"`
 }
 
 // ClaudeEffort represents reasoning effort information for the current session.
@@ -52,6 +68,25 @@ type ClaudeEffort struct {
 // ClaudeThinking represents extended thinking state for the current session.
 type ClaudeThinking struct {
 	Enabled bool `json:"enabled"`
+}
+
+// ClaudeVim represents vim mode state.
+type ClaudeVim struct {
+	Mode string `json:"mode"`
+}
+
+// ClaudeAgent represents the active agent.
+type ClaudeAgent struct {
+	Name string `json:"name"`
+}
+
+// ClaudeWorktree represents Claude Code --worktree session information.
+type ClaudeWorktree struct {
+	Name           string `json:"name"`
+	Path           string `json:"path"`
+	Branch         string `json:"branch"`
+	OriginalCWD    string `json:"original_cwd"`
+	OriginalBranch string `json:"original_branch"`
 }
 
 // DurationMS is a duration in milliseconds that formats as "Xm Ys".

--- a/src/segments/claude.go
+++ b/src/segments/claude.go
@@ -24,8 +24,10 @@ type ClaudeData struct {
 	Model         ClaudeModel         `json:"model"`
 	Workspace     ClaudeWorkspace     `json:"workspace"`
 	SessionID     string              `json:"session_id"`
+	Effort        ClaudeEffort        `json:"effort"`
 	ContextWindow ClaudeContextWindow `json:"context_window"`
 	Cost          ClaudeCost          `json:"cost"`
+	Thinking      ClaudeThinking      `json:"thinking"`
 }
 
 // ClaudeModel represents the AI model information
@@ -39,6 +41,17 @@ type ClaudeWorkspace struct {
 	CurrentDir  string `json:"current_dir"`
 	ProjectDir  string `json:"project_dir"`
 	GitWorktree string `json:"git_worktree"`
+}
+
+// ClaudeEffort represents reasoning effort information for the current session.
+// Level is empty when the active model does not support reasoning effort.
+type ClaudeEffort struct {
+	Level string `json:"level"`
+}
+
+// ClaudeThinking represents extended thinking state for the current session.
+type ClaudeThinking struct {
+	Enabled bool `json:"enabled"`
 }
 
 // DurationMS is a duration in milliseconds that formats as "Xm Ys".

--- a/src/segments/claude_test.go
+++ b/src/segments/claude_test.go
@@ -1,6 +1,7 @@
 package segments
 
 import (
+	"encoding/json"
 	"testing"
 	libtime "time"
 
@@ -218,6 +219,42 @@ func TestClaudeEffortAndThinking(t *testing.T) {
 		assert.True(t, claude.Enabled(), tc.Case)
 		assert.Equal(t, tc.ExpectedLevel, claude.Effort.Level, tc.Case)
 		assert.Equal(t, tc.ExpectedThinking, claude.Thinking.Enabled, tc.Case)
+	}
+}
+
+func TestClaudeEffortAndThinkingJSONShape(t *testing.T) {
+	cases := []struct {
+		Case             string
+		JSON             string
+		ExpectedLevel    string
+		ExpectedThinking bool
+	}{
+		{
+			Case:             "Both fields present",
+			JSON:             `{"effort":{"level":"xhigh"},"thinking":{"enabled":true}}`,
+			ExpectedLevel:    "xhigh",
+			ExpectedThinking: true,
+		},
+		{
+			Case:             "Both fields absent",
+			JSON:             `{}`,
+			ExpectedLevel:    "",
+			ExpectedThinking: false,
+		},
+		{
+			Case:             "Effort object empty, thinking disabled",
+			JSON:             `{"effort":{},"thinking":{"enabled":false}}`,
+			ExpectedLevel:    "",
+			ExpectedThinking: false,
+		},
+	}
+
+	for _, tc := range cases {
+		var data ClaudeData
+		err := json.Unmarshal([]byte(tc.JSON), &data)
+		assert.NoError(t, err, tc.Case)
+		assert.Equal(t, tc.ExpectedLevel, data.Effort.Level, tc.Case)
+		assert.Equal(t, tc.ExpectedThinking, data.Thinking.Enabled, tc.Case)
 	}
 }
 

--- a/src/segments/claude_test.go
+++ b/src/segments/claude_test.go
@@ -126,8 +126,8 @@ func TestClaudeWorkspaceGitWorktree(t *testing.T) {
 
 	cases := []struct {
 		Case                string
-		Workspace           ClaudeWorkspace
 		ExpectedGitWorktree string
+		Workspace           ClaudeWorkspace
 	}{
 		{
 			Case: "Inside a linked worktree",
@@ -255,6 +255,146 @@ func TestClaudeEffortAndThinkingJSONShape(t *testing.T) {
 		assert.NoError(t, err, tc.Case)
 		assert.Equal(t, tc.ExpectedLevel, data.Effort.Level, tc.Case)
 		assert.Equal(t, tc.ExpectedThinking, data.Thinking.Enabled, tc.Case)
+	}
+}
+
+func TestClaudeAdditionalStatusLineFieldsJSONShape(t *testing.T) {
+	const (
+		defaultOutputStyleName = "default"
+		originalBranchName     = "main"
+	)
+
+	cases := []struct {
+		Case                 string
+		JSON                 string
+		Expected             ClaudeData
+		ExpectedAddedDirsNil bool
+	}{
+		{
+			Case: "All fields present",
+			JSON: `{
+				"cwd": "/repo/project",
+				"session_name": "release-check",
+				"transcript_path": "/repo/project/.claude/transcript.jsonl",
+				"version": "2.1.123",
+				"output_style": {
+					"name": "default"
+				},
+				"workspace": {
+					"added_dirs": ["/repo/shared", "/repo/docs"]
+				},
+				"exceeds_200k_tokens": true,
+				"vim": {
+					"mode": "NORMAL"
+				},
+				"agent": {
+					"name": "security-reviewer"
+				},
+				"worktree": {
+					"name": "my-feature",
+					"path": "/repo/project/.claude/worktrees/my-feature",
+					"branch": "worktree-my-feature",
+					"original_cwd": "/repo/project",
+					"original_branch": "main"
+				},
+				"fast_mode": true
+			}`,
+			Expected: ClaudeData{
+				CWD:               "/repo/project",
+				SessionName:       "release-check",
+				TranscriptPath:    "/repo/project/.claude/transcript.jsonl",
+				Version:           "2.1.123",
+				OutputStyle:       ClaudeOutputStyle{Name: defaultOutputStyleName},
+				Workspace:         ClaudeWorkspace{AddedDirs: []string{"/repo/shared", "/repo/docs"}},
+				Exceeds200KTokens: true,
+				Vim:               ClaudeVim{Mode: "NORMAL"},
+				Agent:             ClaudeAgent{Name: "security-reviewer"},
+				Worktree: ClaudeWorktree{
+					Name:           "my-feature",
+					Path:           "/repo/project/.claude/worktrees/my-feature",
+					Branch:         "worktree-my-feature",
+					OriginalCWD:    "/repo/project",
+					OriginalBranch: originalBranchName,
+				},
+				FastMode: true,
+			},
+		},
+		{
+			Case:                 "All fields absent",
+			JSON:                 `{}`,
+			Expected:             ClaudeData{},
+			ExpectedAddedDirsNil: true,
+		},
+		{
+			Case: "Nested objects empty",
+			JSON: `{
+				"output_style": {},
+				"workspace": {},
+				"vim": {},
+				"agent": {},
+				"worktree": {}
+			}`,
+			Expected:             ClaudeData{},
+			ExpectedAddedDirsNil: true,
+		},
+		{
+			Case: "Partial nested fields",
+			JSON: `{
+				"workspace": {
+					"added_dirs": ["/repo/shared"]
+				},
+				"worktree": {
+					"name": "review",
+					"path": "/repo/project/.claude/worktrees/review"
+				}
+			}`,
+			Expected: ClaudeData{
+				Workspace: ClaudeWorkspace{AddedDirs: []string{"/repo/shared"}},
+				Worktree: ClaudeWorktree{
+					Name: "review",
+					Path: "/repo/project/.claude/worktrees/review",
+				},
+			},
+		},
+		{
+			Case: "Added dirs explicitly empty",
+			JSON: `{
+				"workspace": {
+					"added_dirs": []
+				}
+			}`,
+			Expected: ClaudeData{
+				Workspace: ClaudeWorkspace{AddedDirs: []string{}},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		// Act
+		var data ClaudeData
+		err := json.Unmarshal([]byte(tc.JSON), &data)
+
+		// Assert
+		assert.NoError(t, err, tc.Case)
+		assert.Equal(t, tc.Expected.CWD, data.CWD, tc.Case)
+		assert.Equal(t, tc.Expected.SessionName, data.SessionName, tc.Case)
+		assert.Equal(t, tc.Expected.TranscriptPath, data.TranscriptPath, tc.Case)
+		assert.Equal(t, tc.Expected.Version, data.Version, tc.Case)
+		assert.Equal(t, tc.Expected.OutputStyle.Name, data.OutputStyle.Name, tc.Case)
+		if tc.ExpectedAddedDirsNil {
+			assert.Nil(t, data.Workspace.AddedDirs, tc.Case)
+		} else {
+			assert.Equal(t, tc.Expected.Workspace.AddedDirs, data.Workspace.AddedDirs, tc.Case)
+		}
+		assert.Equal(t, tc.Expected.Exceeds200KTokens, data.Exceeds200KTokens, tc.Case)
+		assert.Equal(t, tc.Expected.Vim.Mode, data.Vim.Mode, tc.Case)
+		assert.Equal(t, tc.Expected.Agent.Name, data.Agent.Name, tc.Case)
+		assert.Equal(t, tc.Expected.Worktree.Name, data.Worktree.Name, tc.Case)
+		assert.Equal(t, tc.Expected.Worktree.Path, data.Worktree.Path, tc.Case)
+		assert.Equal(t, tc.Expected.Worktree.Branch, data.Worktree.Branch, tc.Case)
+		assert.Equal(t, tc.Expected.Worktree.OriginalCWD, data.Worktree.OriginalCWD, tc.Case)
+		assert.Equal(t, tc.Expected.Worktree.OriginalBranch, data.Worktree.OriginalBranch, tc.Case)
+		assert.Equal(t, tc.Expected.FastMode, data.FastMode, tc.Case)
 	}
 }
 

--- a/src/segments/claude_test.go
+++ b/src/segments/claude_test.go
@@ -163,6 +163,52 @@ func TestClaudeWorkspaceGitWorktree(t *testing.T) {
 	}
 }
 
+func TestClaudeEffortAndThinking(t *testing.T) {
+	t.Cleanup(func() {
+		cache.Delete(cache.Session, cache.CLAUDECACHE)
+	})
+
+	cases := []struct {
+		Case             string
+		Effort           ClaudeEffort
+		ExpectedLevel    string
+		Thinking         ClaudeThinking
+		ExpectedThinking bool
+	}{
+		{
+			Case:             "Reasoning effort active, thinking enabled",
+			Effort:           ClaudeEffort{Level: "xhigh"},
+			ExpectedLevel:    "xhigh",
+			Thinking:         ClaudeThinking{Enabled: true},
+			ExpectedThinking: true,
+		},
+		{
+			Case:             "Model without effort support, thinking off",
+			ExpectedLevel:    "",
+			ExpectedThinking: false,
+		},
+	}
+
+	for _, tc := range cases {
+		cache.Set(cache.Session, cache.CLAUDECACHE, ClaudeData{
+			Effort:   tc.Effort,
+			Thinking: tc.Thinking,
+		}, cache.INFINITE)
+
+		env := new(mock.Environment)
+		claude := &Claude{
+			Base: Base{
+				env:     env,
+				options: options.Map{},
+			},
+		}
+
+		assert.True(t, claude.Enabled(), tc.Case)
+		assert.Equal(t, tc.ExpectedLevel, claude.Effort.Level, tc.Case)
+		assert.Equal(t, tc.ExpectedThinking, claude.Thinking.Enabled, tc.Case)
+	}
+}
+
 func TestClaudeTokenUsagePercent(t *testing.T) {
 	cases := []struct {
 		UsedPercentage           *int

--- a/src/segments/claude_test.go
+++ b/src/segments/claude_test.go
@@ -183,7 +183,19 @@ func TestClaudeEffortAndThinking(t *testing.T) {
 			ExpectedThinking: true,
 		},
 		{
-			Case:             "Model without effort support, thinking off",
+			Case:             "Reasoning effort active, thinking disabled",
+			Effort:           ClaudeEffort{Level: "high"},
+			ExpectedLevel:    "high",
+			ExpectedThinking: false,
+		},
+		{
+			Case:             "Reasoning effort absent, thinking enabled",
+			ExpectedLevel:    "",
+			Thinking:         ClaudeThinking{Enabled: true},
+			ExpectedThinking: true,
+		},
+		{
+			Case:             "Reasoning effort absent, thinking disabled",
 			ExpectedLevel:    "",
 			ExpectedThinking: false,
 		},

--- a/website/docs/segments/cli/claude.mdx
+++ b/website/docs/segments/cli/claude.mdx
@@ -53,6 +53,8 @@ import Config from "@site/src/components/Config.js";
 | `.SessionID`         | `string`        | Unique identifier for the Claude session           |
 | `.Model`             | `Model`         | AI model information                               |
 | `.Workspace`         | `Workspace`     | Workspace directory information                    |
+| `.Effort`            | `Effort`        | Reasoning effort information                       |
+| `.Thinking`          | `Thinking`      | Extended thinking state                            |
 | `.Cost`              | `Cost`          | Cost and duration information                      |
 | `.ContextWindow`     | `ContextWindow` | Token usage information                            |
 | `.TokenUsagePercent` | `Percentage`    | Percentage of context window used (0-100)          |
@@ -85,6 +87,18 @@ import Config from "@site/src/components/Config.js";
 | `.CurrentDir`  | `string` | Current working directory                                                    |
 | `.ProjectDir`  | `string` | Root project directory                                                       |
 | `.GitWorktree` | `string` | Path to the linked git worktree, empty when not inside a linked git worktree |
+
+#### Effort Properties
+
+| Name     | Type     | Description                                                                                  |
+| -------- | -------- | -------------------------------------------------------------------------------------------- |
+| `.Level` | `string` | Reasoning effort level (e.g., `low`, `medium`, `high`, `xhigh`, `max`); empty if unsupported |
+
+#### Thinking Properties
+
+| Name       | Type   | Description                                  |
+| ---------- | ------ | -------------------------------------------- |
+| `.Enabled` | `bool` | Whether extended thinking is enabled         |
 
 #### Cost Properties
 

--- a/website/docs/segments/cli/claude.mdx
+++ b/website/docs/segments/cli/claude.mdx
@@ -90,15 +90,15 @@ import Config from "@site/src/components/Config.js";
 
 #### Effort Properties
 
-| Name     | Type     | Description                                                                                  |
-| -------- | -------- | -------------------------------------------------------------------------------------------- |
-| `.Level` | `string` | Reasoning effort level (e.g., `low`, `medium`, `high`, `xhigh`, `max`); empty if unsupported |
+| Name     | Type     | Description                                                                                                  |
+| -------- | -------- | ------------------------------------------------------------------------------------------------------------ |
+| `.Level` | `string` | Reasoning effort level (`low`, `medium`, `high`, `xhigh`, `max`); empty when absent or unsupported           |
 
 #### Thinking Properties
 
-| Name       | Type   | Description                                  |
-| ---------- | ------ | -------------------------------------------- |
-| `.Enabled` | `bool` | Whether extended thinking is enabled         |
+| Name       | Type   | Description                                                  |
+| ---------- | ------ | ------------------------------------------------------------ |
+| `.Enabled` | `bool` | Whether extended thinking is enabled; `false` when absent    |
 
 #### Cost Properties
 

--- a/website/docs/segments/cli/claude.mdx
+++ b/website/docs/segments/cli/claude.mdx
@@ -50,7 +50,7 @@ import Config from "@site/src/components/Config.js";
 
 | Name                    | Type            | Description                                                                          |
 | ----------------------- | --------------- | ------------------------------------------------------------------------------------ |
-| `.CWD`                  | `string`        | Current working directory                                                            |
+| `.CWD`                  | `string`        | Current working directory; same value as `.Workspace.CurrentDir`                     |
 | `.SessionID`            | `string`        | Unique identifier for the Claude session                                             |
 | `.SessionName`          | `string`        | Custom session name; empty when absent                                               |
 | `.TranscriptPath`       | `string`        | Path to the conversation transcript file                                             |
@@ -66,7 +66,7 @@ import Config from "@site/src/components/Config.js";
 | `.Vim`                  | `Vim`           | Vim mode information; empty when absent                                              |
 | `.Agent`                | `Agent`         | Agent information; empty when absent                                                 |
 | `.Worktree`             | `Worktree`      | Claude Code worktree information; empty when absent                                  |
-| `.FastMode`             | `bool`          | Whether fast mode is enabled when Claude Code provides the field                     |
+| `.FastMode`             | `bool`          | Whether fast mode is enabled; `false` when absent or unsupported                     |
 | `.TokenUsagePercent`    | `Percentage`    | Percentage of context window used (0-100)                                            |
 | `.TokenGauge`           | `string`        | Gauge showing remaining context capacity using configured characters (e.g., `▰▰▰▱▱`) |
 | `.TokenGaugeUsed`       | `string`        | Gauge showing used context capacity using configured characters (e.g., `▰▰▱▱▱`)      |
@@ -94,7 +94,7 @@ import Config from "@site/src/components/Config.js";
 
 | Name           | Type       | Description                                                                  |
 | -------------- | ---------- | ---------------------------------------------------------------------------- |
-| `.CurrentDir`  | `string`   | Current working directory                                                    |
+| `.CurrentDir`  | `string`   | Current working directory; preferred when using other workspace fields       |
 | `.ProjectDir`  | `string`   | Root project directory                                                       |
 | `.AddedDirs`   | `[]string` | Additional directories added via `/add-dir` or `--add-dir`                   |
 | `.GitWorktree` | `string`   | Path to the linked git worktree, empty when not inside a linked git worktree |

--- a/website/docs/segments/cli/claude.mdx
+++ b/website/docs/segments/cli/claude.mdx
@@ -94,8 +94,8 @@ import Config from "@site/src/components/Config.js";
 
 | Name           | Type       | Description                                                                  |
 | -------------- | ---------- | ---------------------------------------------------------------------------- |
-| `.CurrentDir`  | `string`   | Current working directory; preferred when using other workspace fields       |
-| `.ProjectDir`  | `string`   | Root project directory                                                       |
+| `.CurrentDir`  | `string`   | Current working directory; same value as `.CWD`                              |
+| `.ProjectDir`  | `string`   | Directory where Claude Code was launched; may differ from `.CurrentDir`      |
 | `.AddedDirs`   | `[]string` | Additional directories added via `/add-dir` or `--add-dir`                   |
 | `.GitWorktree` | `string`   | Path to the linked git worktree, empty when not inside a linked git worktree |
 

--- a/website/docs/segments/cli/claude.mdx
+++ b/website/docs/segments/cli/claude.mdx
@@ -50,13 +50,23 @@ import Config from "@site/src/components/Config.js";
 
 | Name                 | Type            | Description                                        |
 | -------------------- | --------------- | -------------------------------------------------- |
+| `.CWD`               | `string`        | Current working directory                          |
 | `.SessionID`         | `string`        | Unique identifier for the Claude session           |
+| `.SessionName`       | `string`        | Custom session name; empty when absent             |
+| `.TranscriptPath`    | `string`        | Path to the conversation transcript file           |
 | `.Model`             | `Model`         | AI model information                               |
 | `.Workspace`         | `Workspace`     | Workspace directory information                    |
+| `.Version`           | `string`        | Claude Code version                                |
+| `.OutputStyle`       | `OutputStyle`   | Current output style information                   |
 | `.Effort`            | `Effort`        | Reasoning effort information                       |
 | `.Thinking`          | `Thinking`      | Extended thinking state                            |
 | `.Cost`              | `Cost`          | Cost and duration information                      |
 | `.ContextWindow`     | `ContextWindow` | Token usage information                            |
+| `.Exceeds200KTokens` | `bool`          | Whether the most recent API response exceeded 200K total tokens |
+| `.Vim`               | `Vim`           | Vim mode information; empty when absent            |
+| `.Agent`             | `Agent`         | Agent information; empty when absent               |
+| `.Worktree`          | `Worktree`      | Claude Code worktree information; empty when absent |
+| `.FastMode`          | `bool`          | Whether fast mode is enabled when Claude Code provides the field |
 | `.TokenUsagePercent` | `Percentage`    | Percentage of context window used (0-100)          |
 | `.TokenGauge`        | `string`        | Gauge showing remaining context capacity using configured characters (e.g., `▰▰▰▱▱`) |
 | `.TokenGaugeUsed`    | `string`        | Gauge showing used context capacity using configured characters (e.g., `▰▰▱▱▱`) |
@@ -86,7 +96,14 @@ import Config from "@site/src/components/Config.js";
 | -------------- | -------- | ---------------------------------------------------------------------------- |
 | `.CurrentDir`  | `string` | Current working directory                                                    |
 | `.ProjectDir`  | `string` | Root project directory                                                       |
+| `.AddedDirs`   | `[]string` | Additional directories added via `/add-dir` or `--add-dir`                 |
 | `.GitWorktree` | `string` | Path to the linked git worktree, empty when not inside a linked git worktree |
+
+#### OutputStyle Properties
+
+| Name    | Type     | Description                  |
+| ------- | -------- | ---------------------------- |
+| `.Name` | `string` | Name of the current output style |
 
 #### Effort Properties
 
@@ -99,6 +116,28 @@ import Config from "@site/src/components/Config.js";
 | Name       | Type   | Description                                                  |
 | ---------- | ------ | ------------------------------------------------------------ |
 | `.Enabled` | `bool` | Whether extended thinking is enabled; `false` when absent    |
+
+#### Vim Properties
+
+| Name    | Type     | Description                                        |
+| ------- | -------- | -------------------------------------------------- |
+| `.Mode` | `string` | Current vim mode; empty when vim mode is disabled  |
+
+#### Agent Properties
+
+| Name    | Type     | Description                                  |
+| ------- | -------- | -------------------------------------------- |
+| `.Name` | `string` | Agent name; empty when no agent is active    |
+
+#### Worktree Properties
+
+| Name              | Type     | Description                                             |
+| ----------------- | -------- | ------------------------------------------------------- |
+| `.Name`           | `string` | Name of the active Claude Code worktree                 |
+| `.Path`           | `string` | Absolute path to the worktree directory                 |
+| `.Branch`         | `string` | Git branch name for the worktree; empty when absent     |
+| `.OriginalCWD`    | `string` | Directory Claude Code was in before entering worktree   |
+| `.OriginalBranch` | `string` | Branch checked out before entering worktree; empty when absent |
 
 #### Cost Properties
 

--- a/website/docs/segments/cli/claude.mdx
+++ b/website/docs/segments/cli/claude.mdx
@@ -48,40 +48,40 @@ import Config from "@site/src/components/Config.js";
 
 ### Properties
 
-| Name                 | Type            | Description                                        |
-| -------------------- | --------------- | -------------------------------------------------- |
-| `.CWD`               | `string`        | Current working directory                          |
-| `.SessionID`         | `string`        | Unique identifier for the Claude session           |
-| `.SessionName`       | `string`        | Custom session name; empty when absent             |
-| `.TranscriptPath`    | `string`        | Path to the conversation transcript file           |
-| `.Model`             | `Model`         | AI model information                               |
-| `.Workspace`         | `Workspace`     | Workspace directory information                    |
-| `.Version`           | `string`        | Claude Code version                                |
-| `.OutputStyle`       | `OutputStyle`   | Current output style information                   |
-| `.Effort`            | `Effort`        | Reasoning effort information                       |
-| `.Thinking`          | `Thinking`      | Extended thinking state                            |
-| `.Cost`              | `Cost`          | Cost and duration information                      |
-| `.ContextWindow`     | `ContextWindow` | Token usage information                            |
-| `.Exceeds200KTokens` | `bool`          | Whether the most recent API response exceeded 200K total tokens |
-| `.Vim`               | `Vim`           | Vim mode information; empty when absent            |
-| `.Agent`             | `Agent`         | Agent information; empty when absent               |
-| `.Worktree`          | `Worktree`      | Claude Code worktree information; empty when absent |
-| `.FastMode`          | `bool`          | Whether fast mode is enabled when Claude Code provides the field |
-| `.TokenUsagePercent` | `Percentage`    | Percentage of context window used (0-100)          |
-| `.TokenGauge`        | `string`        | Gauge showing remaining context capacity using configured characters (e.g., `▰▰▰▱▱`) |
-| `.TokenGaugeUsed`    | `string`        | Gauge showing used context capacity using configured characters (e.g., `▰▰▱▱▱`) |
-| `.FiveHourGauge`     | `string`        | Gauge showing 5-hour rate limit usage using configured characters |
-| `.SevenDayGauge`     | `string`        | Gauge showing 7-day rate limit usage using configured characters |
-| `.FiveHourResetsAt`  | `time.Time`     | 5-hour rate limit window reset time                |
-| `.SevenDayResetsAt`  | `time.Time`     | 7-day rate limit window reset time                 |
-| `.FiveHourResetsIn`  | `time.Duration` | time until 5-hour resets; 0=unavailable, neg=past  |
-| `.SevenDayResetsIn`  | `time.Duration` | time until 7-day resets; 0=unavailable, neg=past   |
-| `.FormattedCost`     | `string`        | Formatted cost string (e.g., "$0.15" or "$0.0012") |
-| `.FormattedTokens`   | `string`        | Human-readable token count (e.g., "1.2K", "15.3M") |
-| `.FormattedDuration`    | `string`        | Total session duration (e.g., "2m 5s")             |
-| `.FormattedAPIDuration` | `string`        | API wait time (e.g., "0m 45s")                     |
-| `.FiveHourUsage`        | `Percentage`    | 5-hour rolling rate limit usage (0-100)            |
-| `.SevenDayUsage`        | `Percentage`    | 7-day rate limit usage (0-100)                     |
+| Name                    | Type            | Description                                                                          |
+| ----------------------- | --------------- | ------------------------------------------------------------------------------------ |
+| `.CWD`                  | `string`        | Current working directory                                                            |
+| `.SessionID`            | `string`        | Unique identifier for the Claude session                                             |
+| `.SessionName`          | `string`        | Custom session name; empty when absent                                               |
+| `.TranscriptPath`       | `string`        | Path to the conversation transcript file                                             |
+| `.Model`                | `Model`         | AI model information                                                                 |
+| `.Workspace`            | `Workspace`     | Workspace directory information                                                      |
+| `.Version`              | `string`        | Claude Code version                                                                  |
+| `.OutputStyle`          | `OutputStyle`   | Current output style information                                                     |
+| `.Effort`               | `Effort`        | Reasoning effort information                                                         |
+| `.Thinking`             | `Thinking`      | Extended thinking state                                                              |
+| `.Cost`                 | `Cost`          | Cost and duration information                                                        |
+| `.ContextWindow`        | `ContextWindow` | Token usage information                                                              |
+| `.Exceeds200KTokens`    | `bool`          | Whether the most recent API response exceeded 200K total tokens                      |
+| `.Vim`                  | `Vim`           | Vim mode information; empty when absent                                              |
+| `.Agent`                | `Agent`         | Agent information; empty when absent                                                 |
+| `.Worktree`             | `Worktree`      | Claude Code worktree information; empty when absent                                  |
+| `.FastMode`             | `bool`          | Whether fast mode is enabled when Claude Code provides the field                     |
+| `.TokenUsagePercent`    | `Percentage`    | Percentage of context window used (0-100)                                            |
+| `.TokenGauge`           | `string`        | Gauge showing remaining context capacity using configured characters (e.g., `▰▰▰▱▱`) |
+| `.TokenGaugeUsed`       | `string`        | Gauge showing used context capacity using configured characters (e.g., `▰▰▱▱▱`)      |
+| `.FiveHourGauge`        | `string`        | Gauge showing 5-hour rate limit usage using configured characters                    |
+| `.SevenDayGauge`        | `string`        | Gauge showing 7-day rate limit usage using configured characters                     |
+| `.FiveHourResetsAt`     | `time.Time`     | 5-hour rate limit window reset time                                                  |
+| `.SevenDayResetsAt`     | `time.Time`     | 7-day rate limit window reset time                                                   |
+| `.FiveHourResetsIn`     | `time.Duration` | time until 5-hour resets; 0=unavailable, neg=past                                    |
+| `.SevenDayResetsIn`     | `time.Duration` | time until 7-day resets; 0=unavailable, neg=past                                     |
+| `.FormattedCost`        | `string`        | Formatted cost string (e.g., "$0.15" or "$0.0012")                                   |
+| `.FormattedTokens`      | `string`        | Human-readable token count (e.g., "1.2K", "15.3M")                                   |
+| `.FormattedDuration`    | `string`        | Total session duration (e.g., "2m 5s")                                               |
+| `.FormattedAPIDuration` | `string`        | API wait time (e.g., "0m 45s")                                                       |
+| `.FiveHourUsage`        | `Percentage`    | 5-hour rolling rate limit usage (0-100)                                              |
+| `.SevenDayUsage`        | `Percentage`    | 7-day rate limit usage (0-100)                                                       |
 
 #### Model Properties
 
@@ -92,62 +92,62 @@ import Config from "@site/src/components/Config.js";
 
 #### Workspace Properties
 
-| Name           | Type     | Description                                                                  |
-| -------------- | -------- | ---------------------------------------------------------------------------- |
-| `.CurrentDir`  | `string` | Current working directory                                                    |
-| `.ProjectDir`  | `string` | Root project directory                                                       |
-| `.AddedDirs`   | `[]string` | Additional directories added via `/add-dir` or `--add-dir`                 |
-| `.GitWorktree` | `string` | Path to the linked git worktree, empty when not inside a linked git worktree |
+| Name           | Type       | Description                                                                  |
+| -------------- | ---------- | ---------------------------------------------------------------------------- |
+| `.CurrentDir`  | `string`   | Current working directory                                                    |
+| `.ProjectDir`  | `string`   | Root project directory                                                       |
+| `.AddedDirs`   | `[]string` | Additional directories added via `/add-dir` or `--add-dir`                   |
+| `.GitWorktree` | `string`   | Path to the linked git worktree, empty when not inside a linked git worktree |
 
 #### OutputStyle Properties
 
-| Name    | Type     | Description                  |
-| ------- | -------- | ---------------------------- |
+| Name    | Type     | Description                      |
+| ------- | -------- | -------------------------------- |
 | `.Name` | `string` | Name of the current output style |
 
 #### Effort Properties
 
-| Name     | Type     | Description                                                                                                  |
-| -------- | -------- | ------------------------------------------------------------------------------------------------------------ |
-| `.Level` | `string` | Reasoning effort level (`low`, `medium`, `high`, `xhigh`, `max`); empty when absent or unsupported           |
+| Name     | Type     | Description                                                                                        |
+| -------- | -------- | -------------------------------------------------------------------------------------------------- |
+| `.Level` | `string` | Reasoning effort level (`low`, `medium`, `high`, `xhigh`, `max`); empty when absent or unsupported |
 
 #### Thinking Properties
 
-| Name       | Type   | Description                                                  |
-| ---------- | ------ | ------------------------------------------------------------ |
-| `.Enabled` | `bool` | Whether extended thinking is enabled; `false` when absent    |
+| Name       | Type   | Description                                               |
+| ---------- | ------ | --------------------------------------------------------- |
+| `.Enabled` | `bool` | Whether extended thinking is enabled; `false` when absent |
 
 #### Vim Properties
 
-| Name    | Type     | Description                                        |
-| ------- | -------- | -------------------------------------------------- |
-| `.Mode` | `string` | Current vim mode; empty when vim mode is disabled  |
+| Name    | Type     | Description                                       |
+| ------- | -------- | ------------------------------------------------- |
+| `.Mode` | `string` | Current vim mode; empty when vim mode is disabled |
 
 #### Agent Properties
 
-| Name    | Type     | Description                                  |
-| ------- | -------- | -------------------------------------------- |
-| `.Name` | `string` | Agent name; empty when no agent is active    |
+| Name    | Type     | Description                               |
+| ------- | -------- | ----------------------------------------- |
+| `.Name` | `string` | Agent name; empty when no agent is active |
 
 #### Worktree Properties
 
-| Name              | Type     | Description                                             |
-| ----------------- | -------- | ------------------------------------------------------- |
-| `.Name`           | `string` | Name of the active Claude Code worktree                 |
-| `.Path`           | `string` | Absolute path to the worktree directory                 |
-| `.Branch`         | `string` | Git branch name for the worktree; empty when absent     |
-| `.OriginalCWD`    | `string` | Directory Claude Code was in before entering worktree   |
+| Name              | Type     | Description                                                    |
+| ----------------- | -------- | -------------------------------------------------------------- |
+| `.Name`           | `string` | Name of the active Claude Code worktree                        |
+| `.Path`           | `string` | Absolute path to the worktree directory                        |
+| `.Branch`         | `string` | Git branch name for the worktree; empty when absent            |
+| `.OriginalCWD`    | `string` | Directory Claude Code was in before entering worktree          |
 | `.OriginalBranch` | `string` | Branch checked out before entering worktree; empty when absent |
 
 #### Cost Properties
 
-| Name               | Type      | Description                            |
-| ------------------ | --------- | -------------------------------------- |
-| `.TotalCostUSD`       | `float64` | Total cost in USD                                 |
+| Name                  | Type         | Description                                                 |
+| --------------------- | ------------ | ----------------------------------------------------------- |
+| `.TotalCostUSD`       | `float64`    | Total cost in USD                                           |
 | `.TotalDurationMS`    | `DurationMS` | Total session duration in milliseconds (formats as "Xm Ys") |
 | `.TotalAPIDurationMS` | `DurationMS` | Time spent waiting for API responses (formats as "Xm Ys")   |
-| `.TotalLinesAdded`    | `int`     | Lines of code added in the session                |
-| `.TotalLinesRemoved`  | `int`     | Lines of code removed in the session              |
+| `.TotalLinesAdded`    | `int`        | Lines of code added in the session                          |
+| `.TotalLinesRemoved`  | `int`        | Lines of code removed in the session                        |
 
 #### ContextWindow Properties
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Claude Code exposes additional fields in the [status line JSON input][cc-statusline]. This PR wires the missing fields through the `claude` segment so templates can access the current session, workspace, output style, token threshold, vim, agent, and worktree state.

This includes `effort.level`, `thinking.enabled`, `cwd`, `session_name`, `transcript_path`, `version`, `output_style.name`, `exceeds_200k_tokens`, `workspace.added_dirs`, `vim.mode`, `agent.name`, `worktree.*`, and the observed `fast_mode` field.

The tests cover the full JSON shape plus absent, empty, and partial nested objects to verify omitted fields fall back to zero values safely.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[cc-statusline]: https://code.claude.com/docs/en/statusline
