### PR TITLE
feat(upgrade): unlock `oh-my-posh upgrade` on FreeBSD

### DIFF
--- a/src/cli/upgrade.go
+++ b/src/cli/upgrade.go
@@ -48,6 +48,7 @@ var upgradeCmd = &cobra.Command{
 			runtime.WINDOWS,
 			runtime.DARWIN,
 			runtime.LINUX,
+			runtime.FREEBSD,
 		}
 
 		if !slices.Contains(supportedPlatforms, stdruntime.GOOS) {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

`oh-my-posh upgrade` does not support FreeBSD currently, but prebuilt binaries for FreeBSD are distributed in GitHub release pages, so it should be able to support FreeBSD now.

### Testing

I tested this change locally.

```console
$ uname -a
FreeBSD Coconut-rhinoceros-beetle 15.0-RELEASE-p8 FreeBSD 15.0-RELEASE-p8 releng/15.0-n281036-53054229dcb3 GENERIC amd64
$ cd oh-my-posh
$ doas pkg install go126
...
$ git switch unlock-upgrade-on-freebsd
$ cd src
$ go126 build -o $GOPATH/bin/oh-my-posh
...
$ $GOPATH/bin/oh-my-posh --version
0.0.0-dev
$ $GOPATH/bin/oh-my-posh upgrade

  🚨 major upgrade available: v0.0.0-dev -> v29.13.1, use oh-my-posh upgrade --force to upgrade

$ $GOPATH/bin/oh-my-posh upgrade --force

  🚀 Upgraded from v0.0.0-dev to v29.13.1, restart your shell to take full advantage of the new functionality

$ $GOPATH/bin/oh-my-posh --version
29.13.1
```

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
