### PR TITLE
docs: simplify Copilot CLI and Claude Code statusline setup

### DIFF
--- a/website/docs/installation/prompt.mdx
+++ b/website/docs/installation/prompt.mdx
@@ -72,8 +72,8 @@ Add the following to your Claude Code settings:
 :::tip
 You can use the `--config` flag to point to a tailored Oh My Posh config just for Claude Code:
 
-```json
-"command": "oh-my-posh claude --config ~/.config/ohmyposh/claude.json"
+```bash
+oh-my-posh claude --config /path/to/claude.omp.json
 ```
 
 :::
@@ -101,8 +101,8 @@ To enable GitHub Copilot CLI integration with Oh My Posh, add the following to y
 :::tip
 You can use the `--config` flag to point to a tailored Oh My Posh config just for Copilot CLI:
 
-```json
-"command": "oh-my-posh copilot --config ~/.config/ohmyposh/copilot.json"
+```bash
+oh-my-posh copilot --config /path/to/copilot.omp.json
 ```
 
 :::

--- a/website/docs/installation/prompt.mdx
+++ b/website/docs/installation/prompt.mdx
@@ -69,39 +69,27 @@ Add the following to your Claude Code settings:
 }
 ```
 
+:::tip
+You can use the `--config` flag to point to a tailored Oh My Posh config just for Claude Code:
+
+```json
+"command": "oh-my-posh claude --config ~/.config/ohmyposh/claude.json"
+```
+
+:::
+
 For more information about the Claude segment properties and customization options, see the [Claude segment documentation](/docs/segments/cli/claude).
 
 </TabItem>
 <TabItem value="copilot">
 
-To enable GitHub Copilot CLI integration with Oh My Posh, configure Copilot CLI to use Oh My Posh as
-the statusline command.
-
-<Tabs
-  queryString="platform"
-  defaultValue="windows"
-  groupId="platform"
-  values={[
-    { label: 'windows', value: 'windows', },
-    { label: 'unix', value: 'unix', },
-  ]
-}>
-<TabItem value="windows">
-
-First, create a command wrapper.
-
-```cmd title="~/.copilot/statusline.cmd"
-@echo off
-oh-my-posh copilot
-```
-
-Then, add the following to your Copilot CLI settings:
+To enable GitHub Copilot CLI integration with Oh My Posh, add the following to your Copilot CLI settings:
 
 ```json title="~/.copilot/settings.json"
 {
   "statusLine": {
     "type": "command",
-    "command": "C:\\Users\\YOURUSER\\.copilot\\statusline.cmd"
+    "command": "oh-my-posh copilot"
   },
   "feature_flags": {
     "enabled": ["STATUS_LINE"]
@@ -110,33 +98,14 @@ Then, add the following to your Copilot CLI settings:
 }
 ```
 
-</TabItem>
-<TabItem value="unix">
+:::tip
+You can use the `--config` flag to point to a tailored Oh My Posh config just for Copilot CLI:
 
-First, create a command wrapper.
-
-```bash title="~/.copilot/statusline.sh"
-#!/bin/bash
-oh-my-posh copilot
+```json
+"command": "oh-my-posh copilot --config ~/.config/ohmyposh/copilot.json"
 ```
 
-Then, add the following to your Copilot CLI settings:
-
-```json title="~/.copilot/settings.json"
-{
-  "statusLine": {
-    "type": "command",
-    "command": "~/.copilot/statusline.sh"
-  },
-  "feature_flags": {
-    "enabled": ["STATUS_LINE"]
-  },
-  "experimental": true
-}
-```
-
-</TabItem>
-</Tabs>
+:::
 
 Restart Copilot CLI or run `/restart` in an open session to pick up the new settings.
 

--- a/website/docs/segments/cli/copilot-cli.mdx
+++ b/website/docs/segments/cli/copilot-cli.mdx
@@ -143,5 +143,5 @@ JSON payload on every statusline refresh.
 
 The segment is only visible when Copilot CLI is actively providing session data.
 
-[copilot-statusline]: https://docs.github.com/copilot/cli
+[copilot-statusline]: https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-config-dir-reference#user-settings-copilotsettingsjson
 [templates]: /docs/configuration/templates


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

The Copilot CLI statusline no longer requires a separate wrapper script. `oh-my-posh copilot` can now be set directly as the `command` value in `settings.json`, so the docs are updated to reflect that simpler setup (removing the platform-specific `.cmd`/`.sh` wrapper files and nested platform tabs).

Both the Copilot CLI and Claude Code tabs now include a `:::tip` hint showing how to use the `--config` flag to point at a tailored Oh My Posh config specifically for that statusline.

The reference link in the Copilot CLI segment doc is also updated to the new canonical URL: `https://docs.github.com/en/copilot/how-tos/copilot-cli`.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary