### PR TITLE
feat(project): add Lean 4 lakefile project name detection

### DIFF
--- a/src/segments/project.go
+++ b/src/segments/project.go
@@ -30,6 +30,11 @@ type ProjectData struct {
 	Target  string
 }
 
+// Lake file package
+type LakeFileTOML struct {
+	Name string
+}
+
 // Rust Cargo package
 type CargoTOML struct {
 	Package ProjectData
@@ -117,6 +122,11 @@ func (n *Project) Enabled() bool {
 			Name:    juliaToolName,
 			Files:   []string{"JuliaProject.toml", "Project.toml"},
 			Fetcher: n.getProjectData,
+		},
+		{
+			Name:    "lake",
+			Files:   []string{"lakefile.lean", "lakefile.toml"},
+			Fetcher: n.getLakePackage,
 		},
 		{
 			Name:    "powershell",
@@ -346,6 +356,51 @@ func (n *Project) getPowerShellModuleData(_ ProjectItem) *ProjectData {
 	}
 
 	return data
+}
+
+func (n *Project) getLakePackage(item ProjectItem) *ProjectData {
+	file := n.firstExistingFile(item.Files)
+	if len(file) == 0 {
+		return nil
+	}
+
+	if strings.HasSuffix(file, ".lean") {
+		return n.getLakeLeanPackage(file)
+	}
+
+	return n.getLakeTomlPackage(file)
+}
+
+func (n *Project) getLakeLeanPackage(file string) *ProjectData {
+	content := n.env.FileContent(file)
+
+	match := regex.FindNamedRegexMatch(`package\s+(?P<NAME>.+?)\s+where`, content)
+	name, ok := match["NAME"]
+	if !ok || len(name) == 0 {
+		return nil
+	}
+
+	// Strip guillemets (Unicode «\u00AB» and »\u00BB) if present
+	name = strings.Trim(name, "«\u00AB\u00BB")
+
+	return &ProjectData{
+		Name: strings.TrimSpace(name),
+	}
+}
+
+func (n *Project) getLakeTomlPackage(file string) *ProjectData {
+	content := n.env.FileContent(file)
+
+	var data LakeFileTOML
+	err := toml.Unmarshal([]byte(content), &data)
+	if err != nil {
+		n.Error = err.Error()
+		return nil
+	}
+
+	return &ProjectData{
+		Name: data.Name,
+	}
 }
 
 func (n *Project) getProjectData(item ProjectItem) *ProjectData {

--- a/src/segments/project.go
+++ b/src/segments/project.go
@@ -380,8 +380,8 @@ func (n *Project) getLakeLeanPackage(file string) *ProjectData {
 		return nil
 	}
 
-	// Strip guillemets (Unicode «\u00AB» and »\u00BB) if present
-	name = strings.Trim(name, "«\u00AB\u00BB")
+	// Strip guillemets (« U+00AB and » U+00BB) if present
+	name = strings.Trim(name, "\u00AB\u00BB")
 
 	return &ProjectData{
 		Name: strings.TrimSpace(name),

--- a/src/segments/project_test.go
+++ b/src/segments/project_test.go
@@ -429,6 +429,52 @@ func TestPackage(t *testing.T) {
 			File:            "JuliaProject.toml",
 			PackageContents: "[",
 		},
+		{
+			Case:            "lakefile.lean plain name",
+			ExpectedEnabled: true,
+			ExpectedString:  "Example1",
+			Name:            "lake",
+			File:            "lakefile.lean",
+			PackageContents: "import Lake\nopen Lake DSL\n\npackage Example1 where\n\nlean_lib Example1 where\n  precompileModules := true\n",
+		},
+		{
+			Case:            "lakefile.lean guillemet name",
+			ExpectedEnabled: true,
+			ExpectedString:  "Example2",
+			Name:            "lake",
+			File:            "lakefile.lean",
+			PackageContents: "import Lake\nopen Lake DSL\n\npackage «Example2» where\n\nrequire mathlib from git\n  \"https://github.com/leanprover-community/mathlib4.git\"\n",
+		},
+		{
+			Case:            "lakefile.toml name",
+			ExpectedEnabled: true,
+			ExpectedString:  "example",
+			Name:            "lake",
+			File:            "lakefile.toml",
+			PackageContents: "name = \"example\"\ndefaultTargets = [\"Example\"]\n\n[[require]]\nname = \"foo\"\npath = \"foo\"\n",
+		},
+		{
+			Case:            "lakefile.lean no package name",
+			ExpectedEnabled: false,
+			Name:            "lake",
+			File:            "lakefile.lean",
+			PackageContents: "import Lake\nopen Lake DSL\n\nlean_lib Foo where\n",
+		},
+		{
+			Case:            "lakefile.toml no name",
+			ExpectedEnabled: true,
+			ExpectedString:  "",
+			Name:            "lake",
+			File:            "lakefile.toml",
+			PackageContents: "defaultTargets = [\"Example\"]\n",
+		},
+		{
+			Case:            "lakefile.toml invalid toml",
+			ExpectedString:  "toml: line 1: unexpected end of table name (table names cannot be empty)",
+			Name:            "lake",
+			File:            "lakefile.toml",
+			PackageContents: "[",
+		},
 	}
 
 	for _, tc := range cases {

--- a/website/docs/segments/system/project.mdx
+++ b/website/docs/segments/system/project.mdx
@@ -22,6 +22,7 @@ Supports:
 - .NET project (`*.sln`, `*.slnf`, `*.slnx`, `*.csproj`, `*.vbproj` or `*.fsproj`, first file match info is displayed)
 - Julia project (`JuliaProject.toml`, `Project.toml`)
 - PowerShell project (`*.psd1`, first file match info is displayed)
+- Lean 4 project (`lakefile.lean`, `lakefile.toml`)
 
 ## Sample Configuration
 
@@ -60,7 +61,7 @@ import Config from "@site/src/components/Config.js";
 
 | Name       | Type     | Description                                                                                                                                                                                      |
 | ---------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `.Type`    | `string` | The type of project:<ul><li>`node`</li><li>`deno`</li><li>`jsr`</li><li>`cargo`</li><li>`python`</li><li>`mojo`</li><li>`php`</li><li>`dart`</li><li>`nuspec`</li><li>`dotnet`</li><li>`julia`</li><li>`powershell`</li></ul> |
+| `.Type`    | `string` | The type of project:<ul><li>`node`</li><li>`deno`</li><li>`jsr`</li><li>`cargo`</li><li>`python`</li><li>`mojo`</li><li>`php`</li><li>`dart`</li><li>`nuspec`</li><li>`dotnet`</li><li>`julia`</li><li>`powershell`</li><li>`lake`</li></ul> |
 | `.Version` | `string` | The version of your project                                                                                                                                                                      |
 | `.Target`  | `string` | The target framework/language version of your project                                                                                                                                            |
 | `.Name`    | `string` | The name of your project                                                                                                                                                                         |


### PR DESCRIPTION
Support lakefile.lean (plain and guillemet-quoted names via regex) and lakefile.toml (name field via TOML parsing).

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

This commit was entirely generated by AI;

I don't use Go, I just did a simple review.

Add project dectection support for Lean4 lakefile

[Lean4](https://github.com/leanprover/lean4)
[Lake](https://github.com/leanprover/lean4/tree/master/src/lake)

---

Examples:

```lean
package Example1 where
...
```

```lean
package «Example2» where
...
```

```toml
name = "example"
...
```
