### PR TITLE
feat(cli): add `oh-my-posh copilot` command and `copilot_cli` segment

### DIFF
--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,7 +1,40 @@
 lockfile_version: '1'
-generated_at: '2026-05-07T10:54:22.196155+00:00'
+generated_at: '2026-05-17T14:33:11.312146+00:00'
 apm_version: 0.12.3
 dependencies:
+- repo_url: JanDeDobbeleer/agentic
+  host: github.com
+  resolved_commit: 92d80e66873d98885281291a11c8acbcf30709f0
+  virtual_path: instructions/golang.instructions.md
+  is_virtual: true
+  package_type: apm_package
+  deployed_files:
+  - .github/instructions/golang.instructions.md
+  deployed_file_hashes:
+    .github/instructions/golang.instructions.md: sha256:89b03e000879a36a4b68f37136d1dcad039a908f242dd412f59a71e5c159cbb3
+  content_hash: sha256:94556f47cd95ee4c76dec6f7e53aad1948a1a51c6c85a810b320ecf3ebe075b4
+- repo_url: JanDeDobbeleer/agentic
+  host: github.com
+  resolved_commit: 92d80e66873d98885281291a11c8acbcf30709f0
+  virtual_path: instructions/markdown.instructions.md
+  is_virtual: true
+  package_type: apm_package
+  deployed_files:
+  - .github/instructions/markdown.instructions.md
+  deployed_file_hashes:
+    .github/instructions/markdown.instructions.md: sha256:e16f52f4e7f24c8b59caef5b423332690e5bf95d3f3cd37f86eb782b36e6ea82
+  content_hash: sha256:0f47d924eba5b69635958c5fe13194a39deb56fa1e9cab3f556f0d810ac283cd
+- repo_url: JanDeDobbeleer/agentic
+  host: github.com
+  resolved_commit: 92d80e66873d98885281291a11c8acbcf30709f0
+  virtual_path: instructions/powershell.instructions.md
+  is_virtual: true
+  package_type: apm_package
+  deployed_files:
+  - .github/instructions/powershell.instructions.md
+  deployed_file_hashes:
+    .github/instructions/powershell.instructions.md: sha256:8a6d0340bb63944ad6b318051a412a380275aa5750e2a9d0d50e2e78b3ecac3f
+  content_hash: sha256:0b75b2bb281c733a5beb1503104c164649d5d2dbc386a4aac3f784da6420c590
 - repo_url: JanDeDobbeleer/agentic
   host: github.com
   resolved_commit: b4e8062eaeef93582bf4cbb86ad4816f37630bb2

--- a/src/cache/cache.go
+++ b/src/cache/cache.go
@@ -24,6 +24,7 @@ const (
 	ENGINECACHE      = "engine_cache"
 	FONTLISTCACHE    = "font_list_cache"
 	CLAUDECACHE      = "claude_cache"
+	COPILOTCLICACHE  = "copilot_cli_cache"
 )
 
 type Entry[T any] struct {

--- a/src/cli/auth.go
+++ b/src/cli/auth.go
@@ -21,7 +21,7 @@ Available services:
 - copilot: GitHub Copilot API
 - ytmda: YouTube Music Desktop App (YTMDA) API`,
 	ValidArgs: []string{
-		"copilot",
+		copilotServiceName,
 		"ytmda",
 	},
 	Args: NoArgsOrOneValidArg,
@@ -45,7 +45,7 @@ Available services:
 		}()
 
 		switch args[0] {
-		case "copilot":
+		case copilotServiceName:
 			authenticator := auth.NewCopilot(env)
 			if err := auth.Run(authenticator); err != nil {
 				log.Error(err)

--- a/src/cli/claude.go
+++ b/src/cli/claude.go
@@ -1,25 +1,14 @@
 package cli
 
 import (
-	"encoding/json"
-	"fmt"
-	"io"
-	"os"
-
 	"github.com/jandedobbeleer/oh-my-posh/src/cache"
 	"github.com/jandedobbeleer/oh-my-posh/src/config"
-	"github.com/jandedobbeleer/oh-my-posh/src/log"
-	"github.com/jandedobbeleer/oh-my-posh/src/prompt"
-	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
 	"github.com/jandedobbeleer/oh-my-posh/src/segments"
 	"github.com/jandedobbeleer/oh-my-posh/src/shell"
-	"github.com/jandedobbeleer/oh-my-posh/src/template"
-	"github.com/jandedobbeleer/oh-my-posh/src/terminal"
 
 	"github.com/spf13/cobra"
 )
 
-// claudeCmd represents the claude command
 var claudeCmd = &cobra.Command{
 	Use:   "claude",
 	Short: "Render a prompt for Claude Code statusline",
@@ -34,84 +23,12 @@ Example usage in Claude Code settings:
     "command": "oh-my-posh claude --config ~/.config/ohmyposh/claude.toml"
   }`,
 	Args: cobra.NoArgs,
-	Run: func(_ *cobra.Command, _ []string) {
-		log.Debug("claude command started")
-
-		// Read JSON from stdin
-		stdinData, err := io.ReadAll(os.Stdin)
-		if err != nil {
-			log.Error(err)
-			return
-		}
-
-		log.Debugf("received data from stdin: %s", string(stdinData))
-
-		// Process Claude data and initialize cache
-		processClaudeData(stdinData)
-
-		flags := &runtime.Flags{
-			ConfigPath: configFlag,
-			Shell:      shell.CLAUDE,
-		}
-
-		env := &runtime.Terminal{}
-		env.Init(flags)
-
-		var cfg *config.Config
-
-		cfg, err = config.Parse(configFlag)
-		if err != nil {
-			cfg = config.Claude()
-		}
-
-		template.Init(env, cfg.Var, cfg.Maps)
-		terminal.Init(shell.CLAUDE)
-		terminal.BackgroundColor = cfg.TerminalBackground.ResolveTemplate()
-		terminal.Colors = cfg.MakeColors(env)
-
-		eng := &prompt.Engine{
-			Config: cfg,
-			Env:    env,
-		}
-
-		defer func() {
-			template.SaveCache()
-			cache.Close()
-		}()
-
-		result := eng.Status()
-		fmt.Print(result)
-	},
-}
-
-// processClaudeData handles parsing and caching of Claude JSON data
-func processClaudeData(stdinData []byte) {
-	if len(stdinData) == 0 {
-		cache.Init(shell.CLAUDE, cache.Persist, cache.NoSession)
-		return
-	}
-
-	var claudeData segments.ClaudeData
-	if err := json.Unmarshal(stdinData, &claudeData); err != nil {
-		log.Error(err)
-		cache.Init(shell.CLAUDE, cache.Persist, cache.NoSession)
-		return
-	}
-
-	log.Debugf("parsed Claude data: session_id=%s, model=%s", claudeData.SessionID, claudeData.Model.DisplayName)
-
-	// Set the session ID from Claude data if available
-	if claudeData.SessionID != "" {
-		os.Setenv("POSH_SESSION_ID", claudeData.SessionID)
-		log.Debugf("set POSH_SESSION_ID to: %s", claudeData.SessionID)
-	}
-
-	// Initialize cache first so we can store the data
-	cache.Init(shell.CLAUDE, cache.Persist)
-
-	// Store the parsed data in session cache
-	cache.Set(cache.Session, cache.CLAUDECACHE, claudeData, cache.INFINITE)
-	log.Debug("stored Claude data in session cache")
+	Run: statuslineRun[segments.ClaudeData](
+		shell.CLAUDE,
+		cache.CLAUDECACHE,
+		func(d *segments.ClaudeData) string { return d.SessionID },
+		config.Claude,
+	),
 }
 
 func init() {

--- a/src/cli/copilot.go
+++ b/src/cli/copilot.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"github.com/jandedobbeleer/oh-my-posh/src/cache"
+	"github.com/jandedobbeleer/oh-my-posh/src/config"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments"
+	"github.com/jandedobbeleer/oh-my-posh/src/shell"
+
+	"github.com/spf13/cobra"
+)
+
+const copilotServiceName = "copilot"
+
+var copilotCmd = &cobra.Command{
+	Use:   copilotServiceName,
+	Short: "Render a prompt for GitHub Copilot CLI statusline",
+	Long: `Render a prompt for GitHub Copilot CLI statusline integration.
+
+This command reads GitHub Copilot CLI's contextual JSON data from stdin and renders
+a prompt that can include a Copilot CLI segment with session information like
+model name, token usage, costs, and more.
+
+Example usage in GitHub Copilot CLI settings (%USERPROFILE%\.copilot\statusline.cmd):
+  @echo off
+  oh-my-posh copilot --config %USERPROFILE%\.config\ohmyposh\copilot.toml`,
+	Args: cobra.NoArgs,
+	Run: statuslineRun(
+		shell.COPILOTCLI,
+		cache.COPILOTCLICACHE,
+		func(d *segments.CopilotCLIData) string { return d.SessionID },
+		config.CopilotCLI,
+	),
+}
+
+func init() {
+	RootCmd.AddCommand(copilotCmd)
+}

--- a/src/cli/statusline.go
+++ b/src/cli/statusline.go
@@ -1,0 +1,104 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/cache"
+	"github.com/jandedobbeleer/oh-my-posh/src/config"
+	"github.com/jandedobbeleer/oh-my-posh/src/log"
+	"github.com/jandedobbeleer/oh-my-posh/src/prompt"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
+	"github.com/jandedobbeleer/oh-my-posh/src/template"
+	"github.com/jandedobbeleer/oh-my-posh/src/terminal"
+
+	"github.com/spf13/cobra"
+)
+
+// statuslineRun returns a cobra Run function for statusline commands.
+// T is the type of the JSON data read from stdin.
+// shellConst identifies the shell (used for cache init and terminal init).
+// cacheKey is the session cache key under which data is stored.
+// sessionID extracts the session ID from parsed data so it can be set as POSH_SESSION_ID.
+// defaultCfg is called when no --config flag is provided or parsing fails.
+func statuslineRun[T any](shellConst, cacheKey string, sessionID func(*T) string, defaultCfg func() *config.Config) func(*cobra.Command, []string) {
+	return func(cmd *cobra.Command, _ []string) {
+		log.Debugf("%s command started", shellConst)
+
+		stdinData, err := io.ReadAll(os.Stdin)
+		if err != nil {
+			log.Error(err)
+			return
+		}
+
+		log.Debugf("received data from stdin: %s", string(stdinData))
+
+		processStatuslineData(stdinData, shellConst, cacheKey, sessionID)
+
+		// Only use a config file when --config was explicitly passed on the command line.
+		// POSH_CONFIG is intentionally ignored here: statusline commands always render their
+		// own dedicated layout and must not inherit the user's regular shell prompt config.
+		explicitConfig := ""
+		if cmd.Root().PersistentFlags().Changed("config") {
+			explicitConfig = configFlag
+			log.Debugf("using explicit config: %s", explicitConfig)
+		}
+
+		flags := &runtime.Flags{
+			ConfigPath: explicitConfig,
+			Shell:      shellConst,
+		}
+
+		env := &runtime.Terminal{}
+		env.Init(flags)
+
+		cfg, err := config.Parse(explicitConfig)
+		if err != nil {
+			log.Debug("no config found, using default")
+			cfg = defaultCfg()
+		}
+
+		template.Init(env, cfg.Var, cfg.Maps)
+		terminal.Init(shellConst)
+		terminal.BackgroundColor = cfg.TerminalBackground.ResolveTemplate()
+		terminal.Colors = cfg.MakeColors(env)
+
+		eng := &prompt.Engine{
+			Config: cfg,
+			Env:    env,
+		}
+
+		defer func() {
+			template.SaveCache()
+			cache.Close()
+		}()
+
+		fmt.Print(eng.Status())
+	}
+}
+
+// processStatuslineData parses stdin JSON into T and stores it in the session cache.
+func processStatuslineData[T any](stdinData []byte, shellConst, cacheKey string, sessionID func(*T) string) {
+	if len(stdinData) == 0 {
+		cache.Init(shellConst, cache.Persist, cache.NoSession)
+		return
+	}
+
+	var data T
+	if err := json.Unmarshal(stdinData, &data); err != nil {
+		log.Error(err)
+		cache.Init(shellConst, cache.Persist, cache.NoSession)
+		return
+	}
+
+	if id := sessionID(&data); id != "" {
+		os.Setenv("POSH_SESSION_ID", id)
+		log.Debugf("set POSH_SESSION_ID to: %s", id)
+	}
+
+	cache.Init(shellConst, cache.Persist)
+	cache.Set(cache.Session, cacheKey, data, cache.INFINITE)
+	log.Debugf("stored %s data in session cache", shellConst)
+}

--- a/src/config/default.go
+++ b/src/config/default.go
@@ -217,8 +217,19 @@ func Default(configError error) *Config {
 }
 
 func Claude() *Config {
-	cfg := &Config{
-		hash:    1234567890, // placeholder hash value
+	return statuslineCLIConfig(1234567890, CLAUDE, " \U000f0bc9 {{ .Model.DisplayName }} \uf2d0 {{ .TokenGauge }} ")
+}
+
+func CopilotCLI() *Config {
+	return statuslineCLIConfig(1234567891, COPILOTCLI, " \uec1e {{ .Model.DisplayName }} \uf2d0 {{ .TokenGauge }} ")
+}
+
+// statuslineCLIConfig builds the shared default config for AI CLI statusline integrations
+// (e.g. Claude, Copilot CLI). The left block is always PATH + GIT; the right block
+// contains a single segment of the given type and template.
+func statuslineCLIConfig(hash uint64, segmentType SegmentType, template string) *Config {
+	return &Config{
+		hash:    hash,
 		Version: 4,
 		Blocks: []*Block{
 			{
@@ -268,13 +279,13 @@ func Claude() *Config {
 				Alignment: Right,
 				Segments: []*Segment{
 					{
-						Type:            CLAUDE,
+						Type:            segmentType,
 						Style:           Diamond,
 						LeadingDiamond:  "\ue0b6",
 						TrailingDiamond: "\ue0b4",
 						Foreground:      paletteBlack,
 						Background:      paletteBlue,
-						Template:        " \U000f0bc9 {{ .Model.DisplayName }} \uf2d0 {{ .TokenUsagePercent.Gauge }} ",
+						Template:        template,
 					},
 				},
 			},
@@ -289,6 +300,4 @@ func Claude() *Config {
 			"yellow": "#F3AE35",
 		},
 	}
-
-	return cfg
 }

--- a/src/config/segment_types.go
+++ b/src/config/segment_types.go
@@ -40,6 +40,8 @@ func init() {
 	gob.Register(&segments.CarbonIntensity{})
 	gob.Register(&segments.Cds{})
 	gob.Register(&segments.Copilot{})
+	gob.Register(&segments.CopilotCLI{})
+	gob.Register(&segments.CopilotCLIData{})
 	gob.Register(&segments.Cf{})
 	gob.Register(&segments.CfTarget{})
 	gob.Register(&segments.Claude{})
@@ -203,6 +205,8 @@ const (
 	CONNECTION SegmentType = "connection"
 	// COPILOT writes GitHub Copilot usage statistics
 	COPILOT SegmentType = "copilot"
+	// COPILOTCLI writes GitHub Copilot CLI session information
+	COPILOTCLI SegmentType = "copilot_cli"
 	// CRYSTAL writes the active crystal version
 	CRYSTAL SegmentType = "crystal"
 	// DART writes the active dart version
@@ -405,6 +409,7 @@ var Segments = map[SegmentType]func() SegmentWriter{
 	CMAKE:           func() SegmentWriter { return &segments.Cmake{} },
 	CONNECTION:      func() SegmentWriter { return &segments.Connection{} },
 	COPILOT:         func() SegmentWriter { return &segments.Copilot{} },
+	COPILOTCLI:      func() SegmentWriter { return &segments.CopilotCLI{} },
 	CRYSTAL:         func() SegmentWriter { return &segments.Crystal{} },
 	DART:            func() SegmentWriter { return &segments.Dart{} },
 	DENO:            func() SegmentWriter { return &segments.Deno{} },

--- a/src/runtime/terminal_unix.go
+++ b/src/runtime/terminal_unix.go
@@ -82,12 +82,6 @@ func (term *Terminal) TerminalWidth() (int, error) {
 	term.CmdFlags.TerminalWidth = int(width)
 	log.Debugf("terminal width: %d", term.CmdFlags.TerminalWidth)
 
-	// Claude CLI has a 2 character padding on both sides
-	if term.CmdFlags.Shell == "claude" {
-		log.Debug("adjusting terminal width for Claude CLI")
-		term.CmdFlags.TerminalWidth -= 4
-	}
-
 	return term.CmdFlags.TerminalWidth, err
 }
 

--- a/src/runtime/terminal_windows.go
+++ b/src/runtime/terminal_windows.go
@@ -98,12 +98,6 @@ func (term *Terminal) TerminalWidth() (int, error) {
 	term.CmdFlags.TerminalWidth = int(info.Size.X)
 	log.Debugf("terminal width: %d", term.CmdFlags.TerminalWidth)
 
-	// Claude CLI has a 2 character padding on both sides
-	if term.CmdFlags.Shell == "claude" {
-		log.Debug("adjusting terminal width for Claude CLI")
-		term.CmdFlags.TerminalWidth -= 4
-	}
-
 	return term.CmdFlags.TerminalWidth, nil
 }
 

--- a/src/segments/claude.go
+++ b/src/segments/claude.go
@@ -22,7 +22,7 @@ type Claude struct {
 type ClaudeData struct {
 	RateLimits        *ClaudeRateLimits   `json:"rate_limits"`
 	Worktree          ClaudeWorktree      `json:"worktree"`
-	Model             ClaudeModel         `json:"model"`
+	Model             AIModel             `json:"model"`
 	OutputStyle       ClaudeOutputStyle   `json:"output_style"`
 	Vim               ClaudeVim           `json:"vim"`
 	TranscriptPath    string              `json:"transcript_path"`
@@ -40,8 +40,8 @@ type ClaudeData struct {
 	FastMode          bool                `json:"fast_mode"`
 }
 
-// ClaudeModel represents the AI model information
-type ClaudeModel struct {
+// AIModel represents the AI model information shared across AI CLI segments.
+type AIModel struct {
 	ID          string `json:"id"`
 	DisplayName string `json:"display_name"`
 }
@@ -145,6 +145,19 @@ const (
 	gaugeMarkedChar   options.Option = "gauge_marked_char"
 	gaugeUnmarkedChar options.Option = "gauge_unmarked_char"
 )
+
+// formatTokenCount formats a token count as a human-readable string ("1.2K", "3.4M", or raw).
+func formatTokenCount(n int) string {
+	if n < int(thousand) {
+		return fmt.Sprintf("%d", n)
+	}
+
+	if n < int(million) {
+		return fmt.Sprintf("%.1fK", float64(n)/thousand)
+	}
+
+	return fmt.Sprintf("%.1fM", float64(n)/million)
+}
 
 func (c *Claude) Template() string {
 	return " \U000f0bc9 {{ .Model.DisplayName }} \uf2d0 {{ .TokenGauge }} "
@@ -366,13 +379,5 @@ func (c *Claude) FormattedTokens() string {
 		currentTokens = c.ContextWindow.TotalInputTokens + c.ContextWindow.TotalOutputTokens
 	}
 
-	if currentTokens < int(thousand) {
-		return fmt.Sprintf("%d", currentTokens)
-	}
-
-	if currentTokens < int(million) {
-		return fmt.Sprintf("%.1fK", float64(currentTokens)/thousand)
-	}
-
-	return fmt.Sprintf("%.1fM", float64(currentTokens)/million)
+	return formatTokenCount(currentTokens)
 }

--- a/src/segments/claude_test.go
+++ b/src/segments/claude_test.go
@@ -31,7 +31,7 @@ func TestClaudeSegment(t *testing.T) {
 			Case: "Valid cache data with all fields",
 			ClaudeData: &ClaudeData{
 				SessionID: "abc123",
-				Model: ClaudeModel{
+				Model: AIModel{
 					ID:          "claude-opus-4-1",
 					DisplayName: "Opus",
 				},
@@ -76,7 +76,7 @@ func TestClaudeSegment(t *testing.T) {
 			Case: "Valid cache data with partial fields",
 			ClaudeData: &ClaudeData{
 				SessionID: "xyz789",
-				Model: ClaudeModel{
+				Model: AIModel{
 					ID:          "claude-sonnet-3-5",
 					DisplayName: "Sonnet 3.5",
 				},
@@ -855,7 +855,7 @@ func TestClaudeGaugeOptionsReadInEnabled(t *testing.T) {
 	})
 
 	cache.Set(cache.Session, cache.CLAUDECACHE, ClaudeData{
-		Model: ClaudeModel{DisplayName: "Opus"},
+		Model: AIModel{DisplayName: "Opus"},
 	}, cache.INFINITE)
 
 	env := new(mock.Environment)

--- a/src/segments/copilot_cli.go
+++ b/src/segments/copilot_cli.go
@@ -1,0 +1,207 @@
+package segments
+
+import (
+	"github.com/jandedobbeleer/oh-my-posh/src/cache"
+	"github.com/jandedobbeleer/oh-my-posh/src/log"
+	"github.com/jandedobbeleer/oh-my-posh/src/text"
+)
+
+// CopilotCLI segment displays GitHub Copilot CLI session information
+type CopilotCLI struct {
+	Base
+	markedChar   string
+	unmarkedChar string
+	CopilotCLIData
+}
+
+// CopilotCLIData represents the parsed Copilot CLI JSON data
+type CopilotCLIData struct {
+	Model          AIModel                 `json:"model"`
+	Workspace      CopilotCLIWorkspace     `json:"workspace"`
+	TranscriptPath string                  `json:"transcript_path"`
+	CWD            string                  `json:"cwd"`
+	Version        string                  `json:"version"`
+	SessionID      string                  `json:"session_id"`
+	SessionName    string                  `json:"session_name"`
+	Username       string                  `json:"username"`
+	ContextWindow  CopilotCLIContextWindow `json:"context_window"`
+	Cost           CopilotCLICost          `json:"cost"`
+	Remote         CopilotCLIRemote        `json:"remote"`
+}
+
+// CopilotCLIWorkspace represents workspace directory information
+type CopilotCLIWorkspace struct {
+	CurrentDir string `json:"current_dir"`
+}
+
+// CopilotCLIRemote represents remote connection state
+type CopilotCLIRemote struct {
+	Connected bool `json:"connected"`
+}
+
+// CopilotCLICost represents cost and duration information
+type CopilotCLICost struct {
+	TotalDurationMS      DurationMS `json:"total_duration_ms"`
+	TotalAPIDurationMS   DurationMS `json:"total_api_duration_ms"`
+	TotalLinesAdded      int        `json:"total_lines_added"`
+	TotalLinesRemoved    int        `json:"total_lines_removed"`
+	TotalPremiumRequests int        `json:"total_premium_requests"`
+}
+
+// CopilotCLIContextWindow represents token usage information
+type CopilotCLIContextWindow struct {
+	ContextWindowSize     *int     `json:"context_window_size"`
+	UsedPercentage        *float64 `json:"used_percentage"`
+	RemainingPercentage   *float64 `json:"remaining_percentage"`
+	RemainingTokens       *int     `json:"remaining_tokens"`
+	TotalInputTokens      int      `json:"total_input_tokens"`
+	TotalOutputTokens     int      `json:"total_output_tokens"`
+	TotalCacheReadTokens  int      `json:"total_cache_read_tokens"`
+	TotalCacheWriteTokens int      `json:"total_cache_write_tokens"`
+	TotalReasoningTokens  int      `json:"total_reasoning_tokens"`
+	TotalTokens           int      `json:"total_tokens"`
+	LastCallInputTokens   int      `json:"last_call_input_tokens"`
+	LastCallOutputTokens  int      `json:"last_call_output_tokens"`
+	CurrentContextTokens  int      `json:"current_context_tokens"`
+}
+
+func (c *CopilotCLI) Template() string {
+	return " \uec1e {{ .Model.DisplayName }} \uf2d0 {{ .TokenGauge }} "
+}
+
+func (c *CopilotCLI) Enabled() bool {
+	log.Debug("copilot_cli segment: checking if enabled")
+
+	data, found := cache.Get[CopilotCLIData](cache.Session, cache.COPILOTCLICACHE)
+	if !found {
+		log.Debug("copilot_cli segment: no data found in session cache")
+		return false
+	}
+
+	log.Debug("copilot_cli segment: found data in session cache")
+	log.Debugf("copilot_cli segment: model=%s, session=%s", data.Model.DisplayName, data.SessionID)
+
+	c.CopilotCLIData = data
+
+	c.markedChar = c.options.String(gaugeMarkedChar, "▰")
+	c.unmarkedChar = c.options.String(gaugeUnmarkedChar, "▱")
+
+	return true
+}
+
+// TokenUsagePercent returns the percentage of context window used.
+// Uses pre-calculated UsedPercentage when available; falls back to computing
+// from CurrentContextTokens / ContextWindowSize; returns 0 when unavailable.
+func (c *CopilotCLI) TokenUsagePercent() text.Percentage {
+	if c.ContextWindow.UsedPercentage != nil {
+		v := *c.ContextWindow.UsedPercentage
+		if v > 100 {
+			return 100
+		}
+
+		if v < 0 {
+			return 0
+		}
+
+		return text.Percentage(int(v + 0.5))
+	}
+
+	if c.ContextWindow.ContextWindowSize == nil || *c.ContextWindow.ContextWindowSize <= 0 {
+		return 0
+	}
+
+	tokens := c.ContextWindow.CurrentContextTokens
+	if tokens <= 0 {
+		tokens = c.ContextWindow.TotalTokens
+	}
+
+	if tokens <= 0 {
+		return 0
+	}
+
+	percent := (float64(tokens) * 100.0) / float64(*c.ContextWindow.ContextWindowSize)
+
+	rounded := int(percent + 0.5)
+	if rounded > 100 {
+		return 100
+	}
+
+	return text.Percentage(rounded)
+}
+
+// TokenGauge returns a 5-block gauge showing remaining context window capacity using the configured characters.
+func (c *CopilotCLI) TokenGauge() string {
+	return c.TokenUsagePercent().GaugeWith(c.markedChar, c.unmarkedChar)
+}
+
+// TokenGaugeUsed returns a 5-block gauge showing used context window capacity using the configured characters.
+func (c *CopilotCLI) TokenGaugeUsed() string {
+	return c.TokenUsagePercent().GaugeUsedWith(c.markedChar, c.unmarkedChar)
+}
+
+// FormattedTokens returns a human-readable string of current context tokens.
+func (c *CopilotCLI) FormattedTokens() string {
+	tokens := c.ContextWindow.CurrentContextTokens
+	if tokens <= 0 {
+		tokens = c.ContextWindow.TotalTokens
+	}
+
+	return formatTokenCount(tokens)
+}
+
+// FormattedDuration returns total session duration as "Xm Ys".
+func (c *CopilotCLI) FormattedDuration() string {
+	return c.Cost.TotalDurationMS.String()
+}
+
+// FormattedAPIDuration returns API wait time as "Xm Ys".
+func (c *CopilotCLI) FormattedAPIDuration() string {
+	return c.Cost.TotalAPIDurationMS.String()
+}
+
+// RemainingPercent returns the percentage of context window remaining (0-100).
+func (c *CopilotCLI) RemainingPercent() text.Percentage {
+	if c.ContextWindow.RemainingPercentage != nil {
+		v := *c.ContextWindow.RemainingPercentage
+		if v > 100 {
+			return 100
+		}
+
+		if v < 0 {
+			return 0
+		}
+
+		return text.Percentage(int(v + 0.5))
+	}
+
+	used := int(c.TokenUsagePercent())
+	remaining := 100 - used
+	if remaining < 0 {
+		return 0
+	}
+
+	return text.Percentage(remaining)
+}
+
+// RemainingTokensCount returns the number of remaining context window tokens.
+func (c *CopilotCLI) RemainingTokensCount() int {
+	if c.ContextWindow.RemainingTokens != nil {
+		return *c.ContextWindow.RemainingTokens
+	}
+
+	if c.ContextWindow.ContextWindowSize == nil || *c.ContextWindow.ContextWindowSize <= 0 {
+		return 0
+	}
+
+	tokens := c.ContextWindow.CurrentContextTokens
+	if tokens <= 0 {
+		tokens = c.ContextWindow.TotalTokens
+	}
+
+	remaining := *c.ContextWindow.ContextWindowSize - tokens
+	if remaining < 0 {
+		return 0
+	}
+
+	return remaining
+}

--- a/src/segments/copilot_cli_test.go
+++ b/src/segments/copilot_cli_test.go
@@ -1,0 +1,329 @@
+package segments
+
+import (
+	"testing"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/cache"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+	"github.com/jandedobbeleer/oh-my-posh/src/text"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCopilotCLISegment(t *testing.T) {
+	cases := []struct {
+		Data            *CopilotCLIData
+		Case            string
+		ExpectedModel   string
+		ExpectedSession string
+		ExpectedEnabled bool
+	}{
+		{
+			Case:            "No cache data",
+			Data:            nil,
+			ExpectedEnabled: false,
+		},
+		{
+			Case: "Valid data with model and session",
+			Data: &CopilotCLIData{
+				SessionID: "eb2d84b0-1091",
+				Model: AIModel{
+					ID:          "gpt-4o",
+					DisplayName: "GPT-4o",
+				},
+				Version: "1.0.48",
+				Cost: CopilotCLICost{
+					TotalDurationMS: 668,
+					TotalLinesAdded: 10,
+				},
+			},
+			ExpectedEnabled: true,
+			ExpectedModel:   "GPT-4o",
+			ExpectedSession: "eb2d84b0-1091",
+		},
+		{
+			Case: "Valid data with empty model",
+			Data: &CopilotCLIData{
+				SessionID: "test-123",
+				Model:     AIModel{},
+			},
+			ExpectedEnabled: true,
+			ExpectedModel:   "",
+			ExpectedSession: "test-123",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Case, func(t *testing.T) {
+			if tc.Data != nil {
+				cache.Set(cache.Session, cache.COPILOTCLICACHE, *tc.Data, cache.INFINITE)
+			} else {
+				cache.Delete(cache.Session, cache.COPILOTCLICACHE)
+			}
+
+			env := new(mock.Environment)
+			segment := &CopilotCLI{
+				Base: Base{
+					env:     env,
+					options: options.Map{},
+				},
+			}
+
+			enabled := segment.Enabled()
+			assert.Equal(t, tc.ExpectedEnabled, enabled, tc.Case)
+
+			if tc.ExpectedEnabled {
+				assert.Equal(t, tc.ExpectedModel, segment.Model.DisplayName, tc.Case)
+				assert.Equal(t, tc.ExpectedSession, segment.SessionID, tc.Case)
+			}
+
+			cache.Delete(cache.Session, cache.COPILOTCLICACHE)
+		})
+	}
+}
+
+func TestCopilotCLITokenUsagePercent(t *testing.T) {
+	t.Cleanup(func() {
+		cache.Delete(cache.Session, cache.COPILOTCLICACHE)
+	})
+
+	cases := []struct {
+		Case            string
+		ContextWindow   CopilotCLIContextWindow
+		ExpectedPercent text.Percentage
+	}{
+		{
+			Case:            "No data available",
+			ContextWindow:   CopilotCLIContextWindow{},
+			ExpectedPercent: 0,
+		},
+		{
+			Case: "UsedPercentage provided",
+			ContextWindow: CopilotCLIContextWindow{
+				UsedPercentage: new(61.7),
+			},
+			ExpectedPercent: 62,
+		},
+		{
+			Case: "UsedPercentage zero",
+			ContextWindow: CopilotCLIContextWindow{
+				UsedPercentage: new(0.0),
+			},
+			ExpectedPercent: 0,
+		},
+		{
+			Case: "UsedPercentage over 100 capped",
+			ContextWindow: CopilotCLIContextWindow{
+				UsedPercentage: new(105.0),
+			},
+			ExpectedPercent: 100,
+		},
+		{
+			Case: "Computed from CurrentContextTokens",
+			ContextWindow: CopilotCLIContextWindow{
+				CurrentContextTokens: 50000,
+				ContextWindowSize:    new(200000),
+			},
+			ExpectedPercent: 25,
+		},
+		{
+			Case: "Computed from TotalTokens fallback",
+			ContextWindow: CopilotCLIContextWindow{
+				TotalTokens:       100000,
+				ContextWindowSize: new(200000),
+			},
+			ExpectedPercent: 50,
+		},
+		{
+			Case: "ContextWindowSize nil, no UsedPercentage",
+			ContextWindow: CopilotCLIContextWindow{
+				CurrentContextTokens: 50000,
+				ContextWindowSize:    nil,
+			},
+			ExpectedPercent: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Case, func(t *testing.T) {
+			data := CopilotCLIData{ContextWindow: tc.ContextWindow}
+			cache.Set(cache.Session, cache.COPILOTCLICACHE, data, cache.INFINITE)
+
+			env := new(mock.Environment)
+			segment := &CopilotCLI{
+				Base: Base{
+					env:     env,
+					options: options.Map{},
+				},
+			}
+
+			enabled := segment.Enabled()
+			assert.True(t, enabled, tc.Case)
+			assert.Equal(t, tc.ExpectedPercent, segment.TokenUsagePercent(), tc.Case)
+
+			cache.Delete(cache.Session, cache.COPILOTCLICACHE)
+		})
+	}
+}
+
+func TestCopilotCLIFormattedTokens(t *testing.T) {
+	cases := []struct {
+		Case          string
+		Expected      string
+		ContextWindow CopilotCLIContextWindow
+	}{
+		{
+			Case:          "Zero tokens",
+			ContextWindow: CopilotCLIContextWindow{},
+			Expected:      "0",
+		},
+		{
+			Case: "Current context tokens preferred",
+			ContextWindow: CopilotCLIContextWindow{
+				CurrentContextTokens: 1234,
+				TotalTokens:          9999,
+			},
+			Expected: "1.2K",
+		},
+		{
+			Case: "Falls back to total tokens",
+			ContextWindow: CopilotCLIContextWindow{
+				TotalTokens: 500000,
+			},
+			Expected: "500.0K",
+		},
+		{
+			Case: "Millions",
+			ContextWindow: CopilotCLIContextWindow{
+				CurrentContextTokens: 1500000,
+			},
+			Expected: "1.5M",
+		},
+		{
+			Case: "Small count",
+			ContextWindow: CopilotCLIContextWindow{
+				CurrentContextTokens: 42,
+			},
+			Expected: "42",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Case, func(t *testing.T) {
+			data := CopilotCLIData{ContextWindow: tc.ContextWindow}
+			cache.Set(cache.Session, cache.COPILOTCLICACHE, data, cache.INFINITE)
+
+			env := new(mock.Environment)
+			segment := &CopilotCLI{
+				Base: Base{
+					env:     env,
+					options: options.Map{},
+				},
+			}
+
+			segment.Enabled()
+			assert.Equal(t, tc.Expected, segment.FormattedTokens(), tc.Case)
+
+			cache.Delete(cache.Session, cache.COPILOTCLICACHE)
+		})
+	}
+}
+
+func TestCopilotCLIFormattedDuration(t *testing.T) {
+	data := CopilotCLIData{
+		Cost: CopilotCLICost{
+			TotalDurationMS:    90000, // 1m 30s
+			TotalAPIDurationMS: 30000, // 0m 30s
+		},
+	}
+	cache.Set(cache.Session, cache.COPILOTCLICACHE, data, cache.INFINITE)
+	defer cache.Delete(cache.Session, cache.COPILOTCLICACHE)
+
+	env := new(mock.Environment)
+	segment := &CopilotCLI{
+		Base: Base{
+			env:     env,
+			options: options.Map{},
+		},
+	}
+
+	segment.Enabled()
+	assert.Equal(t, "1m 30s", segment.FormattedDuration())
+	assert.Equal(t, "0m 30s", segment.FormattedAPIDuration())
+}
+
+func TestCopilotCLITokenGaugeCustomChars(t *testing.T) {
+	usedPct := 60.0
+	data := CopilotCLIData{
+		ContextWindow: CopilotCLIContextWindow{
+			UsedPercentage: &usedPct,
+		},
+	}
+	cache.Set(cache.Session, cache.COPILOTCLICACHE, data, cache.INFINITE)
+	defer cache.Delete(cache.Session, cache.COPILOTCLICACHE)
+
+	env := new(mock.Environment)
+	segment := &CopilotCLI{
+		Base: Base{
+			env: env,
+			options: options.Map{
+				gaugeMarkedChar:   "█",
+				gaugeUnmarkedChar: "░",
+			},
+		},
+	}
+
+	segment.Enabled()
+	gauge := segment.TokenGaugeUsed()
+	assert.NotEmpty(t, gauge)
+	assert.Contains(t, gauge, "█")
+}
+
+func TestCopilotCLIRemainingPercent(t *testing.T) {
+	cases := []struct {
+		Case          string
+		ContextWindow CopilotCLIContextWindow
+		Expected      text.Percentage
+	}{
+		{
+			Case: "RemainingPercentage provided",
+			ContextWindow: CopilotCLIContextWindow{
+				RemainingPercentage: new(40.0),
+			},
+			Expected: 40,
+		},
+		{
+			Case: "Computed from used percentage",
+			ContextWindow: CopilotCLIContextWindow{
+				UsedPercentage: new(75.0),
+			},
+			Expected: 25,
+		},
+		{
+			Case:          "No data",
+			ContextWindow: CopilotCLIContextWindow{},
+			Expected:      100,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Case, func(t *testing.T) {
+			data := CopilotCLIData{ContextWindow: tc.ContextWindow}
+			cache.Set(cache.Session, cache.COPILOTCLICACHE, data, cache.INFINITE)
+
+			env := new(mock.Environment)
+			segment := &CopilotCLI{
+				Base: Base{
+					env:     env,
+					options: options.Map{},
+				},
+			}
+
+			segment.Enabled()
+			assert.Equal(t, tc.Expected, segment.RemainingPercent(), tc.Case)
+
+			cache.Delete(cache.Session, cache.COPILOTCLICACHE)
+		})
+	}
+}

--- a/src/shell/constants.go
+++ b/src/shell/constants.go
@@ -1,14 +1,15 @@
 package shell
 
 const (
-	ZSH     = "zsh"
-	BASH    = "bash"
-	PWSH    = "pwsh"
-	FISH    = "fish"
-	CMD     = "cmd"
-	NU      = "nu"
-	GENERIC = "shell"
-	ELVISH  = "elvish"
-	XONSH   = "xonsh"
-	CLAUDE  = "claude"
+	ZSH        = "zsh"
+	BASH       = "bash"
+	PWSH       = "pwsh"
+	FISH       = "fish"
+	CMD        = "cmd"
+	NU         = "nu"
+	GENERIC    = "shell"
+	ELVISH     = "elvish"
+	XONSH      = "xonsh"
+	CLAUDE     = "claude"
+	COPILOTCLI = "copilot-cli"
 )

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -386,6 +386,7 @@
             "clojure",
             "cmake",
             "copilot",
+            "copilot_cli",
             "connection",
             "crystal",
             "dart",
@@ -1315,6 +1316,20 @@
             "description": "https://ohmyposh.dev/docs/segments/cli/claude",
             "properties": {
               "options": {
+                "properties": {
+                  "gauge_marked_char": {
+                    "type": "string",
+                    "title": "Gauge marked character",
+                    "description": "The character used for the filled part of the token usage gauge",
+                    "default": "▰"
+                  },
+                  "gauge_unmarked_char": {
+                    "type": "string",
+                    "title": "Gauge unmarked character",
+                    "description": "The character used for the empty part of the token usage gauge",
+                    "default": "▱"
+                  }
+                },
                 "unevaluatedProperties": false
               }
             }
@@ -1336,6 +1351,38 @@
                 "properties": {
                   "http_timeout": {
                     "$ref": "#/definitions/http_timeout"
+                  }
+                },
+                "unevaluatedProperties": false
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "copilot_cli"
+              }
+            }
+          },
+          "then": {
+            "title": "Copilot CLI Segment",
+            "description": "https://ohmyposh.dev/docs/segments/cli/copilot-cli",
+            "properties": {
+              "options": {
+                "properties": {
+                  "gauge_marked_char": {
+                    "type": "string",
+                    "title": "Gauge marked character",
+                    "description": "The character used for the filled part of the token usage gauge",
+                    "default": "▰"
+                  },
+                  "gauge_unmarked_char": {
+                    "type": "string",
+                    "title": "Gauge unmarked character",
+                    "description": "The character used for the empty part of the token usage gauge",
+                    "default": "▱"
                   }
                 },
                 "unevaluatedProperties": false

--- a/website/docs/installation/prompt.mdx
+++ b/website/docs/installation/prompt.mdx
@@ -23,6 +23,7 @@ oh-my-posh get shell
     { label: 'bash', value: 'bash', },
     { label: 'claude', value: 'claude', },
     { label: 'cmd', value: 'cmd', },
+    { label: 'copilot', value: 'copilot', },
     { label: 'elvish', value: 'elvish', },
     { label: 'fish', value: 'fish', },
     { label: 'nu', value: 'nu', },
@@ -71,6 +72,33 @@ Add the following to your Claude Code settings:
 For more information about the Claude segment properties and customization options, see the [Claude segment documentation](/docs/segments/cli/claude).
 
 </TabItem>
+<TabItem value="copilot">
+
+To enable GitHub Copilot CLI integration with Oh My Posh, configure Copilot CLI to use Oh My Posh as
+the statusline command.
+
+Add the following to your Copilot CLI settings:
+
+```json title="~/.copilot/settings.json"
+{
+  "statusLine": {
+    "type": "command",
+    "command": "oh-my-posh copilot",
+    "padding": 2
+  },
+  "feature_flags": {
+    "enabled": ["STATUS_LINE"]
+  },
+  "experimental": true
+}
+```
+
+Restart Copilot CLI or run `/restart` in an open session to pick up the new settings.
+
+For more information about the Copilot CLI segment properties and customization options, see the
+[Copilot CLI segment documentation](/docs/segments/cli/copilot-cli).
+
+</TabItem>
 <TabItem value="cmd">
 
 There's no out-of-the-box support for Windows CMD when it comes to custom prompts.
@@ -98,6 +126,7 @@ To set the configuration file, use the following command:
 ```bash
 clink set ohmyposh.theme <path>
 ```
+
 :::
 
 </TabItem>

--- a/website/docs/segments/cli/copilot-cli.mdx
+++ b/website/docs/segments/cli/copilot-cli.mdx
@@ -1,0 +1,147 @@
+---
+id: copilot-cli
+title: GitHub Copilot CLI
+sidebar_label: GitHub Copilot CLI
+---
+
+## What
+
+Display GitHub Copilot CLI session information including the current AI model, token usage,
+and workspace details. Shows a visual gauge of context window usage and formatted token/duration
+information for monitoring your Copilot CLI session.
+
+This segment integrates with [GitHub Copilot CLI's statusline functionality][copilot-statusline]
+to provide real-time session data in your prompt.
+
+For setup instructions, see [Change your prompt](/docs/installation/prompt?shell=copilot).
+
+## Sample Configuration
+
+import Config from "@site/src/components/Config.js";
+
+<Config
+  data={{
+    type: "copilot_cli",
+    style: "diamond",
+    leading_diamond: "\ue0b6",
+    trailing_diamond: "\ue0b4",
+    foreground: "#111111",
+    background: "#fee898",
+    template: " \uec1e {{ .Model.DisplayName }} \uf2d0 {{ .TokenGauge }} ",
+  }}
+/>
+
+## Template ([info][templates])
+
+:::note default template
+
+```template
+ \uec1e {{ .Model.DisplayName }} \uf2d0 {{ .TokenGauge }}
+```
+
+:::
+
+## Options
+
+| Name                  | Type     | Default | Description                                              |
+| --------------------- | -------- | ------- | -------------------------------------------------------- |
+| `gauge_marked_char`   | `string` | `▰`     | Character used for filled blocks in gauge visualizations |
+| `gauge_unmarked_char` | `string` | `▱`     | Character used for empty blocks in gauge visualizations  |
+
+### Properties
+
+| Name                    | Type            | Description                                                                              |
+| ----------------------- | --------------- | ---------------------------------------------------------------------------------------- |
+| `.CWD`                  | `string`        | Current working directory                                                                |
+| `.SessionID`            | `string`        | Unique identifier for the Copilot CLI session                                            |
+| `.SessionName`          | `string`        | Custom session name; empty when absent                                                   |
+| `.TranscriptPath`       | `string`        | Path to the session transcript directory                                                 |
+| `.Model`                | `Model`         | AI model information                                                                     |
+| `.Workspace`            | `Workspace`     | Workspace directory information                                                          |
+| `.Remote`               | `Remote`        | Remote connection state                                                                  |
+| `.Version`              | `string`        | Copilot CLI version                                                                      |
+| `.Username`             | `string`        | Authenticated username; empty when absent                                                |
+| `.Cost`                 | `Cost`          | Duration and line-change information                                                     |
+| `.ContextWindow`        | `ContextWindow` | Token usage information                                                                  |
+| `.TokenUsagePercent`    | `Percentage`    | Percentage of context window used (0-100)                                                |
+| `.TokenGauge`           | `string`        | Gauge showing remaining context capacity using configured characters (e.g., `▰▰▰▱▱`)    |
+| `.TokenGaugeUsed`       | `string`        | Gauge showing used context capacity using configured characters (e.g., `▰▰▱▱▱`)         |
+| `.RemainingPercent`     | `Percentage`    | Percentage of context window remaining (0-100)                                           |
+| `.RemainingTokensCount` | `int`           | Number of remaining context window tokens; 0 when context window size is unknown         |
+| `.FormattedTokens`      | `string`        | Human-readable token count (e.g., "1.2K", "15.3M")                                      |
+| `.FormattedDuration`    | `string`        | Total session duration (e.g., "2m 5s")                                                   |
+| `.FormattedAPIDuration` | `string`        | API wait time (e.g., "0m 45s")                                                           |
+
+#### Model Properties
+
+| Name           | Type     | Description                                     |
+| -------------- | -------- | ----------------------------------------------- |
+| `.ID`          | `string` | Technical model identifier                      |
+| `.DisplayName` | `string` | Human-readable model name (e.g., "claude-sonnet-4.6 (medium)")  |
+
+#### Workspace Properties
+
+| Name          | Type     | Description              |
+| ------------- | -------- | ------------------------ |
+| `.CurrentDir` | `string` | Current working directory |
+
+#### Remote Properties
+
+| Name         | Type   | Description                               |
+| ------------ | ------ | ----------------------------------------- |
+| `.Connected` | `bool` | Whether a remote connection is active     |
+
+#### Cost Properties
+
+| Name                    | Type         | Description                                                 |
+| ----------------------- | ------------ | ----------------------------------------------------------- |
+| `.TotalDurationMS`      | `DurationMS` | Total session duration in milliseconds (formats as "Xm Ys") |
+| `.TotalAPIDurationMS`   | `DurationMS` | Time spent waiting for API responses (formats as "Xm Ys")   |
+| `.TotalLinesAdded`      | `int`        | Lines of code added in the session                          |
+| `.TotalLinesRemoved`    | `int`        | Lines of code removed in the session                        |
+| `.TotalPremiumRequests` | `int`        | Number of premium model requests made in the session        |
+
+#### ContextWindow Properties
+
+| Name                    | Type      | Description                                                 |
+| ----------------------- | --------- | ----------------------------------------------------------- |
+| `.ContextWindowSize`    | `*int`    | Maximum context window size; `nil` when unknown             |
+| `.UsedPercentage`       | `*float64`| Percentage used (0-100); `nil` when unknown                 |
+| `.RemainingPercentage`  | `*float64`| Percentage remaining (0-100); `nil` when unknown            |
+| `.RemainingTokens`      | `*int`    | Remaining token count; `nil` when unknown                   |
+| `.CurrentContextTokens` | `int`     | Tokens in the current active context                        |
+| `.TotalInputTokens`     | `int`     | Total input tokens used in the session                      |
+| `.TotalOutputTokens`    | `int`     | Total output tokens generated in the session                |
+| `.TotalCacheReadTokens` | `int`     | Total tokens read from cache                                |
+| `.TotalCacheWriteTokens`| `int`     | Total tokens written to cache                               |
+| `.TotalReasoningTokens` | `int`     | Total reasoning tokens used in the session                  |
+| `.TotalTokens`          | `int`     | Grand total of all tokens used in the session               |
+| `.LastCallInputTokens`  | `int`     | Input tokens for the most recent API call                   |
+| `.LastCallOutputTokens` | `int`     | Output tokens for the most recent API call                  |
+
+### Percentage Methods
+
+The `Percentage` type (returned by `.TokenUsagePercent`, `.RemainingPercent`) provides
+additional methods for direct use in templates:
+
+| Method       | Returns  | Description                                                               |
+| ------------ | -------- | ------------------------------------------------------------------------- |
+| `.Gauge`     | `string` | Visual gauge showing remaining capacity using hardcoded `▰`/`▱` characters |
+| `.GaugeUsed` | `string` | Visual gauge showing used capacity using hardcoded `▰`/`▱` characters     |
+| `.String`    | `string` | Numeric percentage value (e.g., "75")                                     |
+
+:::tip Custom gauge characters
+Use `.TokenGauge` and `.TokenGaugeUsed` instead of the raw `.Percentage` methods above —
+they respect the `gauge_marked_char` and `gauge_unmarked_char` options.
+:::
+
+## How it works
+
+The `oh-my-posh copilot` command reads GitHub Copilot CLI's session JSON from stdin,
+caches the parsed data, then renders your configured prompt. Copilot CLI sends a fresh
+JSON payload on every statusline refresh.
+
+The segment is only visible when Copilot CLI is actively providing session data.
+
+[copilot-statusline]: https://docs.github.com/copilot/cli
+[templates]: /docs/configuration/templates

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -62,6 +62,7 @@ export default {
             "segments/cli/claude",
             "segments/cli/cmake",
             "segments/cli/copilot",
+            "segments/cli/copilot-cli",
             "segments/cli/deno",
             "segments/cli/docker",
             "segments/cli/firebase",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Adds `oh-my-posh copilot` -- a statusline command for GitHub Copilot CLI -- mirroring the existing `oh-my-posh claude` command.

**New functionality**

- `oh-my-posh copilot` reads the session JSON that GitHub Copilot CLI sends to its statusline command via stdin, caches it, and renders a prompt using a new `copilot_cli` segment type. The segment exposes model info, token gauge, context window usage, cost/duration, and workspace details as template properties.
- A `copilot` tab is added to the [Change your prompt](/docs/installation/prompt) page with the one-time `settings.json` setup. Segment properties are documented in a new `website/docs/segments/cli/copilot-cli.mdx` page.

**Deduplication**

The Claude and Copilot CLI commands shared ~120 lines of identical boilerplate. That logic is now extracted into a generic `statuslineRun[T]` + `processStatuslineData[T]` pipeline in `src/cli/statusline.go`, reducing each command file to ~35 lines.

Shared types and helpers (`AIModel`, `formatTokenCount`, `statuslineCLIConfig`) were also extracted so both segments stay lean.

**Bug fix: `POSH_CONFIG` env var bypass**

When `POSH_CONFIG` is set in the shell (common for regular prompt users), `PersistentPreRun` in `root.go` was copying it into `configFlag`. This caused statusline commands to load the user's regular shell config instead of the built-in default, so the statusline segment never rendered. The fix checks `cmd.Root().PersistentFlags().Changed("config")` -- Cobra only marks a flag changed when it was explicitly set on the command line, not when injected programmatically.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary