### PR TITLE
fix: update git no commits icon

### DIFF
--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -1063,7 +1063,7 @@ func (g *Git) resolveDetachedHEAD() {
 
 	// fallback to no commits found
 	if g.ShortHash == "" {
-		g.HEAD = g.options.String(NoCommitsIcon, "\uF594 ")
+		g.HEAD = g.options.String(NoCommitsIcon, "\U000F0095 ")
 		return
 	}
 

--- a/src/segments/git_test.go
+++ b/src/segments/git_test.go
@@ -439,6 +439,27 @@ func TestSetPrettyHEADName(t *testing.T) {
 	}
 }
 
+func TestSetPrettyHEADNameDefaultsToCurrentNoCommitsIcon(t *testing.T) {
+	env := new(mock.Environment)
+	env.On("FileContent", "/HEAD").Return("")
+	env.On("GOOS").Return("unix")
+	env.On("IsWsl").Return(false)
+	env.MockGitCommand("", "", "rev-parse", "HEAD")
+	env.MockGitCommand("", "", "describe", "--tags", "--exact-match")
+
+	g := &Git{
+		Scm: Scm{
+			command: GITCOMMAND,
+		},
+	}
+	g.Init(options.Map{}, env)
+	g.mainSCMDir = ""
+
+	g.updateHEADReference()
+
+	assert.Equal(t, "\U000F0095 ", g.HEAD)
+}
+
 func TestSetGitStatus(t *testing.T) {
 	cases := []struct {
 		ExpectedWorking      *GitStatus

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -2003,7 +2003,7 @@
                     "type": "string",
                     "title": "No Commits Icon",
                     "description": "Icon/text to display when there are no commits in the repo",
-                    "default": "\uf594"
+                    "default": "\udb80\udc95"
                   },
                   "github_icon": {
                     "type": "string",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Fixes #7554.

Updates the Git segment default `no_commits_icon` from the old Nerd Font U+F594 glyph to the current U+F0095 glyph and keeps the checked-in schema default in sync. A regression test covers the empty repository HEAD fallback so the default does not drift again.

Tests run:

- `GOMODCACHE=/tmp/omp-7554-gomodcache GOCACHE=/tmp/omp-7554-gocache go test ./segments -run TestSetPrettyHEADNameDefaultsToCurrentNoCommitsIcon -count=1`
- `GOMODCACHE=/tmp/omp-7554-gomodcache GOCACHE=/tmp/omp-7554-gocache go test ./segments -count=1`
- `GOMODCACHE=/tmp/omp-7554-gomodcache GOCACHE=/tmp/omp-7554-gocache go test ./segments ./config -run 'TestSetPrettyHEADNameDefaultsToCurrentNoCommitsIcon|TestEscapeGlyphs' -count=1`\n- `python3 -m json.tool themes/schema.json`\n- `git diff --check`\n\nI also ran `go test ./...`; changed packages passed, but the run failed locally in unrelated `src/terminal TestWriteANSIColors` expectations because this terminal emitted 256-color escape sequences where the test expected truecolor escape sequences.\n\nI used AI assistance while preparing this change and reviewed/tested the result locally.\n\n[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md\n[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary