### PR TITLE
fix: Update options to properties in peru.omp.json

### DIFF
--- a/themes/peru.omp.json
+++ b/themes/peru.omp.json
@@ -96,7 +96,7 @@
       "segments": [
         {
           "foreground": "#77E4F7",
-          "options": {
+          "properties": {
             "style": "full"
           },
           "style": "plain",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

fix(peru): use `properties` key for path style

The path segment had `options.style: full`, which oh-my-posh ignores, causing the prompt to fall back to the default agnoster-short path display. The correct key per the schema is `properties.style`.

Before:
<img width="961" height="90" alt="image" src="https://github.com/user-attachments/assets/1837e600-737d-407e-83e6-ee24631efe5d" />

After:
<img width="951" height="59" alt="image" src="https://github.com/user-attachments/assets/cf3c1b23-bb90-4094-8d37-c899487f0fe6" />

<!---

Tips:

If you're not comfortable with working with Git,
we're working on a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D)
as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
