### PR TITLE
feat(themes): add rezion theme

### DIFF
--- a/themes/rezion.omp.json
+++ b/themes/rezion.omp.json
@@ -1,0 +1,135 @@
+{
+   "$schema": "https://raw.githubusercontent.com/JanDeDobbeleer/oh-my-posh/main/themes/schema.json",
+   "blocks": [
+      {
+         "alignment": "left",
+         "segments": [
+            {
+               "foreground": "cyan",
+               "foreground_templates": ["{{ if gt .Code 0 }}red{{ end }}"],
+               "style": "powerline",
+               "template": "{{ if .WSL }}WSL at {{ end }}{{.Icon}} ",
+               "type": "os"
+            },
+            {
+               "background": "#0087D8",
+               "foreground": "#003544",
+               "leading_diamond": "",
+               "trailing_diamond": "\ue0b0",
+               "style": "diamond",
+               "template": " {{ .Path }} ",
+               "type": "path",
+               "options": {
+                  "folder_separator_icon": "/",
+                  "style": "full"
+               }
+            },
+            {
+               "foreground": "#d2ff5e",
+               "foreground_templates": [
+                  "{{ if or (.Working.Changed) (.Staging.Changed) }}#ff9248{{ end }}",
+                  "{{ if and (gt .Ahead 0) (gt .Behind 0) }}#f26d50{{ end }}",
+                  "{{ if gt .Ahead 0 }}#89d1dc{{ end }}",
+                  "{{ if gt .Behind 0 }}#f17c37{{ end }}"
+               ],
+               "powerline_symbol": "\ue0b0",
+               "options": {
+                  "fetch_status": true,
+                  "fetch_upstream_icon": true
+               },
+               "template": " :: {{ .HEAD }}{{if .BranchStatus }} {{ .BranchStatus }}{{ end }}{{ if .Working.Changed }} \uf044 {{ .Working.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Staging.Changed }} \uf046 {{ .Staging.String }}{{ end }}{{ if gt .StashCount 0 }} \ueb4b {{ .StashCount }}{{ end }} ",
+               "type": "git"
+            }
+         ],
+         "type": "prompt"
+      },
+      {
+         "alignment": "right",
+         "segments": [
+            {
+               "foreground": "#f36943",
+               "foreground_templates": [
+                  "{{if eq \"Charging\" .State.String}}#33DD2D{{end}}",
+                  "{{if eq \"Discharging\" .State.String}}#FFCD58{{end}}",
+                  "{{if eq \"Full\" .State.String}}#0476d0{{end}}"
+               ],
+               "invert_powerline": true,
+               "powerline_symbol": "\ue0b2",
+               "style": "powerline",
+               "template": " {{ if not .Error }}{{ .Icon }}{{ .Percentage }}{{ end }}{{ .Error }}\uf295 \ueb2d ",
+               "type": "battery"
+            },
+            {
+               "type": "node",
+               "style": "plain",
+               "foreground": "#68a063",
+               "template": "{{ if .PackageManagerIcon }}{{ .PackageManagerIcon }} {{ .Full }}{{ end }}",
+               "properties": {
+                  "display_mode": "files",
+                  "fetch_package_manager": true,
+                  "npm_icon": "\ue616",
+                  "yarn_icon": "\ue6a7",
+                  "pnpm_icon": "\ue865",
+                  "bun_icon": "\ue76f"
+               }
+            },
+            {
+               "foreground": "#4063D8",
+               "options": {
+                  "display_mode": "files",
+                  "fetch_version": true
+               },
+               "style": "plain",
+               "template": " {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }}",
+               "type": "crystal"
+            },
+            {
+               "foreground": "#DE3F24",
+               "options": {
+                  "display_mode": "files",
+                  "fetch_version": true
+               },
+               "style": "plain",
+               "template": " {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }}",
+               "type": "ruby"
+            },
+            {
+               "foreground": "#FED142",
+               "options": {
+                  "display_mode": "context",
+                  "fetch_virtual_env": true
+               },
+               "style": "powerline",
+               "template": " {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }} \ue235 {{ .Venv }}",
+               "type": "python"
+            },
+            {
+               "foreground": "lightGreen",
+               "style": "plain",
+               "template": " {{ .CurrentDate | date .Format }} ",
+               "type": "time"
+            }
+         ],
+         "type": "prompt"
+      },
+      {
+         "alignment": "left",
+         "newline": true,
+         "segments": [
+            {
+               "foreground": "cyan",
+               "foreground_templates": ["{{ if gt .Code 0 }}red{{ end }}"],
+               "options": {
+                  "always_enabled": true
+               },
+               "style": "powerline",
+               "template": "\uf061  ",
+               "type": "status"
+            }
+         ],
+         "type": "prompt"
+      }
+   ],
+
+   "version": 4
+}


### PR DESCRIPTION
## Description
I am submitting a new theme called **rezion**. This theme is a custom, extended remix designed to bring together the best elements of the **iterm2**, **wopian**, and **unicorn** themes into a single, cohesive experience.

## Key Features
- **Modern Package Manager Support**: Added custom segments/icons for **Bun**, **pnpm**, and **Yarn**.
- **Hybrid Design**: Combines the color depth of `iterm2`, the structural layout of `wopian`, and the smooth transitions of `unicorn`.
- **Developer Focused**: Optimized for web developers using modern toolsets.

## Screenshot
<img width="3704" height="698" alt="rezion" src="https://github.com/user-attachments/assets/0316abf1-7e44-4721-8463-e14aaab8d724" />

## Checklist
- [x] My theme file is named `rezion.omp.json` and is located in the `/themes` folder.
- [x] I have validated the configuration using `oh-my-posh debug`.
- [x] I have confirmed the theme works correctly with a **Nerd Font** (Checked with Hack Nerd and MesloLGM Nerd Font).
- [x] I have included a screenshot showing the theme in action (including the new package manager icons).

## Requirements
- **Font**: [Nerd Fonts](https://nerdfonts.com) required for icons.



