### PR TITLE
feat: add OpenAI Codex segment

### DIFF
--- a/.github/workflows/ai-changelog.yml
+++ b/.github/workflows/ai-changelog.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository (with tags)
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.tag || github.ref }}
           fetch-depth: 0

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -9,7 +9,7 @@ jobs:
     container: ghcr.io/jandedobbeleer/golang-android-container:latest
     steps:
     - name: Checkout code 👋
-      uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - name: Build
       run: |
         VERSION=$(echo "${{ github.event.release.name }}" | cut -c2-)

--- a/.github/workflows/auto-merge-dependabot-caller.yml
+++ b/.github/workflows/auto-merge-dependabot-caller.yml
@@ -1,0 +1,58 @@
+name: "Dependabot Auto Merge"
+
+run-name: >-
+    ${{
+        github.event_name == 'pull_request' &&
+        format('Dependabot Auto Merge #{0}', github.event.pull_request.number) ||
+        github.event_name == 'merge_group' &&
+        format('Dependabot Auto Merge merge group {0}', github.event.merge_group.head_sha || github.ref_name || github.run_id) ||
+        format('Dependabot Auto Merge {0}', github.ref_name || github.run_id)
+    }}
+
+concurrency:
+    group: >-
+        dependabot-auto-merge-${{ github.workflow }}-${{
+            github.event.pull_request.number ||
+            github.event.merge_group.head_sha ||
+            github.event.merge_group.head_ref ||
+            github.ref ||
+            github.run_id
+        }}
+    cancel-in-progress: true
+
+on:
+    pull_request:
+        branches:
+            - "main"
+            - "master"
+            - "develop"
+            - "release/*"
+        types:
+            - "opened"
+            - "synchronize"
+            - "reopened"
+            - "ready_for_review"
+    merge_group:
+        branches:
+            - "main"
+            - "master"
+            - "develop"
+            - "release/*"
+        types:
+            - "checks_requested"
+
+permissions: {}
+
+defaults:
+    run:
+        shell: "bash"
+
+jobs:
+    dependabot-auto-merge:
+        name: "Dependabot Auto Merge"
+        permissions:
+            contents: "write"
+            pull-requests: "write"
+        uses: "Nick2bad4u/workflow-templates/.github/workflows/reusable-auto-merge-dependabot.yml@aca93c9f0f022b2c006bde8102bdb1588878b713"
+        with:
+            semver-policy: "patch,minor"

--- a/.github/workflows/auto-merge-dependabot-caller.yml
+++ b/.github/workflows/auto-merge-dependabot-caller.yml
@@ -53,6 +53,6 @@ jobs:
         permissions:
             contents: "write"
             pull-requests: "write"
-        uses: "Nick2bad4u/workflow-templates/.github/workflows/reusable-auto-merge-dependabot.yml@aca93c9f0f022b2c006bde8102bdb1588878b713"
+        uses: "Nick2bad4u/workflow-templates/.github/workflows/reusable-auto-merge-dependabot.yml@d8d4958ee20f3089dc0baeed32c27afbec4c8502"
         with:
             semver-policy: "patch,minor"

--- a/.github/workflows/build_code.yml
+++ b/.github/workflows/build_code.yml
@@ -21,7 +21,7 @@ jobs:
         shell: pwsh
     steps:
     - name: Checkout code 👋
-      uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - name: Install Go 🗳
       uses: ./.github/workflows/composite/bootstrap-go
     - name: Run GoReleaser 🚀

--- a/.github/workflows/close_themes_pr.yml
+++ b/.github/workflows/close_themes_pr.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code 👋
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Check and close 🔐
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -24,7 +24,7 @@ jobs:
         working-directory: ${{ github.workspace }}/src
     steps:
     - name: Checkout code
-      uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - name: Install Go 🗳
       uses: ./.github/workflows/composite/bootstrap-go
     - name: Golang CI

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install apm-cli and run apm install
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and Deploy
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: true
           persist-credentials: false

--- a/.github/workflows/gomod.yml
+++ b/.github/workflows/gomod.yml
@@ -14,7 +14,7 @@ jobs:
         working-directory: ${{ github.workspace }}/src
     steps:
     - name: Checkout code
-      uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - name: Install Go 🗳
       uses: ./.github/workflows/composite/bootstrap-go
     - name: Check for unused dependencies

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - name: Lint files
       uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd
       with:

--- a/.github/workflows/merge_contributions_pr.yml
+++ b/.github/workflows/merge_contributions_pr.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code 👋
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Check and merge ⛙
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0  # Fetch all tags
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       skipped: ${{ steps.changelog.outputs.skipped }}
     steps:
       - name: Checkout code 👋
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Create changelog ✍️
         id: changelog
         uses: TriPSs/conventional-changelog-action@952b14bbc4be87e8458a6ac5926fc655608b1b19
@@ -45,7 +45,7 @@ jobs:
         working-directory: ${{ github.workspace }}/build
     steps:
       - name: Checkout code 👋
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Go 🗳
         uses: ./.github/workflows/composite/bootstrap-go
       - name: Pre Build 😸
@@ -88,7 +88,7 @@ jobs:
         working-directory: ${{ github.workspace }}/packages/msi
     steps:
       - name: Checkout code 👋
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: build-artifacts

--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -11,7 +11,7 @@ jobs:
     name: runner / vale
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Vale
         run: |
           curl -sfL https://github.com/errata-ai/vale/releases/download/v3.13.1/vale_3.13.1_Linux_64-bit.tar.gz | tar -xz

--- a/src/cache/cache.go
+++ b/src/cache/cache.go
@@ -24,6 +24,7 @@ const (
 	ENGINECACHE      = "engine_cache"
 	FONTLISTCACHE    = "font_list_cache"
 	CLAUDECACHE      = "claude_cache"
+	CODEXCACHE       = "codex_cache"
 	COPILOTCLICACHE  = "copilot_cli_cache"
 )
 

--- a/src/cli/codex.go
+++ b/src/cli/codex.go
@@ -14,20 +14,29 @@ var codexCmd = &cobra.Command{
 	Short: "Render a prompt for OpenAI Codex status data",
 	Long: `Render a prompt for OpenAI Codex status data.
 
-This command reads Codex status JSON data from stdin and renders a prompt
-that can include a Codex segment with model, token, and rate limit information.
+This command renders the latest OpenAI Codex token usage data from local Codex
+session transcripts. It reads the newest token_count event from
+$CODEX_HOME/sessions, falling back to ~/.codex/sessions when CODEX_HOME is not set.
+
+When JSON is provided on stdin, stdin takes precedence over local session discovery.
 
 Example usage:
+  oh-my-posh codex --config ~/.config/ohmyposh/codex.omp.json
+  oh-my-posh codex --session 019e9eac-83ec-7393-ae18-cc2e566394d5
   cat codex-status.json | oh-my-posh codex --config ~/.config/ohmyposh/codex.omp.json`,
 	Args: cobra.NoArgs,
-	Run: statuslineRun[segments.CodexData](
+	Run: statuslineRunWithDataSource[segments.CodexData](
 		shell.CODEX,
 		cache.CODEXCACHE,
 		func(d *segments.CodexData) string { return d.ThreadID },
 		config.Codex,
+		codexStatusDataSource,
 	),
 }
 
 func init() {
+	codexCmd.Flags().String("session", "", "Codex session/thread ID to render; defaults to the newest session with token usage")
+	codexCmd.Flags().String("codex-home", "", "Codex home directory; defaults to CODEX_HOME or ~/.codex")
+	codexCmd.Flags().String("session-root", "", "Codex sessions directory; defaults to <codex-home>/sessions")
 	RootCmd.AddCommand(codexCmd)
 }

--- a/src/cli/codex.go
+++ b/src/cli/codex.go
@@ -1,0 +1,33 @@
+package cli
+
+import (
+	"github.com/jandedobbeleer/oh-my-posh/src/cache"
+	"github.com/jandedobbeleer/oh-my-posh/src/config"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments"
+	"github.com/jandedobbeleer/oh-my-posh/src/shell"
+
+	"github.com/spf13/cobra"
+)
+
+var codexCmd = &cobra.Command{
+	Use:   "codex",
+	Short: "Render a prompt for OpenAI Codex status data",
+	Long: `Render a prompt for OpenAI Codex status data.
+
+This command reads Codex status JSON data from stdin and renders a prompt
+that can include a Codex segment with model, token, and rate limit information.
+
+Example usage:
+  cat codex-status.json | oh-my-posh codex --config ~/.config/ohmyposh/codex.omp.json`,
+	Args: cobra.NoArgs,
+	Run: statuslineRun[segments.CodexData](
+		shell.CODEX,
+		cache.CODEXCACHE,
+		func(d *segments.CodexData) string { return d.ThreadID },
+		config.Codex,
+	),
+}
+
+func init() {
+	RootCmd.AddCommand(codexCmd)
+}

--- a/src/cli/codex_status.go
+++ b/src/cli/codex_status.go
@@ -1,0 +1,317 @@
+package cli
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	toml "github.com/pelletier/go-toml/v2"
+
+	"github.com/spf13/cobra"
+)
+
+const codexMaxSessionFiles = 25
+
+type codexLocalStatusOptions struct {
+	CodexHome   string
+	SessionRoot string
+	SessionID   string
+}
+
+type codexSessionFile struct {
+	path    string
+	modTime int64
+}
+
+type codexJSONLEvent struct {
+	Timestamp string          `json:"timestamp"`
+	Type      string          `json:"type"`
+	Payload   json.RawMessage `json:"payload"`
+}
+
+type codexSessionMeta struct {
+	ID              string `json:"id"`
+	CWD             string `json:"cwd"`
+	CLIVersion      string `json:"cli_version"`
+	Model           string `json:"model"`
+	ReasoningEffort string `json:"reasoning_effort"`
+	ApprovalMode    string `json:"approval_policy"`
+	SandboxPolicy   string `json:"sandbox_mode"`
+}
+
+type codexConfigStatus struct {
+	Model                string `toml:"model"`
+	ModelReasoningEffort string `toml:"model_reasoning_effort"`
+	ApprovalPolicy       string `toml:"approval_policy"`
+	SandboxMode          string `toml:"sandbox_mode"`
+}
+
+func codexStatusDataSource(cmd *cobra.Command) ([]byte, error) {
+	options, err := codexLocalStatusOptionsFromCommand(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	return codexStatusFromLocalSessions(options)
+}
+
+func codexLocalStatusOptionsFromCommand(cmd *cobra.Command) (codexLocalStatusOptions, error) {
+	sessionID, err := cmd.Flags().GetString("session")
+	if err != nil {
+		return codexLocalStatusOptions{}, err
+	}
+
+	codexHome, err := cmd.Flags().GetString("codex-home")
+	if err != nil {
+		return codexLocalStatusOptions{}, err
+	}
+
+	sessionRoot, err := cmd.Flags().GetString("session-root")
+	if err != nil {
+		return codexLocalStatusOptions{}, err
+	}
+
+	if codexHome == "" {
+		codexHome = defaultCodexHome()
+	}
+
+	if sessionRoot == "" && codexHome != "" {
+		sessionRoot = filepath.Join(codexHome, "sessions")
+	}
+
+	return codexLocalStatusOptions{
+		CodexHome:   codexHome,
+		SessionRoot: sessionRoot,
+		SessionID:   sessionID,
+	}, nil
+}
+
+func defaultCodexHome() string {
+	if home := os.Getenv("CODEX_HOME"); home != "" {
+		return home
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+
+	return filepath.Join(home, ".codex")
+}
+
+func codexStatusFromLocalSessions(options codexLocalStatusOptions) ([]byte, error) {
+	if options.SessionRoot == "" {
+		return nil, errors.New("codex sessions directory could not be determined")
+	}
+
+	files, err := codexSessionFiles(options.SessionRoot, options.SessionID)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no Codex session files found in %s", options.SessionRoot)
+	}
+
+	cfg := loadCodexConfigStatus(options.CodexHome)
+	for _, file := range files {
+		data, err := codexStatusFromSessionFile(file.path, cfg)
+		if err == nil && len(data) > 0 {
+			return data, nil
+		}
+	}
+
+	if options.SessionID != "" {
+		return nil, fmt.Errorf("no token_count event found for Codex session %s", options.SessionID)
+	}
+
+	return nil, fmt.Errorf("no token_count event found in the newest Codex session files")
+}
+
+func codexSessionFiles(root, sessionID string) ([]codexSessionFile, error) {
+	files := []codexSessionFile{}
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+
+		if entry.IsDir() {
+			return nil
+		}
+
+		if !strings.EqualFold(filepath.Ext(entry.Name()), ".jsonl") {
+			return nil
+		}
+
+		if sessionID != "" && !strings.Contains(entry.Name(), sessionID) {
+			return nil
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			return nil
+		}
+
+		files = append(files, codexSessionFile{
+			path:    path,
+			modTime: info.ModTime().UnixNano(),
+		})
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].modTime > files[j].modTime
+	})
+
+	if sessionID == "" && len(files) > codexMaxSessionFiles {
+		files = files[:codexMaxSessionFiles]
+	}
+
+	return files, nil
+}
+
+func codexStatusFromSessionFile(path string, cfg codexConfigStatus) ([]byte, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	reader := bufio.NewReader(file)
+	var meta codexSessionMeta
+	var latest map[string]any
+
+	for {
+		line, err := reader.ReadBytes('\n')
+		if len(line) > 0 {
+			event, ok := parseCodexJSONLEvent(line)
+			if ok {
+				switch event.Type {
+				case "session_meta":
+					_ = json.Unmarshal(event.Payload, &meta)
+				case "event_msg":
+					payload, ok := parseCodexTokenCountPayload(event.Payload)
+					if ok {
+						latest = payload
+					}
+				}
+			}
+		}
+
+		if errors.Is(err, io.EOF) {
+			break
+		}
+
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if latest == nil {
+		return nil, errors.New("no token_count event found")
+	}
+
+	enrichCodexStatusPayload(latest, &meta, cfg)
+
+	return json.Marshal(latest)
+}
+
+func parseCodexJSONLEvent(line []byte) (codexJSONLEvent, bool) {
+	var event codexJSONLEvent
+	if err := json.Unmarshal(line, &event); err != nil {
+		return codexJSONLEvent{}, false
+	}
+
+	return event, true
+}
+
+func parseCodexTokenCountPayload(payload json.RawMessage) (map[string]any, bool) {
+	var typed struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(payload, &typed); err != nil || typed.Type != "token_count" {
+		return nil, false
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(payload, &result); err != nil {
+		return nil, false
+	}
+
+	return result, true
+}
+
+func enrichCodexStatusPayload(payload map[string]any, meta *codexSessionMeta, cfg codexConfigStatus) {
+	setIfMissing(payload, "thread_id", meta.ID)
+	setIfMissing(payload, "cwd", meta.CWD)
+	setIfMissing(payload, "version", meta.CLIVersion)
+	setIfMissing(payload, "approval_mode", firstNonEmpty(meta.ApprovalMode, cfg.ApprovalPolicy))
+	setIfMissing(payload, "sandbox_policy", firstNonEmpty(meta.SandboxPolicy, cfg.SandboxMode))
+	setIfMissing(payload, "reasoning_effort", firstNonEmpty(meta.ReasoningEffort, cfg.ModelReasoningEffort))
+
+	if _, ok := payload["model"]; ok {
+		return
+	}
+
+	model := firstNonEmpty(meta.Model, cfg.Model)
+	if model == "" {
+		return
+	}
+
+	payload["model"] = map[string]string{
+		"id":           model,
+		"display_name": model,
+	}
+}
+
+func setIfMissing(payload map[string]any, key, value string) {
+	if value == "" {
+		return
+	}
+
+	if existing, ok := payload[key]; ok && existing != nil {
+		if text, ok := existing.(string); !ok || text != "" {
+			return
+		}
+	}
+
+	payload[key] = value
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+
+	return ""
+}
+
+func loadCodexConfigStatus(codexHome string) codexConfigStatus {
+	if codexHome == "" {
+		return codexConfigStatus{}
+	}
+
+	data, err := os.ReadFile(filepath.Join(codexHome, "config.toml"))
+	if err != nil {
+		return codexConfigStatus{}
+	}
+
+	var cfg codexConfigStatus
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		return codexConfigStatus{}
+	}
+
+	return cfg
+}

--- a/src/cli/codex_status.go
+++ b/src/cli/codex_status.go
@@ -1,56 +1,13 @@
 package cli
 
 import (
-	"bufio"
 	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
 	"os"
-	"path/filepath"
-	"sort"
-	"strings"
 
-	toml "github.com/pelletier/go-toml/v2"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments"
 
 	"github.com/spf13/cobra"
 )
-
-const codexMaxSessionFiles = 25
-
-type codexLocalStatusOptions struct {
-	CodexHome   string
-	SessionRoot string
-	SessionID   string
-}
-
-type codexSessionFile struct {
-	path    string
-	modTime int64
-}
-
-type codexJSONLEvent struct {
-	Timestamp string          `json:"timestamp"`
-	Type      string          `json:"type"`
-	Payload   json.RawMessage `json:"payload"`
-}
-
-type codexSessionMeta struct {
-	ID              string `json:"id"`
-	CWD             string `json:"cwd"`
-	CLIVersion      string `json:"cli_version"`
-	Model           string `json:"model"`
-	ReasoningEffort string `json:"reasoning_effort"`
-	ApprovalMode    string `json:"approval_policy"`
-	SandboxPolicy   string `json:"sandbox_mode"`
-}
-
-type codexConfigStatus struct {
-	Model                string `toml:"model"`
-	ModelReasoningEffort string `toml:"model_reasoning_effort"`
-	ApprovalPolicy       string `toml:"approval_policy"`
-	SandboxMode          string `toml:"sandbox_mode"`
-}
 
 func codexStatusDataSource(cmd *cobra.Command) ([]byte, error) {
 	options, err := codexLocalStatusOptionsFromCommand(cmd)
@@ -58,260 +15,35 @@ func codexStatusDataSource(cmd *cobra.Command) ([]byte, error) {
 		return nil, err
 	}
 
-	return codexStatusFromLocalSessions(options)
+	data, err := segments.CodexStatusFromLocalSessions(options)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(data)
 }
 
-func codexLocalStatusOptionsFromCommand(cmd *cobra.Command) (codexLocalStatusOptions, error) {
+func codexLocalStatusOptionsFromCommand(cmd *cobra.Command) (segments.CodexLocalStatusOptions, error) {
 	sessionID, err := cmd.Flags().GetString("session")
 	if err != nil {
-		return codexLocalStatusOptions{}, err
+		return segments.CodexLocalStatusOptions{}, err
 	}
 
 	codexHome, err := cmd.Flags().GetString("codex-home")
 	if err != nil {
-		return codexLocalStatusOptions{}, err
+		return segments.CodexLocalStatusOptions{}, err
 	}
 
 	sessionRoot, err := cmd.Flags().GetString("session-root")
 	if err != nil {
-		return codexLocalStatusOptions{}, err
+		return segments.CodexLocalStatusOptions{}, err
 	}
 
-	if codexHome == "" {
-		codexHome = defaultCodexHome()
-	}
+	userHome, _ := os.UserHomeDir()
 
-	if sessionRoot == "" && codexHome != "" {
-		sessionRoot = filepath.Join(codexHome, "sessions")
-	}
-
-	return codexLocalStatusOptions{
+	return segments.ResolveCodexLocalStatusOptions(segments.CodexLocalStatusOptions{
 		CodexHome:   codexHome,
 		SessionRoot: sessionRoot,
 		SessionID:   sessionID,
-	}, nil
-}
-
-func defaultCodexHome() string {
-	if home := os.Getenv("CODEX_HOME"); home != "" {
-		return home
-	}
-
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ""
-	}
-
-	return filepath.Join(home, ".codex")
-}
-
-func codexStatusFromLocalSessions(options codexLocalStatusOptions) ([]byte, error) {
-	if options.SessionRoot == "" {
-		return nil, errors.New("codex sessions directory could not be determined")
-	}
-
-	files, err := codexSessionFiles(options.SessionRoot, options.SessionID)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(files) == 0 {
-		return nil, fmt.Errorf("no Codex session files found in %s", options.SessionRoot)
-	}
-
-	cfg := loadCodexConfigStatus(options.CodexHome)
-	for _, file := range files {
-		data, err := codexStatusFromSessionFile(file.path, cfg)
-		if err == nil && len(data) > 0 {
-			return data, nil
-		}
-	}
-
-	if options.SessionID != "" {
-		return nil, fmt.Errorf("no token_count event found for Codex session %s", options.SessionID)
-	}
-
-	return nil, fmt.Errorf("no token_count event found in the newest Codex session files")
-}
-
-func codexSessionFiles(root, sessionID string) ([]codexSessionFile, error) {
-	files := []codexSessionFile{}
-	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
-		if err != nil {
-			return nil
-		}
-
-		if entry.IsDir() {
-			return nil
-		}
-
-		if !strings.EqualFold(filepath.Ext(entry.Name()), ".jsonl") {
-			return nil
-		}
-
-		if sessionID != "" && !strings.Contains(entry.Name(), sessionID) {
-			return nil
-		}
-
-		info, err := entry.Info()
-		if err != nil {
-			return nil
-		}
-
-		files = append(files, codexSessionFile{
-			path:    path,
-			modTime: info.ModTime().UnixNano(),
-		})
-
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	sort.Slice(files, func(i, j int) bool {
-		return files[i].modTime > files[j].modTime
-	})
-
-	if sessionID == "" && len(files) > codexMaxSessionFiles {
-		files = files[:codexMaxSessionFiles]
-	}
-
-	return files, nil
-}
-
-func codexStatusFromSessionFile(path string, cfg codexConfigStatus) ([]byte, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	reader := bufio.NewReader(file)
-	var meta codexSessionMeta
-	var latest map[string]any
-
-	for {
-		line, err := reader.ReadBytes('\n')
-		if len(line) > 0 {
-			event, ok := parseCodexJSONLEvent(line)
-			if ok {
-				switch event.Type {
-				case "session_meta":
-					_ = json.Unmarshal(event.Payload, &meta)
-				case "event_msg":
-					payload, ok := parseCodexTokenCountPayload(event.Payload)
-					if ok {
-						latest = payload
-					}
-				}
-			}
-		}
-
-		if errors.Is(err, io.EOF) {
-			break
-		}
-
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if latest == nil {
-		return nil, errors.New("no token_count event found")
-	}
-
-	enrichCodexStatusPayload(latest, &meta, cfg)
-
-	return json.Marshal(latest)
-}
-
-func parseCodexJSONLEvent(line []byte) (codexJSONLEvent, bool) {
-	var event codexJSONLEvent
-	if err := json.Unmarshal(line, &event); err != nil {
-		return codexJSONLEvent{}, false
-	}
-
-	return event, true
-}
-
-func parseCodexTokenCountPayload(payload json.RawMessage) (map[string]any, bool) {
-	var typed struct {
-		Type string `json:"type"`
-	}
-	if err := json.Unmarshal(payload, &typed); err != nil || typed.Type != "token_count" {
-		return nil, false
-	}
-
-	var result map[string]any
-	if err := json.Unmarshal(payload, &result); err != nil {
-		return nil, false
-	}
-
-	return result, true
-}
-
-func enrichCodexStatusPayload(payload map[string]any, meta *codexSessionMeta, cfg codexConfigStatus) {
-	setIfMissing(payload, "thread_id", meta.ID)
-	setIfMissing(payload, "cwd", meta.CWD)
-	setIfMissing(payload, "version", meta.CLIVersion)
-	setIfMissing(payload, "approval_mode", firstNonEmpty(meta.ApprovalMode, cfg.ApprovalPolicy))
-	setIfMissing(payload, "sandbox_policy", firstNonEmpty(meta.SandboxPolicy, cfg.SandboxMode))
-	setIfMissing(payload, "reasoning_effort", firstNonEmpty(meta.ReasoningEffort, cfg.ModelReasoningEffort))
-
-	if _, ok := payload["model"]; ok {
-		return
-	}
-
-	model := firstNonEmpty(meta.Model, cfg.Model)
-	if model == "" {
-		return
-	}
-
-	payload["model"] = map[string]string{
-		"id":           model,
-		"display_name": model,
-	}
-}
-
-func setIfMissing(payload map[string]any, key, value string) {
-	if value == "" {
-		return
-	}
-
-	if existing, ok := payload[key]; ok && existing != nil {
-		if text, ok := existing.(string); !ok || text != "" {
-			return
-		}
-	}
-
-	payload[key] = value
-}
-
-func firstNonEmpty(values ...string) string {
-	for _, value := range values {
-		if value != "" {
-			return value
-		}
-	}
-
-	return ""
-}
-
-func loadCodexConfigStatus(codexHome string) codexConfigStatus {
-	if codexHome == "" {
-		return codexConfigStatus{}
-	}
-
-	data, err := os.ReadFile(filepath.Join(codexHome, "config.toml"))
-	if err != nil {
-		return codexConfigStatus{}
-	}
-
-	var cfg codexConfigStatus
-	if err := toml.Unmarshal(data, &cfg); err != nil {
-		return codexConfigStatus{}
-	}
-
-	return cfg
+	}, os.Getenv("CODEX_HOME"), userHome), nil
 }

--- a/src/cli/codex_status_test.go
+++ b/src/cli/codex_status_test.go
@@ -1,0 +1,117 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCodexStatusFromLocalSessions(t *testing.T) {
+	tmp := t.TempDir()
+	codexHome := filepath.Join(tmp, ".codex")
+	sessionRoot := filepath.Join(codexHome, "sessions", "2026", "06", "09")
+	require.NoError(t, os.MkdirAll(sessionRoot, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(codexHome, "config.toml"),
+		[]byte("model = \"gpt-5.5\"\nmodel_reasoning_effort = \"high\"\napproval_policy = \"never\"\nsandbox_mode = \"workspace-write\"\n"),
+		0o644,
+	))
+
+	older := filepath.Join(sessionRoot, "rollout-2026-06-09T10-00-00-older-session.jsonl")
+	writeCodexSessionFile(t, older, "older-session", "2026-06-09T14:00:00Z", 10, 20)
+	newer := filepath.Join(sessionRoot, "rollout-2026-06-09T11-00-00-newer-session.jsonl")
+	writeCodexSessionFile(t, newer, "newer-session", "2026-06-09T15:00:00Z", 30, 40)
+
+	require.NoError(t, os.Chtimes(older, time.Now().Add(-time.Hour), time.Now().Add(-time.Hour)))
+	require.NoError(t, os.Chtimes(newer, time.Now(), time.Now()))
+
+	data, err := codexStatusFromLocalSessions(codexLocalStatusOptions{
+		CodexHome:   codexHome,
+		SessionRoot: filepath.Join(codexHome, "sessions"),
+	})
+	require.NoError(t, err)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(data, &payload))
+	assert.Equal(t, "token_count", payload["type"])
+	assert.Equal(t, "newer-session", payload["thread_id"])
+	assert.Equal(t, "C:/repo/newer-session", payload["cwd"])
+	assert.Equal(t, "0.138.0", payload["version"])
+	assert.Equal(t, "high", payload["reasoning_effort"])
+	assert.Equal(t, "never", payload["approval_mode"])
+	assert.Equal(t, "workspace-write", payload["sandbox_policy"])
+	assert.Equal(t, float64(40), payload["sequence"])
+	assert.Equal(t, map[string]any{
+		"id":           "gpt-5.5",
+		"display_name": "gpt-5.5",
+	}, payload["model"])
+}
+
+func TestCodexStatusFromLocalSessionsUsesRequestedSession(t *testing.T) {
+	tmp := t.TempDir()
+	sessionRoot := filepath.Join(tmp, "sessions")
+	require.NoError(t, os.MkdirAll(sessionRoot, 0o755))
+
+	older := filepath.Join(sessionRoot, "rollout-2026-06-09T10-00-00-older-session.jsonl")
+	writeCodexSessionFile(t, older, "older-session", "2026-06-09T14:00:00Z", 10, 20)
+	newer := filepath.Join(sessionRoot, "rollout-2026-06-09T11-00-00-newer-session.jsonl")
+	writeCodexSessionFile(t, newer, "newer-session", "2026-06-09T15:00:00Z", 30, 40)
+
+	require.NoError(t, os.Chtimes(older, time.Now().Add(-time.Hour), time.Now().Add(-time.Hour)))
+	require.NoError(t, os.Chtimes(newer, time.Now(), time.Now()))
+
+	data, err := codexStatusFromLocalSessions(codexLocalStatusOptions{
+		SessionRoot: sessionRoot,
+		SessionID:   "older-session",
+	})
+	require.NoError(t, err)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(data, &payload))
+	assert.Equal(t, "older-session", payload["thread_id"])
+	assert.Equal(t, float64(20), payload["sequence"])
+}
+
+func TestCodexStatusFromLocalSessionsReturnsErrorWhenNoTokenCount(t *testing.T) {
+	tmp := t.TempDir()
+	sessionRoot := filepath.Join(tmp, "sessions")
+	require.NoError(t, os.MkdirAll(sessionRoot, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sessionRoot, "rollout-no-token.jsonl"),
+		[]byte("{\"timestamp\":\"2026-06-09T14:00:00Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"agent_message\",\"message\":\"done\"}}\n"),
+		0o644,
+	))
+
+	_, err := codexStatusFromLocalSessions(codexLocalStatusOptions{
+		SessionRoot: sessionRoot,
+	})
+	require.Error(t, err)
+}
+
+func writeCodexSessionFile(t *testing.T, path, sessionID, timestamp string, firstSequence, secondSequence int) {
+	t.Helper()
+
+	content := "" +
+		"{\"timestamp\":\"" + timestamp + "\",\"type\":\"session_meta\",\"payload\":{\"id\":\"" + sessionID + "\",\"cwd\":\"C:/repo/" + sessionID + "\",\"cli_version\":\"0.138.0\"}}\n" +
+		codexTokenCountLine(timestamp, firstSequence) + "\n" +
+		codexTokenCountLine(timestamp, secondSequence) + "\n"
+
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}
+
+func codexTokenCountLine(timestamp string, sequence int) string {
+	return fmt.Sprintf(
+		`{"timestamp":"%s","type":"event_msg","payload":{"type":"token_count","sequence":%d,`+
+			`"info":{"total_token_usage":{"total_tokens":1000},"last_token_usage":{"total_tokens":100},`+
+			`"model_context_window":10000},"rate_limits":{"primary":{"used_percent":12},`+
+			`"secondary":{"used_percent":34}}}}`,
+		timestamp,
+		sequence,
+	)
+}

--- a/src/cli/statusline.go
+++ b/src/cli/statusline.go
@@ -46,7 +46,7 @@ func statuslineRunWithDataSource[T any](
 		}
 
 		if len(stdinData) > 0 {
-			log.Debugf("received data from stdin: %s", string(stdinData))
+			log.Debugf("received %d bytes from stdin", len(stdinData))
 		}
 
 		if len(bytes.TrimSpace(stdinData)) == 0 && dataSource != nil {

--- a/src/cli/statusline.go
+++ b/src/cli/statusline.go
@@ -52,7 +52,7 @@ func statuslineRunWithDataSource[T any](
 		if len(bytes.TrimSpace(stdinData)) == 0 && dataSource != nil {
 			stdinData, err = dataSource(cmd)
 			if err != nil {
-				log.Debug(err.Error())
+				log.Error(err)
 			}
 		}
 

--- a/src/cli/statusline.go
+++ b/src/cli/statusline.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -17,6 +18,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type statuslineDataSource func(*cobra.Command) ([]byte, error)
+
 // statuslineRun returns a cobra Run function for statusline commands.
 // T is the type of the JSON data read from stdin.
 // shellConst identifies the shell (used for cache init and terminal init).
@@ -24,16 +27,34 @@ import (
 // sessionID extracts the session ID from parsed data so it can be set as POSH_SESSION_ID.
 // defaultCfg is called when no --config flag is provided or parsing fails.
 func statuslineRun[T any](shellConst, cacheKey string, sessionID func(*T) string, defaultCfg func() *config.Config) func(*cobra.Command, []string) {
+	return statuslineRunWithDataSource[T](shellConst, cacheKey, sessionID, defaultCfg, nil)
+}
+
+func statuslineRunWithDataSource[T any](
+	shellConst, cacheKey string,
+	sessionID func(*T) string,
+	defaultCfg func() *config.Config,
+	dataSource statuslineDataSource,
+) func(*cobra.Command, []string) {
 	return func(cmd *cobra.Command, _ []string) {
 		log.Debugf("%s command started", shellConst)
 
-		stdinData, err := io.ReadAll(os.Stdin)
+		stdinData, err := readStatuslineStdin()
 		if err != nil {
 			log.Error(err)
 			return
 		}
 
-		log.Debugf("received data from stdin: %s", string(stdinData))
+		if len(stdinData) > 0 {
+			log.Debugf("received data from stdin: %s", string(stdinData))
+		}
+
+		if len(bytes.TrimSpace(stdinData)) == 0 && dataSource != nil {
+			stdinData, err = dataSource(cmd)
+			if err != nil {
+				log.Debug(err.Error())
+			}
+		}
 
 		processStatuslineData(stdinData, shellConst, cacheKey, sessionID)
 
@@ -77,6 +98,19 @@ func statuslineRun[T any](shellConst, cacheKey string, sessionID func(*T) string
 
 		fmt.Print(eng.Status())
 	}
+}
+
+func readStatuslineStdin() ([]byte, error) {
+	info, err := os.Stdin.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	if info.Mode()&os.ModeCharDevice != 0 {
+		return nil, nil
+	}
+
+	return io.ReadAll(os.Stdin)
 }
 
 // processStatuslineData parses stdin JSON into T and stores it in the session cache.

--- a/src/config/default.go
+++ b/src/config/default.go
@@ -220,12 +220,20 @@ func Claude() *Config {
 	return statuslineCLIConfig(1234567890, CLAUDE, " \U000f0bc9 {{ .Model.DisplayName }} \uf2d0 {{ .TokenGauge }} ")
 }
 
+func Codex() *Config {
+	return statuslineCLIConfig(
+		1234567892,
+		CODEX,
+		" {{ .FormattedText }} ",
+	)
+}
+
 func CopilotCLI() *Config {
 	return statuslineCLIConfig(1234567891, COPILOTCLI, " \uec1e {{ .Model.DisplayName }} \uf2d0 {{ .TokenGauge }} ")
 }
 
 // statuslineCLIConfig builds the shared default config for AI CLI statusline integrations
-// (e.g. Claude, Copilot CLI). The left block is always PATH + GIT; the right block
+// (e.g. Claude, Codex, Copilot CLI). The left block is always PATH + GIT; the right block
 // contains a single segment of the given type and template.
 func statuslineCLIConfig(hash uint64, segmentType SegmentType, template string) *Config {
 	return &Config{

--- a/src/config/segment_types.go
+++ b/src/config/segment_types.go
@@ -46,6 +46,8 @@ func init() {
 	gob.Register(&segments.CfTarget{})
 	gob.Register(&segments.Claude{})
 	gob.Register(&segments.ClaudeData{})
+	gob.Register(&segments.Codex{})
+	gob.Register(&segments.CodexData{})
 	gob.Register(&segments.Clojure{})
 	gob.Register(&segments.Cmake{})
 	gob.Register(&segments.Connection{})
@@ -197,6 +199,8 @@ const (
 	CFTARGET SegmentType = "cftarget"
 	// CLAUDE writes Claude Code session information
 	CLAUDE SegmentType = "claude"
+	// CODEX writes OpenAI Codex session information
+	CODEX SegmentType = "codex"
 	// CLOJURE writes the active clojure version
 	CLOJURE SegmentType = "clojure"
 	// CMAKE writes the active cmake version
@@ -405,6 +409,7 @@ var Segments = map[SegmentType]func() SegmentWriter{
 	CF:              func() SegmentWriter { return &segments.Cf{} },
 	CFTARGET:        func() SegmentWriter { return &segments.CfTarget{} },
 	CLAUDE:          func() SegmentWriter { return &segments.Claude{} },
+	CODEX:           func() SegmentWriter { return &segments.Codex{} },
 	CLOJURE:         func() SegmentWriter { return &segments.Clojure{} },
 	CMAKE:           func() SegmentWriter { return &segments.Cmake{} },
 	CONNECTION:      func() SegmentWriter { return &segments.Connection{} },

--- a/src/segments/ai.go
+++ b/src/segments/ai.go
@@ -7,8 +7,8 @@ import (
 )
 
 const (
-	thousand = 1000.0
-	million  = 1000000.0
+	thousand = 1000
+	million  = 1000000
 
 	gaugeMarkedChar   options.Option = "gauge_marked_char"
 	gaugeUnmarkedChar options.Option = "gauge_unmarked_char"
@@ -16,13 +16,13 @@ const (
 
 // formatTokenCount formats a token count as a human-readable string ("1.2K", "3.4M", or raw).
 func formatTokenCount(n int) string {
-	if n < int(thousand) {
+	if n < thousand {
 		return fmt.Sprintf("%d", n)
 	}
 
-	if n < int(million) {
-		return fmt.Sprintf("%.1fK", float64(n)/thousand)
+	if n < million {
+		return fmt.Sprintf("%.1fK", float64(n)/float64(thousand))
 	}
 
-	return fmt.Sprintf("%.1fM", float64(n)/million)
+	return fmt.Sprintf("%.1fM", float64(n)/float64(million))
 }

--- a/src/segments/ai.go
+++ b/src/segments/ai.go
@@ -1,0 +1,28 @@
+package segments
+
+import (
+	"fmt"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+)
+
+const (
+	thousand = 1000.0
+	million  = 1000000.0
+
+	gaugeMarkedChar   options.Option = "gauge_marked_char"
+	gaugeUnmarkedChar options.Option = "gauge_unmarked_char"
+)
+
+// formatTokenCount formats a token count as a human-readable string ("1.2K", "3.4M", or raw).
+func formatTokenCount(n int) string {
+	if n < int(thousand) {
+		return fmt.Sprintf("%d", n)
+	}
+
+	if n < int(million) {
+		return fmt.Sprintf("%.1fK", float64(n)/thousand)
+	}
+
+	return fmt.Sprintf("%.1fM", float64(n)/million)
+}

--- a/src/segments/claude.go
+++ b/src/segments/claude.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/jandedobbeleer/oh-my-posh/src/cache"
 	"github.com/jandedobbeleer/oh-my-posh/src/log"
-	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
 	"github.com/jandedobbeleer/oh-my-posh/src/text"
 )
 
@@ -136,27 +135,6 @@ type ClaudeCurrentUsage struct {
 	OutputTokens             int `json:"output_tokens"`
 	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
 	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
-}
-
-const (
-	thousand = 1000.0
-	million  = 1000000.0
-
-	gaugeMarkedChar   options.Option = "gauge_marked_char"
-	gaugeUnmarkedChar options.Option = "gauge_unmarked_char"
-)
-
-// formatTokenCount formats a token count as a human-readable string ("1.2K", "3.4M", or raw).
-func formatTokenCount(n int) string {
-	if n < int(thousand) {
-		return fmt.Sprintf("%d", n)
-	}
-
-	if n < int(million) {
-		return fmt.Sprintf("%.1fK", float64(n)/thousand)
-	}
-
-	return fmt.Sprintf("%.1fM", float64(n)/million)
 }
 
 func (c *Claude) Template() string {

--- a/src/segments/codex.go
+++ b/src/segments/codex.go
@@ -1,6 +1,7 @@
 package segments
 
 import (
+	"crypto/sha1"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
@@ -304,14 +305,14 @@ func (c *Codex) CacheKey() (string, bool) {
 	parts := []string{"codex", "discover", fmt.Sprintf("%t", c.optionBool(discoverLocalStatus, true))}
 
 	if value := c.optionString(statusFile, ""); value != "" {
-		parts = append(parts, "file", value)
+		parts = append(parts, "file", codexCacheKeyHash(value))
 	}
 
 	if value := c.optionString(statusFileEnv, defaultCodexStatusFileEnv); value != "" {
 		parts = append(parts, "file-env", value)
 		if c.env != nil {
 			if file := c.env.Getenv(value); file != "" {
-				parts = append(parts, "file", file)
+				parts = append(parts, "file", codexCacheKeyHash(file))
 			}
 		}
 	}
@@ -325,17 +326,21 @@ func (c *Codex) CacheKey() (string, bool) {
 	}
 
 	if value := c.optionString(sessionRoot, ""); value != "" {
-		parts = append(parts, "root", value)
+		parts = append(parts, "root", codexCacheKeyHash(value))
 	} else if value := c.optionString(codexHome, ""); value != "" {
-		parts = append(parts, "root", filepath.Join(value, "sessions"))
+		parts = append(parts, "root", codexCacheKeyHash(filepath.Join(value, "sessions")))
 	} else if c.env != nil {
 		localOptions := ResolveCodexLocalStatusOptions(CodexLocalStatusOptions{}, c.env.Getenv("CODEX_HOME"), c.env.Home())
 		if localOptions.SessionRoot != "" {
-			parts = append(parts, "root", localOptions.SessionRoot)
+			parts = append(parts, "root", codexCacheKeyHash(localOptions.SessionRoot))
 		}
 	}
 
 	return strings.Join(parts, "|"), true
+}
+
+func codexCacheKeyHash(value string) string {
+	return fmt.Sprintf("%x", sha1.Sum([]byte(value)))
 }
 
 func parseCodexStatus(status string) (CodexData, bool) {

--- a/src/segments/codex.go
+++ b/src/segments/codex.go
@@ -317,7 +317,9 @@ func (c *Codex) FormattedText() string {
 	}
 
 	if c.DisplayContext() {
-		parts = append(parts, "\uf2d0 "+c.TokenGauge())
+		if gauge := c.TokenGauge(); gauge != "" {
+			parts = append(parts, "\uf2d0 "+gauge)
+		}
 	}
 
 	if c.DisplayTokens() {
@@ -360,10 +362,7 @@ func (c *Codex) FormattedModel() string {
 
 // TokenUsagePercent returns the percentage of the Codex model context window used.
 func (c *Codex) TokenUsagePercent() text.Percentage {
-	tokens := c.Info.LastTokenUsage.TotalTokens
-	if tokens <= 0 {
-		tokens = c.Info.TotalTokenUsage.TotalTokens
-	}
+	tokens := c.contextTokens()
 
 	if c.Info.ModelContextWindow <= 0 || tokens <= 0 {
 		return 0
@@ -378,13 +377,34 @@ func (c *Codex) TokenUsagePercent() text.Percentage {
 	return text.Percentage(rounded)
 }
 
+func (c *Codex) hasContextUsage() bool {
+	return c.Info.ModelContextWindow > 0 && c.contextTokens() > 0
+}
+
+func (c *Codex) contextTokens() int {
+	tokens := c.Info.LastTokenUsage.TotalTokens
+	if tokens <= 0 {
+		tokens = c.Info.TotalTokenUsage.TotalTokens
+	}
+
+	return tokens
+}
+
 // TokenGauge returns a 5-block gauge showing remaining context capacity using the configured characters.
 func (c *Codex) TokenGauge() string {
+	if !c.hasContextUsage() {
+		return ""
+	}
+
 	return c.TokenUsagePercent().GaugeWith(c.optionString(gaugeMarkedChar, "▰"), c.optionString(gaugeUnmarkedChar, "▱"))
 }
 
 // TokenGaugeUsed returns a 5-block gauge showing used context capacity using the configured characters.
 func (c *Codex) TokenGaugeUsed() string {
+	if !c.hasContextUsage() {
+		return ""
+	}
+
 	return c.TokenUsagePercent().GaugeUsedWith(c.optionString(gaugeMarkedChar, "▰"), c.optionString(gaugeUnmarkedChar, "▱"))
 }
 
@@ -468,31 +488,55 @@ func (c *Codex) WeeklyRemaining() text.Percentage {
 
 // FiveHourGauge returns a 5-block gauge showing primary window usage.
 func (c *Codex) FiveHourGauge() string {
+	if !codexRateLimitHasUsage(c.RateLimits, codexPrimaryRateLimitWindow) {
+		return ""
+	}
+
 	return c.FiveHourUsage().GaugeUsedWith(c.optionString(gaugeMarkedChar, "▰"), c.optionString(gaugeUnmarkedChar, "▱"))
 }
 
 // WeeklyGauge returns a 5-block gauge showing weekly window usage.
 func (c *Codex) WeeklyGauge() string {
+	if !codexRateLimitHasUsage(c.RateLimits, codexSecondaryRateLimitWindow) {
+		return ""
+	}
+
 	return c.WeeklyUsage().GaugeUsedWith(c.optionString(gaugeMarkedChar, "▰"), c.optionString(gaugeUnmarkedChar, "▱"))
 }
 
 // FiveHourRemainingGauge returns a 5-block gauge showing primary quota remaining.
 func (c *Codex) FiveHourRemainingGauge() string {
+	if !codexRateLimitHasUsage(c.RateLimits, codexPrimaryRateLimitWindow) {
+		return ""
+	}
+
 	return c.FiveHourUsage().GaugeWith(c.optionString(gaugeMarkedChar, "▰"), c.optionString(gaugeUnmarkedChar, "▱"))
 }
 
 // WeeklyRemainingGauge returns a 5-block gauge showing weekly quota remaining.
 func (c *Codex) WeeklyRemainingGauge() string {
+	if !codexRateLimitHasUsage(c.RateLimits, codexSecondaryRateLimitWindow) {
+		return ""
+	}
+
 	return c.WeeklyUsage().GaugeWith(c.optionString(gaugeMarkedChar, "▰"), c.optionString(gaugeUnmarkedChar, "▱"))
 }
 
 // FormattedFiveHourRemaining returns the primary rolling window remaining percentage with a percent sign.
 func (c *Codex) FormattedFiveHourRemaining() string {
+	if !codexRateLimitHasUsage(c.RateLimits, codexPrimaryRateLimitWindow) {
+		return ""
+	}
+
 	return fmt.Sprintf("%d%%", c.FiveHourRemaining())
 }
 
 // FormattedWeeklyRemaining returns the weekly rolling window remaining percentage with a percent sign.
 func (c *Codex) FormattedWeeklyRemaining() string {
+	if !codexRateLimitHasUsage(c.RateLimits, codexSecondaryRateLimitWindow) {
+		return ""
+	}
+
 	return fmt.Sprintf("%d%%", c.WeeklyRemaining())
 }
 
@@ -501,11 +545,15 @@ func (c *Codex) FormattedLimits() string {
 	limits := []string{}
 
 	if c.DisplayFiveHourLimit() {
-		limits = append(limits, "5h "+c.FormattedFiveHourRemaining())
+		if remaining := c.FormattedFiveHourRemaining(); remaining != "" {
+			limits = append(limits, "5h "+remaining)
+		}
 	}
 
 	if c.DisplayWeeklyLimit() {
-		limits = append(limits, "7d "+c.FormattedWeeklyRemaining())
+		if remaining := c.FormattedWeeklyRemaining(); remaining != "" {
+			limits = append(limits, "7d "+remaining)
+		}
 	}
 
 	return strings.Join(limits, " ")
@@ -551,7 +599,7 @@ func remainingPercentage(used text.Percentage) text.Percentage {
 }
 
 func codexRateLimitUsage(limits *CodexRateLimits, window func(*CodexRateLimits) *CodexRateLimitWindow) text.Percentage {
-	if limits == nil || window == nil {
+	if !codexRateLimitHasUsage(limits, window) {
 		return 0
 	}
 
@@ -570,6 +618,22 @@ func codexRateLimitUsage(limits *CodexRateLimits, window func(*CodexRateLimits) 
 	}
 
 	return text.Percentage(percent)
+}
+
+func codexRateLimitHasUsage(limits *CodexRateLimits, window func(*CodexRateLimits) *CodexRateLimitWindow) bool {
+	if limits == nil || window == nil {
+		return false
+	}
+
+	return codexRateLimitWindowHasUsage(window(limits))
+}
+
+func codexPrimaryRateLimitWindow(limits *CodexRateLimits) *CodexRateLimitWindow {
+	return limits.Primary
+}
+
+func codexSecondaryRateLimitWindow(limits *CodexRateLimits) *CodexRateLimitWindow {
+	return limits.Secondary
 }
 
 func codexRateLimitReset(limits *CodexRateLimits, window func(*CodexRateLimits) *CodexRateLimitWindow) time.Time {

--- a/src/segments/codex.go
+++ b/src/segments/codex.go
@@ -1,0 +1,584 @@
+package segments
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/cache"
+	"github.com/jandedobbeleer/oh-my-posh/src/log"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+	"github.com/jandedobbeleer/oh-my-posh/src/text"
+)
+
+// Codex segment displays OpenAI Codex session information.
+type Codex struct {
+	Base
+	CodexData
+}
+
+// CodexData represents Codex statusline data.
+type CodexData struct {
+	Type            string           `json:"type"`
+	ThreadID        string           `json:"thread_id"`
+	CWD             string           `json:"cwd"`
+	Version         string           `json:"version"`
+	ReasoningEffort string           `json:"reasoning_effort"`
+	ApprovalMode    string           `json:"approval_mode"`
+	SandboxPolicy   string           `json:"sandbox_policy"`
+	Model           CodexModel       `json:"model"`
+	Info            CodexTokenInfo   `json:"info"`
+	RateLimits      *CodexRateLimits `json:"rate_limits"`
+}
+
+// CodexModel represents OpenAI Codex model information.
+type CodexModel struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"display_name"`
+}
+
+// CodexTokenInfo represents token count information emitted by Codex.
+type CodexTokenInfo struct {
+	TotalTokenUsage    CodexTokenUsage `json:"total_token_usage"`
+	LastTokenUsage     CodexTokenUsage `json:"last_token_usage"`
+	ModelContextWindow int             `json:"model_context_window"`
+}
+
+// CodexTokenUsage represents a token usage snapshot.
+type CodexTokenUsage struct {
+	InputTokens           int `json:"input_tokens"`
+	CachedInputTokens     int `json:"cached_input_tokens"`
+	OutputTokens          int `json:"output_tokens"`
+	ReasoningOutputTokens int `json:"reasoning_output_tokens"`
+	TotalTokens           int `json:"total_tokens"`
+}
+
+// CodexRateLimits represents Codex rate limit information.
+type CodexRateLimits struct {
+	LimitID              string                `json:"limit_id"`
+	LimitName            string                `json:"limit_name"`
+	Primary              *CodexRateLimitWindow `json:"primary"`
+	Secondary            *CodexRateLimitWindow `json:"secondary"`
+	PlanType             string                `json:"plan_type"`
+	RateLimitReachedType string                `json:"rate_limit_reached_type"`
+}
+
+// CodexRateLimitWindow represents one Codex rate limit window.
+type CodexRateLimitWindow struct {
+	UsedPercent   *float64 `json:"used_percent"`
+	WindowMinutes int      `json:"window_minutes"`
+	ResetsAt      *int64   `json:"resets_at"`
+}
+
+const (
+	displayModel         options.Option = "display_model"
+	displayReasoning     options.Option = "display_reasoning"
+	displayContext       options.Option = "display_context"
+	displayTokens        options.Option = "display_tokens"
+	displayFiveHourLimit options.Option = "display_five_hour_limit"
+	displayWeeklyLimit   options.Option = "display_weekly_limit"
+	statusFile           options.Option = "status_file"
+	statusFileEnv        options.Option = "status_file_env"
+	statusJSONEnv        options.Option = "status_json_env"
+
+	defaultCodexStatusFileEnv = "POSH_CODEX_STATUS_FILE"
+	defaultCodexStatusJSONEnv = "POSH_CODEX_STATUS"
+)
+
+func (m *CodexModel) UnmarshalJSON(data []byte) error {
+	var id string
+	if err := json.Unmarshal(data, &id); err == nil {
+		m.ID = id
+		m.DisplayName = id
+		return nil
+	}
+
+	type model CodexModel
+	var parsed model
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return err
+	}
+
+	*m = CodexModel(parsed)
+	if m.DisplayName == "" {
+		m.DisplayName = m.ID
+	}
+
+	return nil
+}
+
+func (c *CodexData) UnmarshalJSON(data []byte) error {
+	type codexData CodexData
+
+	var wrapped struct {
+		Type    string          `json:"type"`
+		Payload json.RawMessage `json:"payload"`
+	}
+
+	if err := json.Unmarshal(data, &wrapped); err == nil && wrapped.Type == "event_msg" && len(wrapped.Payload) > 0 {
+		var payload struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal(wrapped.Payload, &payload); err != nil {
+			return err
+		}
+
+		if payload.Type != "token_count" {
+			return fmt.Errorf("unsupported codex event payload type: %s", payload.Type)
+		}
+
+		return json.Unmarshal(wrapped.Payload, (*codexData)(c))
+	}
+
+	var parsed codexData
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return err
+	}
+
+	*c = CodexData(parsed)
+	return nil
+}
+
+func (c *Codex) Template() string {
+	return " {{ .FormattedText }} "
+}
+
+func (c *Codex) Enabled() bool {
+	log.Debug("codex segment: checking if enabled")
+
+	data, found := cache.Get[CodexData](cache.Session, cache.CODEXCACHE)
+	if found {
+		if !data.hasStatus() {
+			log.Debug("codex segment: cached data has no status information")
+			return false
+		}
+
+		log.Debug("codex segment: found data in session cache")
+		log.Debugf("codex segment: model=%s, thread=%s", data.Model.DisplayName, data.ThreadID)
+
+		c.CodexData = data
+		return true
+	}
+
+	log.Debug("codex segment: no data found in session cache")
+
+	if data, found = c.statusFileData(); found {
+		if !data.hasStatus() {
+			log.Debug("codex segment: status file has no status information")
+			return false
+		}
+
+		log.Debug("codex segment: found data in status file")
+		log.Debugf("codex segment: model=%s, thread=%s", data.Model.DisplayName, data.ThreadID)
+
+		c.CodexData = data
+		return true
+	}
+
+	if data, found = c.statusEnvData(); found {
+		if !data.hasStatus() {
+			log.Debug("codex segment: status environment variable has no status information")
+			return false
+		}
+
+		log.Debug("codex segment: found data in status environment variable")
+		log.Debugf("codex segment: model=%s, thread=%s", data.Model.DisplayName, data.ThreadID)
+
+		c.CodexData = data
+		return true
+	}
+
+	log.Debug("codex segment: no data found")
+	return false
+}
+
+func (c *CodexData) hasStatus() bool {
+	return c.Model.DisplayName != "" ||
+		c.Model.ID != "" ||
+		c.Info.TotalTokenUsage.TotalTokens > 0 ||
+		c.Info.LastTokenUsage.TotalTokens > 0 ||
+		c.RateLimits != nil
+}
+
+func (c *Codex) statusFileData() (CodexData, bool) {
+	if c.env == nil {
+		return CodexData{}, false
+	}
+
+	file := c.optionString(statusFile, "")
+	if file == "" {
+		fileEnv := c.optionString(statusFileEnv, defaultCodexStatusFileEnv)
+		if fileEnv == "" {
+			return CodexData{}, false
+		}
+
+		file = c.env.Getenv(fileEnv)
+	}
+
+	if file == "" {
+		return CodexData{}, false
+	}
+
+	return parseCodexStatus(c.env.FileContent(file))
+}
+
+func (c *Codex) optionBool(option options.Option, defaultValue bool) bool {
+	if c.options == nil {
+		return defaultValue
+	}
+
+	return c.options.Bool(option, defaultValue)
+}
+
+func (c *Codex) optionString(option options.Option, defaultValue string) string {
+	if c.options == nil {
+		return defaultValue
+	}
+
+	return c.options.String(option, defaultValue)
+}
+
+func (c *Codex) statusEnvData() (CodexData, bool) {
+	if c.env == nil {
+		return CodexData{}, false
+	}
+
+	envName := c.optionString(statusJSONEnv, defaultCodexStatusJSONEnv)
+	if envName == "" {
+		return CodexData{}, false
+	}
+
+	return parseCodexStatus(c.env.Getenv(envName))
+}
+
+func parseCodexStatus(status string) (CodexData, bool) {
+	status = strings.TrimSpace(status)
+	if status == "" {
+		return CodexData{}, false
+	}
+
+	var data CodexData
+	if err := json.Unmarshal([]byte(status), &data); err != nil {
+		log.Debugf("codex segment: failed to parse status data: %v", err)
+		return CodexData{}, false
+	}
+
+	return data, true
+}
+
+// DisplayModel returns whether the default template should display the model name.
+func (c *Codex) DisplayModel() bool {
+	return c.optionBool(displayModel, true)
+}
+
+// DisplayReasoning returns whether the default template should display the reasoning level.
+func (c *Codex) DisplayReasoning() bool {
+	return c.optionBool(displayReasoning, false)
+}
+
+// DisplayContext returns whether the default template should display context usage.
+func (c *Codex) DisplayContext() bool {
+	return c.optionBool(displayContext, true)
+}
+
+// DisplayTokens returns whether the default template should display total tokens.
+func (c *Codex) DisplayTokens() bool {
+	return c.optionBool(displayTokens, false)
+}
+
+// DisplayFiveHourLimit returns whether the default template should display the 5-hour rolling limit.
+func (c *Codex) DisplayFiveHourLimit() bool {
+	return c.optionBool(displayFiveHourLimit, false)
+}
+
+// DisplayWeeklyLimit returns whether the default template should display the weekly rolling limit.
+func (c *Codex) DisplayWeeklyLimit() bool {
+	return c.optionBool(displayWeeklyLimit, true)
+}
+
+// FormattedText returns the default Codex segment text based on display options.
+func (c *Codex) FormattedText() string {
+	parts := []string{}
+
+	if model := c.FormattedModel(); model != "" {
+		parts = append(parts, "\ue7cf "+model)
+	}
+
+	if c.DisplayContext() {
+		parts = append(parts, "\uf2d0 "+c.TokenGauge())
+	}
+
+	if c.DisplayTokens() {
+		parts = append(parts, "tok "+c.FormattedTokens())
+	}
+
+	if limits := c.FormattedLimits(); limits != "" {
+		parts = append(parts, "\uf017 "+limits)
+	}
+
+	return strings.Join(parts, " ")
+}
+
+// FormattedModel returns model and reasoning text based on display options.
+func (c *Codex) FormattedModel() string {
+	model := c.Model.DisplayName
+	if model == "" {
+		model = c.Model.ID
+	}
+
+	if !c.DisplayModel() {
+		model = ""
+	}
+
+	if !c.DisplayReasoning() || c.ReasoningEffort == "" {
+		return model
+	}
+
+	if model == "" {
+		return c.ReasoningEffort
+	}
+
+	reasoning := "(" + c.ReasoningEffort + ")"
+	if strings.Contains(strings.ToLower(model), strings.ToLower(reasoning)) {
+		return model
+	}
+
+	return fmt.Sprintf("%s %s", model, reasoning)
+}
+
+// TokenUsagePercent returns the percentage of the Codex model context window used.
+func (c *Codex) TokenUsagePercent() text.Percentage {
+	tokens := c.Info.LastTokenUsage.TotalTokens
+	if tokens <= 0 {
+		tokens = c.Info.TotalTokenUsage.TotalTokens
+	}
+
+	if c.Info.ModelContextWindow <= 0 || tokens <= 0 {
+		return 0
+	}
+
+	percent := (float64(tokens) * 100.0) / float64(c.Info.ModelContextWindow)
+	rounded := int(percent + 0.5)
+	if rounded > 100 {
+		return 100
+	}
+
+	return text.Percentage(rounded)
+}
+
+// TokenGauge returns a 5-block gauge showing remaining context capacity using the configured characters.
+func (c *Codex) TokenGauge() string {
+	return c.TokenUsagePercent().GaugeWith(c.optionString(gaugeMarkedChar, "▰"), c.optionString(gaugeUnmarkedChar, "▱"))
+}
+
+// TokenGaugeUsed returns a 5-block gauge showing used context capacity using the configured characters.
+func (c *Codex) TokenGaugeUsed() string {
+	return c.TokenUsagePercent().GaugeUsedWith(c.optionString(gaugeMarkedChar, "▰"), c.optionString(gaugeUnmarkedChar, "▱"))
+}
+
+// FormattedTokens returns total session tokens as a human-readable string.
+func (c *Codex) FormattedTokens() string {
+	return formatTokenCount(c.Info.TotalTokenUsage.TotalTokens)
+}
+
+// FormattedInputTokens returns total input tokens as a human-readable string.
+func (c *Codex) FormattedInputTokens() string {
+	return formatTokenCount(c.Info.TotalTokenUsage.InputTokens)
+}
+
+// FormattedOutputTokens returns total output tokens as a human-readable string.
+func (c *Codex) FormattedOutputTokens() string {
+	return formatTokenCount(c.Info.TotalTokenUsage.OutputTokens)
+}
+
+// FormattedReasoningTokens returns total reasoning output tokens as a human-readable string.
+func (c *Codex) FormattedReasoningTokens() string {
+	return formatTokenCount(c.Info.TotalTokenUsage.ReasoningOutputTokens)
+}
+
+// FormattedCachedInputTokens returns cached input tokens as a human-readable string.
+func (c *Codex) FormattedCachedInputTokens() string {
+	return formatTokenCount(c.Info.TotalTokenUsage.CachedInputTokens)
+}
+
+// FormattedLastTokens returns the latest response token count as a human-readable string.
+func (c *Codex) FormattedLastTokens() string {
+	return formatTokenCount(c.Info.LastTokenUsage.TotalTokens)
+}
+
+// RemainingPercent returns the percentage of context window remaining (0-100).
+func (c *Codex) RemainingPercent() text.Percentage {
+	return remainingPercentage(c.TokenUsagePercent())
+}
+
+// RemainingTokensCount returns the number of remaining context window tokens.
+func (c *Codex) RemainingTokensCount() int {
+	if c.Info.ModelContextWindow <= 0 {
+		return 0
+	}
+
+	tokens := c.Info.LastTokenUsage.TotalTokens
+	if tokens <= 0 {
+		tokens = c.Info.TotalTokenUsage.TotalTokens
+	}
+
+	remaining := c.Info.ModelContextWindow - tokens
+	if remaining < 0 {
+		return 0
+	}
+
+	return remaining
+}
+
+// FiveHourUsage returns the primary rolling window usage percentage.
+func (c *Codex) FiveHourUsage() text.Percentage {
+	return codexRateLimitUsage(c.RateLimits, func(l *CodexRateLimits) *CodexRateLimitWindow {
+		return l.Primary
+	})
+}
+
+// WeeklyUsage returns the secondary rolling window usage percentage.
+func (c *Codex) WeeklyUsage() text.Percentage {
+	return codexRateLimitUsage(c.RateLimits, func(l *CodexRateLimits) *CodexRateLimitWindow {
+		return l.Secondary
+	})
+}
+
+// FiveHourRemaining returns the primary rolling window remaining percentage.
+func (c *Codex) FiveHourRemaining() text.Percentage {
+	return remainingPercentage(c.FiveHourUsage())
+}
+
+// WeeklyRemaining returns the secondary rolling window remaining percentage.
+func (c *Codex) WeeklyRemaining() text.Percentage {
+	return remainingPercentage(c.WeeklyUsage())
+}
+
+// FiveHourGauge returns a 5-block gauge showing primary window usage.
+func (c *Codex) FiveHourGauge() string {
+	return c.FiveHourUsage().GaugeUsedWith(c.optionString(gaugeMarkedChar, "▰"), c.optionString(gaugeUnmarkedChar, "▱"))
+}
+
+// WeeklyGauge returns a 5-block gauge showing weekly window usage.
+func (c *Codex) WeeklyGauge() string {
+	return c.WeeklyUsage().GaugeUsedWith(c.optionString(gaugeMarkedChar, "▰"), c.optionString(gaugeUnmarkedChar, "▱"))
+}
+
+// FiveHourRemainingGauge returns a 5-block gauge showing primary quota remaining.
+func (c *Codex) FiveHourRemainingGauge() string {
+	return c.FiveHourUsage().GaugeWith(c.optionString(gaugeMarkedChar, "▰"), c.optionString(gaugeUnmarkedChar, "▱"))
+}
+
+// WeeklyRemainingGauge returns a 5-block gauge showing weekly quota remaining.
+func (c *Codex) WeeklyRemainingGauge() string {
+	return c.WeeklyUsage().GaugeWith(c.optionString(gaugeMarkedChar, "▰"), c.optionString(gaugeUnmarkedChar, "▱"))
+}
+
+// FormattedFiveHourRemaining returns the primary rolling window remaining percentage with a percent sign.
+func (c *Codex) FormattedFiveHourRemaining() string {
+	return fmt.Sprintf("%d%%", c.FiveHourRemaining())
+}
+
+// FormattedWeeklyRemaining returns the weekly rolling window remaining percentage with a percent sign.
+func (c *Codex) FormattedWeeklyRemaining() string {
+	return fmt.Sprintf("%d%%", c.WeeklyRemaining())
+}
+
+// FormattedLimits returns rate limit text for the default template.
+func (c *Codex) FormattedLimits() string {
+	limits := []string{}
+
+	if c.DisplayFiveHourLimit() {
+		limits = append(limits, "5h "+c.FormattedFiveHourRemaining())
+	}
+
+	if c.DisplayWeeklyLimit() {
+		limits = append(limits, "7d "+c.FormattedWeeklyRemaining())
+	}
+
+	return strings.Join(limits, " ")
+}
+
+// FiveHourResetsAt returns the reset time for the primary rolling window.
+func (c *Codex) FiveHourResetsAt() time.Time {
+	return codexRateLimitReset(c.RateLimits, func(l *CodexRateLimits) *CodexRateLimitWindow {
+		return l.Primary
+	})
+}
+
+// WeeklyResetsAt returns the reset time for the secondary rolling window.
+func (c *Codex) WeeklyResetsAt() time.Time {
+	return codexRateLimitReset(c.RateLimits, func(l *CodexRateLimits) *CodexRateLimitWindow {
+		return l.Secondary
+	})
+}
+
+// FiveHourResetsIn returns the signed duration until the primary rolling window resets.
+// Returns 0 when unavailable, negative when the window already reset.
+func (c *Codex) FiveHourResetsIn() time.Duration {
+	return codexRateLimitResetsIn(c.RateLimits, func(l *CodexRateLimits) *CodexRateLimitWindow {
+		return l.Primary
+	})
+}
+
+// WeeklyResetsIn returns the signed duration until the secondary rolling window resets.
+// Returns 0 when unavailable, negative when the window already reset.
+func (c *Codex) WeeklyResetsIn() time.Duration {
+	return codexRateLimitResetsIn(c.RateLimits, func(l *CodexRateLimits) *CodexRateLimitWindow {
+		return l.Secondary
+	})
+}
+
+func remainingPercentage(used text.Percentage) text.Percentage {
+	remaining := 100 - int(used)
+	if remaining < 0 {
+		return 0
+	}
+
+	return text.Percentage(remaining)
+}
+
+func codexRateLimitUsage(limits *CodexRateLimits, window func(*CodexRateLimits) *CodexRateLimitWindow) text.Percentage {
+	if limits == nil || window == nil {
+		return 0
+	}
+
+	w := window(limits)
+	if w == nil || w.UsedPercent == nil {
+		return 0
+	}
+
+	percent := int(*w.UsedPercent + 0.5)
+	if percent > 100 {
+		return 100
+	}
+
+	if percent < 0 {
+		return 0
+	}
+
+	return text.Percentage(percent)
+}
+
+func codexRateLimitReset(limits *CodexRateLimits, window func(*CodexRateLimits) *CodexRateLimitWindow) time.Time {
+	if limits == nil || window == nil {
+		return time.Time{}
+	}
+
+	w := window(limits)
+	if w == nil || w.ResetsAt == nil {
+		return time.Time{}
+	}
+
+	return time.Unix(*w.ResetsAt, 0)
+}
+
+func codexRateLimitResetsIn(limits *CodexRateLimits, window func(*CodexRateLimits) *CodexRateLimitWindow) time.Duration {
+	t := codexRateLimitReset(limits, window)
+	if t.IsZero() {
+		return 0
+	}
+
+	return time.Until(t)
+}

--- a/src/segments/codex.go
+++ b/src/segments/codex.go
@@ -3,6 +3,7 @@ package segments
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -196,7 +197,6 @@ func (c *Codex) Enabled() bool {
 		log.Debugf("codex segment: model=%s, thread=%s", data.Model.DisplayName, data.ThreadID)
 
 		c.CodexData = data
-		cache.Set(cache.Session, cache.CODEXCACHE, data, cache.ToDuration(30))
 		return true
 	}
 
@@ -298,6 +298,39 @@ func (c *Codex) localStatusData() (CodexData, bool) {
 	}
 
 	return data, true
+}
+
+func (c *Codex) CacheKey() (string, bool) {
+	parts := []string{"codex"}
+
+	if value := c.optionString(statusFile, ""); value != "" {
+		parts = append(parts, "file", value)
+	}
+
+	if value := c.optionString(statusFileEnv, defaultCodexStatusFileEnv); value != "" {
+		parts = append(parts, "file-env", value)
+	}
+
+	if value := c.optionString(statusJSONEnv, defaultCodexStatusJSONEnv); value != "" {
+		parts = append(parts, "json-env", value)
+	}
+
+	if value := c.optionString(codexSessionID, ""); value != "" {
+		parts = append(parts, "session", value)
+	}
+
+	if value := c.optionString(sessionRoot, ""); value != "" {
+		parts = append(parts, "root", value)
+	} else if value := c.optionString(codexHome, ""); value != "" {
+		parts = append(parts, "root", filepath.Join(value, "sessions"))
+	} else if c.env != nil {
+		localOptions := ResolveCodexLocalStatusOptions(CodexLocalStatusOptions{}, c.env.Getenv("CODEX_HOME"), c.env.Home())
+		if localOptions.SessionRoot != "" {
+			parts = append(parts, "root", localOptions.SessionRoot)
+		}
+	}
+
+	return strings.Join(parts, "|"), true
 }
 
 func parseCodexStatus(status string) (CodexData, bool) {

--- a/src/segments/codex.go
+++ b/src/segments/codex.go
@@ -150,30 +150,29 @@ func (c *Codex) Enabled() bool {
 	data, found := cache.Get[CodexData](cache.Session, cache.CODEXCACHE)
 	if found {
 		if !data.hasStatus() {
-			log.Debug("codex segment: cached data has no status information")
-			return false
+			log.Debug("codex segment: cached data has no status information, ignoring cache entry")
+			cache.Delete(cache.Session, cache.CODEXCACHE)
+		} else {
+			log.Debug("codex segment: found data in session cache")
+			log.Debugf("codex segment: model=%s, thread=%s", data.Model.DisplayName, data.ThreadID)
+
+			c.CodexData = data
+			return true
 		}
-
-		log.Debug("codex segment: found data in session cache")
-		log.Debugf("codex segment: model=%s, thread=%s", data.Model.DisplayName, data.ThreadID)
-
-		c.CodexData = data
-		return true
+	} else {
+		log.Debug("codex segment: no data found in session cache")
 	}
-
-	log.Debug("codex segment: no data found in session cache")
 
 	if data, found = c.statusFileData(); found {
 		if !data.hasStatus() {
-			log.Debug("codex segment: status file has no status information")
-			return false
+			log.Debug("codex segment: status file has no status information, checking environment variable")
+		} else {
+			log.Debug("codex segment: found data in status file")
+			log.Debugf("codex segment: model=%s, thread=%s", data.Model.DisplayName, data.ThreadID)
+
+			c.CodexData = data
+			return true
 		}
-
-		log.Debug("codex segment: found data in status file")
-		log.Debugf("codex segment: model=%s, thread=%s", data.Model.DisplayName, data.ThreadID)
-
-		c.CodexData = data
-		return true
 	}
 
 	if data, found = c.statusEnvData(); found {
@@ -198,7 +197,19 @@ func (c *CodexData) hasStatus() bool {
 		c.Model.ID != "" ||
 		c.Info.TotalTokenUsage.TotalTokens > 0 ||
 		c.Info.LastTokenUsage.TotalTokens > 0 ||
-		c.RateLimits != nil
+		(c.RateLimits != nil && c.RateLimits.hasUsage())
+}
+
+func (c *CodexRateLimits) hasUsage() bool {
+	if c == nil {
+		return false
+	}
+
+	return codexRateLimitWindowHasUsage(c.Primary) || codexRateLimitWindowHasUsage(c.Secondary)
+}
+
+func codexRateLimitWindowHasUsage(window *CodexRateLimitWindow) bool {
+	return window != nil && window.UsedPercent != nil
 }
 
 func (c *Codex) statusFileData() (CodexData, bool) {

--- a/src/segments/codex.go
+++ b/src/segments/codex.go
@@ -78,6 +78,10 @@ const (
 	displayTokens        options.Option = "display_tokens"
 	displayFiveHourLimit options.Option = "display_five_hour_limit"
 	displayWeeklyLimit   options.Option = "display_weekly_limit"
+	discoverLocalStatus  options.Option = "discover_local_status"
+	codexHome            options.Option = "codex_home"
+	sessionRoot          options.Option = "session_root"
+	codexSessionID       options.Option = "session_id"
 	statusFile           options.Option = "status_file"
 	statusFileEnv        options.Option = "status_file_env"
 	statusJSONEnv        options.Option = "status_json_env"
@@ -178,13 +182,21 @@ func (c *Codex) Enabled() bool {
 	if data, found = c.statusEnvData(); found {
 		if !data.hasStatus() {
 			log.Debug("codex segment: status environment variable has no status information")
-			return false
-		}
+		} else {
+			log.Debug("codex segment: found data in status environment variable")
+			log.Debugf("codex segment: model=%s, thread=%s", data.Model.DisplayName, data.ThreadID)
 
-		log.Debug("codex segment: found data in status environment variable")
+			c.CodexData = data
+			return true
+		}
+	}
+
+	if data, found = c.localStatusData(); found {
+		log.Debug("codex segment: found data in local session transcripts")
 		log.Debugf("codex segment: model=%s, thread=%s", data.Model.DisplayName, data.ThreadID)
 
 		c.CodexData = data
+		cache.Set(cache.Session, cache.CODEXCACHE, data, cache.ToDuration(30))
 		return true
 	}
 
@@ -261,6 +273,31 @@ func (c *Codex) statusEnvData() (CodexData, bool) {
 	}
 
 	return parseCodexStatus(c.env.Getenv(envName))
+}
+
+func (c *Codex) localStatusData() (CodexData, bool) {
+	if c.env == nil || !c.optionBool(discoverLocalStatus, true) {
+		return CodexData{}, false
+	}
+
+	localOptions := ResolveCodexLocalStatusOptions(CodexLocalStatusOptions{
+		CodexHome:   c.optionString(codexHome, ""),
+		SessionRoot: c.optionString(sessionRoot, ""),
+		SessionID:   c.optionString(codexSessionID, ""),
+	}, c.env.Getenv("CODEX_HOME"), c.env.Home())
+
+	data, err := CodexStatusFromLocalSessions(localOptions)
+	if err != nil {
+		log.Debugf("codex segment: failed to discover local status data: %v", err)
+		return CodexData{}, false
+	}
+
+	if !data.hasStatus() {
+		log.Debug("codex segment: local session data has no status information")
+		return CodexData{}, false
+	}
+
+	return data, true
 }
 
 func parseCodexStatus(status string) (CodexData, bool) {

--- a/src/segments/codex.go
+++ b/src/segments/codex.go
@@ -301,7 +301,7 @@ func (c *Codex) localStatusData() (CodexData, bool) {
 }
 
 func (c *Codex) CacheKey() (string, bool) {
-	parts := []string{"codex"}
+	parts := []string{"codex", "discover", fmt.Sprintf("%t", c.optionBool(discoverLocalStatus, true))}
 
 	if value := c.optionString(statusFile, ""); value != "" {
 		parts = append(parts, "file", value)
@@ -309,6 +309,11 @@ func (c *Codex) CacheKey() (string, bool) {
 
 	if value := c.optionString(statusFileEnv, defaultCodexStatusFileEnv); value != "" {
 		parts = append(parts, "file-env", value)
+		if c.env != nil {
+			if file := c.env.Getenv(value); file != "" {
+				parts = append(parts, "file", file)
+			}
+		}
 	}
 
 	if value := c.optionString(statusJSONEnv, defaultCodexStatusJSONEnv); value != "" {

--- a/src/segments/codex_status.go
+++ b/src/segments/codex_status.go
@@ -18,6 +18,7 @@ const codexMaxSessionFiles = 25
 
 var errCodexNoTokenCount = errors.New("no token_count event found")
 
+// CodexLocalStatusOptions configures local Codex session transcript discovery.
 type CodexLocalStatusOptions struct {
 	CodexHome   string
 	SessionRoot string
@@ -52,6 +53,7 @@ type codexConfigStatus struct {
 	SandboxMode          string `toml:"sandbox_mode"`
 }
 
+// ResolveCodexLocalStatusOptions fills default local Codex discovery paths.
 func ResolveCodexLocalStatusOptions(options CodexLocalStatusOptions, codexHomeEnv, userHome string) CodexLocalStatusOptions {
 	if options.CodexHome == "" {
 		options.CodexHome = defaultCodexHome(codexHomeEnv, userHome)
@@ -64,6 +66,7 @@ func ResolveCodexLocalStatusOptions(options CodexLocalStatusOptions, codexHomeEn
 	return options
 }
 
+// CodexStatusFromLocalSessions returns the latest token_count status from local Codex session transcripts.
 func CodexStatusFromLocalSessions(options CodexLocalStatusOptions) (CodexData, error) {
 	if options.SessionRoot == "" {
 		return CodexData{}, errors.New("codex sessions directory could not be determined")
@@ -107,7 +110,7 @@ func codexSessionFiles(root, sessionID string) ([]codexSessionFile, error) {
 	files := []codexSessionFile{}
 	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
 		if err != nil {
-			return nil
+			return err
 		}
 
 		if entry.IsDir() {

--- a/src/segments/codex_status.go
+++ b/src/segments/codex_status.go
@@ -27,7 +27,7 @@ type CodexLocalStatusOptions struct {
 
 type codexSessionFile struct {
 	path    string
-	modTime int64
+	sortKey string
 }
 
 type codexJSONLEvent struct {
@@ -86,6 +86,10 @@ func CodexStatusFromLocalSessions(options CodexLocalStatusOptions) (CodexData, e
 
 	for _, file := range files {
 		data, err := codexStatusFromSessionFile(file.path, cfg)
+		if err == nil && options.SessionID != "" && data.ThreadID != options.SessionID {
+			continue
+		}
+
 		if err == nil && data.hasStatus() {
 			return data, nil
 		}
@@ -108,60 +112,124 @@ func CodexStatusFromLocalSessions(options CodexLocalStatusOptions) (CodexData, e
 
 func codexSessionFiles(root, sessionID string) ([]codexSessionFile, error) {
 	files := []codexSessionFile{}
-	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
 
-		if entry.IsDir() {
-			return nil
-		}
-
-		if !strings.EqualFold(filepath.Ext(entry.Name()), ".jsonl") {
-			return nil
-		}
-
-		if sessionID != "" && !strings.Contains(entry.Name(), sessionID) {
-			return nil
-		}
-
-		info, err := entry.Info()
-		if err != nil {
-			return err
-		}
-
-		files = appendNewestCodexSessionFile(files, codexSessionFile{
-			path:    path,
-			modTime: info.ModTime().UnixNano(),
-		}, sessionID == "")
-
-		return nil
-	})
+	dirs, err := codexSessionSearchDirs(root)
 	if err != nil {
 		return nil, err
 	}
 
-	sort.Slice(files, func(i, j int) bool {
-		return files[i].modTime > files[j].modTime
-	})
+	for _, dir := range dirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return nil, err
+		}
 
-	return files, nil
-}
+		for _, file := range codexSessionFilesInDir(dir, entries, sessionID) {
+			files = append(files, file)
 
-func appendNewestCodexSessionFile(files []codexSessionFile, file codexSessionFile, bound bool) []codexSessionFile {
-	files = append(files, file)
-	if !bound || len(files) <= codexMaxSessionFiles {
-		return files
-	}
-
-	oldestIndex := 0
-	for i := 1; i < len(files); i++ {
-		if files[i].modTime < files[oldestIndex].modTime {
-			oldestIndex = i
+			if sessionID == "" && len(files) >= codexMaxSessionFiles {
+				sortCodexSessionFiles(files)
+				return files, nil
+			}
 		}
 	}
 
-	return append(files[:oldestIndex], files[oldestIndex+1:]...)
+	sortCodexSessionFiles(files)
+	return files, nil
+}
+
+func codexSessionSearchDirs(root string) ([]string, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, err
+	}
+
+	years := filterCodexSessionDirs(entries, 4)
+	sort.Sort(sort.Reverse(sort.StringSlice(years)))
+
+	dirs := []string{}
+	for _, year := range years {
+		yearPath := filepath.Join(root, year)
+		monthEntries, err := os.ReadDir(yearPath)
+		if err != nil {
+			return nil, err
+		}
+
+		months := filterCodexSessionDirs(monthEntries, 2)
+		sort.Sort(sort.Reverse(sort.StringSlice(months)))
+
+		for _, month := range months {
+			monthPath := filepath.Join(yearPath, month)
+			dayEntries, err := os.ReadDir(monthPath)
+			if err != nil {
+				return nil, err
+			}
+
+			days := filterCodexSessionDirs(dayEntries, 2)
+			sort.Sort(sort.Reverse(sort.StringSlice(days)))
+
+			for _, day := range days {
+				dirs = append(dirs, filepath.Join(monthPath, day))
+			}
+		}
+	}
+
+	return append(dirs, root), nil
+}
+
+func filterCodexSessionDirs(entries []os.DirEntry, length int) []string {
+	dirs := []string{}
+	for _, entry := range entries {
+		if entry.IsDir() && isDigits(entry.Name(), length) {
+			dirs = append(dirs, entry.Name())
+		}
+	}
+
+	return dirs
+}
+
+func isDigits(value string, length int) bool {
+	if len(value) != length {
+		return false
+	}
+
+	for _, char := range value {
+		if char < '0' || char > '9' {
+			return false
+		}
+	}
+
+	return true
+}
+
+func codexSessionFilesInDir(dir string, entries []os.DirEntry, sessionID string) []codexSessionFile {
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name() > entries[j].Name()
+	})
+
+	files := []codexSessionFile{}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.EqualFold(filepath.Ext(entry.Name()), ".jsonl") {
+			continue
+		}
+
+		if sessionID != "" && !strings.Contains(entry.Name(), sessionID) {
+			continue
+		}
+
+		files = append(files, codexSessionFile{
+			path:    filepath.Join(dir, entry.Name()),
+			sortKey: entry.Name(),
+		})
+	}
+
+	return files
+}
+
+func sortCodexSessionFiles(files []codexSessionFile) {
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].sortKey > files[j].sortKey
+	})
 }
 
 func codexStatusFromSessionFile(path string, cfg codexConfigStatus) (CodexData, error) {
@@ -177,16 +245,25 @@ func codexStatusFromSessionFile(path string, cfg codexConfigStatus) (CodexData, 
 
 	for {
 		line, err := reader.ReadBytes('\n')
-		if len(line) > 0 {
-			event, ok := parseCodexJSONLEvent(line)
-			if ok {
-				switch event.Type {
-				case "session_meta":
-					_ = json.Unmarshal(event.Payload, &meta)
-				case "event_msg":
-					if isCodexTokenCountPayload(event.Payload) {
-						latest = event.Payload
-					}
+		if len(strings.TrimSpace(string(line))) > 0 {
+			event, parseErr := parseCodexJSONLEvent(line)
+			if parseErr != nil {
+				return CodexData{}, parseErr
+			}
+
+			switch event.Type {
+			case "session_meta":
+				if parseErr := json.Unmarshal(event.Payload, &meta); parseErr != nil {
+					return CodexData{}, parseErr
+				}
+			case "event_msg":
+				matches, parseErr := isCodexTokenCountPayload(event.Payload)
+				if parseErr != nil {
+					return CodexData{}, parseErr
+				}
+
+				if matches {
+					latest = event.Payload
 				}
 			}
 		}
@@ -214,21 +291,24 @@ func codexStatusFromSessionFile(path string, cfg codexConfigStatus) (CodexData, 
 	return data, nil
 }
 
-func parseCodexJSONLEvent(line []byte) (codexJSONLEvent, bool) {
+func parseCodexJSONLEvent(line []byte) (codexJSONLEvent, error) {
 	var event codexJSONLEvent
 	if err := json.Unmarshal(line, &event); err != nil {
-		return codexJSONLEvent{}, false
+		return codexJSONLEvent{}, err
 	}
 
-	return event, true
+	return event, nil
 }
 
-func isCodexTokenCountPayload(payload json.RawMessage) bool {
+func isCodexTokenCountPayload(payload json.RawMessage) (bool, error) {
 	var typed struct {
 		Type string `json:"type"`
 	}
+	if err := json.Unmarshal(payload, &typed); err != nil {
+		return false, err
+	}
 
-	return json.Unmarshal(payload, &typed) == nil && typed.Type == "token_count"
+	return typed.Type == "token_count", nil
 }
 
 func enrichCodexStatusPayload(payload *CodexData, meta *codexSessionMeta, cfg codexConfigStatus) {

--- a/src/segments/codex_status.go
+++ b/src/segments/codex_status.go
@@ -2,6 +2,7 @@ package segments
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -245,7 +246,7 @@ func codexStatusFromSessionFile(path string, cfg codexConfigStatus) (CodexData, 
 
 	for {
 		line, err := reader.ReadBytes('\n')
-		if len(strings.TrimSpace(string(line))) > 0 {
+		if len(bytes.TrimSpace(line)) > 0 {
 			event, parseErr := parseCodexJSONLEvent(line)
 			if parseErr != nil {
 				return CodexData{}, parseErr

--- a/src/segments/codex_status.go
+++ b/src/segments/codex_status.go
@@ -1,0 +1,294 @@
+package segments
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	toml "github.com/pelletier/go-toml/v2"
+)
+
+const codexMaxSessionFiles = 25
+
+var errCodexNoTokenCount = errors.New("no token_count event found")
+
+type CodexLocalStatusOptions struct {
+	CodexHome   string
+	SessionRoot string
+	SessionID   string
+}
+
+type codexSessionFile struct {
+	path    string
+	modTime int64
+}
+
+type codexJSONLEvent struct {
+	Timestamp string          `json:"timestamp"`
+	Type      string          `json:"type"`
+	Payload   json.RawMessage `json:"payload"`
+}
+
+type codexSessionMeta struct {
+	ID              string `json:"id"`
+	CWD             string `json:"cwd"`
+	CLIVersion      string `json:"cli_version"`
+	Model           string `json:"model"`
+	ReasoningEffort string `json:"reasoning_effort"`
+	ApprovalMode    string `json:"approval_policy"`
+	SandboxPolicy   string `json:"sandbox_mode"`
+}
+
+type codexConfigStatus struct {
+	Model                string `toml:"model"`
+	ModelReasoningEffort string `toml:"model_reasoning_effort"`
+	ApprovalPolicy       string `toml:"approval_policy"`
+	SandboxMode          string `toml:"sandbox_mode"`
+}
+
+func ResolveCodexLocalStatusOptions(options CodexLocalStatusOptions, codexHomeEnv, userHome string) CodexLocalStatusOptions {
+	if options.CodexHome == "" {
+		options.CodexHome = defaultCodexHome(codexHomeEnv, userHome)
+	}
+
+	if options.SessionRoot == "" && options.CodexHome != "" {
+		options.SessionRoot = filepath.Join(options.CodexHome, "sessions")
+	}
+
+	return options
+}
+
+func CodexStatusFromLocalSessions(options CodexLocalStatusOptions) (CodexData, error) {
+	if options.SessionRoot == "" {
+		return CodexData{}, errors.New("codex sessions directory could not be determined")
+	}
+
+	files, err := codexSessionFiles(options.SessionRoot, options.SessionID)
+	if err != nil {
+		return CodexData{}, err
+	}
+
+	if len(files) == 0 {
+		return CodexData{}, fmt.Errorf("no codex session files found in %s", options.SessionRoot)
+	}
+
+	cfg := loadCodexConfigStatus(options.CodexHome)
+	var lastErr error
+
+	for _, file := range files {
+		data, err := codexStatusFromSessionFile(file.path, cfg)
+		if err == nil && data.hasStatus() {
+			return data, nil
+		}
+
+		if err != nil && !errors.Is(err, errCodexNoTokenCount) {
+			lastErr = fmt.Errorf("%s: %w", file.path, err)
+		}
+	}
+
+	if lastErr != nil {
+		return CodexData{}, lastErr
+	}
+
+	if options.SessionID != "" {
+		return CodexData{}, fmt.Errorf("%w for codex session %s", errCodexNoTokenCount, options.SessionID)
+	}
+
+	return CodexData{}, fmt.Errorf("%w in the newest codex session files", errCodexNoTokenCount)
+}
+
+func codexSessionFiles(root, sessionID string) ([]codexSessionFile, error) {
+	files := []codexSessionFile{}
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+
+		if entry.IsDir() {
+			return nil
+		}
+
+		if !strings.EqualFold(filepath.Ext(entry.Name()), ".jsonl") {
+			return nil
+		}
+
+		if sessionID != "" && !strings.Contains(entry.Name(), sessionID) {
+			return nil
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+
+		files = appendNewestCodexSessionFile(files, codexSessionFile{
+			path:    path,
+			modTime: info.ModTime().UnixNano(),
+		}, sessionID == "")
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].modTime > files[j].modTime
+	})
+
+	return files, nil
+}
+
+func appendNewestCodexSessionFile(files []codexSessionFile, file codexSessionFile, bound bool) []codexSessionFile {
+	files = append(files, file)
+	if !bound || len(files) <= codexMaxSessionFiles {
+		return files
+	}
+
+	oldestIndex := 0
+	for i := 1; i < len(files); i++ {
+		if files[i].modTime < files[oldestIndex].modTime {
+			oldestIndex = i
+		}
+	}
+
+	return append(files[:oldestIndex], files[oldestIndex+1:]...)
+}
+
+func codexStatusFromSessionFile(path string, cfg codexConfigStatus) (CodexData, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return CodexData{}, err
+	}
+	defer file.Close()
+
+	reader := bufio.NewReader(file)
+	var meta codexSessionMeta
+	var latest json.RawMessage
+
+	for {
+		line, err := reader.ReadBytes('\n')
+		if len(line) > 0 {
+			event, ok := parseCodexJSONLEvent(line)
+			if ok {
+				switch event.Type {
+				case "session_meta":
+					_ = json.Unmarshal(event.Payload, &meta)
+				case "event_msg":
+					if isCodexTokenCountPayload(event.Payload) {
+						latest = event.Payload
+					}
+				}
+			}
+		}
+
+		if errors.Is(err, io.EOF) {
+			break
+		}
+
+		if err != nil {
+			return CodexData{}, err
+		}
+	}
+
+	if latest == nil {
+		return CodexData{}, errCodexNoTokenCount
+	}
+
+	var data CodexData
+	if err := json.Unmarshal(latest, &data); err != nil {
+		return CodexData{}, err
+	}
+
+	enrichCodexStatusPayload(&data, &meta, cfg)
+
+	return data, nil
+}
+
+func parseCodexJSONLEvent(line []byte) (codexJSONLEvent, bool) {
+	var event codexJSONLEvent
+	if err := json.Unmarshal(line, &event); err != nil {
+		return codexJSONLEvent{}, false
+	}
+
+	return event, true
+}
+
+func isCodexTokenCountPayload(payload json.RawMessage) bool {
+	var typed struct {
+		Type string `json:"type"`
+	}
+
+	return json.Unmarshal(payload, &typed) == nil && typed.Type == "token_count"
+}
+
+func enrichCodexStatusPayload(payload *CodexData, meta *codexSessionMeta, cfg codexConfigStatus) {
+	setStringIfMissing(&payload.ThreadID, meta.ID)
+	setStringIfMissing(&payload.CWD, meta.CWD)
+	setStringIfMissing(&payload.Version, meta.CLIVersion)
+	setStringIfMissing(&payload.ApprovalMode, firstNonEmpty(meta.ApprovalMode, cfg.ApprovalPolicy))
+	setStringIfMissing(&payload.SandboxPolicy, firstNonEmpty(meta.SandboxPolicy, cfg.SandboxMode))
+	setStringIfMissing(&payload.ReasoningEffort, firstNonEmpty(meta.ReasoningEffort, cfg.ModelReasoningEffort))
+
+	model := firstNonEmpty(meta.Model, cfg.Model)
+	if model == "" {
+		return
+	}
+
+	setStringIfMissing(&payload.Model.ID, model)
+	setStringIfMissing(&payload.Model.DisplayName, model)
+}
+
+func setStringIfMissing(target *string, value string) {
+	if *target != "" || value == "" {
+		return
+	}
+
+	*target = value
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+
+	return ""
+}
+
+func defaultCodexHome(codexHomeEnv, userHome string) string {
+	if codexHomeEnv != "" {
+		return codexHomeEnv
+	}
+
+	if userHome == "" {
+		return ""
+	}
+
+	return filepath.Join(userHome, ".codex")
+}
+
+func loadCodexConfigStatus(codexHome string) codexConfigStatus {
+	if codexHome == "" {
+		return codexConfigStatus{}
+	}
+
+	data, err := os.ReadFile(filepath.Join(codexHome, "config.toml"))
+	if err != nil {
+		return codexConfigStatus{}
+	}
+
+	var cfg codexConfigStatus
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		return codexConfigStatus{}
+	}
+
+	return cfg
+}

--- a/src/segments/codex_status_test.go
+++ b/src/segments/codex_status_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/cache"
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
@@ -30,9 +29,6 @@ func TestCodexStatusFromLocalSessions(t *testing.T) {
 	writeCodexSessionFile(t, older, "older-session", "2026-06-09T14:00:00Z", 10, 20)
 	newer := filepath.Join(sessionRoot, "rollout-2026-06-09T11-00-00-newer-session.jsonl")
 	writeCodexSessionFile(t, newer, "newer-session", "2026-06-09T15:00:00Z", 30, 40)
-
-	require.NoError(t, os.Chtimes(older, time.Now().Add(-time.Hour), time.Now().Add(-time.Hour)))
-	require.NoError(t, os.Chtimes(newer, time.Now(), time.Now()))
 
 	payload, err := CodexStatusFromLocalSessions(CodexLocalStatusOptions{
 		CodexHome:   codexHome,
@@ -60,9 +56,6 @@ func TestCodexStatusFromLocalSessionsUsesRequestedSession(t *testing.T) {
 	writeCodexSessionFile(t, older, "older-session", "2026-06-09T14:00:00Z", 10, 20)
 	newer := filepath.Join(sessionRoot, "rollout-2026-06-09T11-00-00-newer-session.jsonl")
 	writeCodexSessionFile(t, newer, "newer-session", "2026-06-09T15:00:00Z", 30, 40)
-
-	require.NoError(t, os.Chtimes(older, time.Now().Add(-time.Hour), time.Now().Add(-time.Hour)))
-	require.NoError(t, os.Chtimes(newer, time.Now(), time.Now()))
 
 	payload, err := CodexStatusFromLocalSessions(CodexLocalStatusOptions{
 		SessionRoot: sessionRoot,
@@ -186,9 +179,11 @@ func TestCodexCacheKeyUsesStatusSource(t *testing.T) {
 	key, ok := segment.CacheKey()
 	require.True(t, ok)
 
+	statusFileHash := codexCacheKeyHash("C:/tmp/codex-status.json")
+	sessionRootHash := codexCacheKeyHash(filepath.Join("C:/Users/Test/.codex", "sessions"))
 	expectedKey := "codex|discover|true|file-env|POSH_CODEX_STATUS_FILE|" +
-		"file|C:/tmp/codex-status.json|json-env|POSH_CODEX_STATUS|" +
-		"session|thread-1|root|" + filepath.Join("C:/Users/Test/.codex", "sessions")
+		"file|" + statusFileHash + "|json-env|POSH_CODEX_STATUS|" +
+		"session|thread-1|root|" + sessionRootHash
 	assert.Equal(
 		t,
 		expectedKey,

--- a/src/segments/codex_status_test.go
+++ b/src/segments/codex_status_test.go
@@ -1,12 +1,15 @@
-package cli
+package segments
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/cache"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -31,26 +34,21 @@ func TestCodexStatusFromLocalSessions(t *testing.T) {
 	require.NoError(t, os.Chtimes(older, time.Now().Add(-time.Hour), time.Now().Add(-time.Hour)))
 	require.NoError(t, os.Chtimes(newer, time.Now(), time.Now()))
 
-	data, err := codexStatusFromLocalSessions(codexLocalStatusOptions{
+	payload, err := CodexStatusFromLocalSessions(CodexLocalStatusOptions{
 		CodexHome:   codexHome,
 		SessionRoot: filepath.Join(codexHome, "sessions"),
 	})
 	require.NoError(t, err)
 
-	var payload map[string]any
-	require.NoError(t, json.Unmarshal(data, &payload))
-	assert.Equal(t, "token_count", payload["type"])
-	assert.Equal(t, "newer-session", payload["thread_id"])
-	assert.Equal(t, "C:/repo/newer-session", payload["cwd"])
-	assert.Equal(t, "0.138.0", payload["version"])
-	assert.Equal(t, "high", payload["reasoning_effort"])
-	assert.Equal(t, "never", payload["approval_mode"])
-	assert.Equal(t, "workspace-write", payload["sandbox_policy"])
-	assert.Equal(t, float64(40), payload["sequence"])
-	assert.Equal(t, map[string]any{
-		"id":           "gpt-5.5",
-		"display_name": "gpt-5.5",
-	}, payload["model"])
+	assert.Equal(t, "token_count", payload.Type)
+	assert.Equal(t, "newer-session", payload.ThreadID)
+	assert.Equal(t, "C:/repo/newer-session", payload.CWD)
+	assert.Equal(t, "0.138.0", payload.Version)
+	assert.Equal(t, "high", payload.ReasoningEffort)
+	assert.Equal(t, "never", payload.ApprovalMode)
+	assert.Equal(t, "workspace-write", payload.SandboxPolicy)
+	assert.Equal(t, "gpt-5.5", payload.Model.DisplayName)
+	assert.Equal(t, 40, payload.Info.TotalTokenUsage.TotalTokens)
 }
 
 func TestCodexStatusFromLocalSessionsUsesRequestedSession(t *testing.T) {
@@ -66,16 +64,14 @@ func TestCodexStatusFromLocalSessionsUsesRequestedSession(t *testing.T) {
 	require.NoError(t, os.Chtimes(older, time.Now().Add(-time.Hour), time.Now().Add(-time.Hour)))
 	require.NoError(t, os.Chtimes(newer, time.Now(), time.Now()))
 
-	data, err := codexStatusFromLocalSessions(codexLocalStatusOptions{
+	payload, err := CodexStatusFromLocalSessions(CodexLocalStatusOptions{
 		SessionRoot: sessionRoot,
 		SessionID:   "older-session",
 	})
 	require.NoError(t, err)
 
-	var payload map[string]any
-	require.NoError(t, json.Unmarshal(data, &payload))
-	assert.Equal(t, "older-session", payload["thread_id"])
-	assert.Equal(t, float64(20), payload["sequence"])
+	assert.Equal(t, "older-session", payload.ThreadID)
+	assert.Equal(t, 20, payload.Info.TotalTokenUsage.TotalTokens)
 }
 
 func TestCodexStatusFromLocalSessionsReturnsErrorWhenNoTokenCount(t *testing.T) {
@@ -88,30 +84,60 @@ func TestCodexStatusFromLocalSessionsReturnsErrorWhenNoTokenCount(t *testing.T) 
 		0o644,
 	))
 
-	_, err := codexStatusFromLocalSessions(codexLocalStatusOptions{
+	_, err := CodexStatusFromLocalSessions(CodexLocalStatusOptions{
 		SessionRoot: sessionRoot,
 	})
 	require.Error(t, err)
+	assert.ErrorIs(t, err, errCodexNoTokenCount)
 }
 
-func writeCodexSessionFile(t *testing.T, path, sessionID, timestamp string, firstSequence, secondSequence int) {
+func TestCodexSegmentDiscoversLocalStatus(t *testing.T) {
+	cache.Delete(cache.Session, cache.CODEXCACHE)
+
+	tmp := t.TempDir()
+	codexHome := filepath.Join(tmp, ".codex")
+	sessionRoot := filepath.Join(codexHome, "sessions", "2026", "06", "09")
+	require.NoError(t, os.MkdirAll(sessionRoot, 0o755))
+	writeCodexSessionFile(t, filepath.Join(sessionRoot, "rollout-local-session.jsonl"), "local-session", "2026-06-09T14:00:00Z", 10, 20)
+
+	env := new(mock.Environment)
+	env.On("Getenv", defaultCodexStatusFileEnv).Return("")
+	env.On("Getenv", defaultCodexStatusJSONEnv).Return("")
+	env.On("Getenv", "CODEX_HOME").Return(codexHome)
+	env.On("Home").Return(tmp)
+
+	segment := &Codex{
+		Base: Base{
+			env:     env,
+			options: options.Map{},
+		},
+	}
+
+	require.True(t, segment.Enabled())
+	assert.Equal(t, "local-session", segment.ThreadID)
+	assert.Equal(t, 20, segment.Info.TotalTokenUsage.TotalTokens)
+
+	cache.Delete(cache.Session, cache.CODEXCACHE)
+}
+
+func writeCodexSessionFile(t *testing.T, path, sessionID, timestamp string, firstTokens, secondTokens int) {
 	t.Helper()
 
 	content := "" +
 		"{\"timestamp\":\"" + timestamp + "\",\"type\":\"session_meta\",\"payload\":{\"id\":\"" + sessionID + "\",\"cwd\":\"C:/repo/" + sessionID + "\",\"cli_version\":\"0.138.0\"}}\n" +
-		codexTokenCountLine(timestamp, firstSequence) + "\n" +
-		codexTokenCountLine(timestamp, secondSequence) + "\n"
+		codexTokenCountLine(timestamp, firstTokens) + "\n" +
+		codexTokenCountLine(timestamp, secondTokens) + "\n"
 
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
 }
 
-func codexTokenCountLine(timestamp string, sequence int) string {
+func codexTokenCountLine(timestamp string, totalTokens int) string {
 	return fmt.Sprintf(
-		`{"timestamp":"%s","type":"event_msg","payload":{"type":"token_count","sequence":%d,`+
-			`"info":{"total_token_usage":{"total_tokens":1000},"last_token_usage":{"total_tokens":100},`+
+		`{"timestamp":"%s","type":"event_msg","payload":{"type":"token_count",`+
+			`"info":{"total_token_usage":{"total_tokens":%d},"last_token_usage":{"total_tokens":100},`+
 			`"model_context_window":10000},"rate_limits":{"primary":{"used_percent":12},`+
 			`"secondary":{"used_percent":34}}}}`,
 		timestamp,
-		sequence,
+		totalTokens,
 	)
 }

--- a/src/segments/codex_status_test.go
+++ b/src/segments/codex_status_test.go
@@ -171,6 +171,7 @@ func TestCodexSegmentDiscoversLocalStatus(t *testing.T) {
 
 func TestCodexCacheKeyUsesStatusSource(t *testing.T) {
 	env := new(mock.Environment)
+	env.On("Getenv", defaultCodexStatusFileEnv).Return("C:/tmp/codex-status.json")
 
 	segment := &Codex{
 		Base: Base{
@@ -184,9 +185,13 @@ func TestCodexCacheKeyUsesStatusSource(t *testing.T) {
 
 	key, ok := segment.CacheKey()
 	require.True(t, ok)
+
+	expectedKey := "codex|discover|true|file-env|POSH_CODEX_STATUS_FILE|" +
+		"file|C:/tmp/codex-status.json|json-env|POSH_CODEX_STATUS|" +
+		"session|thread-1|root|" + filepath.Join("C:/Users/Test/.codex", "sessions")
 	assert.Equal(
 		t,
-		"codex|file-env|POSH_CODEX_STATUS_FILE|json-env|POSH_CODEX_STATUS|session|thread-1|root|"+filepath.Join("C:/Users/Test/.codex", "sessions"),
+		expectedKey,
 		key,
 	)
 }

--- a/src/segments/codex_status_test.go
+++ b/src/segments/codex_status_test.go
@@ -74,6 +74,22 @@ func TestCodexStatusFromLocalSessionsUsesRequestedSession(t *testing.T) {
 	assert.Equal(t, 20, payload.Info.TotalTokenUsage.TotalTokens)
 }
 
+func TestCodexStatusFromLocalSessionsSkipsMismatchedRequestedSession(t *testing.T) {
+	tmp := t.TempDir()
+	sessionRoot := filepath.Join(tmp, "sessions")
+	require.NoError(t, os.MkdirAll(sessionRoot, 0o755))
+
+	mismatch := filepath.Join(sessionRoot, "rollout-2026-06-09T10-00-00-requested-session.jsonl")
+	writeCodexSessionFile(t, mismatch, "different-session", "2026-06-09T14:00:00Z", 10, 20)
+
+	_, err := CodexStatusFromLocalSessions(CodexLocalStatusOptions{
+		SessionRoot: sessionRoot,
+		SessionID:   "requested-session",
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errCodexNoTokenCount)
+}
+
 func TestCodexStatusFromLocalSessionsReturnsErrorWhenNoTokenCount(t *testing.T) {
 	tmp := t.TempDir()
 	sessionRoot := filepath.Join(tmp, "sessions")
@@ -89,6 +105,39 @@ func TestCodexStatusFromLocalSessionsReturnsErrorWhenNoTokenCount(t *testing.T) 
 	})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errCodexNoTokenCount)
+}
+
+func TestCodexStatusFromLocalSessionsReturnsMalformedJSONLError(t *testing.T) {
+	tmp := t.TempDir()
+	sessionRoot := filepath.Join(tmp, "sessions")
+	require.NoError(t, os.MkdirAll(sessionRoot, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sessionRoot, "rollout-malformed.jsonl"),
+		[]byte("{\"timestamp\":\"2026-06-09T14:00:00Z\",\"type\":\"event_msg\",\"payload\":"),
+		0o644,
+	))
+
+	_, err := CodexStatusFromLocalSessions(CodexLocalStatusOptions{
+		SessionRoot: sessionRoot,
+	})
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, errCodexNoTokenCount)
+}
+
+func TestCodexStatusFromLocalSessionsIgnoresNonDateDirectories(t *testing.T) {
+	tmp := t.TempDir()
+	sessionRoot := filepath.Join(tmp, "sessions")
+	require.NoError(t, os.MkdirAll(filepath.Join(sessionRoot, "archive"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(sessionRoot, "2026", "06", "09"), 0o755))
+
+	session := filepath.Join(sessionRoot, "2026", "06", "09", "rollout-2026-06-09T10-00-00-session.jsonl")
+	writeCodexSessionFile(t, session, "session", "2026-06-09T14:00:00Z", 10, 20)
+
+	payload, err := CodexStatusFromLocalSessions(CodexLocalStatusOptions{
+		SessionRoot: sessionRoot,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "session", payload.ThreadID)
 }
 
 func TestCodexSegmentDiscoversLocalStatus(t *testing.T) {
@@ -118,6 +167,28 @@ func TestCodexSegmentDiscoversLocalStatus(t *testing.T) {
 	assert.Equal(t, 20, segment.Info.TotalTokenUsage.TotalTokens)
 
 	cache.Delete(cache.Session, cache.CODEXCACHE)
+}
+
+func TestCodexCacheKeyUsesStatusSource(t *testing.T) {
+	env := new(mock.Environment)
+
+	segment := &Codex{
+		Base: Base{
+			env: env,
+			options: options.Map{
+				codexHome:      "C:/Users/Test/.codex",
+				codexSessionID: "thread-1",
+			},
+		},
+	}
+
+	key, ok := segment.CacheKey()
+	require.True(t, ok)
+	assert.Equal(
+		t,
+		"codex|file-env|POSH_CODEX_STATUS_FILE|json-env|POSH_CODEX_STATUS|session|thread-1|root|"+filepath.Join("C:/Users/Test/.codex", "sessions"),
+		key,
+	)
 }
 
 func writeCodexSessionFile(t *testing.T, path, sessionID, timestamp string, firstTokens, secondTokens int) {

--- a/src/segments/codex_test.go
+++ b/src/segments/codex_test.go
@@ -345,6 +345,25 @@ func TestCodexFormattedTextUsesOptionsWithoutEnabled(t *testing.T) {
 	assert.Equal(t, "\ue7cf GPT-5.5 (high) \uf2d0 ####- tok 1.2K \uf017 5h 87% 7d 74%", segment.FormattedText())
 }
 
+func TestCodexFormattedTextOmitsUnknownContext(t *testing.T) {
+	segment := &Codex{
+		CodexData: CodexData{
+			Model: CodexModel{
+				DisplayName: "GPT-5.5",
+			},
+			Info: CodexTokenInfo{
+				TotalTokenUsage: CodexTokenUsage{
+					TotalTokens: 1200,
+				},
+			},
+		},
+	}
+
+	assert.Empty(t, segment.TokenGauge())
+	assert.Empty(t, segment.TokenGaugeUsed())
+	assert.Equal(t, "\ue7cf GPT-5.5", segment.FormattedText())
+}
+
 func TestCodexTokenUsagePercent(t *testing.T) {
 	cases := []struct {
 		Case            string
@@ -476,6 +495,54 @@ func TestCodexRateLimitUsage(t *testing.T) {
 	assert.Equal(t, "74%", segment.FormattedWeeklyRemaining())
 	assert.Equal(t, "7d 74%", segment.FormattedLimits())
 	assert.Equal(t, time.Unix(reset, 0), segment.WeeklyResetsAt())
+}
+
+func TestCodexFormattedLimitsOmitsUnknownWindows(t *testing.T) {
+	primary := 12.5
+	segment := &Codex{
+		Base: Base{
+			options: options.Map{
+				displayFiveHourLimit: true,
+			},
+		},
+		CodexData: CodexData{
+			RateLimits: &CodexRateLimits{
+				Primary: &CodexRateLimitWindow{
+					UsedPercent: &primary,
+				},
+				Secondary: &CodexRateLimitWindow{},
+			},
+		},
+	}
+
+	assert.Equal(t, "5h 87%", segment.FormattedLimits())
+	assert.Equal(t, "87%", segment.FormattedFiveHourRemaining())
+	assert.Empty(t, segment.FormattedWeeklyRemaining())
+	assert.NotEmpty(t, segment.FiveHourGauge())
+	assert.NotEmpty(t, segment.FiveHourRemainingGauge())
+	assert.Empty(t, segment.WeeklyGauge())
+	assert.Empty(t, segment.WeeklyRemainingGauge())
+}
+
+func TestCodexFormattedLimitsEmptyWhenUsageUnknown(t *testing.T) {
+	segment := &Codex{
+		Base: Base{
+			options: options.Map{
+				displayFiveHourLimit: true,
+			},
+		},
+		CodexData: CodexData{
+			RateLimits: &CodexRateLimits{},
+		},
+	}
+
+	assert.Empty(t, segment.FormattedLimits())
+	assert.Empty(t, segment.FormattedFiveHourRemaining())
+	assert.Empty(t, segment.FormattedWeeklyRemaining())
+	assert.Empty(t, segment.FiveHourGauge())
+	assert.Empty(t, segment.WeeklyGauge())
+	assert.Empty(t, segment.FiveHourRemainingGauge())
+	assert.Empty(t, segment.WeeklyRemainingGauge())
 }
 
 func TestCodexTokenGaugeCustomChars(t *testing.T) {

--- a/src/segments/codex_test.go
+++ b/src/segments/codex_test.go
@@ -58,8 +58,10 @@ func TestCodexSegment(t *testing.T) {
 
 			segment := &Codex{
 				Base: Base{
-					env:     env,
-					options: options.Map{},
+					env: env,
+					options: options.Map{
+						discoverLocalStatus: false,
+					},
 				},
 			}
 
@@ -144,8 +146,10 @@ func TestCodexSegmentEmptyPayloadDisabled(t *testing.T) {
 
 	segment := &Codex{
 		Base: Base{
-			env:     env,
-			options: options.Map{},
+			env: env,
+			options: options.Map{
+				discoverLocalStatus: false,
+			},
 		},
 	}
 
@@ -196,8 +200,10 @@ func TestCodexSegmentStatusFileEnv(t *testing.T) {
 
 	segment := &Codex{
 		Base: Base{
-			env:     env,
-			options: options.Map{},
+			env: env,
+			options: options.Map{
+				discoverLocalStatus: false,
+			},
 		},
 	}
 
@@ -221,8 +227,10 @@ func TestCodexSegmentStatusEnv(t *testing.T) {
 
 	segment := &Codex{
 		Base: Base{
-			env:     env,
-			options: options.Map{},
+			env: env,
+			options: options.Map{
+				discoverLocalStatus: false,
+			},
 		},
 	}
 
@@ -247,8 +255,10 @@ func TestCodexSegmentInvalidCacheFallsBackToStatusFile(t *testing.T) {
 
 	segment := &Codex{
 		Base: Base{
-			env:     env,
-			options: options.Map{},
+			env: env,
+			options: options.Map{
+				discoverLocalStatus: false,
+			},
 		},
 	}
 
@@ -298,8 +308,10 @@ func TestCodexSegmentEmptyRateLimitsDisabled(t *testing.T) {
 
 	segment := &Codex{
 		Base: Base{
-			env:     env,
-			options: options.Map{},
+			env: env,
+			options: options.Map{
+				discoverLocalStatus: false,
+			},
 		},
 	}
 

--- a/src/segments/codex_test.go
+++ b/src/segments/codex_test.go
@@ -1,0 +1,540 @@
+package segments
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/cache"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+	"github.com/jandedobbeleer/oh-my-posh/src/text"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCodexSegment(t *testing.T) {
+	cases := []struct {
+		Data            *CodexData
+		Case            string
+		ExpectedModel   string
+		ExpectedThread  string
+		ExpectedEnabled bool
+	}{
+		{
+			Case:            "No cache data",
+			Data:            nil,
+			ExpectedEnabled: false,
+		},
+		{
+			Case: "Valid data",
+			Data: &CodexData{
+				ThreadID: "019e9eac-83ec-7393-ae18-cc2e566394d5",
+				Model: CodexModel{
+					ID:          "gpt-5.5",
+					DisplayName: "GPT-5.5",
+				},
+			},
+			ExpectedEnabled: true,
+			ExpectedModel:   "GPT-5.5",
+			ExpectedThread:  "019e9eac-83ec-7393-ae18-cc2e566394d5",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Case, func(t *testing.T) {
+			if tc.Data != nil {
+				cache.Set(cache.Session, cache.CODEXCACHE, *tc.Data, cache.INFINITE)
+			} else {
+				cache.Delete(cache.Session, cache.CODEXCACHE)
+			}
+
+			env := new(mock.Environment)
+			if tc.Data == nil {
+				env.On("Getenv", defaultCodexStatusFileEnv).Return("")
+				env.On("Getenv", defaultCodexStatusJSONEnv).Return("")
+			}
+
+			segment := &Codex{
+				Base: Base{
+					env:     env,
+					options: options.Map{},
+				},
+			}
+
+			enabled := segment.Enabled()
+			assert.Equal(t, tc.ExpectedEnabled, enabled)
+
+			if tc.ExpectedEnabled {
+				assert.Equal(t, tc.ExpectedModel, segment.Model.DisplayName)
+				assert.Equal(t, tc.ExpectedThread, segment.ThreadID)
+			}
+
+			cache.Delete(cache.Session, cache.CODEXCACHE)
+		})
+	}
+}
+
+func TestCodexDataUnmarshalWrappedTokenCountEvent(t *testing.T) {
+	input := []byte(`{
+		"type": "event_msg",
+		"payload": {
+			"type": "token_count",
+			"model": "gpt-5.5",
+			"thread_id": "thread-1",
+			"info": {
+				"total_token_usage": {
+					"input_tokens": 1000,
+					"cached_input_tokens": 200,
+					"output_tokens": 300,
+					"reasoning_output_tokens": 50,
+					"total_tokens": 1300
+				},
+				"last_token_usage": {
+					"input_tokens": 100,
+					"output_tokens": 30,
+					"total_tokens": 130
+				},
+				"model_context_window": 260000
+			},
+			"rate_limits": {
+				"plan_type": "pro",
+				"primary": {
+					"used_percent": 12.5,
+					"window_minutes": 300,
+					"resets_at": 1780794869
+				},
+				"secondary": {
+					"used_percent": 26,
+					"window_minutes": 10080,
+					"resets_at": 1781137565
+				}
+			}
+		}
+	}`)
+
+	var data CodexData
+	require.NoError(t, json.Unmarshal(input, &data))
+	assert.Equal(t, "token_count", data.Type)
+	assert.Equal(t, "gpt-5.5", data.Model.DisplayName)
+	assert.Equal(t, 1300, data.Info.TotalTokenUsage.TotalTokens)
+	assert.Equal(t, 26.0, *data.RateLimits.Secondary.UsedPercent)
+}
+
+func TestCodexDataUnmarshalUnsupportedEvent(t *testing.T) {
+	input := []byte(`{
+		"type": "event_msg",
+		"payload": {
+			"type": "agent_message",
+			"message": "not token data"
+		}
+	}`)
+
+	var data CodexData
+	require.Error(t, json.Unmarshal(input, &data))
+}
+
+func TestCodexSegmentEmptyPayloadDisabled(t *testing.T) {
+	cache.Delete(cache.Session, cache.CODEXCACHE)
+
+	env := new(mock.Environment)
+	env.On("Getenv", defaultCodexStatusFileEnv).Return("")
+	env.On("Getenv", defaultCodexStatusJSONEnv).Return(`{"type":"token_count"}`)
+
+	segment := &Codex{
+		Base: Base{
+			env:     env,
+			options: options.Map{},
+		},
+	}
+
+	assert.False(t, segment.Enabled())
+}
+
+func TestCodexSegmentStatusFile(t *testing.T) {
+	cache.Delete(cache.Session, cache.CODEXCACHE)
+
+	status := `{
+		"type": "token_count",
+		"thread_id": "thread-from-file",
+		"model": {
+			"id": "gpt-5.5",
+			"display_name": "GPT-5.5"
+		}
+	}`
+
+	env := new(mock.Environment)
+	env.On("FileContent", "/tmp/codex-status.json").Return(status)
+
+	segment := &Codex{
+		Base: Base{
+			env: env,
+			options: options.Map{
+				statusFile: "/tmp/codex-status.json",
+			},
+		},
+	}
+
+	require.True(t, segment.Enabled())
+	assert.Equal(t, "thread-from-file", segment.ThreadID)
+	assert.Equal(t, "GPT-5.5", segment.Model.DisplayName)
+}
+
+func TestCodexSegmentStatusFileEnv(t *testing.T) {
+	cache.Delete(cache.Session, cache.CODEXCACHE)
+
+	status := `{
+		"type": "token_count",
+		"thread_id": "thread-from-file-env",
+		"model": "gpt-5.5"
+	}`
+
+	env := new(mock.Environment)
+	env.On("Getenv", defaultCodexStatusFileEnv).Return("/tmp/codex-status.json")
+	env.On("FileContent", "/tmp/codex-status.json").Return(status)
+
+	segment := &Codex{
+		Base: Base{
+			env:     env,
+			options: options.Map{},
+		},
+	}
+
+	require.True(t, segment.Enabled())
+	assert.Equal(t, "thread-from-file-env", segment.ThreadID)
+	assert.Equal(t, "gpt-5.5", segment.Model.DisplayName)
+}
+
+func TestCodexSegmentStatusEnv(t *testing.T) {
+	cache.Delete(cache.Session, cache.CODEXCACHE)
+
+	status := `{
+		"type": "token_count",
+		"thread_id": "thread-from-env",
+		"model": "gpt-5.5"
+	}`
+
+	env := new(mock.Environment)
+	env.On("Getenv", defaultCodexStatusFileEnv).Return("")
+	env.On("Getenv", defaultCodexStatusJSONEnv).Return(status)
+
+	segment := &Codex{
+		Base: Base{
+			env:     env,
+			options: options.Map{},
+		},
+	}
+
+	require.True(t, segment.Enabled())
+	assert.Equal(t, "thread-from-env", segment.ThreadID)
+	assert.Equal(t, "gpt-5.5", segment.Model.DisplayName)
+}
+
+func TestCodexFormattedTextUsesOptionsWithoutEnabled(t *testing.T) {
+	primary := 12.5
+	secondary := 26.0
+	segment := &Codex{
+		Base: Base{
+			options: options.Map{
+				displayFiveHourLimit: true,
+				displayReasoning:     true,
+				displayTokens:        true,
+				gaugeMarkedChar:      "#",
+				gaugeUnmarkedChar:    "-",
+			},
+		},
+		CodexData: CodexData{
+			ReasoningEffort: "high",
+			Model: CodexModel{
+				ID:          "gpt-5.5",
+				DisplayName: "GPT-5.5",
+			},
+			Info: CodexTokenInfo{
+				TotalTokenUsage: CodexTokenUsage{
+					TotalTokens: 1200,
+				},
+				ModelContextWindow: 10000,
+			},
+			RateLimits: &CodexRateLimits{
+				Primary: &CodexRateLimitWindow{
+					UsedPercent: &primary,
+				},
+				Secondary: &CodexRateLimitWindow{
+					UsedPercent: &secondary,
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, "\ue7cf GPT-5.5 (high) \uf2d0 ####- tok 1.2K \uf017 5h 87% 7d 74%", segment.FormattedText())
+}
+
+func TestCodexTokenUsagePercent(t *testing.T) {
+	cases := []struct {
+		Case            string
+		Info            CodexTokenInfo
+		ExpectedPercent text.Percentage
+	}{
+		{
+			Case:            "No data",
+			Info:            CodexTokenInfo{},
+			ExpectedPercent: 0,
+		},
+		{
+			Case: "Rounded usage",
+			Info: CodexTokenInfo{
+				TotalTokenUsage: CodexTokenUsage{
+					TotalTokens: 1300,
+				},
+				ModelContextWindow: 10000,
+			},
+			ExpectedPercent: 13,
+		},
+		{
+			Case: "Usage capped",
+			Info: CodexTokenInfo{
+				TotalTokenUsage: CodexTokenUsage{
+					TotalTokens: 12000,
+				},
+				ModelContextWindow: 10000,
+			},
+			ExpectedPercent: 100,
+		},
+		{
+			Case: "Last usage preferred over cumulative total",
+			Info: CodexTokenInfo{
+				TotalTokenUsage: CodexTokenUsage{
+					TotalTokens: 12000,
+				},
+				LastTokenUsage: CodexTokenUsage{
+					TotalTokens: 2500,
+				},
+				ModelContextWindow: 10000,
+			},
+			ExpectedPercent: 25,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Case, func(t *testing.T) {
+			segment := &Codex{
+				CodexData: CodexData{
+					Info: tc.Info,
+				},
+			}
+			assert.Equal(t, tc.ExpectedPercent, segment.TokenUsagePercent())
+		})
+	}
+}
+
+func TestCodexFormattedTokens(t *testing.T) {
+	segment := &Codex{
+		CodexData: CodexData{
+			Info: CodexTokenInfo{
+				TotalTokenUsage: CodexTokenUsage{
+					InputTokens:           1200,
+					CachedInputTokens:     400,
+					OutputTokens:          500000,
+					ReasoningOutputTokens: 42,
+					TotalTokens:           1500000,
+				},
+				LastTokenUsage: CodexTokenUsage{
+					TotalTokens: 987,
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, "1.5M", segment.FormattedTokens())
+	assert.Equal(t, "1.2K", segment.FormattedInputTokens())
+	assert.Equal(t, "500.0K", segment.FormattedOutputTokens())
+	assert.Equal(t, "42", segment.FormattedReasoningTokens())
+	assert.Equal(t, "400", segment.FormattedCachedInputTokens())
+	assert.Equal(t, "987", segment.FormattedLastTokens())
+}
+
+func TestCodexRemainingContext(t *testing.T) {
+	segment := &Codex{
+		CodexData: CodexData{
+			Info: CodexTokenInfo{
+				TotalTokenUsage: CodexTokenUsage{
+					TotalTokens: 250000,
+				},
+				LastTokenUsage: CodexTokenUsage{
+					TotalTokens: 25000,
+				},
+				ModelContextWindow: 100000,
+			},
+		},
+	}
+
+	assert.Equal(t, text.Percentage(75), segment.RemainingPercent())
+	assert.Equal(t, 75000, segment.RemainingTokensCount())
+}
+
+func TestCodexRateLimitUsage(t *testing.T) {
+	primary := 12.5
+	secondary := 26.0
+	reset := int64(1781137565)
+	segment := &Codex{
+		Base: Base{
+			options: options.Map{},
+		},
+		CodexData: CodexData{
+			RateLimits: &CodexRateLimits{
+				Primary: &CodexRateLimitWindow{
+					UsedPercent: &primary,
+				},
+				Secondary: &CodexRateLimitWindow{
+					UsedPercent: &secondary,
+					ResetsAt:    &reset,
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, text.Percentage(13), segment.FiveHourUsage())
+	assert.Equal(t, text.Percentage(26), segment.WeeklyUsage())
+	assert.Equal(t, text.Percentage(87), segment.FiveHourRemaining())
+	assert.Equal(t, text.Percentage(74), segment.WeeklyRemaining())
+	assert.Equal(t, "74%", segment.FormattedWeeklyRemaining())
+	assert.Equal(t, "7d 74%", segment.FormattedLimits())
+	assert.Equal(t, time.Unix(reset, 0), segment.WeeklyResetsAt())
+}
+
+func TestCodexTokenGaugeCustomChars(t *testing.T) {
+	data := CodexData{
+		Info: CodexTokenInfo{
+			TotalTokenUsage: CodexTokenUsage{
+				TotalTokens: 60000,
+			},
+			ModelContextWindow: 100000,
+		},
+	}
+	cache.Set(cache.Session, cache.CODEXCACHE, data, cache.INFINITE)
+	defer cache.Delete(cache.Session, cache.CODEXCACHE)
+
+	segment := &Codex{
+		Base: Base{
+			env: new(mock.Environment),
+			options: options.Map{
+				gaugeMarkedChar:   "█",
+				gaugeUnmarkedChar: "░",
+			},
+		},
+	}
+
+	require.True(t, segment.Enabled())
+	assert.Contains(t, segment.TokenGaugeUsed(), "█")
+	assert.Contains(t, segment.TokenGauge(), "░")
+}
+
+func TestCodexDisplayOptions(t *testing.T) {
+	primary := 12.5
+	secondary := 26.0
+	data := CodexData{
+		ThreadID:        "thread-1",
+		ReasoningEffort: "high",
+		Model: CodexModel{
+			ID:          "gpt-5.5",
+			DisplayName: "GPT-5.5",
+		},
+		Info: CodexTokenInfo{
+			TotalTokenUsage: CodexTokenUsage{
+				TotalTokens: 1200,
+			},
+			ModelContextWindow: 10000,
+		},
+		RateLimits: &CodexRateLimits{
+			Primary: &CodexRateLimitWindow{
+				UsedPercent: &primary,
+			},
+			Secondary: &CodexRateLimitWindow{
+				UsedPercent: &secondary,
+			},
+		},
+	}
+	cache.Set(cache.Session, cache.CODEXCACHE, data, cache.INFINITE)
+	defer cache.Delete(cache.Session, cache.CODEXCACHE)
+
+	cases := []struct {
+		Case              string
+		Options           options.Map
+		ExpectedModel     bool
+		ExpectedReason    bool
+		ExpectedContext   bool
+		ExpectedTokens    bool
+		ExpectedFiveHour  bool
+		ExpectedWeekly    bool
+		ExpectedModelText string
+		ExpectedLimits    string
+	}{
+		{
+			Case:              "Defaults",
+			Options:           options.Map{},
+			ExpectedModel:     true,
+			ExpectedReason:    false,
+			ExpectedContext:   true,
+			ExpectedTokens:    false,
+			ExpectedFiveHour:  false,
+			ExpectedWeekly:    true,
+			ExpectedModelText: "GPT-5.5",
+			ExpectedLimits:    "7d 74%",
+		},
+		{
+			Case: "Everything enabled",
+			Options: options.Map{
+				displayFiveHourLimit: true,
+				displayReasoning:     true,
+				displayTokens:        true,
+			},
+			ExpectedModel:     true,
+			ExpectedReason:    true,
+			ExpectedContext:   true,
+			ExpectedTokens:    true,
+			ExpectedFiveHour:  true,
+			ExpectedWeekly:    true,
+			ExpectedModelText: "GPT-5.5 (high)",
+			ExpectedLimits:    "5h 87% 7d 74%",
+		},
+		{
+			Case: "Minimal limits only",
+			Options: options.Map{
+				displayModel:         false,
+				displayContext:       false,
+				displayWeeklyLimit:   false,
+				displayFiveHourLimit: true,
+			},
+			ExpectedModel:     false,
+			ExpectedReason:    false,
+			ExpectedContext:   false,
+			ExpectedTokens:    false,
+			ExpectedFiveHour:  true,
+			ExpectedWeekly:    false,
+			ExpectedModelText: "",
+			ExpectedLimits:    "5h 87%",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Case, func(t *testing.T) {
+			segment := &Codex{
+				Base: Base{
+					env:     new(mock.Environment),
+					options: tc.Options,
+				},
+			}
+
+			require.True(t, segment.Enabled())
+			assert.Equal(t, tc.ExpectedModel, segment.DisplayModel())
+			assert.Equal(t, tc.ExpectedReason, segment.DisplayReasoning())
+			assert.Equal(t, tc.ExpectedContext, segment.DisplayContext())
+			assert.Equal(t, tc.ExpectedTokens, segment.DisplayTokens())
+			assert.Equal(t, tc.ExpectedFiveHour, segment.DisplayFiveHourLimit())
+			assert.Equal(t, tc.ExpectedWeekly, segment.DisplayWeeklyLimit())
+			assert.Equal(t, tc.ExpectedModelText, segment.FormattedModel())
+			assert.Equal(t, tc.ExpectedLimits, segment.FormattedLimits())
+		})
+	}
+}

--- a/src/segments/codex_test.go
+++ b/src/segments/codex_test.go
@@ -231,6 +231,81 @@ func TestCodexSegmentStatusEnv(t *testing.T) {
 	assert.Equal(t, "gpt-5.5", segment.Model.DisplayName)
 }
 
+func TestCodexSegmentInvalidCacheFallsBackToStatusFile(t *testing.T) {
+	cache.Set(cache.Session, cache.CODEXCACHE, CodexData{}, cache.INFINITE)
+	defer cache.Delete(cache.Session, cache.CODEXCACHE)
+
+	status := `{
+		"type": "token_count",
+		"thread_id": "thread-from-file-after-cache-miss",
+		"model": "gpt-5.5"
+	}`
+
+	env := new(mock.Environment)
+	env.On("Getenv", defaultCodexStatusFileEnv).Return("/tmp/codex-status.json")
+	env.On("FileContent", "/tmp/codex-status.json").Return(status)
+
+	segment := &Codex{
+		Base: Base{
+			env:     env,
+			options: options.Map{},
+		},
+	}
+
+	require.True(t, segment.Enabled())
+	assert.Equal(t, "thread-from-file-after-cache-miss", segment.ThreadID)
+	assert.Equal(t, "gpt-5.5", segment.Model.DisplayName)
+
+	_, found := cache.Get[CodexData](cache.Session, cache.CODEXCACHE)
+	assert.False(t, found)
+}
+
+func TestCodexSegmentInvalidStatusFileFallsBackToStatusEnv(t *testing.T) {
+	cache.Delete(cache.Session, cache.CODEXCACHE)
+
+	status := `{
+		"type": "token_count",
+		"thread_id": "thread-from-env-after-file-miss",
+		"model": "gpt-5.5"
+	}`
+
+	env := new(mock.Environment)
+	env.On("Getenv", defaultCodexStatusFileEnv).Return("/tmp/codex-status.json")
+	env.On("FileContent", "/tmp/codex-status.json").Return(`{"type":"token_count"}`)
+	env.On("Getenv", defaultCodexStatusJSONEnv).Return(status)
+
+	segment := &Codex{
+		Base: Base{
+			env:     env,
+			options: options.Map{},
+		},
+	}
+
+	require.True(t, segment.Enabled())
+	assert.Equal(t, "thread-from-env-after-file-miss", segment.ThreadID)
+	assert.Equal(t, "gpt-5.5", segment.Model.DisplayName)
+}
+
+func TestCodexSegmentEmptyRateLimitsDisabled(t *testing.T) {
+	cache.Set(cache.Session, cache.CODEXCACHE, CodexData{
+		RateLimits: &CodexRateLimits{},
+	}, cache.INFINITE)
+	defer cache.Delete(cache.Session, cache.CODEXCACHE)
+
+	env := new(mock.Environment)
+	env.On("Getenv", defaultCodexStatusFileEnv).Return("")
+	env.On("Getenv", defaultCodexStatusJSONEnv).Return("")
+
+	segment := &Codex{
+		Base: Base{
+			env:     env,
+			options: options.Map{},
+		},
+	}
+
+	assert.False(t, segment.Enabled())
+}
+
 func TestCodexFormattedTextUsesOptionsWithoutEnabled(t *testing.T) {
 	primary := 12.5
 	secondary := 26.0

--- a/src/shell/constants.go
+++ b/src/shell/constants.go
@@ -11,5 +11,6 @@ const (
 	ELVISH     = "elvish"
 	XONSH      = "xonsh"
 	CLAUDE     = "claude"
+	CODEX      = "codex"
 	COPILOTCLI = "copilot-cli"
 )

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -1349,6 +1349,7 @@
             "description": "https://ohmyposh.dev/docs/segments/cli/codex",
             "properties": {
               "options": {
+                "type": "object",
                 "properties": {
                   "display_model": {
                     "type": "boolean",

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -383,6 +383,7 @@
             "cf",
             "cftarget",
             "claude",
+            "codex",
             "clojure",
             "cmake",
             "copilot",
@@ -1317,6 +1318,91 @@
             "properties": {
               "options": {
                 "properties": {
+                  "gauge_marked_char": {
+                    "type": "string",
+                    "title": "Gauge marked character",
+                    "description": "The character used for the filled part of the token usage gauge",
+                    "default": "▰"
+                  },
+                  "gauge_unmarked_char": {
+                    "type": "string",
+                    "title": "Gauge unmarked character",
+                    "description": "The character used for the empty part of the token usage gauge",
+                    "default": "▱"
+                  }
+                },
+                "unevaluatedProperties": false
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "codex"
+              }
+            }
+          },
+          "then": {
+            "title": "OpenAI Codex Segment",
+            "description": "https://ohmyposh.dev/docs/segments/cli/codex",
+            "properties": {
+              "options": {
+                "properties": {
+                  "display_model": {
+                    "type": "boolean",
+                    "title": "Display model",
+                    "description": "Display the Codex model name in the default template",
+                    "default": true
+                  },
+                  "display_reasoning": {
+                    "type": "boolean",
+                    "title": "Display reasoning",
+                    "description": "Display the Codex reasoning level in the default template",
+                    "default": false
+                  },
+                  "display_context": {
+                    "type": "boolean",
+                    "title": "Display context",
+                    "description": "Display context window usage in the default template",
+                    "default": true
+                  },
+                  "display_tokens": {
+                    "type": "boolean",
+                    "title": "Display tokens",
+                    "description": "Display total token usage in the default template",
+                    "default": false
+                  },
+                  "display_five_hour_limit": {
+                    "type": "boolean",
+                    "title": "Display five-hour limit",
+                    "description": "Display the primary 5-hour rolling limit in the default template",
+                    "default": false
+                  },
+                  "display_weekly_limit": {
+                    "type": "boolean",
+                    "title": "Display weekly limit",
+                    "description": "Display the secondary 7-day rolling limit in the default template",
+                    "default": true
+                  },
+                  "status_file": {
+                    "type": "string",
+                    "title": "Status file",
+                    "description": "Path to a JSON file containing Codex status data"
+                  },
+                  "status_file_env": {
+                    "type": "string",
+                    "title": "Status file environment variable",
+                    "description": "Environment variable containing the Codex status file path",
+                    "default": "POSH_CODEX_STATUS_FILE"
+                  },
+                  "status_json_env": {
+                    "type": "string",
+                    "title": "Status JSON environment variable",
+                    "description": "Environment variable containing Codex status JSON",
+                    "default": "POSH_CODEX_STATUS"
+                  },
                   "gauge_marked_char": {
                     "type": "string",
                     "title": "Gauge marked character",

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -1387,6 +1387,27 @@
                     "description": "Display the secondary 7-day rolling limit in the default template",
                     "default": true
                   },
+                  "discover_local_status": {
+                    "type": "boolean",
+                    "title": "Discover local status",
+                    "description": "Discover Codex status from local session transcripts when no explicit status data is available",
+                    "default": true
+                  },
+                  "codex_home": {
+                    "type": "string",
+                    "title": "Codex home",
+                    "description": "Codex home directory; defaults to CODEX_HOME or ~/.codex"
+                  },
+                  "session_root": {
+                    "type": "string",
+                    "title": "Session root",
+                    "description": "Codex sessions directory; defaults to <codex_home>/sessions"
+                  },
+                  "session_id": {
+                    "type": "string",
+                    "title": "Session ID",
+                    "description": "Codex session/thread ID to render; defaults to the newest session with token usage"
+                  },
                   "status_file": {
                     "type": "string",
                     "title": "Status file",

--- a/website/docs/installation/prompt.mdx
+++ b/website/docs/installation/prompt.mdx
@@ -84,31 +84,42 @@ For more information about the Claude segment properties and customization optio
 </TabItem>
 <TabItem value="codex">
 
-To render OpenAI Codex session information with Oh My Posh, provide a compatible Codex status JSON
-payload to Oh My Posh.
+To render OpenAI Codex session information with Oh My Posh, use the `oh-my-posh codex`
+command. It reads the latest Codex `token_count` event from local Codex session transcripts
+under `$CODEX_HOME/sessions`, or `~/.codex/sessions` when `CODEX_HOME` is not set.
 
-The `oh-my-posh codex` command reads status JSON from standard input and renders a dedicated
-statusline prompt:
+The command renders a dedicated statusline prompt:
 
 ```bash
-cat codex-status.json | oh-my-posh codex
+oh-my-posh codex
 ```
 
 :::tip
 You can use the `--config` flag to point to a tailored Oh My Posh config just for Codex:
 
 ```bash
-cat codex-status.json | oh-my-posh codex --config /path/to/codex.omp.json
+oh-my-posh codex --config /path/to/codex.omp.json
 ```
 
 :::
 
-For regular shell prompts, write the Codex status payload to a file and point the segment at it with
-`status_file`, or set `POSH_CODEX_STATUS_FILE` to the file path. You can also set
-`POSH_CODEX_STATUS` directly to the JSON payload.
+To render a specific Codex session, pass its thread ID:
 
-The Codex segment does not authenticate to Codex or read Codex auth files. It only renders the
-status data you provide.
+```bash
+oh-my-posh codex --session 019e9eac-83ec-7393-ae18-cc2e566394d5
+```
+
+The Codex command does not authenticate to Codex, call Codex APIs, or read Codex auth files. It
+only reads local session metadata and `token_count` events. If status JSON is provided on standard
+input, standard input takes precedence over local session discovery:
+
+```bash
+cat codex-status.json | oh-my-posh codex
+```
+
+For regular shell prompts, you can also write a Codex status payload to a file and point the
+segment at it with `status_file`, set `POSH_CODEX_STATUS_FILE` to the file path, or set
+`POSH_CODEX_STATUS` directly to the JSON payload.
 
 For more information about the Codex segment properties and customization options, see the
 [Codex segment documentation].

--- a/website/docs/installation/prompt.mdx
+++ b/website/docs/installation/prompt.mdx
@@ -87,6 +87,7 @@ For more information about the Claude segment properties and customization optio
 To render OpenAI Codex session information with Oh My Posh, add the `codex` segment to your
 prompt config. The segment reads the latest Codex `token_count` event from local Codex session
 transcripts under `$CODEX_HOME/sessions`, or `~/.codex/sessions` when `CODEX_HOME` is not set.
+Use the standard segment `cache` setting to control how often local discovery refreshes.
 
 You can also use the `oh-my-posh codex` command to render a dedicated Codex statusline prompt:
 

--- a/website/docs/installation/prompt.mdx
+++ b/website/docs/installation/prompt.mdx
@@ -84,11 +84,11 @@ For more information about the Claude segment properties and customization optio
 </TabItem>
 <TabItem value="codex">
 
-To render OpenAI Codex session information with Oh My Posh, use the `oh-my-posh codex`
-command. It reads the latest Codex `token_count` event from local Codex session transcripts
-under `$CODEX_HOME/sessions`, or `~/.codex/sessions` when `CODEX_HOME` is not set.
+To render OpenAI Codex session information with Oh My Posh, add the `codex` segment to your
+prompt config. The segment reads the latest Codex `token_count` event from local Codex session
+transcripts under `$CODEX_HOME/sessions`, or `~/.codex/sessions` when `CODEX_HOME` is not set.
 
-The command renders a dedicated statusline prompt:
+You can also use the `oh-my-posh codex` command to render a dedicated Codex statusline prompt:
 
 ```bash
 oh-my-posh codex
@@ -109,17 +109,17 @@ To render a specific Codex session, pass its thread ID:
 oh-my-posh codex --session 019e9eac-83ec-7393-ae18-cc2e566394d5
 ```
 
-The Codex command does not authenticate to Codex, call Codex APIs, or read Codex auth files. It
-only reads local session metadata and `token_count` events. If status JSON is provided on standard
-input, standard input takes precedence over local session discovery:
+The Codex segment and command do not authenticate to Codex, call Codex APIs, or read Codex auth
+files. They only read local session metadata and `token_count` events. If status JSON is provided
+to the command on standard input, standard input takes precedence over local session discovery:
 
 ```bash
 cat codex-status.json | oh-my-posh codex
 ```
 
-For regular shell prompts, you can also write a Codex status payload to a file and point the
-segment at it with `status_file`, set `POSH_CODEX_STATUS_FILE` to the file path, or set
-`POSH_CODEX_STATUS` directly to the JSON payload.
+For regular shell prompts, explicit status data takes precedence over local session discovery. You
+can write a Codex status payload to a file and point the segment at it with `status_file`, set
+`POSH_CODEX_STATUS_FILE` to the file path, or set `POSH_CODEX_STATUS` directly to the JSON payload.
 
 For more information about the Codex segment properties and customization options, see the
 [Codex segment documentation].

--- a/website/docs/installation/prompt.mdx
+++ b/website/docs/installation/prompt.mdx
@@ -23,6 +23,7 @@ oh-my-posh get shell
     { label: 'bash', value: 'bash', },
     { label: 'claude', value: 'claude', },
     { label: 'cmd', value: 'cmd', },
+    { label: 'codex', value: 'codex', },
     { label: 'copilot', value: 'copilot', },
     { label: 'elvish', value: 'elvish', },
     { label: 'fish', value: 'fish', },
@@ -79,6 +80,38 @@ oh-my-posh claude --config /path/to/claude.omp.json
 :::
 
 For more information about the Claude segment properties and customization options, see the [Claude segment documentation](/docs/segments/cli/claude).
+
+</TabItem>
+<TabItem value="codex">
+
+To render OpenAI Codex session information with Oh My Posh, provide a compatible Codex status JSON
+payload to Oh My Posh.
+
+The `oh-my-posh codex` command reads status JSON from standard input and renders a dedicated
+statusline prompt:
+
+```bash
+cat codex-status.json | oh-my-posh codex
+```
+
+:::tip
+You can use the `--config` flag to point to a tailored Oh My Posh config just for Codex:
+
+```bash
+cat codex-status.json | oh-my-posh codex --config /path/to/codex.omp.json
+```
+
+:::
+
+For regular shell prompts, write the Codex status payload to a file and point the segment at it with
+`status_file`, or set `POSH_CODEX_STATUS_FILE` to the file path. You can also set
+`POSH_CODEX_STATUS` directly to the JSON payload.
+
+The Codex segment does not authenticate to Codex or read Codex auth files. It only renders the
+status data you provide.
+
+For more information about the Codex segment properties and customization options, see the
+[Codex segment documentation].
 
 </TabItem>
 <TabItem value="copilot">
@@ -281,6 +314,7 @@ exec zsh
 </Tabs>
 
 [Copilot CLI segment documentation]: /docs/segments/cli/copilot-cli
+[Codex segment documentation]: /docs/segments/cli/codex
 [clink]: https://chrisant996.github.io/clink/
 [iterm2]: https://iterm2.com/
 [sign]: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_signing?view=powershell-7.3#methods-of-signing-scripts

--- a/website/docs/segments/cli/codex.mdx
+++ b/website/docs/segments/cli/codex.mdx
@@ -29,6 +29,10 @@ import Config from "@site/src/components/Config.js";
     foreground: "#111111",
     background: "#10A37F",
     template: " {{ .FormattedText }} ",
+    cache: {
+      duration: "30s",
+      strategy: "device",
+    },
     options: {
       display_model: true,
       display_reasoning: true,
@@ -241,6 +245,9 @@ When the segment is added to a normal Oh My Posh config, it first checks the ses
 then `status_file`, then the file path in `POSH_CODEX_STATUS_FILE`, then the JSON payload in
 `POSH_CODEX_STATUS`. If none of those sources provide usable status data, it automatically
 reads the latest local Codex session `token_count` event.
+
+Use the standard segment `cache` setting to control how often local discovery refreshes. Without
+a segment cache, local discovery runs whenever the segment renders.
 
 The `oh-my-posh codex` command uses the same local discovery logic, caches the parsed data,
 then renders your configured statusline prompt. Standard input takes precedence when a

--- a/website/docs/segments/cli/codex.mdx
+++ b/website/docs/segments/cli/codex.mdx
@@ -10,8 +10,9 @@ Display OpenAI Codex session information including the current model, token usag
 context window usage, and available rate-limit data. Shows visual gauges for context
 usage, five-hour usage, and weekly usage.
 
-This segment is designed for Codex status payloads. It does not read Codex auth files
-or scrape private log databases.
+The `oh-my-posh codex` command reads the latest Codex `token_count` event from local
+Codex session transcripts under `$CODEX_HOME/sessions`, or `~/.codex/sessions` when
+`CODEX_HOME` is not set. It does not read Codex auth files or call Codex APIs.
 
 For setup instructions, see [Change your prompt](/docs/installation/prompt?shell=codex).
 
@@ -51,8 +52,9 @@ import Config from "@site/src/components/Config.js";
 
 ## Status Payload
 
-The segment accepts either a direct `token_count` payload or a Codex rollout `event_msg`
-wrapper whose `payload.type` is `token_count`.
+The Codex command discovers this payload from local Codex JSONL session transcripts by
+default. The segment also accepts either a direct `token_count` payload or a Codex rollout
+`event_msg` wrapper whose `payload.type` is `token_count`.
 
 ```json
 {
@@ -112,6 +114,14 @@ wrapper whose `payload.type` is `token_count`.
 | `status_json_env` | `string` | `POSH_CODEX_STATUS` | Environment variable containing Codex status JSON |
 | `gauge_marked_char` | `string` | `▰` | Character used for filled blocks in gauge visualizations |
 | `gauge_unmarked_char` | `string` | `▱` | Character used for empty blocks in gauge visualizations |
+
+## Command Options
+
+| Name | Description |
+| ---- | ----------- |
+| `--session <id>` | Render a specific Codex session/thread ID instead of the newest session with token usage |
+| `--codex-home <path>` | Override the Codex home directory; defaults to `CODEX_HOME` or `~/.codex` |
+| `--session-root <path>` | Override the Codex sessions directory; defaults to `<codex-home>/sessions` |
 
 ### Properties
 
@@ -223,14 +233,18 @@ the `gauge_marked_char` and `gauge_unmarked_char` options to apply.
 
 ## How it works
 
-The `oh-my-posh codex` command reads Codex status JSON from stdin, caches the parsed
-data, then renders your configured prompt. Oh My Posh renders the status payload you
-provide; it does not discover Codex state by itself.
+The `oh-my-posh codex` command reads the latest local Codex session `token_count` event,
+caches the parsed data, then renders your configured prompt. Standard input takes precedence
+when a payload is piped to the command:
+
+```bash
+oh-my-posh codex --config ~/.config/ohmyposh/codex.omp.json < codex-status.json
+```
 
 For normal prompt rendering, the segment can also read status data from
 `status_file`, from the file path in `POSH_CODEX_STATUS_FILE`, or from the JSON
 payload in `POSH_CODEX_STATUS`. This is useful when the prompt is rendered outside
-the Codex statusline process.
+the Codex command process.
 
 The segment is only visible when Codex status data is available.
 

--- a/website/docs/segments/cli/codex.mdx
+++ b/website/docs/segments/cli/codex.mdx
@@ -136,8 +136,8 @@ wrapper whose `payload.type` is `token_count`.
 | `.FormattedText` | `string` | Default Codex segment text assembled from display options |
 | `.FormattedModel` | `string` | Model text assembled from `display_model` and `display_reasoning` |
 | `.TokenUsagePercent` | `Percentage` | Percentage of model context window used by the latest token usage snapshot (0-100) |
-| `.TokenGauge` | `string` | Gauge showing remaining context capacity |
-| `.TokenGaugeUsed` | `string` | Gauge showing used context capacity |
+| `.TokenGauge` | `string` | Gauge showing remaining context capacity; empty when context usage is unavailable |
+| `.TokenGaugeUsed` | `string` | Gauge showing used context capacity; empty when context usage is unavailable |
 | `.RemainingPercent` | `Percentage` | Percentage of model context window remaining (0-100) |
 | `.RemainingTokensCount` | `int` | Number of remaining context window tokens; 0 when unavailable |
 | `.FormattedTokens` | `string` | Human-readable total token count |
@@ -150,13 +150,13 @@ wrapper whose `payload.type` is `token_count`.
 | `.WeeklyUsage` | `Percentage` | Secondary rolling window usage percentage (0-100) |
 | `.FiveHourRemaining` | `Percentage` | Primary rolling window remaining percentage (0-100) |
 | `.WeeklyRemaining` | `Percentage` | Secondary rolling window remaining percentage (0-100) |
-| `.FiveHourGauge` | `string` | Gauge showing primary rolling window usage |
-| `.WeeklyGauge` | `string` | Gauge showing weekly rolling window usage |
-| `.FiveHourRemainingGauge` | `string` | Gauge showing primary rolling quota remaining |
-| `.WeeklyRemainingGauge` | `string` | Gauge showing weekly quota remaining |
-| `.FormattedFiveHourRemaining` | `string` | Primary rolling window remaining with a percent sign |
-| `.FormattedWeeklyRemaining` | `string` | Weekly rolling window remaining with a percent sign |
-| `.FormattedLimits` | `string` | Default remaining-limit text, controlled by the limit display options |
+| `.FiveHourGauge` | `string` | Gauge showing primary rolling window usage; empty when unavailable |
+| `.WeeklyGauge` | `string` | Gauge showing weekly rolling window usage; empty when unavailable |
+| `.FiveHourRemainingGauge` | `string` | Gauge showing primary rolling quota remaining; empty when unavailable |
+| `.WeeklyRemainingGauge` | `string` | Gauge showing weekly quota remaining; empty when unavailable |
+| `.FormattedFiveHourRemaining` | `string` | Primary rolling window remaining with a percent sign; empty when unavailable |
+| `.FormattedWeeklyRemaining` | `string` | Weekly rolling window remaining with a percent sign; empty when unavailable |
+| `.FormattedLimits` | `string` | Default remaining-limit text, controlled by available limit data and display options |
 | `.FiveHourResetsAt` | `time.Time` | Reset time for the primary rolling window, or zero when unavailable |
 | `.WeeklyResetsAt` | `time.Time` | Reset time for the weekly rolling window, or zero when unavailable |
 | `.FiveHourResetsIn` | `time.Duration` | Time until the primary rolling window resets; 0 when unavailable |

--- a/website/docs/segments/cli/codex.mdx
+++ b/website/docs/segments/cli/codex.mdx
@@ -10,9 +10,9 @@ Display OpenAI Codex session information including the current model, token usag
 context window usage, and available rate-limit data. Shows visual gauges for context
 usage, five-hour usage, and weekly usage.
 
-The `oh-my-posh codex` command reads the latest Codex `token_count` event from local
-Codex session transcripts under `$CODEX_HOME/sessions`, or `~/.codex/sessions` when
-`CODEX_HOME` is not set. It does not read Codex auth files or call Codex APIs.
+The segment reads the latest Codex `token_count` event from local Codex session
+transcripts under `$CODEX_HOME/sessions`, or `~/.codex/sessions` when `CODEX_HOME`
+is not set. It does not read Codex auth files or call Codex APIs.
 
 For setup instructions, see [Change your prompt](/docs/installation/prompt?shell=codex).
 
@@ -52,8 +52,8 @@ import Config from "@site/src/components/Config.js";
 
 ## Status Payload
 
-The Codex command discovers this payload from local Codex JSONL session transcripts by
-default. The segment also accepts either a direct `token_count` payload or a Codex rollout
+The segment discovers this payload from local Codex JSONL session transcripts by
+default. It also accepts either a direct `token_count` payload or a Codex rollout
 `event_msg` wrapper whose `payload.type` is `token_count`.
 
 ```json
@@ -109,6 +109,10 @@ default. The segment also accepts either a direct `token_count` payload or a Cod
 | `display_tokens` | `boolean` | `false` | Display total token usage in the default template |
 | `display_five_hour_limit` | `boolean` | `false` | Display the 5-hour limit in the default template |
 | `display_weekly_limit` | `boolean` | `true` | Display the 7-day limit in the default template |
+| `discover_local_status` | `boolean` | `true` | Discover Codex status from local session transcripts when no explicit status data is available |
+| `codex_home` | `string` | `CODEX_HOME` or `~/.codex` | Codex home directory |
+| `session_root` | `string` | `<codex_home>/sessions` | Codex sessions directory |
+| `session_id` | `string` | `""` | Codex session/thread ID to render; defaults to the newest session with token usage |
 | `status_file` | `string` | `""` | Path to a JSON file containing Codex status data |
 | `status_file_env` | `string` | `POSH_CODEX_STATUS_FILE` | Environment variable containing a Codex status file path |
 | `status_json_env` | `string` | `POSH_CODEX_STATUS` | Environment variable containing Codex status JSON |
@@ -233,18 +237,18 @@ the `gauge_marked_char` and `gauge_unmarked_char` options to apply.
 
 ## How it works
 
-The `oh-my-posh codex` command reads the latest local Codex session `token_count` event,
-caches the parsed data, then renders your configured prompt. Standard input takes precedence
-when a payload is piped to the command:
+When the segment is added to a normal Oh My Posh config, it first checks the session cache,
+then `status_file`, then the file path in `POSH_CODEX_STATUS_FILE`, then the JSON payload in
+`POSH_CODEX_STATUS`. If none of those sources provide usable status data, it automatically
+reads the latest local Codex session `token_count` event.
+
+The `oh-my-posh codex` command uses the same local discovery logic, caches the parsed data,
+then renders your configured statusline prompt. Standard input takes precedence when a
+payload is piped to the command:
 
 ```bash
 oh-my-posh codex --config ~/.config/ohmyposh/codex.omp.json < codex-status.json
 ```
-
-For normal prompt rendering, the segment can also read status data from
-`status_file`, from the file path in `POSH_CODEX_STATUS_FILE`, or from the JSON
-payload in `POSH_CODEX_STATUS`. This is useful when the prompt is rendered outside
-the Codex command process.
 
 The segment is only visible when Codex status data is available.
 

--- a/website/docs/segments/cli/codex.mdx
+++ b/website/docs/segments/cli/codex.mdx
@@ -1,0 +1,240 @@
+---
+id: codex
+title: OpenAI Codex
+sidebar_label: OpenAI Codex
+---
+
+## What
+
+Display OpenAI Codex session information including the current model, token usage,
+context window usage, and available rate-limit data. Shows visual gauges for context
+usage, five-hour usage, and weekly usage.
+
+This segment is designed for Codex status payloads. It does not read Codex auth files
+or scrape private log databases.
+
+For setup instructions, see [Change your prompt](/docs/installation/prompt?shell=codex).
+
+## Sample Configuration
+
+import Config from "@site/src/components/Config.js";
+
+<Config
+  data={{
+    type: "codex",
+    style: "diamond",
+    leading_diamond: "\ue0b6",
+    trailing_diamond: "\ue0b4",
+    foreground: "#111111",
+    background: "#10A37F",
+    template: " {{ .FormattedText }} ",
+    options: {
+      display_model: true,
+      display_reasoning: true,
+      display_context: true,
+      display_tokens: true,
+      display_five_hour_limit: true,
+      display_weekly_limit: true,
+    },
+  }}
+/>
+
+## Template ([info][templates])
+
+:::note default template
+
+```template
+ {{ .FormattedText }}
+```
+
+:::
+
+## Status Payload
+
+The segment accepts either a direct `token_count` payload or a Codex rollout `event_msg`
+wrapper whose `payload.type` is `token_count`.
+
+```json
+{
+  "type": "token_count",
+  "thread_id": "019e9eac-83ec-7393-ae18-cc2e566394d5",
+  "version": "0.137.0",
+  "reasoning_effort": "high",
+  "model": {
+    "id": "gpt-5",
+    "display_name": "gpt-5"
+  },
+  "info": {
+    "total_token_usage": {
+      "input_tokens": 420000,
+      "cached_input_tokens": 300000,
+      "output_tokens": 24000,
+      "reasoning_output_tokens": 8000,
+      "total_tokens": 444000
+    },
+    "last_token_usage": {
+      "input_tokens": 150000,
+      "cached_input_tokens": 120000,
+      "output_tokens": 4000,
+      "reasoning_output_tokens": 1500,
+      "total_tokens": 154000
+    },
+    "model_context_window": 258000
+  },
+  "rate_limits": {
+    "primary": {
+      "used_percent": 12,
+      "window_minutes": 300,
+      "resets_at": 1780794869
+    },
+    "secondary": {
+      "used_percent": 28,
+      "window_minutes": 10080,
+      "resets_at": 1781137565
+    },
+    "plan_type": "pro"
+  }
+}
+```
+
+## Options
+
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `display_model` | `boolean` | `true` | Display the model name in the default template |
+| `display_reasoning` | `boolean` | `false` | Display the reasoning level in the default template |
+| `display_context` | `boolean` | `true` | Display context window usage in the default template |
+| `display_tokens` | `boolean` | `false` | Display total token usage in the default template |
+| `display_five_hour_limit` | `boolean` | `false` | Display the 5-hour limit in the default template |
+| `display_weekly_limit` | `boolean` | `true` | Display the 7-day limit in the default template |
+| `status_file` | `string` | `""` | Path to a JSON file containing Codex status data |
+| `status_file_env` | `string` | `POSH_CODEX_STATUS_FILE` | Environment variable containing a Codex status file path |
+| `status_json_env` | `string` | `POSH_CODEX_STATUS` | Environment variable containing Codex status JSON |
+| `gauge_marked_char` | `string` | `▰` | Character used for filled blocks in gauge visualizations |
+| `gauge_unmarked_char` | `string` | `▱` | Character used for empty blocks in gauge visualizations |
+
+### Properties
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `.Type` | `string` | Codex event type, commonly `token_count` |
+| `.ThreadID` | `string` | Unique identifier for the Codex thread |
+| `.CWD` | `string` | Current working directory |
+| `.Version` | `string` | Codex CLI version |
+| `.ReasoningEffort` | `string` | Configured reasoning effort |
+| `.ApprovalMode` | `string` | Active approval mode |
+| `.SandboxPolicy` | `string` | Active sandbox policy |
+| `.Model` | `Model` | AI model information |
+| `.Info` | `TokenInfo` | Token usage information |
+| `.RateLimits` | `RateLimits` | Rate limit information; `nil` when Codex does not provide it |
+| `.DisplayModel` | `boolean` | Whether the default template displays the model name |
+| `.DisplayReasoning` | `boolean` | Whether the default template displays the reasoning level |
+| `.DisplayContext` | `boolean` | Whether the default template displays context usage |
+| `.DisplayTokens` | `boolean` | Whether the default template displays total tokens |
+| `.DisplayFiveHourLimit` | `boolean` | Whether the default template displays the 5-hour limit |
+| `.DisplayWeeklyLimit` | `boolean` | Whether the default template displays the 7-day limit |
+| `.FormattedText` | `string` | Default Codex segment text assembled from display options |
+| `.FormattedModel` | `string` | Model text assembled from `display_model` and `display_reasoning` |
+| `.TokenUsagePercent` | `Percentage` | Percentage of model context window used by the latest token usage snapshot (0-100) |
+| `.TokenGauge` | `string` | Gauge showing remaining context capacity |
+| `.TokenGaugeUsed` | `string` | Gauge showing used context capacity |
+| `.RemainingPercent` | `Percentage` | Percentage of model context window remaining (0-100) |
+| `.RemainingTokensCount` | `int` | Number of remaining context window tokens; 0 when unavailable |
+| `.FormattedTokens` | `string` | Human-readable total token count |
+| `.FormattedInputTokens` | `string` | Human-readable input token count |
+| `.FormattedOutputTokens` | `string` | Human-readable output token count |
+| `.FormattedReasoningTokens` | `string` | Human-readable reasoning output token count |
+| `.FormattedCachedInputTokens` | `string` | Human-readable cached input token count |
+| `.FormattedLastTokens` | `string` | Human-readable token count for the latest response |
+| `.FiveHourUsage` | `Percentage` | Primary rolling window usage percentage (0-100) |
+| `.WeeklyUsage` | `Percentage` | Secondary rolling window usage percentage (0-100) |
+| `.FiveHourRemaining` | `Percentage` | Primary rolling window remaining percentage (0-100) |
+| `.WeeklyRemaining` | `Percentage` | Secondary rolling window remaining percentage (0-100) |
+| `.FiveHourGauge` | `string` | Gauge showing primary rolling window usage |
+| `.WeeklyGauge` | `string` | Gauge showing weekly rolling window usage |
+| `.FiveHourRemainingGauge` | `string` | Gauge showing primary rolling quota remaining |
+| `.WeeklyRemainingGauge` | `string` | Gauge showing weekly quota remaining |
+| `.FormattedFiveHourRemaining` | `string` | Primary rolling window remaining with a percent sign |
+| `.FormattedWeeklyRemaining` | `string` | Weekly rolling window remaining with a percent sign |
+| `.FormattedLimits` | `string` | Default remaining-limit text, controlled by the limit display options |
+| `.FiveHourResetsAt` | `time.Time` | Reset time for the primary rolling window, or zero when unavailable |
+| `.WeeklyResetsAt` | `time.Time` | Reset time for the weekly rolling window, or zero when unavailable |
+| `.FiveHourResetsIn` | `time.Duration` | Time until the primary rolling window resets; 0 when unavailable |
+| `.WeeklyResetsIn` | `time.Duration` | Time until the weekly rolling window resets; 0 when unavailable |
+
+#### Model Properties
+
+| Name           | Type     | Description                 |
+| -------------- | -------- | --------------------------- |
+| `.ID`          | `string` | Technical model identifier  |
+| `.DisplayName` | `string` | Human-readable model name   |
+
+#### TokenInfo Properties
+
+| Name                  | Type         | Description                       |
+| --------------------- | ------------ | --------------------------------- |
+| `.TotalTokenUsage`    | `TokenUsage` | Total token usage for the session |
+| `.LastTokenUsage`     | `TokenUsage` | Token usage for the latest call   |
+| `.ModelContextWindow` | `int`        | Active model context window size  |
+
+#### TokenUsage Properties
+
+| Name                     | Type  | Description                   |
+| ------------------------ | ----- | ----------------------------- |
+| `.InputTokens`           | `int` | Input tokens                  |
+| `.CachedInputTokens`     | `int` | Cached input tokens           |
+| `.OutputTokens`          | `int` | Output tokens                 |
+| `.ReasoningOutputTokens` | `int` | Reasoning output tokens       |
+| `.TotalTokens`           | `int` | Total tokens                  |
+
+#### RateLimits Properties
+
+| Name                    | Type              | Description                                   |
+| ----------------------- | ----------------- | --------------------------------------------- |
+| `.LimitID`              | `string`          | Rate limit identifier                         |
+| `.LimitName`            | `string`          | Human-readable rate limit name                |
+| `.Primary`              | `RateLimitWindow` | Primary rolling limit window                  |
+| `.Secondary`            | `RateLimitWindow` | Secondary rolling limit window, usually weekly |
+| `.PlanType`             | `string`          | Active plan type                              |
+| `.RateLimitReachedType` | `string`          | Reached limit type; empty when not limited    |
+
+#### RateLimitWindow Properties
+
+| Name             | Type       | Description                                       |
+| ---------------- | ---------- | ------------------------------------------------- |
+| `.UsedPercent`   | `*float64` | Percentage used (0-100); `nil` when unavailable   |
+| `.WindowMinutes` | `int`      | Window size in minutes                            |
+| `.ResetsAt`      | `*int64`   | Unix timestamp when the window resets             |
+
+### Percentage Methods
+
+The `Percentage` type provides additional methods for direct use in templates:
+
+| Method       | Returns  | Description                                                               |
+| ------------ | -------- | ------------------------------------------------------------------------- |
+| `.Gauge`     | `string` | Visual gauge showing remaining capacity using hardcoded `▰`/`▱` characters |
+| `.GaugeUsed` | `string` | Visual gauge showing used capacity using hardcoded `▰`/`▱` characters     |
+| `.String`    | `string` | Numeric percentage value (e.g., "75")                                     |
+
+:::tip Custom gauge characters
+Use the segment gauge methods instead of raw `.Percentage` methods when you want
+the `gauge_marked_char` and `gauge_unmarked_char` options to apply.
+:::
+
+## How it works
+
+The `oh-my-posh codex` command reads Codex status JSON from stdin, caches the parsed
+data, then renders your configured prompt. Oh My Posh renders the status payload you
+provide; it does not discover Codex state by itself.
+
+For normal prompt rendering, the segment can also read status data from
+`status_file`, from the file path in `POSH_CODEX_STATUS_FILE`, or from the JSON
+payload in `POSH_CODEX_STATUS`. This is useful when the prompt is rendered outside
+the Codex statusline process.
+
+The segment is only visible when Codex status data is available.
+
+The parser accepts either a direct Codex token-count payload or a Codex rollout
+`event_msg` wrapper whose `payload.type` is `token_count`.
+
+[templates]: /docs/configuration/templates

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -61,6 +61,7 @@ export default {
             "segments/cli/bun",
             "segments/cli/claude",
             "segments/cli/cmake",
+            "segments/cli/codex",
             "segments/cli/copilot",
             "segments/cli/copilot-cli",
             "segments/cli/deno",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

adds a native OpenAI Codex segment and a matching `oh-my-posh codex` command.

this follows the same general shape as the Claude/Copilot CLI status data segments, but does not try to read Codex auth files or scrape private state. the segment renders Codex status JSON provided through stdin, a status file, or env vars.

included here:

- new `codex` segment with model, reasoning, token, context, and rate limit helpers
- `oh-my-posh codex` command for rendering supplied Codex status JSON
- schema/sidebar/default config registration
- docs for the segment and the prompt setup path
- tests for direct and wrapped payloads, unsupported events, env/file data sources, display options, gauges, and cache-safe rendering

validated with:

- `go test ./segments -run TestCodex`
- `go test ./...`
- `golangci-lint run`
- `npm run build`
- `git diff --check`

note: docs build still reports the existing unrelated broken anchor for `/docs/installation/customize -> /docs/themes#jandedobbeleer`.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary