### PR TITLE
chore(shell): satisfy modernize slices.Backward

### DIFF
--- a/src/shell/dsc.go
+++ b/src/shell/dsc.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/dsc"
@@ -174,8 +175,7 @@ func (s *Shell) addInitLine(content string) string {
 }
 
 func (s *Shell) getLastInitLinePosition(lines []string) int {
-	for i := len(lines) - 1; i >= 0; i-- {
-		line := lines[i]
+	for i, line := range slices.Backward(lines) {
 		if regex.MatchString(initCommandRegex, line) && !strings.HasPrefix(strings.TrimSpace(line), "#") {
 			return i
 		}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

The `Modernize` CI step (using `golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest`) now flags the manual backward loop in `getLastInitLinePosition` and suggests `slices.Backward`. Because the workflow installs `@latest`, this is currently breaking CI on unrelated PRs (e.g. #7499).

This change applies the suggested modernization:

```go
for i, line := range slices.Backward(lines) {
    ...
}
```

No behaviour change — same iteration order, same return semantics.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary