### PR TITLE
feat(dotnet): suppress telemetry in version probe

### DIFF
--- a/src/runtime/cmd/run.go
+++ b/src/runtime/cmd/run.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -14,7 +15,16 @@ import (
 // cleanup (KillGoroutineChildren) if they decide to abort waiting for the
 // goroutine that spawned it.
 func Run(command string, args ...string) (string, error) {
+	return RunWithEnv(command, nil, args...)
+}
+
+// RunWithEnv executes a command with additional environment variables.
+func RunWithEnv(command string, envs []string, args ...string) (string, error) {
 	cmd := exec.CommandContext(context.Background(), command, args...)
+	if len(envs) > 0 {
+		cmd.Env = append(os.Environ(), envs...)
+	}
+
 	var out bytes.Buffer
 	var errb bytes.Buffer
 	cmd.Stdout = &out

--- a/src/runtime/cmd/run_test.go
+++ b/src/runtime/cmd/run_test.go
@@ -15,6 +15,8 @@ func TestCurrentGID(t *testing.T) {
 }
 
 func TestRunWithEnv(t *testing.T) {
+	t.Setenv("OMP_TEST_CHILD_ENV", "parent")
+
 	output, err := RunWithEnv(
 		os.Args[0],
 		[]string{

--- a/src/runtime/cmd/run_test.go
+++ b/src/runtime/cmd/run_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
 	runjobs "github.com/jandedobbeleer/oh-my-posh/src/runtime/jobs"
@@ -10,4 +12,31 @@ func TestCurrentGID(t *testing.T) {
 	if gid := runjobs.CurrentGID(); gid == 0 {
 		t.Fatalf("CurrentGID returned 0")
 	}
+}
+
+func TestRunWithEnv(t *testing.T) {
+	output, err := RunWithEnv(
+		os.Args[0],
+		[]string{
+			"GO_WANT_HELPER_PROCESS=1",
+			"OMP_TEST_CHILD_ENV=injected",
+		},
+		"-test.run=TestRunWithEnvHelperProcess",
+	)
+	if err != nil {
+		t.Fatalf("RunWithEnv returned error: %v", err)
+	}
+
+	if output != "injected" {
+		t.Fatalf("RunWithEnv output = %q, want %q", output, "injected")
+	}
+}
+
+func TestRunWithEnvHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	fmt.Fprint(os.Stdout, os.Getenv("OMP_TEST_CHILD_ENV"))
+	os.Exit(0)
 }

--- a/src/runtime/environment.go
+++ b/src/runtime/environment.go
@@ -46,6 +46,7 @@ type Environment interface {
 	FileContent(file string) string
 	LsDir(input string) []fs.DirEntry
 	RunCommand(command string, args ...string) (string, error)
+	RunCommandWithEnv(command string, envs []string, args ...string) (string, error)
 	RunShellCommand(shell, command string) string
 	ExecutionTime() float64
 	Flags() *Flags

--- a/src/runtime/mock/environment.go
+++ b/src/runtime/mock/environment.go
@@ -3,7 +3,6 @@ package mock
 import (
 	"io"
 	"io/fs"
-	"reflect"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime/battery"
@@ -97,18 +96,7 @@ func (env *Environment) RunCommand(command string, args ...string) (string, erro
 }
 
 func (env *Environment) RunCommandWithEnv(command string, envs []string, args ...string) (string, error) {
-	for _, call := range env.ExpectedCalls {
-		if call.Method == "RunCommandWithEnv" &&
-			len(call.Arguments) == 3 &&
-			call.Arguments[0] == command &&
-			reflect.DeepEqual(call.Arguments[1], envs) &&
-			reflect.DeepEqual(call.Arguments[2], args) {
-			arguments := env.Called(command, envs, args)
-			return arguments.String(0), arguments.Error(1)
-		}
-	}
-
-	arguments := env.MethodCalled("RunCommand", command, args)
+	arguments := env.Called(command, envs, args)
 	return arguments.String(0), arguments.Error(1)
 }
 

--- a/src/runtime/mock/environment.go
+++ b/src/runtime/mock/environment.go
@@ -95,6 +95,11 @@ func (env *Environment) RunCommand(command string, args ...string) (string, erro
 	return arguments.String(0), arguments.Error(1)
 }
 
+func (env *Environment) RunCommandWithEnv(command string, envs []string, args ...string) (string, error) {
+	arguments := env.Called(command, envs, args)
+	return arguments.String(0), arguments.Error(1)
+}
+
 func (env *Environment) RunShellCommand(shell, command string) string {
 	args := env.Called(shell, command)
 	return args.String(0)

--- a/src/runtime/mock/environment.go
+++ b/src/runtime/mock/environment.go
@@ -3,6 +3,7 @@ package mock
 import (
 	"io"
 	"io/fs"
+	"reflect"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime/battery"
@@ -96,7 +97,18 @@ func (env *Environment) RunCommand(command string, args ...string) (string, erro
 }
 
 func (env *Environment) RunCommandWithEnv(command string, envs []string, args ...string) (string, error) {
-	arguments := env.Called(command, envs, args)
+	for _, call := range env.ExpectedCalls {
+		if call.Method == "RunCommandWithEnv" &&
+			len(call.Arguments) == 3 &&
+			call.Arguments[0] == command &&
+			reflect.DeepEqual(call.Arguments[1], envs) &&
+			reflect.DeepEqual(call.Arguments[2], args) {
+			arguments := env.Called(command, envs, args)
+			return arguments.String(0), arguments.Error(1)
+		}
+	}
+
+	arguments := env.MethodCalled("RunCommand", command, args)
 	return arguments.String(0), arguments.Error(1)
 }
 

--- a/src/runtime/terminal.go
+++ b/src/runtime/terminal.go
@@ -266,13 +266,17 @@ func (term *Terminal) Home() string {
 }
 
 func (term *Terminal) RunCommand(command string, args ...string) (string, error) {
+	return term.RunCommandWithEnv(command, nil, args...)
+}
+
+func (term *Terminal) RunCommandWithEnv(command string, envs []string, args ...string) (string, error) {
 	defer log.Trace(time.Now(), append([]string{command}, args...)...)
 
 	if cacheCommand, ok := term.cmdCache.Get(command); ok {
 		command = cacheCommand
 	}
 
-	output, err := cmd.Run(command, args...)
+	output, err := cmd.RunWithEnv(command, envs, args...)
 	if err != nil {
 		log.Error(err)
 	}

--- a/src/segments/bun_test.go
+++ b/src/segments/bun_test.go
@@ -24,7 +24,7 @@ func TestBun(t *testing.T) {
 	for _, tc := range cases {
 		env := new(mock.Environment)
 		env.On("HasCommand", "bun").Return(true)
-		env.On("RunCommand", "bun", []string{"--version"}).Return(tc.Version, nil)
+		env.On("RunCommandWithEnv", "bun", []string(nil), []string{"--version"}).Return(tc.Version, nil)
 		env.On("HasFiles", "bun.lockb").Return(tc.Extension == "bun.lockb")
 		env.On("HasFiles", "bun.lock").Return(tc.Extension == "bun.lock")
 		env.On("Pwd").Return("/usr/home/project")

--- a/src/segments/dotnet.go
+++ b/src/segments/dotnet.go
@@ -47,6 +47,7 @@ func (d *Dotnet) Enabled() bool {
 		dotnetToolName: {
 			executable: dotnetToolName,
 			args:       []string{versionFlagArg},
+			envs:       []string{"DOTNET_CLI_TELEMETRY_OPTOUT=1"},
 			regex: `(?P<version>((?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)` +
 				`(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?))`,
 		},

--- a/src/segments/dotnet_test.go
+++ b/src/segments/dotnet_test.go
@@ -28,13 +28,14 @@ func TestDotnetSegment(t *testing.T) {
 			versionParam:  "--version",
 			versionOutput: tc.Version,
 			extension:     "*.cs",
+			envs:          []string{"DOTNET_CLI_TELEMETRY_OPTOUT=1"},
 		}
 		env, props := getMockedLanguageEnv(params)
 
 		if tc.ExitCode != 0 {
-			env.Unset("RunCommand")
+			env.Unset("RunCommandWithEnv")
 			err := &runtime.CommandError{ExitCode: tc.ExitCode}
-			env.On("RunCommand", "dotnet", []string{"--version"}).Return("", err)
+			env.On("RunCommandWithEnv", "dotnet", []string{"DOTNET_CLI_TELEMETRY_OPTOUT=1"}, []string{"--version"}).Return("", err)
 		}
 
 		dotnet := &Dotnet{}
@@ -87,6 +88,7 @@ func TestDotnetSDKVersion(t *testing.T) {
 		versionParam:  "--version",
 		versionOutput: "6.0.100",
 		extension:     "*.cs",
+		envs:          []string{"DOTNET_CLI_TELEMETRY_OPTOUT=1"},
 	}
 
 	for _, tc := range cases {
@@ -113,4 +115,27 @@ func TestDotnetSDKVersion(t *testing.T) {
 		assert.True(t, dotnet.Enabled(), tc.Case)
 		assert.Equal(t, tc.ExpectedSDK, dotnet.SDKVersion, tc.Case)
 	}
+}
+
+func TestDotnetSegmentSuppressesTelemetry(t *testing.T) {
+	params := &mockedLanguageParams{
+		cmd:           "dotnet",
+		versionParam:  "--version",
+		versionOutput: "8.0.100",
+		extension:     "*.cs",
+		envs:          []string{"DOTNET_CLI_TELEMETRY_OPTOUT=1"},
+	}
+	env, props := getMockedLanguageEnv(params)
+
+	dotnet := &Dotnet{}
+	dotnet.Init(props, env)
+
+	assert.True(t, dotnet.Enabled())
+	env.AssertCalled(
+		t,
+		"RunCommandWithEnv",
+		"dotnet",
+		[]string{"DOTNET_CLI_TELEMETRY_OPTOUT=1"},
+		[]string{"--version"},
+	)
 }

--- a/src/segments/elixir_test.go
+++ b/src/segments/elixir_test.go
@@ -52,7 +52,7 @@ func TestElixir(t *testing.T) {
 		if tc.AsdfExitCode != 0 {
 			asdfErr = &runtime.CommandError{ExitCode: tc.AsdfExitCode}
 		}
-		env.On("RunCommand", "asdf", []string{"current", "elixir"}).Return(tc.AsdfVersionOutput, asdfErr)
+		env.On("RunCommandWithEnv", "asdf", []string(nil), []string{"current", "elixir"}).Return(tc.AsdfVersionOutput, asdfErr)
 
 		r := &Elixir{}
 		r.Init(props, env)

--- a/src/segments/haskell_test.go
+++ b/src/segments/haskell_test.go
@@ -63,7 +63,7 @@ func TestHaskell(t *testing.T) {
 
 		if tc.StackGhcMode == "always" || (tc.StackGhcMode == "package" && tc.InStackPackage) {
 			env.On("HasCommand", "stack").Return(true)
-			env.On("RunCommand", "stack", []string{"ghc", "--", "--numeric-version"}).Return(tc.StackGhcVersion, nil)
+			env.On("RunCommandWithEnv", "stack", []string(nil), []string{"ghc", "--", "--numeric-version"}).Return(tc.StackGhcVersion, nil)
 		}
 
 		fileInfo := &runtime.FileInfo{

--- a/src/segments/java_test.go
+++ b/src/segments/java_test.go
@@ -64,7 +64,7 @@ func TestJava(t *testing.T) {
 		if tc.JavaHomeEnabled {
 			env.On("Getenv", "JAVA_HOME").Return("/usr/java")
 			env.On("HasCommand", "/usr/java/bin/java").Return(true)
-			env.On("RunCommand", "/usr/java/bin/java", []string{"-Xinternalversion"}).Return(tc.JavaHomeVersion, nil)
+			env.On("RunCommandWithEnv", "/usr/java/bin/java", []string(nil), []string{"-Xinternalversion"}).Return(tc.JavaHomeVersion, nil)
 		} else {
 			env.On("Getenv", "JAVA_HOME").Return("")
 		}

--- a/src/segments/language.go
+++ b/src/segments/language.go
@@ -72,6 +72,7 @@ type cmd struct {
 	regex              string
 	versionURLTemplate string
 	args               []string
+	envs               []string
 }
 
 func (c *cmd) parse(versionInfo string) (*Version, error) {
@@ -299,7 +300,16 @@ func (l *Language) runCommand(command *cmd) (string, error) {
 			return "", errors.New(noVersion)
 		}
 
-		versionStr, err := l.env.RunCommand(command.executable, command.args...)
+		var (
+			versionStr string
+			err        error
+		)
+		if len(command.envs) > 0 {
+			versionStr, err = l.env.RunCommandWithEnv(command.executable, command.envs, command.args...)
+		} else {
+			versionStr, err = l.env.RunCommand(command.executable, command.args...)
+		}
+
 		if exitErr, ok := err.(*runtime.CommandError); ok {
 			l.exitCode = exitErr.ExitCode
 			return "", fmt.Errorf("err executing %s with %s", command.executable, command.args)

--- a/src/segments/language.go
+++ b/src/segments/language.go
@@ -300,19 +300,11 @@ func (l *Language) runCommand(command *cmd) (string, error) {
 			return "", errors.New(noVersion)
 		}
 
-		var (
-			versionStr string
-			err        error
-		)
-		if len(command.envs) > 0 {
-			versionStr, err = l.env.RunCommandWithEnv(command.executable, command.envs, command.args...)
-		} else {
-			versionStr, err = l.env.RunCommand(command.executable, command.args...)
-		}
+		versionStr, err := l.env.RunCommandWithEnv(command.executable, command.envs, command.args...)
 
 		if exitErr, ok := err.(*runtime.CommandError); ok {
 			l.exitCode = exitErr.ExitCode
-			return "", fmt.Errorf("err executing %s with %s", command.executable, command.args)
+			return "", fmt.Errorf("err executing %s with %v", command.executable, command.args)
 		}
 
 		return versionStr, nil

--- a/src/segments/language_test.go
+++ b/src/segments/language_test.go
@@ -40,7 +40,7 @@ func bootStrapLanguageTest(args *languageArgs) *Language {
 
 	for _, command := range args.commands {
 		env.On("HasCommand", command.executable).Return(args.hasvalue(command.executable, args.enabledCommands))
-		env.On("RunCommand", command.executable, command.args).Return(args.version, args.expectedError)
+		env.On("RunCommandWithEnv", command.executable, command.envs, command.args).Return(args.version, args.expectedError)
 	}
 
 	for _, extension := range args.extensions {
@@ -575,13 +575,13 @@ func TestLanguageTooling(t *testing.T) {
 		hasUnicorn := slices.Contains(tc.EnabledTools, "unicorn")
 		env.On("HasCommand", "unicorn").Return(hasUnicorn)
 		if hasUnicorn {
-			env.On("RunCommand", "unicorn", []string{"--version"}).Return(tc.DefaultVersion, nil)
+			env.On("RunCommandWithEnv", "unicorn", []string(nil), []string{"--version"}).Return(tc.DefaultVersion, nil)
 		}
 
 		hasToolCommand := slices.Contains(tc.EnabledTools, "mytool")
 		env.On("HasCommand", "mytool").Return(hasToolCommand)
 		if hasToolCommand {
-			env.On("RunCommand", "mytool", []string{"--version"}).Return(tc.ToolVersion, nil)
+			env.On("RunCommandWithEnv", "mytool", []string(nil), []string{"--version"}).Return(tc.ToolVersion, nil)
 		}
 
 		props := options.Map{
@@ -626,11 +626,7 @@ type mockedLanguageParams struct {
 func getMockedLanguageEnv(params *mockedLanguageParams) (*mock.Environment, options.Map) {
 	env := new(mock.Environment)
 	env.On("HasCommand", params.cmd).Return(true)
-	if len(params.envs) > 0 {
-		env.On("RunCommandWithEnv", params.cmd, params.envs, []string{params.versionParam}).Return(params.versionOutput, nil)
-	} else {
-		env.On("RunCommand", params.cmd, []string{params.versionParam}).Return(params.versionOutput, nil)
-	}
+	env.On("RunCommandWithEnv", params.cmd, params.envs, []string{params.versionParam}).Return(params.versionOutput, nil)
 	env.On("HasFiles", params.extension).Return(true)
 	env.On("Pwd").Return("/usr/home/project")
 	env.On("Home").Return("/usr/home")

--- a/src/segments/language_test.go
+++ b/src/segments/language_test.go
@@ -620,12 +620,17 @@ type mockedLanguageParams struct {
 	versionParam  string
 	versionOutput string
 	extension     string
+	envs          []string
 }
 
 func getMockedLanguageEnv(params *mockedLanguageParams) (*mock.Environment, options.Map) {
 	env := new(mock.Environment)
 	env.On("HasCommand", params.cmd).Return(true)
-	env.On("RunCommand", params.cmd, []string{params.versionParam}).Return(params.versionOutput, nil)
+	if len(params.envs) > 0 {
+		env.On("RunCommandWithEnv", params.cmd, params.envs, []string{params.versionParam}).Return(params.versionOutput, nil)
+	} else {
+		env.On("RunCommand", params.cmd, []string{params.versionParam}).Return(params.versionOutput, nil)
+	}
 	env.On("HasFiles", params.extension).Return(true)
 	env.On("Pwd").Return("/usr/home/project")
 	env.On("Home").Return("/usr/home")

--- a/src/segments/lua_test.go
+++ b/src/segments/lua_test.go
@@ -68,7 +68,7 @@ func TestLua(t *testing.T) {
 		}
 
 		env.On("HasCommand", "luajit").Return(tc.HasLuaJit)
-		env.On("RunCommand", "luajit", []string{"-v"}).Return(tc.Version, nil)
+		env.On("RunCommandWithEnv", "luajit", []string(nil), []string{"-v"}).Return(tc.Version, nil)
 		env.On("Shell").Return("bash")
 
 		// Initialize template system for version URL rendering

--- a/src/segments/mvn_test.go
+++ b/src/segments/mvn_test.go
@@ -51,7 +51,7 @@ func TestMvn(t *testing.T) {
 		}
 		env.On("HasParentFilePath", "mvnw", false).Return(fileInfo, err)
 		env.On("HasCommand", fileInfo.Path).Return(tc.HasMvnw)
-		env.On("RunCommand", fileInfo.Path, []string{"--version"}).Return(tc.MvnwVersion, nil)
+		env.On("RunCommandWithEnv", fileInfo.Path, []string(nil), []string{"--version"}).Return(tc.MvnwVersion, nil)
 
 		m := &Mvn{}
 		m.Init(props, env)

--- a/src/segments/python_test.go
+++ b/src/segments/python_test.go
@@ -312,7 +312,7 @@ func TestPythonUVTooling(t *testing.T) {
 
 		if tc.HasUVCommand {
 			env.On("HasCommand", "uv").Return(true)
-			env.On("RunCommand", "uv", []string{"run", "--no-sync", "--quiet", "--no-python-downloads", "python", "--version"}).Return(tc.UVVersionOutput, nil)
+			env.On("RunCommandWithEnv", "uv", []string(nil), []string{"run", "--no-sync", "--quiet", "--no-python-downloads", "python", "--version"}).Return(tc.UVVersionOutput, nil)
 		} else {
 			env.On("HasCommand", "uv").Return(false)
 		}

--- a/src/segments/r_test.go
+++ b/src/segments/r_test.go
@@ -40,9 +40,9 @@ func TestR(t *testing.T) {
 		env, props := getMockedLanguageEnv(params)
 
 		env.On("HasCommand", "Rscript").Return(tc.HasRscript)
-		env.On("RunCommand", "Rscript", []string{"--version"}).Return(tc.Version, nil)
+		env.On("RunCommandWithEnv", "Rscript", []string(nil), []string{"--version"}).Return(tc.Version, nil)
 		env.On("HasCommand", "R.exe").Return(tc.HasRexe)
-		env.On("RunCommand", "R.exe", []string{"--version"}).Return(tc.Version, nil)
+		env.On("RunCommandWithEnv", "R.exe", []string(nil), []string{"--version"}).Return(tc.Version, nil)
 
 		r := &R{}
 		r.Init(props, env)

--- a/src/segments/ruby_test.go
+++ b/src/segments/ruby_test.go
@@ -84,13 +84,13 @@ func TestRuby(t *testing.T) {
 		env, props := getMockedLanguageEnv(params)
 
 		env.On("HasCommand", "rbenv").Return(tc.HasRbenv)
-		env.On("RunCommand", "rbenv", []string{"version-name"}).Return(tc.Version, nil)
+		env.On("RunCommandWithEnv", "rbenv", []string(nil), []string{"version-name"}).Return(tc.Version, nil)
 		env.On("HasCommand", "rvm-prompt").Return(tc.HasRvmprompt)
-		env.On("RunCommand", "rvm-prompt", []string{"i", "v", "g"}).Return(tc.Version, nil)
+		env.On("RunCommandWithEnv", "rvm-prompt", []string(nil), []string{"i", "v", "g"}).Return(tc.Version, nil)
 		env.On("HasCommand", "chruby").Return(tc.HasChruby)
-		env.On("RunCommand", "chruby", []string(nil)).Return(tc.Version, nil)
+		env.On("RunCommandWithEnv", "chruby", []string(nil), []string(nil)).Return(tc.Version, nil)
 		env.On("HasCommand", "asdf").Return(tc.HasAsdf)
-		env.On("RunCommand", "asdf", []string{"current", "ruby"}).Return(tc.Version, nil)
+		env.On("RunCommandWithEnv", "asdf", []string(nil), []string{"current", "ruby"}).Return(tc.Version, nil)
 		env.On("HasFiles", "Rakefile").Return(tc.HasRakeFile)
 		env.On("HasFiles", "Gemfile").Return(tc.HasGemFile)
 


### PR DESCRIPTION
## Summary

- add a generic command runner path for per-command environment variables
- run the dotnet segment's `dotnet --version` probe with `DOTNET_CLI_TELEMETRY_OPTOUT=1`
- cover the dotnet segment telemetry suppression with tests

Fixes #7561.

## Details

The dotnet segment only needs the SDK version for prompt rendering. Suppressing .NET CLI telemetry for this child process avoids telemetry side effects and avoids shutdown flush overhead observed in some local SDK layouts, while leaving the user's shell environment unchanged.

## Test

```text
go test .\segments -run 'TestDotnet' -count=1
go test .\... -count=1
```