### PR TITLE
feat: add OpenAI Codex segment

### DIFF
--- a/src/cache/cache.go
+++ b/src/cache/cache.go
@@ -24,6 +24,7 @@ const (
 	ENGINECACHE      = "engine_cache"
 	FONTLISTCACHE    = "font_list_cache"
 	CLAUDECACHE      = "claude_cache"
+	CODEXCACHE       = "codex_cache"
 	COPILOTCLICACHE  = "copilot_cli_cache"
 )
 

--- a/src/cli/claude.go
+++ b/src/cli/claude.go
@@ -18,6 +18,9 @@ This command reads Claude Code's contextual JSON data from stdin and renders
 a prompt that can include a Claude segment with session information like
 model name, costs, tokens, and more.
 
+Stdin is read only when data is piped or redirected to the command; interactive
+terminal stdin is ignored to avoid blocking.
+
 Example usage in Claude Code settings:
   "statusLine": {
     "command": "oh-my-posh claude --config ~/.config/ohmyposh/claude.toml"

--- a/src/cli/codex.go
+++ b/src/cli/codex.go
@@ -19,13 +19,11 @@ session transcripts. It reads the newest token_count event from
 $CODEX_HOME/sessions, falling back to ~/.codex/sessions when CODEX_HOME is not set.
 
 When JSON is provided on stdin, stdin takes precedence over local session discovery.
-This is useful for scripts that emit Codex status data, including hook-driven
-workflows that generate a token_count payload.
+This is useful for tests or scripts that already emit a token_count payload.
 
 Example usage:
   oh-my-posh codex --config ~/.config/ohmyposh/codex.omp.json
-  oh-my-posh codex --session 019e9eac-83ec-7393-ae18-cc2e566394d5
-  cat codex-status.json | oh-my-posh codex --config ~/.config/ohmyposh/codex.omp.json`,
+  oh-my-posh codex --session 019e9eac-83ec-7393-ae18-cc2e566394d5`,
 	Args: cobra.NoArgs,
 	Run: statuslineRunWithDataSource[segments.CodexData](
 		shell.CODEX,

--- a/src/cli/codex.go
+++ b/src/cli/codex.go
@@ -1,0 +1,44 @@
+package cli
+
+import (
+	"github.com/jandedobbeleer/oh-my-posh/src/cache"
+	"github.com/jandedobbeleer/oh-my-posh/src/config"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments"
+	"github.com/jandedobbeleer/oh-my-posh/src/shell"
+
+	"github.com/spf13/cobra"
+)
+
+var codexCmd = &cobra.Command{
+	Use:   "codex",
+	Short: "Render a prompt for OpenAI Codex status data",
+	Long: `Render a prompt for OpenAI Codex status data.
+
+This command renders the latest OpenAI Codex token usage data from local Codex
+session transcripts. It reads the newest token_count event from
+$CODEX_HOME/sessions, falling back to ~/.codex/sessions when CODEX_HOME is not set.
+
+When JSON is provided on stdin, stdin takes precedence over local session discovery.
+This is useful for scripts that emit Codex status data, including hook-driven
+workflows that generate a token_count payload.
+
+Example usage:
+  oh-my-posh codex --config ~/.config/ohmyposh/codex.omp.json
+  oh-my-posh codex --session 019e9eac-83ec-7393-ae18-cc2e566394d5
+  cat codex-status.json | oh-my-posh codex --config ~/.config/ohmyposh/codex.omp.json`,
+	Args: cobra.NoArgs,
+	Run: statuslineRunWithDataSource[segments.CodexData](
+		shell.CODEX,
+		cache.CODEXCACHE,
+		func(d *segments.CodexData) string { return d.ThreadID },
+		config.Codex,
+		codexStatusDataSource,
+	),
+}
+
+func init() {
+	codexCmd.Flags().String("session", "", "Codex session/thread ID to render; defaults to the newest session with token usage")
+	codexCmd.Flags().String("codex-home", "", "Codex home directory; defaults to CODEX_HOME or ~/.codex")
+	codexCmd.Flags().String("session-root", "", "Codex sessions directory; defaults to <codex-home>/sessions")
+	RootCmd.AddCommand(codexCmd)
+}

--- a/src/cli/codex.go
+++ b/src/cli/codex.go
@@ -20,6 +20,8 @@ $CODEX_HOME/sessions, falling back to ~/.codex/sessions when CODEX_HOME is not s
 
 When JSON is provided on stdin, stdin takes precedence over local session discovery.
 This is useful for tests or scripts that already emit a token_count payload.
+Stdin is read only when data is piped or redirected to the command; interactive
+terminal stdin is ignored to avoid blocking.
 
 Example usage:
   oh-my-posh codex --config ~/.config/ohmyposh/codex.omp.json

--- a/src/cli/codex_status.go
+++ b/src/cli/codex_status.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/segments"
+
+	"github.com/spf13/cobra"
+)
+
+func codexStatusDataSource(cmd *cobra.Command) ([]byte, error) {
+	options, err := codexLocalStatusOptionsFromCommand(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := segments.CodexStatusFromLocalSessions(options)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(data)
+}
+
+func codexLocalStatusOptionsFromCommand(cmd *cobra.Command) (segments.CodexLocalStatusOptions, error) {
+	sessionID, err := cmd.Flags().GetString("session")
+	if err != nil {
+		return segments.CodexLocalStatusOptions{}, err
+	}
+
+	codexHome, err := cmd.Flags().GetString("codex-home")
+	if err != nil {
+		return segments.CodexLocalStatusOptions{}, err
+	}
+
+	sessionRoot, err := cmd.Flags().GetString("session-root")
+	if err != nil {
+		return segments.CodexLocalStatusOptions{}, err
+	}
+
+	codexHomeEnv := os.Getenv("CODEX_HOME")
+	userHome := ""
+	if codexHome == "" && codexHomeEnv == "" && sessionRoot == "" {
+		userHome, err = os.UserHomeDir()
+		if err != nil {
+			return segments.CodexLocalStatusOptions{}, fmt.Errorf("failed to resolve home directory for codex status discovery: %w", err)
+		}
+	}
+
+	return segments.ResolveCodexLocalStatusOptions(segments.CodexLocalStatusOptions{
+		CodexHome:   codexHome,
+		SessionRoot: sessionRoot,
+		SessionID:   sessionID,
+	}, codexHomeEnv, userHome), nil
+}

--- a/src/cli/copilot.go
+++ b/src/cli/copilot.go
@@ -20,6 +20,9 @@ This command reads GitHub Copilot CLI's contextual JSON data from stdin and rend
 a prompt that can include a Copilot CLI segment with session information like
 model name, token usage, costs, and more.
 
+Stdin is read only when data is piped or redirected to the command; interactive
+terminal stdin is ignored to avoid blocking.
+
 Example usage in GitHub Copilot CLI settings (%USERPROFILE%\.copilot\statusline.cmd):
   @echo off
   oh-my-posh copilot --config %USERPROFILE%\.config\ohmyposh\copilot.toml`,

--- a/src/cli/statusline.go
+++ b/src/cli/statusline.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -17,6 +18,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type statuslineDataSource func(*cobra.Command) ([]byte, error)
+
 // statuslineRun returns a cobra Run function for statusline commands.
 // T is the type of the JSON data read from stdin.
 // shellConst identifies the shell (used for cache init and terminal init).
@@ -24,16 +27,34 @@ import (
 // sessionID extracts the session ID from parsed data so it can be set as POSH_SESSION_ID.
 // defaultCfg is called when no --config flag is provided or parsing fails.
 func statuslineRun[T any](shellConst, cacheKey string, sessionID func(*T) string, defaultCfg func() *config.Config) func(*cobra.Command, []string) {
+	return statuslineRunWithDataSource[T](shellConst, cacheKey, sessionID, defaultCfg, nil)
+}
+
+func statuslineRunWithDataSource[T any](
+	shellConst, cacheKey string,
+	sessionID func(*T) string,
+	defaultCfg func() *config.Config,
+	dataSource statuslineDataSource,
+) func(*cobra.Command, []string) {
 	return func(cmd *cobra.Command, _ []string) {
 		log.Debugf("%s command started", shellConst)
 
-		stdinData, err := io.ReadAll(os.Stdin)
+		stdinData, err := readStatuslineStdin()
 		if err != nil {
 			log.Error(err)
 			return
 		}
 
-		log.Debugf("received data from stdin: %s", string(stdinData))
+		if len(stdinData) > 0 {
+			log.Debugf("received %d bytes from stdin", len(stdinData))
+		}
+
+		if len(bytes.TrimSpace(stdinData)) == 0 && dataSource != nil {
+			stdinData, err = dataSource(cmd)
+			if err != nil {
+				log.Error(err)
+			}
+		}
 
 		processStatuslineData(stdinData, shellConst, cacheKey, sessionID)
 
@@ -77,6 +98,19 @@ func statuslineRun[T any](shellConst, cacheKey string, sessionID func(*T) string
 
 		fmt.Print(eng.Status())
 	}
+}
+
+func readStatuslineStdin() ([]byte, error) {
+	info, err := os.Stdin.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	if info.Mode()&os.ModeCharDevice != 0 {
+		return nil, nil
+	}
+
+	return io.ReadAll(os.Stdin)
 }
 
 // processStatuslineData parses stdin JSON into T and stores it in the session cache.

--- a/src/config/default.go
+++ b/src/config/default.go
@@ -224,7 +224,7 @@ func Codex() *Config {
 	return statuslineCLIConfig(
 		1234567892,
 		CODEX,
-		" {{ if .ModelName }}\ue7cf {{ .ModelName }}{{ end }}{{ if .TokenGauge }} \uf2d0 {{ .TokenGauge }}{{ end }}{{ if .FormattedWeeklyRemaining }} \uf017 7d {{ .FormattedWeeklyRemaining }}{{ end }} ",
+		" {{ if .ModelName }}\ue7cf {{ .ModelName }}{{ end }}{{ if .TokenGauge }} \uf2d0 {{ .TokenGauge }}{{ end }}{{ if .FormattedWeeklyRemaining }} \uf017 {{ .WeeklyLimitLabel }} {{ .FormattedWeeklyRemaining }}{{ end }} ",
 	)
 }
 

--- a/src/config/default.go
+++ b/src/config/default.go
@@ -220,12 +220,20 @@ func Claude() *Config {
 	return statuslineCLIConfig(1234567890, CLAUDE, " \U000f0bc9 {{ .Model.DisplayName }} \uf2d0 {{ .TokenGauge }} ")
 }
 
+func Codex() *Config {
+	return statuslineCLIConfig(
+		1234567892,
+		CODEX,
+		" {{ if .ModelName }}\ue7cf {{ .ModelName }}{{ end }}{{ if .TokenGauge }} \uf2d0 {{ .TokenGauge }}{{ end }}{{ if .FormattedWeeklyRemaining }} \uf017 7d {{ .FormattedWeeklyRemaining }}{{ end }} ",
+	)
+}
+
 func CopilotCLI() *Config {
 	return statuslineCLIConfig(1234567891, COPILOTCLI, " \uec1e {{ .Model.DisplayName }} \uf2d0 {{ .TokenGauge }} ")
 }
 
 // statuslineCLIConfig builds the shared default config for AI CLI statusline integrations
-// (e.g. Claude, Copilot CLI). The left block is always PATH + GIT; the right block
+// (e.g. Claude, Codex, Copilot CLI). The left block is always PATH + GIT; the right block
 // contains a single segment of the given type and template.
 func statuslineCLIConfig(hash uint64, segmentType SegmentType, template string) *Config {
 	return &Config{

--- a/src/config/segment_types.go
+++ b/src/config/segment_types.go
@@ -46,6 +46,8 @@ func init() {
 	gob.Register(&segments.CfTarget{})
 	gob.Register(&segments.Claude{})
 	gob.Register(&segments.ClaudeData{})
+	gob.Register(&segments.Codex{})
+	gob.Register(&segments.CodexData{})
 	gob.Register(&segments.Clojure{})
 	gob.Register(&segments.Cmake{})
 	gob.Register(&segments.Connection{})
@@ -197,6 +199,8 @@ const (
 	CFTARGET SegmentType = "cftarget"
 	// CLAUDE writes Claude Code session information
 	CLAUDE SegmentType = "claude"
+	// CODEX writes OpenAI Codex session information
+	CODEX SegmentType = "codex"
 	// CLOJURE writes the active clojure version
 	CLOJURE SegmentType = "clojure"
 	// CMAKE writes the active cmake version
@@ -405,6 +409,7 @@ var Segments = map[SegmentType]func() SegmentWriter{
 	CF:              func() SegmentWriter { return &segments.Cf{} },
 	CFTARGET:        func() SegmentWriter { return &segments.CfTarget{} },
 	CLAUDE:          func() SegmentWriter { return &segments.Claude{} },
+	CODEX:           func() SegmentWriter { return &segments.Codex{} },
 	CLOJURE:         func() SegmentWriter { return &segments.Clojure{} },
 	CMAKE:           func() SegmentWriter { return &segments.Cmake{} },
 	CONNECTION:      func() SegmentWriter { return &segments.Connection{} },

--- a/src/segments/ai.go
+++ b/src/segments/ai.go
@@ -1,0 +1,28 @@
+package segments
+
+import (
+	"fmt"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+)
+
+const (
+	thousand = 1000
+	million  = 1000000
+
+	gaugeMarkedChar   options.Option = "gauge_marked_char"
+	gaugeUnmarkedChar options.Option = "gauge_unmarked_char"
+)
+
+// formatTokenCount formats a token count as a human-readable string ("1.2K", "3.4M", or raw).
+func formatTokenCount(n int) string {
+	if n < thousand {
+		return fmt.Sprintf("%d", n)
+	}
+
+	if n < million {
+		return fmt.Sprintf("%.1fK", float64(n)/float64(thousand))
+	}
+
+	return fmt.Sprintf("%.1fM", float64(n)/float64(million))
+}

--- a/src/segments/claude.go
+++ b/src/segments/claude.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/jandedobbeleer/oh-my-posh/src/cache"
 	"github.com/jandedobbeleer/oh-my-posh/src/log"
-	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
 	"github.com/jandedobbeleer/oh-my-posh/src/text"
 )
 
@@ -136,27 +135,6 @@ type ClaudeCurrentUsage struct {
 	OutputTokens             int `json:"output_tokens"`
 	CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
 	CacheReadInputTokens     int `json:"cache_read_input_tokens"`
-}
-
-const (
-	thousand = 1000.0
-	million  = 1000000.0
-
-	gaugeMarkedChar   options.Option = "gauge_marked_char"
-	gaugeUnmarkedChar options.Option = "gauge_unmarked_char"
-)
-
-// formatTokenCount formats a token count as a human-readable string ("1.2K", "3.4M", or raw).
-func formatTokenCount(n int) string {
-	if n < int(thousand) {
-		return fmt.Sprintf("%d", n)
-	}
-
-	if n < int(million) {
-		return fmt.Sprintf("%.1fK", float64(n)/thousand)
-	}
-
-	return fmt.Sprintf("%.1fM", float64(n)/million)
 }
 
 func (c *Claude) Template() string {

--- a/src/segments/codex.go
+++ b/src/segments/codex.go
@@ -147,7 +147,7 @@ func (c *CodexData) UnmarshalJSON(data []byte) error {
 }
 
 func (c *Codex) Template() string {
-	return " {{ if .ModelName }}\ue7cf {{ .ModelName }}{{ end }}{{ if .TokenGauge }} \uf2d0 {{ .TokenGauge }}{{ end }}{{ if .FormattedWeeklyRemaining }} \uf017 7d {{ .FormattedWeeklyRemaining }}{{ end }} "
+	return " {{ if .ModelName }}\ue7cf {{ .ModelName }}{{ end }}{{ if .TokenGauge }} \uf2d0 {{ .TokenGauge }}{{ end }}{{ if .FormattedWeeklyRemaining }} \uf017 {{ .WeeklyLimitLabel }} {{ .FormattedWeeklyRemaining }}{{ end }} "
 }
 
 func (c *Codex) Enabled() bool {
@@ -639,19 +639,37 @@ func (c *Codex) FormattedWeeklyRemaining() string {
 	return fmt.Sprintf("%d%%", c.WeeklyRemaining())
 }
 
+// FiveHourLimitLabel returns the primary rolling window label.
+func (c *Codex) FiveHourLimitLabel() string {
+	if c.RateLimits == nil {
+		return "5h"
+	}
+
+	return codexRateLimitWindowLabel(c.RateLimits.Primary, "5h")
+}
+
+// WeeklyLimitLabel returns the secondary rolling window label.
+func (c *Codex) WeeklyLimitLabel() string {
+	if c.RateLimits == nil {
+		return "7d"
+	}
+
+	return codexRateLimitWindowLabel(c.RateLimits.Secondary, "7d")
+}
+
 // FormattedLimits returns rate limit text for the FormattedText preset.
 func (c *Codex) FormattedLimits() string {
 	limits := []string{}
 
 	if c.DisplayFiveHourLimit() {
 		if remaining := c.FormattedFiveHourRemaining(); remaining != "" {
-			limits = append(limits, "5h "+remaining)
+			limits = append(limits, c.FiveHourLimitLabel()+" "+remaining)
 		}
 	}
 
 	if c.DisplayWeeklyLimit() {
 		if remaining := c.FormattedWeeklyRemaining(); remaining != "" {
-			limits = append(limits, "7d "+remaining)
+			limits = append(limits, c.WeeklyLimitLabel()+" "+remaining)
 		}
 	}
 
@@ -725,6 +743,23 @@ func codexRateLimitHasUsage(limits *CodexRateLimits, window func(*CodexRateLimit
 	}
 
 	return codexRateLimitWindowHasUsage(window(limits))
+}
+
+func codexRateLimitWindowLabel(window *CodexRateLimitWindow, fallback string) string {
+	if window == nil || window.WindowMinutes <= 0 {
+		return fallback
+	}
+
+	const minutesPerDay = 24 * 60
+	if window.WindowMinutes%minutesPerDay == 0 {
+		return fmt.Sprintf("%dd", window.WindowMinutes/minutesPerDay)
+	}
+
+	if window.WindowMinutes%60 == 0 {
+		return fmt.Sprintf("%dh", window.WindowMinutes/60)
+	}
+
+	return fmt.Sprintf("%dm", window.WindowMinutes)
 }
 
 func codexPrimaryRateLimitWindow(limits *CodexRateLimits) *CodexRateLimitWindow {

--- a/src/segments/codex.go
+++ b/src/segments/codex.go
@@ -1,0 +1,758 @@
+package segments
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/cache"
+	"github.com/jandedobbeleer/oh-my-posh/src/log"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+	"github.com/jandedobbeleer/oh-my-posh/src/text"
+)
+
+// Codex segment displays OpenAI Codex session information.
+type Codex struct {
+	Base
+	CodexData
+}
+
+// CodexData represents Codex statusline data.
+type CodexData struct {
+	Type            string           `json:"type"`
+	ThreadID        string           `json:"thread_id"`
+	CWD             string           `json:"cwd"`
+	Version         string           `json:"version"`
+	ReasoningEffort string           `json:"reasoning_effort"`
+	ApprovalMode    string           `json:"approval_mode"`
+	SandboxPolicy   string           `json:"sandbox_policy"`
+	Model           CodexModel       `json:"model"`
+	Info            CodexTokenInfo   `json:"info"`
+	RateLimits      *CodexRateLimits `json:"rate_limits"`
+}
+
+// CodexModel represents OpenAI Codex model information.
+type CodexModel struct {
+	ID          string `json:"id"`
+	DisplayName string `json:"display_name"`
+}
+
+// CodexTokenInfo represents token count information emitted by Codex.
+type CodexTokenInfo struct {
+	TotalTokenUsage    CodexTokenUsage `json:"total_token_usage"`
+	LastTokenUsage     CodexTokenUsage `json:"last_token_usage"`
+	ModelContextWindow int             `json:"model_context_window"`
+}
+
+// CodexTokenUsage represents a token usage snapshot.
+type CodexTokenUsage struct {
+	InputTokens           int `json:"input_tokens"`
+	CachedInputTokens     int `json:"cached_input_tokens"`
+	OutputTokens          int `json:"output_tokens"`
+	ReasoningOutputTokens int `json:"reasoning_output_tokens"`
+	TotalTokens           int `json:"total_tokens"`
+}
+
+// CodexRateLimits represents Codex rate limit information.
+type CodexRateLimits struct {
+	LimitID              string                `json:"limit_id"`
+	LimitName            string                `json:"limit_name"`
+	Primary              *CodexRateLimitWindow `json:"primary"`
+	Secondary            *CodexRateLimitWindow `json:"secondary"`
+	PlanType             string                `json:"plan_type"`
+	RateLimitReachedType string                `json:"rate_limit_reached_type"`
+}
+
+// CodexRateLimitWindow represents one Codex rate limit window.
+type CodexRateLimitWindow struct {
+	UsedPercent   *float64 `json:"used_percent"`
+	WindowMinutes int      `json:"window_minutes"`
+	ResetsAt      *int64   `json:"resets_at"`
+}
+
+const (
+	displayModel         options.Option = "display_model"
+	displayReasoning     options.Option = "display_reasoning"
+	displayContext       options.Option = "display_context"
+	displayTokens        options.Option = "display_tokens"
+	displayFiveHourLimit options.Option = "display_five_hour_limit"
+	displayWeeklyLimit   options.Option = "display_weekly_limit"
+	discoverLocalStatus  options.Option = "discover_local_status"
+	codexHome            options.Option = "codex_home"
+	sessionRoot          options.Option = "session_root"
+	codexSessionID       options.Option = "session_id"
+	statusFile           options.Option = "status_file"
+	statusFileEnv        options.Option = "status_file_env"
+	statusJSONEnv        options.Option = "status_json_env"
+
+	defaultCodexStatusFileEnv = "POSH_CODEX_STATUS_FILE"
+	defaultCodexStatusJSONEnv = "POSH_CODEX_STATUS"
+)
+
+func (m *CodexModel) UnmarshalJSON(data []byte) error {
+	var id string
+	if err := json.Unmarshal(data, &id); err == nil {
+		m.ID = id
+		m.DisplayName = id
+		return nil
+	}
+
+	type model CodexModel
+	var parsed model
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return err
+	}
+
+	*m = CodexModel(parsed)
+	if m.DisplayName == "" {
+		m.DisplayName = m.ID
+	}
+
+	return nil
+}
+
+func (c *CodexData) UnmarshalJSON(data []byte) error {
+	type codexData CodexData
+
+	var wrapped struct {
+		Type    string          `json:"type"`
+		Payload json.RawMessage `json:"payload"`
+	}
+
+	if err := json.Unmarshal(data, &wrapped); err == nil && wrapped.Type == "event_msg" && len(wrapped.Payload) > 0 {
+		var payload struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal(wrapped.Payload, &payload); err != nil {
+			return err
+		}
+
+		if payload.Type != "token_count" {
+			return fmt.Errorf("unsupported codex event payload type: %s", payload.Type)
+		}
+
+		return json.Unmarshal(wrapped.Payload, (*codexData)(c))
+	}
+
+	var parsed codexData
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return err
+	}
+
+	*c = CodexData(parsed)
+	return nil
+}
+
+func (c *Codex) Template() string {
+	return " {{ if .ModelName }}\ue7cf {{ .ModelName }}{{ end }}{{ if .TokenGauge }} \uf2d0 {{ .TokenGauge }}{{ end }}{{ if .FormattedWeeklyRemaining }} \uf017 7d {{ .FormattedWeeklyRemaining }}{{ end }} "
+}
+
+func (c *Codex) Enabled() bool {
+	log.Debug("codex segment: checking if enabled")
+
+	data, found := cache.Get[CodexData](cache.Session, cache.CODEXCACHE)
+	if found {
+		if !data.hasStatus() {
+			log.Debug("codex segment: cached data has no status information, ignoring cache entry")
+			cache.Delete(cache.Session, cache.CODEXCACHE)
+		} else {
+			log.Debug("codex segment: found data in session cache")
+			log.Debugf("codex segment: model=%s, thread=%s", data.Model.DisplayName, data.ThreadID)
+
+			c.CodexData = data
+			return true
+		}
+	} else {
+		log.Debug("codex segment: no data found in session cache")
+	}
+
+	if data, found = c.statusFileData(); found {
+		if !data.hasStatus() {
+			log.Debug("codex segment: status file has no status information, checking environment variable")
+		} else {
+			log.Debug("codex segment: found data in status file")
+			log.Debugf("codex segment: model=%s, thread=%s", data.Model.DisplayName, data.ThreadID)
+
+			c.CodexData = data
+			return true
+		}
+	}
+
+	if data, found = c.statusEnvData(); found {
+		if !data.hasStatus() {
+			log.Debug("codex segment: status environment variable has no status information")
+		} else {
+			log.Debug("codex segment: found data in status environment variable")
+			log.Debugf("codex segment: model=%s, thread=%s", data.Model.DisplayName, data.ThreadID)
+
+			c.CodexData = data
+			return true
+		}
+	}
+
+	if data, found = c.localStatusData(); found {
+		log.Debug("codex segment: found data in local session transcripts")
+		log.Debugf("codex segment: model=%s, thread=%s", data.Model.DisplayName, data.ThreadID)
+
+		c.CodexData = data
+		return true
+	}
+
+	log.Debug("codex segment: no data found")
+	return false
+}
+
+func (c *CodexData) hasStatus() bool {
+	return c.Model.DisplayName != "" ||
+		c.Model.ID != "" ||
+		c.Info.TotalTokenUsage.TotalTokens > 0 ||
+		c.Info.LastTokenUsage.TotalTokens > 0 ||
+		(c.RateLimits != nil && c.RateLimits.hasUsage())
+}
+
+func (c *CodexRateLimits) hasUsage() bool {
+	if c == nil {
+		return false
+	}
+
+	return codexRateLimitWindowHasUsage(c.Primary) || codexRateLimitWindowHasUsage(c.Secondary)
+}
+
+func codexRateLimitWindowHasUsage(window *CodexRateLimitWindow) bool {
+	return window != nil && window.UsedPercent != nil
+}
+
+func (c *Codex) statusFileData() (CodexData, bool) {
+	if c.env == nil {
+		return CodexData{}, false
+	}
+
+	file := c.optionString(statusFile, "")
+	if file == "" {
+		fileEnv := c.optionString(statusFileEnv, defaultCodexStatusFileEnv)
+		if fileEnv == "" {
+			return CodexData{}, false
+		}
+
+		file = c.env.Getenv(fileEnv)
+	}
+
+	file = c.expandStatusPath(file)
+	if file == "" {
+		return CodexData{}, false
+	}
+
+	return parseCodexStatus(c.env.FileContent(file))
+}
+
+func (c *Codex) expandStatusPath(file string) string {
+	if c.env == nil {
+		return file
+	}
+
+	if file == "~" {
+		return c.env.Home()
+	}
+
+	if strings.HasPrefix(file, "~/") || strings.HasPrefix(file, `~\`) {
+		return filepath.Join(c.env.Home(), file[2:])
+	}
+
+	return file
+}
+
+func (c *Codex) optionBool(option options.Option, defaultValue bool) bool {
+	if c.options == nil {
+		return defaultValue
+	}
+
+	return c.options.Bool(option, defaultValue)
+}
+
+func (c *Codex) optionString(option options.Option, defaultValue string) string {
+	if c.options == nil {
+		return defaultValue
+	}
+
+	return c.options.String(option, defaultValue)
+}
+
+func (c *Codex) statusEnvData() (CodexData, bool) {
+	if c.env == nil {
+		return CodexData{}, false
+	}
+
+	envName := c.optionString(statusJSONEnv, defaultCodexStatusJSONEnv)
+	if envName == "" {
+		return CodexData{}, false
+	}
+
+	return parseCodexStatus(c.env.Getenv(envName))
+}
+
+func (c *Codex) localStatusData() (CodexData, bool) {
+	if c.env == nil || !c.optionBool(discoverLocalStatus, true) {
+		return CodexData{}, false
+	}
+
+	localOptions := ResolveCodexLocalStatusOptions(CodexLocalStatusOptions{
+		CodexHome:   c.optionString(codexHome, ""),
+		SessionRoot: c.optionString(sessionRoot, ""),
+		SessionID:   c.optionString(codexSessionID, ""),
+	}, c.env.Getenv("CODEX_HOME"), c.env.Home())
+
+	data, err := CodexStatusFromLocalSessions(localOptions)
+	if err != nil {
+		log.Debugf("codex segment: failed to discover local status data: %v", err)
+		return CodexData{}, false
+	}
+
+	if !data.hasStatus() {
+		log.Debug("codex segment: local session data has no status information")
+		return CodexData{}, false
+	}
+
+	return data, true
+}
+
+func (c *Codex) CacheKey() (string, bool) {
+	parts := []string{"codex", "discover", fmt.Sprintf("%t", c.optionBool(discoverLocalStatus, true))}
+
+	if value := c.optionString(statusFile, ""); value != "" {
+		parts = append(parts, "file", codexCacheKeyHash(c.expandStatusPath(value)))
+	}
+
+	if value := c.optionString(statusFileEnv, defaultCodexStatusFileEnv); value != "" {
+		parts = append(parts, "file-env", value)
+		if c.env != nil {
+			if file := c.env.Getenv(value); file != "" {
+				parts = append(parts, "file", codexCacheKeyHash(c.expandStatusPath(file)))
+			}
+		}
+	}
+
+	if value := c.optionString(statusJSONEnv, defaultCodexStatusJSONEnv); value != "" {
+		parts = append(parts, "json-env", value)
+	}
+
+	if value := c.optionString(codexSessionID, ""); value != "" {
+		parts = append(parts, "session", value)
+	}
+
+	if value := c.optionString(sessionRoot, ""); value != "" {
+		parts = append(parts, "root", codexCacheKeyHash(value))
+	} else if value := c.optionString(codexHome, ""); value != "" {
+		parts = append(parts, "root", codexCacheKeyHash(filepath.Join(value, "sessions")))
+	} else if c.env != nil {
+		localOptions := ResolveCodexLocalStatusOptions(CodexLocalStatusOptions{}, c.env.Getenv("CODEX_HOME"), c.env.Home())
+		if localOptions.SessionRoot != "" {
+			parts = append(parts, "root", codexCacheKeyHash(localOptions.SessionRoot))
+		}
+	}
+
+	return strings.Join(parts, "|"), true
+}
+
+func codexCacheKeyHash(value string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(value)))
+}
+
+func parseCodexStatus(status string) (CodexData, bool) {
+	status = strings.TrimSpace(status)
+	if status == "" {
+		return CodexData{}, false
+	}
+
+	var data CodexData
+	if err := json.Unmarshal([]byte(status), &data); err != nil {
+		log.Debugf("codex segment: failed to parse status data: %v", err)
+		return CodexData{}, false
+	}
+
+	return data, true
+}
+
+// DisplayModel returns whether the FormattedText preset should display the model name.
+func (c *Codex) DisplayModel() bool {
+	return c.optionBool(displayModel, true)
+}
+
+// DisplayReasoning returns whether the FormattedText preset should display the reasoning level.
+func (c *Codex) DisplayReasoning() bool {
+	return c.optionBool(displayReasoning, false)
+}
+
+// DisplayContext returns whether the FormattedText preset should display context usage.
+func (c *Codex) DisplayContext() bool {
+	return c.optionBool(displayContext, true)
+}
+
+// DisplayTokens returns whether the FormattedText preset should display total tokens.
+func (c *Codex) DisplayTokens() bool {
+	return c.optionBool(displayTokens, false)
+}
+
+// DisplayFiveHourLimit returns whether the FormattedText preset should display the 5-hour rolling limit.
+func (c *Codex) DisplayFiveHourLimit() bool {
+	return c.optionBool(displayFiveHourLimit, false)
+}
+
+// DisplayWeeklyLimit returns whether the FormattedText preset should display the weekly rolling limit.
+func (c *Codex) DisplayWeeklyLimit() bool {
+	return c.optionBool(displayWeeklyLimit, true)
+}
+
+// FormattedText returns a preset Codex segment text based on display options.
+func (c *Codex) FormattedText() string {
+	parts := []string{}
+
+	if model := c.FormattedModel(); model != "" {
+		parts = append(parts, "\ue7cf "+model)
+	}
+
+	if c.DisplayContext() {
+		if gauge := c.TokenGauge(); gauge != "" {
+			parts = append(parts, "\uf2d0 "+gauge)
+		}
+	}
+
+	if c.DisplayTokens() {
+		parts = append(parts, "tok "+c.FormattedTokens())
+	}
+
+	if limits := c.FormattedLimits(); limits != "" {
+		parts = append(parts, "\uf017 "+limits)
+	}
+
+	return strings.Join(parts, " ")
+}
+
+// ModelName returns the display model name, falling back to the model ID.
+func (c *Codex) ModelName() string {
+	if c.Model.DisplayName != "" {
+		return c.Model.DisplayName
+	}
+
+	return c.Model.ID
+}
+
+// FormattedModel returns model and reasoning text based on display options.
+func (c *Codex) FormattedModel() string {
+	model := c.ModelName()
+
+	if !c.DisplayModel() {
+		model = ""
+	}
+
+	if !c.DisplayReasoning() || c.ReasoningEffort == "" {
+		return model
+	}
+
+	if model == "" {
+		return c.ReasoningEffort
+	}
+
+	reasoning := "(" + c.ReasoningEffort + ")"
+	if strings.Contains(strings.ToLower(model), strings.ToLower(reasoning)) {
+		return model
+	}
+
+	return fmt.Sprintf("%s %s", model, reasoning)
+}
+
+// TokenUsagePercent returns the percentage of the Codex model context window used.
+func (c *Codex) TokenUsagePercent() text.Percentage {
+	tokens := c.contextTokens()
+
+	if c.Info.ModelContextWindow <= 0 || tokens <= 0 {
+		return 0
+	}
+
+	percent := (float64(tokens) * 100.0) / float64(c.Info.ModelContextWindow)
+	rounded := int(percent + 0.5)
+	if rounded > 100 {
+		return 100
+	}
+
+	return text.Percentage(rounded)
+}
+
+func (c *Codex) hasContextUsage() bool {
+	return c.Info.ModelContextWindow > 0 && c.contextTokens() > 0
+}
+
+func (c *Codex) contextTokens() int {
+	tokens := c.Info.LastTokenUsage.TotalTokens
+	if tokens <= 0 {
+		tokens = c.Info.TotalTokenUsage.TotalTokens
+	}
+
+	return tokens
+}
+
+// TokenGauge returns a 5-block gauge showing remaining context capacity using the configured characters.
+func (c *Codex) TokenGauge() string {
+	if !c.hasContextUsage() {
+		return ""
+	}
+
+	return c.TokenUsagePercent().GaugeWith(c.optionString(gaugeMarkedChar, "▰"), c.optionString(gaugeUnmarkedChar, "▱"))
+}
+
+// TokenGaugeUsed returns a 5-block gauge showing used context capacity using the configured characters.
+func (c *Codex) TokenGaugeUsed() string {
+	if !c.hasContextUsage() {
+		return ""
+	}
+
+	return c.TokenUsagePercent().GaugeUsedWith(c.optionString(gaugeMarkedChar, "▰"), c.optionString(gaugeUnmarkedChar, "▱"))
+}
+
+// FormattedTokens returns total session tokens as a human-readable string.
+func (c *Codex) FormattedTokens() string {
+	return formatTokenCount(c.Info.TotalTokenUsage.TotalTokens)
+}
+
+// FormattedInputTokens returns total input tokens as a human-readable string.
+func (c *Codex) FormattedInputTokens() string {
+	return formatTokenCount(c.Info.TotalTokenUsage.InputTokens)
+}
+
+// FormattedOutputTokens returns total output tokens as a human-readable string.
+func (c *Codex) FormattedOutputTokens() string {
+	return formatTokenCount(c.Info.TotalTokenUsage.OutputTokens)
+}
+
+// FormattedReasoningTokens returns total reasoning output tokens as a human-readable string.
+func (c *Codex) FormattedReasoningTokens() string {
+	return formatTokenCount(c.Info.TotalTokenUsage.ReasoningOutputTokens)
+}
+
+// FormattedCachedInputTokens returns cached input tokens as a human-readable string.
+func (c *Codex) FormattedCachedInputTokens() string {
+	return formatTokenCount(c.Info.TotalTokenUsage.CachedInputTokens)
+}
+
+// FormattedLastTokens returns the latest response token count as a human-readable string.
+func (c *Codex) FormattedLastTokens() string {
+	return formatTokenCount(c.Info.LastTokenUsage.TotalTokens)
+}
+
+// RemainingPercent returns the percentage of context window remaining (0-100).
+func (c *Codex) RemainingPercent() text.Percentage {
+	return remainingPercentage(c.TokenUsagePercent())
+}
+
+// RemainingTokensCount returns the number of remaining context window tokens.
+func (c *Codex) RemainingTokensCount() int {
+	if c.Info.ModelContextWindow <= 0 {
+		return 0
+	}
+
+	tokens := c.contextTokens()
+	remaining := c.Info.ModelContextWindow - tokens
+	if remaining < 0 {
+		return 0
+	}
+
+	return remaining
+}
+
+// FiveHourUsage returns the primary rolling window usage percentage.
+func (c *Codex) FiveHourUsage() text.Percentage {
+	return codexRateLimitUsage(c.RateLimits, func(l *CodexRateLimits) *CodexRateLimitWindow {
+		return l.Primary
+	})
+}
+
+// WeeklyUsage returns the secondary rolling window usage percentage.
+func (c *Codex) WeeklyUsage() text.Percentage {
+	return codexRateLimitUsage(c.RateLimits, func(l *CodexRateLimits) *CodexRateLimitWindow {
+		return l.Secondary
+	})
+}
+
+// FiveHourRemaining returns the primary rolling window remaining percentage.
+func (c *Codex) FiveHourRemaining() text.Percentage {
+	return remainingPercentage(c.FiveHourUsage())
+}
+
+// WeeklyRemaining returns the secondary rolling window remaining percentage.
+func (c *Codex) WeeklyRemaining() text.Percentage {
+	return remainingPercentage(c.WeeklyUsage())
+}
+
+// FiveHourGauge returns a 5-block gauge showing primary window usage.
+func (c *Codex) FiveHourGauge() string {
+	if !codexRateLimitHasUsage(c.RateLimits, codexPrimaryRateLimitWindow) {
+		return ""
+	}
+
+	return c.FiveHourUsage().GaugeUsedWith(c.optionString(gaugeMarkedChar, "▰"), c.optionString(gaugeUnmarkedChar, "▱"))
+}
+
+// WeeklyGauge returns a 5-block gauge showing weekly window usage.
+func (c *Codex) WeeklyGauge() string {
+	if !codexRateLimitHasUsage(c.RateLimits, codexSecondaryRateLimitWindow) {
+		return ""
+	}
+
+	return c.WeeklyUsage().GaugeUsedWith(c.optionString(gaugeMarkedChar, "▰"), c.optionString(gaugeUnmarkedChar, "▱"))
+}
+
+// FiveHourRemainingGauge returns a 5-block gauge showing primary quota remaining.
+func (c *Codex) FiveHourRemainingGauge() string {
+	if !codexRateLimitHasUsage(c.RateLimits, codexPrimaryRateLimitWindow) {
+		return ""
+	}
+
+	return c.FiveHourUsage().GaugeWith(c.optionString(gaugeMarkedChar, "▰"), c.optionString(gaugeUnmarkedChar, "▱"))
+}
+
+// WeeklyRemainingGauge returns a 5-block gauge showing weekly quota remaining.
+func (c *Codex) WeeklyRemainingGauge() string {
+	if !codexRateLimitHasUsage(c.RateLimits, codexSecondaryRateLimitWindow) {
+		return ""
+	}
+
+	return c.WeeklyUsage().GaugeWith(c.optionString(gaugeMarkedChar, "▰"), c.optionString(gaugeUnmarkedChar, "▱"))
+}
+
+// FormattedFiveHourRemaining returns the primary rolling window remaining percentage with a percent sign.
+func (c *Codex) FormattedFiveHourRemaining() string {
+	if !codexRateLimitHasUsage(c.RateLimits, codexPrimaryRateLimitWindow) {
+		return ""
+	}
+
+	return fmt.Sprintf("%d%%", c.FiveHourRemaining())
+}
+
+// FormattedWeeklyRemaining returns the weekly rolling window remaining percentage with a percent sign.
+func (c *Codex) FormattedWeeklyRemaining() string {
+	if !codexRateLimitHasUsage(c.RateLimits, codexSecondaryRateLimitWindow) {
+		return ""
+	}
+
+	return fmt.Sprintf("%d%%", c.WeeklyRemaining())
+}
+
+// FormattedLimits returns rate limit text for the FormattedText preset.
+func (c *Codex) FormattedLimits() string {
+	limits := []string{}
+
+	if c.DisplayFiveHourLimit() {
+		if remaining := c.FormattedFiveHourRemaining(); remaining != "" {
+			limits = append(limits, "5h "+remaining)
+		}
+	}
+
+	if c.DisplayWeeklyLimit() {
+		if remaining := c.FormattedWeeklyRemaining(); remaining != "" {
+			limits = append(limits, "7d "+remaining)
+		}
+	}
+
+	return strings.Join(limits, " ")
+}
+
+// FiveHourResetsAt returns the reset time for the primary rolling window.
+func (c *Codex) FiveHourResetsAt() time.Time {
+	return codexRateLimitReset(c.RateLimits, func(l *CodexRateLimits) *CodexRateLimitWindow {
+		return l.Primary
+	})
+}
+
+// WeeklyResetsAt returns the reset time for the secondary rolling window.
+func (c *Codex) WeeklyResetsAt() time.Time {
+	return codexRateLimitReset(c.RateLimits, func(l *CodexRateLimits) *CodexRateLimitWindow {
+		return l.Secondary
+	})
+}
+
+// FiveHourResetsIn returns the signed duration until the primary rolling window resets.
+// Returns 0 when unavailable, negative when the window already reset.
+func (c *Codex) FiveHourResetsIn() time.Duration {
+	return codexRateLimitResetsIn(c.RateLimits, func(l *CodexRateLimits) *CodexRateLimitWindow {
+		return l.Primary
+	})
+}
+
+// WeeklyResetsIn returns the signed duration until the secondary rolling window resets.
+// Returns 0 when unavailable, negative when the window already reset.
+func (c *Codex) WeeklyResetsIn() time.Duration {
+	return codexRateLimitResetsIn(c.RateLimits, func(l *CodexRateLimits) *CodexRateLimitWindow {
+		return l.Secondary
+	})
+}
+
+func remainingPercentage(used text.Percentage) text.Percentage {
+	remaining := 100 - int(used)
+	if remaining < 0 {
+		return 0
+	}
+
+	return text.Percentage(remaining)
+}
+
+func codexRateLimitUsage(limits *CodexRateLimits, window func(*CodexRateLimits) *CodexRateLimitWindow) text.Percentage {
+	if !codexRateLimitHasUsage(limits, window) {
+		return 0
+	}
+
+	w := window(limits)
+	if w == nil || w.UsedPercent == nil {
+		return 0
+	}
+
+	percent := int(*w.UsedPercent + 0.5)
+	if percent > 100 {
+		return 100
+	}
+
+	if percent < 0 {
+		return 0
+	}
+
+	return text.Percentage(percent)
+}
+
+func codexRateLimitHasUsage(limits *CodexRateLimits, window func(*CodexRateLimits) *CodexRateLimitWindow) bool {
+	if limits == nil || window == nil {
+		return false
+	}
+
+	return codexRateLimitWindowHasUsage(window(limits))
+}
+
+func codexPrimaryRateLimitWindow(limits *CodexRateLimits) *CodexRateLimitWindow {
+	return limits.Primary
+}
+
+func codexSecondaryRateLimitWindow(limits *CodexRateLimits) *CodexRateLimitWindow {
+	return limits.Secondary
+}
+
+func codexRateLimitReset(limits *CodexRateLimits, window func(*CodexRateLimits) *CodexRateLimitWindow) time.Time {
+	if limits == nil || window == nil {
+		return time.Time{}
+	}
+
+	w := window(limits)
+	if w == nil || w.ResetsAt == nil {
+		return time.Time{}
+	}
+
+	return time.Unix(*w.ResetsAt, 0)
+}
+
+func codexRateLimitResetsIn(limits *CodexRateLimits, window func(*CodexRateLimits) *CodexRateLimitWindow) time.Duration {
+	t := codexRateLimitReset(limits, window)
+	if t.IsZero() {
+		return 0
+	}
+
+	return time.Until(t)
+}

--- a/src/segments/codex_status.go
+++ b/src/segments/codex_status.go
@@ -1,0 +1,385 @@
+package segments
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	toml "github.com/pelletier/go-toml/v2"
+)
+
+const (
+	codexMaxSessionFiles          = 25
+	codexMaxRequestedSessionFiles = 250
+)
+
+var errCodexNoTokenCount = errors.New("no token_count event found")
+
+// CodexLocalStatusOptions configures local Codex session transcript discovery.
+type CodexLocalStatusOptions struct {
+	CodexHome   string
+	SessionRoot string
+	SessionID   string
+}
+
+type codexSessionFile struct {
+	path    string
+	sortKey string
+}
+
+type codexJSONLEvent struct {
+	Timestamp string          `json:"timestamp"`
+	Type      string          `json:"type"`
+	Payload   json.RawMessage `json:"payload"`
+}
+
+type codexSessionMeta struct {
+	ID              string `json:"id"`
+	CWD             string `json:"cwd"`
+	CLIVersion      string `json:"cli_version"`
+	Model           string `json:"model"`
+	ReasoningEffort string `json:"reasoning_effort"`
+	ApprovalMode    string `json:"approval_policy"`
+	SandboxPolicy   string `json:"sandbox_mode"`
+}
+
+type codexConfigStatus struct {
+	Model                string `toml:"model"`
+	ModelReasoningEffort string `toml:"model_reasoning_effort"`
+	ApprovalPolicy       string `toml:"approval_policy"`
+	SandboxMode          string `toml:"sandbox_mode"`
+}
+
+// ResolveCodexLocalStatusOptions fills default local Codex discovery paths.
+func ResolveCodexLocalStatusOptions(options CodexLocalStatusOptions, codexHomeEnv, userHome string) CodexLocalStatusOptions {
+	if options.CodexHome == "" {
+		options.CodexHome = defaultCodexHome(codexHomeEnv, userHome)
+	}
+
+	if options.SessionRoot == "" && options.CodexHome != "" {
+		options.SessionRoot = filepath.Join(options.CodexHome, "sessions")
+	}
+
+	return options
+}
+
+// CodexStatusFromLocalSessions returns the latest token_count status from local Codex session transcripts.
+func CodexStatusFromLocalSessions(options CodexLocalStatusOptions) (CodexData, error) {
+	if options.SessionRoot == "" {
+		return CodexData{}, errors.New("codex sessions directory could not be determined; set CODEX_HOME, pass --codex-home or --session-root, or configure codex_home/session_root")
+	}
+
+	files, err := codexSessionFiles(options.SessionRoot, options.SessionID)
+	if err != nil {
+		return CodexData{}, err
+	}
+
+	if len(files) == 0 {
+		return CodexData{}, fmt.Errorf("no codex session files found in %s; start Codex once, set CODEX_HOME, pass --codex-home or --session-root, or configure codex_home/session_root", options.SessionRoot)
+	}
+
+	cfg := loadCodexConfigStatus(options.CodexHome)
+	var lastErr error
+
+	for _, file := range files {
+		data, err := codexStatusFromSessionFile(file.path, cfg)
+		if err == nil && options.SessionID != "" && data.ThreadID != options.SessionID {
+			continue
+		}
+
+		if err == nil && data.hasStatus() {
+			return data, nil
+		}
+
+		if err != nil && !errors.Is(err, errCodexNoTokenCount) {
+			lastErr = fmt.Errorf("%s: %w", file.path, err)
+		}
+	}
+
+	if lastErr != nil {
+		return CodexData{}, lastErr
+	}
+
+	if options.SessionID != "" {
+		return CodexData{}, fmt.Errorf("%w for codex session %s", errCodexNoTokenCount, options.SessionID)
+	}
+
+	return CodexData{}, fmt.Errorf("%w in the newest codex session files", errCodexNoTokenCount)
+}
+
+func codexSessionFiles(root, sessionID string) ([]codexSessionFile, error) {
+	files := []codexSessionFile{}
+	limit := codexSessionFileLimit(sessionID)
+
+	dirs, err := codexSessionSearchDirs(root)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, dir := range dirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, file := range codexSessionFilesInDir(dir, entries) {
+			files = append(files, file)
+			if len(files) > limit {
+				sortCodexSessionFiles(files)
+				files = files[:limit]
+			}
+		}
+	}
+
+	sortCodexSessionFiles(files)
+	return files, nil
+}
+
+func codexSessionFileLimit(sessionID string) int {
+	if sessionID != "" {
+		return codexMaxRequestedSessionFiles
+	}
+
+	return codexMaxSessionFiles
+}
+
+func codexSessionSearchDirs(root string) ([]string, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, err
+	}
+
+	years := filterCodexSessionDirs(entries, 4)
+	sort.Sort(sort.Reverse(sort.StringSlice(years)))
+
+	dirs := []string{}
+	for _, year := range years {
+		yearPath := filepath.Join(root, year)
+		monthEntries, err := os.ReadDir(yearPath)
+		if err != nil {
+			return nil, err
+		}
+
+		months := filterCodexSessionDirs(monthEntries, 2)
+		sort.Sort(sort.Reverse(sort.StringSlice(months)))
+
+		for _, month := range months {
+			monthPath := filepath.Join(yearPath, month)
+			dayEntries, err := os.ReadDir(monthPath)
+			if err != nil {
+				return nil, err
+			}
+
+			days := filterCodexSessionDirs(dayEntries, 2)
+			sort.Sort(sort.Reverse(sort.StringSlice(days)))
+
+			for _, day := range days {
+				dirs = append(dirs, filepath.Join(monthPath, day))
+			}
+		}
+	}
+
+	return append(dirs, root), nil
+}
+
+func filterCodexSessionDirs(entries []os.DirEntry, length int) []string {
+	dirs := []string{}
+	for _, entry := range entries {
+		if entry.IsDir() && isDigits(entry.Name(), length) {
+			dirs = append(dirs, entry.Name())
+		}
+	}
+
+	return dirs
+}
+
+func isDigits(value string, length int) bool {
+	if len(value) != length {
+		return false
+	}
+
+	for _, char := range value {
+		if char < '0' || char > '9' {
+			return false
+		}
+	}
+
+	return true
+}
+
+func codexSessionFilesInDir(dir string, entries []os.DirEntry) []codexSessionFile {
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name() > entries[j].Name()
+	})
+
+	files := []codexSessionFile{}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.EqualFold(filepath.Ext(entry.Name()), ".jsonl") {
+			continue
+		}
+
+		files = append(files, codexSessionFile{
+			path:    filepath.Join(dir, entry.Name()),
+			sortKey: entry.Name(),
+		})
+	}
+
+	return files
+}
+
+func sortCodexSessionFiles(files []codexSessionFile) {
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].sortKey > files[j].sortKey
+	})
+}
+
+func codexStatusFromSessionFile(path string, cfg codexConfigStatus) (CodexData, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return CodexData{}, err
+	}
+	defer file.Close()
+
+	reader := bufio.NewReader(file)
+	var meta codexSessionMeta
+	var latest json.RawMessage
+
+	for {
+		line, err := reader.ReadBytes('\n')
+		if len(bytes.TrimSpace(line)) > 0 {
+			event, parseErr := parseCodexJSONLEvent(line)
+			if parseErr != nil {
+				return CodexData{}, parseErr
+			}
+
+			switch event.Type {
+			case "session_meta":
+				if parseErr := json.Unmarshal(event.Payload, &meta); parseErr != nil {
+					return CodexData{}, parseErr
+				}
+			case "event_msg":
+				matches, parseErr := isCodexTokenCountPayload(event.Payload)
+				if parseErr != nil {
+					return CodexData{}, parseErr
+				}
+
+				if matches {
+					latest = event.Payload
+				}
+			}
+		}
+
+		if errors.Is(err, io.EOF) {
+			break
+		}
+
+		if err != nil {
+			return CodexData{}, err
+		}
+	}
+
+	if latest == nil {
+		return CodexData{}, errCodexNoTokenCount
+	}
+
+	var data CodexData
+	if err := json.Unmarshal(latest, &data); err != nil {
+		return CodexData{}, err
+	}
+
+	enrichCodexStatusPayload(&data, &meta, cfg)
+
+	return data, nil
+}
+
+func parseCodexJSONLEvent(line []byte) (codexJSONLEvent, error) {
+	var event codexJSONLEvent
+	if err := json.Unmarshal(line, &event); err != nil {
+		return codexJSONLEvent{}, err
+	}
+
+	return event, nil
+}
+
+func isCodexTokenCountPayload(payload json.RawMessage) (bool, error) {
+	var typed struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(payload, &typed); err != nil {
+		return false, err
+	}
+
+	return typed.Type == "token_count", nil
+}
+
+func enrichCodexStatusPayload(payload *CodexData, meta *codexSessionMeta, cfg codexConfigStatus) {
+	setStringIfMissing(&payload.ThreadID, meta.ID)
+	setStringIfMissing(&payload.CWD, meta.CWD)
+	setStringIfMissing(&payload.Version, meta.CLIVersion)
+	setStringIfMissing(&payload.ApprovalMode, firstNonEmpty(meta.ApprovalMode, cfg.ApprovalPolicy))
+	setStringIfMissing(&payload.SandboxPolicy, firstNonEmpty(meta.SandboxPolicy, cfg.SandboxMode))
+	setStringIfMissing(&payload.ReasoningEffort, firstNonEmpty(meta.ReasoningEffort, cfg.ModelReasoningEffort))
+
+	model := firstNonEmpty(meta.Model, cfg.Model)
+	if model == "" {
+		return
+	}
+
+	setStringIfMissing(&payload.Model.ID, model)
+	setStringIfMissing(&payload.Model.DisplayName, model)
+}
+
+func setStringIfMissing(target *string, value string) {
+	if *target != "" || value == "" {
+		return
+	}
+
+	*target = value
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+
+	return ""
+}
+
+func defaultCodexHome(codexHomeEnv, userHome string) string {
+	if codexHomeEnv != "" {
+		return codexHomeEnv
+	}
+
+	if userHome == "" {
+		return ""
+	}
+
+	return filepath.Join(userHome, ".codex")
+}
+
+func loadCodexConfigStatus(codexHome string) codexConfigStatus {
+	if codexHome == "" {
+		return codexConfigStatus{}
+	}
+
+	data, err := os.ReadFile(filepath.Join(codexHome, "config.toml"))
+	if err != nil {
+		return codexConfigStatus{}
+	}
+
+	var cfg codexConfigStatus
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		return codexConfigStatus{}
+	}
+
+	return cfg
+}

--- a/src/segments/codex_status.go
+++ b/src/segments/codex_status.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	codexMaxSessionFiles          = 25
+	codexMaxSessionDirs           = codexMaxSessionFiles
 	codexMaxRequestedSessionFiles = 250
 )
 
@@ -136,6 +137,23 @@ func codexSessionFiles(root, sessionID string) ([]codexSessionFile, error) {
 				files = files[:limit]
 			}
 		}
+
+		if sessionID == "" && len(files) >= limit {
+			break
+		}
+	}
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, file := range codexSessionFilesInDir(root, entries) {
+		files = append(files, file)
+		if len(files) > limit {
+			sortCodexSessionFiles(files)
+			files = files[:limit]
+		}
 	}
 
 	sortCodexSessionFiles(files)
@@ -182,11 +200,14 @@ func codexSessionSearchDirs(root string) ([]string, error) {
 
 			for _, day := range days {
 				dirs = append(dirs, filepath.Join(monthPath, day))
+				if len(dirs) >= codexMaxSessionDirs {
+					return dirs, nil
+				}
 			}
 		}
 	}
 
-	return append(dirs, root), nil
+	return dirs, nil
 }
 
 func filterCodexSessionDirs(entries []os.DirEntry, length int) []string {
@@ -225,8 +246,9 @@ func codexSessionFilesInDir(dir string, entries []os.DirEntry) []codexSessionFil
 			continue
 		}
 
+		path := filepath.Join(dir, entry.Name())
 		files = append(files, codexSessionFile{
-			path:    filepath.Join(dir, entry.Name()),
+			path:    path,
 			sortKey: entry.Name(),
 		})
 	}
@@ -236,6 +258,10 @@ func codexSessionFilesInDir(dir string, entries []os.DirEntry) []codexSessionFil
 
 func sortCodexSessionFiles(files []codexSessionFile) {
 	sort.Slice(files, func(i, j int) bool {
+		if files[i].sortKey == files[j].sortKey {
+			return files[i].path > files[j].path
+		}
+
 		return files[i].sortKey > files[j].sortKey
 	})
 }

--- a/src/segments/codex_status_test.go
+++ b/src/segments/codex_status_test.go
@@ -73,7 +73,7 @@ func TestCodexStatusFromLocalSessionsConsidersRootFilesAfterDateCap(t *testing.T
 	dateRoot := filepath.Join(sessionRoot, "2026", "06", "09")
 	require.NoError(t, os.MkdirAll(dateRoot, 0o755))
 
-	for i := range codexMaxSessionFiles {
+	for i := 0; i < codexMaxSessionFiles; i++ {
 		sessionID := fmt.Sprintf("dated-session-%02d", i)
 		path := filepath.Join(dateRoot, fmt.Sprintf("rollout-2026-06-09T10-%02d-00-%s.jsonl", i, sessionID))
 		writeCodexSessionFile(t, path, sessionID, "2026-06-09T14:00:00Z", 10, 20)
@@ -101,7 +101,7 @@ func TestCodexSessionFilesCapsRequestedSessionCandidates(t *testing.T) {
 	sessionRoot := filepath.Join(tmp, "sessions")
 	require.NoError(t, os.MkdirAll(sessionRoot, 0o755))
 
-	for i := range codexMaxRequestedSessionFiles + 10 {
+	for i := 0; i < codexMaxRequestedSessionFiles+10; i++ {
 		path := filepath.Join(sessionRoot, fmt.Sprintf("rollout-2026-06-09T10-%03d-00.jsonl", i))
 		writeCodexSessionFile(t, path, fmt.Sprintf("session-%03d", i), "2026-06-09T14:00:00Z", 10, 20)
 	}

--- a/src/segments/codex_status_test.go
+++ b/src/segments/codex_status_test.go
@@ -111,6 +111,17 @@ func TestCodexSessionFilesCapsRequestedSessionCandidates(t *testing.T) {
 	require.Len(t, files, codexMaxRequestedSessionFiles)
 }
 
+func TestSortCodexSessionFilesBreaksTiesByPath(t *testing.T) {
+	files := []codexSessionFile{
+		{path: filepath.Join("sessions", "2026", "06", "09", "rollout.jsonl"), sortKey: "rollout.jsonl"},
+		{path: filepath.Join("sessions", "rollout.jsonl"), sortKey: "rollout.jsonl"},
+	}
+
+	sortCodexSessionFiles(files)
+
+	assert.Equal(t, filepath.Join("sessions", "rollout.jsonl"), files[0].path)
+}
+
 func TestCodexStatusFromLocalSessionsReturnsActionableErrorWhenSessionRootMissing(t *testing.T) {
 	_, err := CodexStatusFromLocalSessions(CodexLocalStatusOptions{})
 	require.Error(t, err)

--- a/src/segments/codex_status_test.go
+++ b/src/segments/codex_status_test.go
@@ -1,0 +1,276 @@
+package segments
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/cache"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCodexStatusFromLocalSessions(t *testing.T) {
+	tmp := t.TempDir()
+	codexHome := filepath.Join(tmp, ".codex")
+	sessionRoot := filepath.Join(codexHome, "sessions", "2026", "06", "09")
+	require.NoError(t, os.MkdirAll(sessionRoot, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(codexHome, "config.toml"),
+		[]byte("model = \"gpt-5.5\"\nmodel_reasoning_effort = \"high\"\napproval_policy = \"never\"\nsandbox_mode = \"workspace-write\"\n"),
+		0o644,
+	))
+
+	older := filepath.Join(sessionRoot, "rollout-2026-06-09T10-00-00-older-session.jsonl")
+	writeCodexSessionFile(t, older, "older-session", "2026-06-09T14:00:00Z", 10, 20)
+	newer := filepath.Join(sessionRoot, "rollout-2026-06-09T11-00-00-newer-session.jsonl")
+	writeCodexSessionFile(t, newer, "newer-session", "2026-06-09T15:00:00Z", 30, 40)
+
+	payload, err := CodexStatusFromLocalSessions(CodexLocalStatusOptions{
+		CodexHome:   codexHome,
+		SessionRoot: filepath.Join(codexHome, "sessions"),
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "token_count", payload.Type)
+	assert.Equal(t, "newer-session", payload.ThreadID)
+	assert.Equal(t, "C:/repo/newer-session", payload.CWD)
+	assert.Equal(t, "0.138.0", payload.Version)
+	assert.Equal(t, "high", payload.ReasoningEffort)
+	assert.Equal(t, "never", payload.ApprovalMode)
+	assert.Equal(t, "workspace-write", payload.SandboxPolicy)
+	assert.Equal(t, "gpt-5.5", payload.Model.DisplayName)
+	assert.Equal(t, 40, payload.Info.TotalTokenUsage.TotalTokens)
+}
+
+func TestCodexStatusFromLocalSessionsUsesRequestedSession(t *testing.T) {
+	tmp := t.TempDir()
+	sessionRoot := filepath.Join(tmp, "sessions")
+	require.NoError(t, os.MkdirAll(sessionRoot, 0o755))
+
+	older := filepath.Join(sessionRoot, "rollout-2026-06-09T10-00-00.jsonl")
+	writeCodexSessionFile(t, older, "older-session", "2026-06-09T14:00:00Z", 10, 20)
+	newer := filepath.Join(sessionRoot, "rollout-2026-06-09T11-00-00-newer-session.jsonl")
+	writeCodexSessionFile(t, newer, "newer-session", "2026-06-09T15:00:00Z", 30, 40)
+
+	payload, err := CodexStatusFromLocalSessions(CodexLocalStatusOptions{
+		SessionRoot: sessionRoot,
+		SessionID:   "older-session",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "older-session", payload.ThreadID)
+	assert.Equal(t, 20, payload.Info.TotalTokenUsage.TotalTokens)
+}
+
+func TestCodexStatusFromLocalSessionsConsidersRootFilesAfterDateCap(t *testing.T) {
+	tmp := t.TempDir()
+	sessionRoot := filepath.Join(tmp, "sessions")
+	dateRoot := filepath.Join(sessionRoot, "2026", "06", "09")
+	require.NoError(t, os.MkdirAll(dateRoot, 0o755))
+
+	for i := range codexMaxSessionFiles {
+		sessionID := fmt.Sprintf("dated-session-%02d", i)
+		path := filepath.Join(dateRoot, fmt.Sprintf("rollout-2026-06-09T10-%02d-00-%s.jsonl", i, sessionID))
+		writeCodexSessionFile(t, path, sessionID, "2026-06-09T14:00:00Z", 10, 20)
+	}
+
+	writeCodexSessionFile(
+		t,
+		filepath.Join(sessionRoot, "rollout-2026-06-10T10-00-00-root-session.jsonl"),
+		"root-session",
+		"2026-06-10T14:00:00Z",
+		30,
+		40,
+	)
+
+	payload, err := CodexStatusFromLocalSessions(CodexLocalStatusOptions{
+		SessionRoot: sessionRoot,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "root-session", payload.ThreadID)
+	assert.Equal(t, 40, payload.Info.TotalTokenUsage.TotalTokens)
+}
+
+func TestCodexSessionFilesCapsRequestedSessionCandidates(t *testing.T) {
+	tmp := t.TempDir()
+	sessionRoot := filepath.Join(tmp, "sessions")
+	require.NoError(t, os.MkdirAll(sessionRoot, 0o755))
+
+	for i := range codexMaxRequestedSessionFiles + 10 {
+		path := filepath.Join(sessionRoot, fmt.Sprintf("rollout-2026-06-09T10-%03d-00.jsonl", i))
+		writeCodexSessionFile(t, path, fmt.Sprintf("session-%03d", i), "2026-06-09T14:00:00Z", 10, 20)
+	}
+
+	files, err := codexSessionFiles(sessionRoot, "requested-session")
+	require.NoError(t, err)
+	require.Len(t, files, codexMaxRequestedSessionFiles)
+}
+
+func TestCodexStatusFromLocalSessionsReturnsActionableErrorWhenSessionRootMissing(t *testing.T) {
+	_, err := CodexStatusFromLocalSessions(CodexLocalStatusOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "set CODEX_HOME")
+	assert.Contains(t, err.Error(), "--session-root")
+}
+
+func TestCodexStatusFromLocalSessionsReturnsActionableErrorWhenNoSessionFiles(t *testing.T) {
+	tmp := t.TempDir()
+
+	_, err := CodexStatusFromLocalSessions(CodexLocalStatusOptions{
+		SessionRoot: tmp,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "start Codex once")
+	assert.Contains(t, err.Error(), "--codex-home")
+}
+
+func TestCodexStatusFromLocalSessionsSkipsMismatchedRequestedSession(t *testing.T) {
+	tmp := t.TempDir()
+	sessionRoot := filepath.Join(tmp, "sessions")
+	require.NoError(t, os.MkdirAll(sessionRoot, 0o755))
+
+	mismatch := filepath.Join(sessionRoot, "rollout-2026-06-09T10-00-00-requested-session.jsonl")
+	writeCodexSessionFile(t, mismatch, "different-session", "2026-06-09T14:00:00Z", 10, 20)
+
+	_, err := CodexStatusFromLocalSessions(CodexLocalStatusOptions{
+		SessionRoot: sessionRoot,
+		SessionID:   "requested-session",
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errCodexNoTokenCount)
+}
+
+func TestCodexStatusFromLocalSessionsReturnsErrorWhenNoTokenCount(t *testing.T) {
+	tmp := t.TempDir()
+	sessionRoot := filepath.Join(tmp, "sessions")
+	require.NoError(t, os.MkdirAll(sessionRoot, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sessionRoot, "rollout-no-token.jsonl"),
+		[]byte("{\"timestamp\":\"2026-06-09T14:00:00Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"agent_message\",\"message\":\"done\"}}\n"),
+		0o644,
+	))
+
+	_, err := CodexStatusFromLocalSessions(CodexLocalStatusOptions{
+		SessionRoot: sessionRoot,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errCodexNoTokenCount)
+}
+
+func TestCodexStatusFromLocalSessionsReturnsMalformedJSONLError(t *testing.T) {
+	tmp := t.TempDir()
+	sessionRoot := filepath.Join(tmp, "sessions")
+	require.NoError(t, os.MkdirAll(sessionRoot, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(sessionRoot, "rollout-malformed.jsonl"),
+		[]byte("{\"timestamp\":\"2026-06-09T14:00:00Z\",\"type\":\"event_msg\",\"payload\":"),
+		0o644,
+	))
+
+	_, err := CodexStatusFromLocalSessions(CodexLocalStatusOptions{
+		SessionRoot: sessionRoot,
+	})
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, errCodexNoTokenCount)
+}
+
+func TestCodexStatusFromLocalSessionsIgnoresNonDateDirectories(t *testing.T) {
+	tmp := t.TempDir()
+	sessionRoot := filepath.Join(tmp, "sessions")
+	require.NoError(t, os.MkdirAll(filepath.Join(sessionRoot, "archive"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(sessionRoot, "2026", "06", "09"), 0o755))
+
+	session := filepath.Join(sessionRoot, "2026", "06", "09", "rollout-2026-06-09T10-00-00-session.jsonl")
+	writeCodexSessionFile(t, session, "session", "2026-06-09T14:00:00Z", 10, 20)
+
+	payload, err := CodexStatusFromLocalSessions(CodexLocalStatusOptions{
+		SessionRoot: sessionRoot,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "session", payload.ThreadID)
+}
+
+func TestCodexSegmentDiscoversLocalStatus(t *testing.T) {
+	cache.Delete(cache.Session, cache.CODEXCACHE)
+
+	tmp := t.TempDir()
+	codexHome := filepath.Join(tmp, ".codex")
+	sessionRoot := filepath.Join(codexHome, "sessions", "2026", "06", "09")
+	require.NoError(t, os.MkdirAll(sessionRoot, 0o755))
+	writeCodexSessionFile(t, filepath.Join(sessionRoot, "rollout-local-session.jsonl"), "local-session", "2026-06-09T14:00:00Z", 10, 20)
+
+	env := new(mock.Environment)
+	env.On("Getenv", defaultCodexStatusFileEnv).Return("")
+	env.On("Getenv", defaultCodexStatusJSONEnv).Return("")
+	env.On("Getenv", "CODEX_HOME").Return(codexHome)
+	env.On("Home").Return(tmp)
+
+	segment := &Codex{
+		Base: Base{
+			env:     env,
+			options: options.Map{},
+		},
+	}
+
+	require.True(t, segment.Enabled())
+	assert.Equal(t, "local-session", segment.ThreadID)
+	assert.Equal(t, 20, segment.Info.TotalTokenUsage.TotalTokens)
+
+	cache.Delete(cache.Session, cache.CODEXCACHE)
+}
+
+func TestCodexCacheKeyUsesStatusSource(t *testing.T) {
+	env := new(mock.Environment)
+	env.On("Getenv", defaultCodexStatusFileEnv).Return("C:/tmp/codex-status.json")
+
+	segment := &Codex{
+		Base: Base{
+			env: env,
+			options: options.Map{
+				codexHome:      "C:/Users/Test/.codex",
+				codexSessionID: "thread-1",
+			},
+		},
+	}
+
+	key, ok := segment.CacheKey()
+	require.True(t, ok)
+
+	statusFileHash := codexCacheKeyHash("C:/tmp/codex-status.json")
+	sessionRootHash := codexCacheKeyHash(filepath.Join("C:/Users/Test/.codex", "sessions"))
+	expectedKey := "codex|discover|true|file-env|POSH_CODEX_STATUS_FILE|" +
+		"file|" + statusFileHash + "|json-env|POSH_CODEX_STATUS|" +
+		"session|thread-1|root|" + sessionRootHash
+	assert.Equal(
+		t,
+		expectedKey,
+		key,
+	)
+}
+
+func writeCodexSessionFile(t *testing.T, path, sessionID, timestamp string, firstTokens, secondTokens int) {
+	t.Helper()
+
+	content := "" +
+		"{\"timestamp\":\"" + timestamp + "\",\"type\":\"session_meta\",\"payload\":{\"id\":\"" + sessionID + "\",\"cwd\":\"C:/repo/" + sessionID + "\",\"cli_version\":\"0.138.0\"}}\n" +
+		codexTokenCountLine(timestamp, firstTokens) + "\n" +
+		codexTokenCountLine(timestamp, secondTokens) + "\n"
+
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+}
+
+func codexTokenCountLine(timestamp string, totalTokens int) string {
+	return fmt.Sprintf(
+		`{"timestamp":"%s","type":"event_msg","payload":{"type":"token_count",`+
+			`"info":{"total_token_usage":{"total_tokens":%d},"last_token_usage":{"total_tokens":100},`+
+			`"model_context_window":10000},"rate_limits":{"primary":{"used_percent":12},`+
+			`"secondary":{"used_percent":34}}}}`,
+		timestamp,
+		totalTokens,
+	)
+}

--- a/src/segments/codex_test.go
+++ b/src/segments/codex_test.go
@@ -541,11 +541,13 @@ func TestCodexRateLimitUsage(t *testing.T) {
 		CodexData: CodexData{
 			RateLimits: &CodexRateLimits{
 				Primary: &CodexRateLimitWindow{
-					UsedPercent: &primary,
+					UsedPercent:   &primary,
+					WindowMinutes: 300,
 				},
 				Secondary: &CodexRateLimitWindow{
-					UsedPercent: &secondary,
-					ResetsAt:    &reset,
+					UsedPercent:   &secondary,
+					WindowMinutes: 10080,
+					ResetsAt:      &reset,
 				},
 			},
 		},
@@ -556,8 +558,38 @@ func TestCodexRateLimitUsage(t *testing.T) {
 	assert.Equal(t, text.Percentage(87), segment.FiveHourRemaining())
 	assert.Equal(t, text.Percentage(74), segment.WeeklyRemaining())
 	assert.Equal(t, "74%", segment.FormattedWeeklyRemaining())
+	assert.Equal(t, "5h", segment.FiveHourLimitLabel())
+	assert.Equal(t, "7d", segment.WeeklyLimitLabel())
 	assert.Equal(t, "7d 74%", segment.FormattedLimits())
 	assert.Equal(t, time.Unix(reset, 0), segment.WeeklyResetsAt())
+}
+
+func TestCodexRateLimitLabelsUseWindowMinutes(t *testing.T) {
+	primary := 12.5
+	secondary := 26.0
+	segment := &Codex{
+		Base: Base{
+			options: options.Map{
+				displayFiveHourLimit: true,
+			},
+		},
+		CodexData: CodexData{
+			RateLimits: &CodexRateLimits{
+				Primary: &CodexRateLimitWindow{
+					UsedPercent:   &primary,
+					WindowMinutes: 90,
+				},
+				Secondary: &CodexRateLimitWindow{
+					UsedPercent:   &secondary,
+					WindowMinutes: 4320,
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, "90m", segment.FiveHourLimitLabel())
+	assert.Equal(t, "3d", segment.WeeklyLimitLabel())
+	assert.Equal(t, "90m 87% 3d 74%", segment.FormattedLimits())
 }
 
 func TestCodexFormattedLimitsOmitsUnknownWindows(t *testing.T) {

--- a/src/segments/codex_test.go
+++ b/src/segments/codex_test.go
@@ -1,0 +1,745 @@
+package segments
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/cache"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+	"github.com/jandedobbeleer/oh-my-posh/src/text"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCodexSegment(t *testing.T) {
+	cases := []struct {
+		Data            *CodexData
+		Case            string
+		ExpectedModel   string
+		ExpectedThread  string
+		ExpectedEnabled bool
+	}{
+		{
+			Case:            "No cache data",
+			Data:            nil,
+			ExpectedEnabled: false,
+		},
+		{
+			Case: "Valid data",
+			Data: &CodexData{
+				ThreadID: "019e9eac-83ec-7393-ae18-cc2e566394d5",
+				Model: CodexModel{
+					ID:          "gpt-5.5",
+					DisplayName: "GPT-5.5",
+				},
+			},
+			ExpectedEnabled: true,
+			ExpectedModel:   "GPT-5.5",
+			ExpectedThread:  "019e9eac-83ec-7393-ae18-cc2e566394d5",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Case, func(t *testing.T) {
+			if tc.Data != nil {
+				cache.Set(cache.Session, cache.CODEXCACHE, *tc.Data, cache.INFINITE)
+			} else {
+				cache.Delete(cache.Session, cache.CODEXCACHE)
+			}
+
+			env := new(mock.Environment)
+			if tc.Data == nil {
+				env.On("Getenv", defaultCodexStatusFileEnv).Return("")
+				env.On("Getenv", defaultCodexStatusJSONEnv).Return("")
+			}
+
+			segment := &Codex{
+				Base: Base{
+					env: env,
+					options: options.Map{
+						discoverLocalStatus: false,
+					},
+				},
+			}
+
+			enabled := segment.Enabled()
+			assert.Equal(t, tc.ExpectedEnabled, enabled)
+
+			if tc.ExpectedEnabled {
+				assert.Equal(t, tc.ExpectedModel, segment.Model.DisplayName)
+				assert.Equal(t, tc.ExpectedThread, segment.ThreadID)
+			}
+
+			cache.Delete(cache.Session, cache.CODEXCACHE)
+		})
+	}
+}
+
+func TestCodexDataUnmarshalWrappedTokenCountEvent(t *testing.T) {
+	input := []byte(`{
+		"type": "event_msg",
+		"payload": {
+			"type": "token_count",
+			"model": "gpt-5.5",
+			"thread_id": "thread-1",
+			"info": {
+				"total_token_usage": {
+					"input_tokens": 1000,
+					"cached_input_tokens": 200,
+					"output_tokens": 300,
+					"reasoning_output_tokens": 50,
+					"total_tokens": 1300
+				},
+				"last_token_usage": {
+					"input_tokens": 100,
+					"output_tokens": 30,
+					"total_tokens": 130
+				},
+				"model_context_window": 260000
+			},
+			"rate_limits": {
+				"plan_type": "pro",
+				"primary": {
+					"used_percent": 12.5,
+					"window_minutes": 300,
+					"resets_at": 1780794869
+				},
+				"secondary": {
+					"used_percent": 26,
+					"window_minutes": 10080,
+					"resets_at": 1781137565
+				}
+			}
+		}
+	}`)
+
+	var data CodexData
+	require.NoError(t, json.Unmarshal(input, &data))
+	assert.Equal(t, "token_count", data.Type)
+	assert.Equal(t, "gpt-5.5", data.Model.DisplayName)
+	assert.Equal(t, 1300, data.Info.TotalTokenUsage.TotalTokens)
+	assert.Equal(t, 26.0, *data.RateLimits.Secondary.UsedPercent)
+}
+
+func TestCodexDataUnmarshalUnsupportedEvent(t *testing.T) {
+	input := []byte(`{
+		"type": "event_msg",
+		"payload": {
+			"type": "agent_message",
+			"message": "not token data"
+		}
+	}`)
+
+	var data CodexData
+	require.Error(t, json.Unmarshal(input, &data))
+}
+
+func TestCodexTemplateUsesExplicitFields(t *testing.T) {
+	weekly := 26.0
+	segment := &Codex{
+		CodexData: CodexData{
+			Model: CodexModel{
+				ID: "gpt-5.5",
+			},
+			Info: CodexTokenInfo{
+				LastTokenUsage: CodexTokenUsage{
+					TotalTokens: 4000,
+				},
+				ModelContextWindow: 10000,
+			},
+			RateLimits: &CodexRateLimits{
+				Secondary: &CodexRateLimitWindow{
+					UsedPercent: &weekly,
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, "\ue7cf gpt-5.5 \uf2d0 ▰▰▰▱▱ \uf017 7d 74%", renderTemplate(new(mock.Environment), segment.Template(), segment))
+}
+
+func TestCodexSegmentEmptyPayloadDisabled(t *testing.T) {
+	cache.Delete(cache.Session, cache.CODEXCACHE)
+
+	env := new(mock.Environment)
+	env.On("Getenv", defaultCodexStatusFileEnv).Return("")
+	env.On("Getenv", defaultCodexStatusJSONEnv).Return(`{"type":"token_count"}`)
+
+	segment := &Codex{
+		Base: Base{
+			env: env,
+			options: options.Map{
+				discoverLocalStatus: false,
+			},
+		},
+	}
+
+	assert.False(t, segment.Enabled())
+}
+
+func TestCodexSegmentStatusFile(t *testing.T) {
+	cache.Delete(cache.Session, cache.CODEXCACHE)
+
+	status := `{
+		"type": "token_count",
+		"thread_id": "thread-from-file",
+		"model": {
+			"id": "gpt-5.5",
+			"display_name": "GPT-5.5"
+		}
+	}`
+
+	env := new(mock.Environment)
+	env.On("FileContent", "/tmp/codex-status.json").Return(status)
+
+	segment := &Codex{
+		Base: Base{
+			env: env,
+			options: options.Map{
+				statusFile: "/tmp/codex-status.json",
+			},
+		},
+	}
+
+	require.True(t, segment.Enabled())
+	assert.Equal(t, "thread-from-file", segment.ThreadID)
+	assert.Equal(t, "GPT-5.5", segment.Model.DisplayName)
+}
+
+func TestCodexSegmentStatusFileExpandsHome(t *testing.T) {
+	cache.Delete(cache.Session, cache.CODEXCACHE)
+
+	status := `{
+		"type": "token_count",
+		"thread_id": "thread-from-home-file",
+		"model": "gpt-5.5"
+	}`
+
+	env := new(mock.Environment)
+	env.On("Home").Return("/home/test")
+	env.On("FileContent", filepath.Join("/home/test", ".codex", "codex-status.json")).Return(status)
+
+	segment := &Codex{
+		Base: Base{
+			env: env,
+			options: options.Map{
+				statusFile: "~/.codex/codex-status.json",
+			},
+		},
+	}
+
+	require.True(t, segment.Enabled())
+	assert.Equal(t, "thread-from-home-file", segment.ThreadID)
+}
+
+func TestCodexSegmentStatusFileEnv(t *testing.T) {
+	cache.Delete(cache.Session, cache.CODEXCACHE)
+
+	status := `{
+		"type": "token_count",
+		"thread_id": "thread-from-file-env",
+		"model": "gpt-5.5"
+	}`
+
+	env := new(mock.Environment)
+	env.On("Getenv", defaultCodexStatusFileEnv).Return("/tmp/codex-status.json")
+	env.On("FileContent", "/tmp/codex-status.json").Return(status)
+
+	segment := &Codex{
+		Base: Base{
+			env: env,
+			options: options.Map{
+				discoverLocalStatus: false,
+			},
+		},
+	}
+
+	require.True(t, segment.Enabled())
+	assert.Equal(t, "thread-from-file-env", segment.ThreadID)
+	assert.Equal(t, "gpt-5.5", segment.Model.DisplayName)
+}
+
+func TestCodexSegmentStatusEnv(t *testing.T) {
+	cache.Delete(cache.Session, cache.CODEXCACHE)
+
+	status := `{
+		"type": "token_count",
+		"thread_id": "thread-from-env",
+		"model": "gpt-5.5"
+	}`
+
+	env := new(mock.Environment)
+	env.On("Getenv", defaultCodexStatusFileEnv).Return("")
+	env.On("Getenv", defaultCodexStatusJSONEnv).Return(status)
+
+	segment := &Codex{
+		Base: Base{
+			env: env,
+			options: options.Map{
+				discoverLocalStatus: false,
+			},
+		},
+	}
+
+	require.True(t, segment.Enabled())
+	assert.Equal(t, "thread-from-env", segment.ThreadID)
+	assert.Equal(t, "gpt-5.5", segment.Model.DisplayName)
+}
+
+func TestCodexSegmentInvalidCacheFallsBackToStatusFile(t *testing.T) {
+	cache.Set(cache.Session, cache.CODEXCACHE, CodexData{}, cache.INFINITE)
+	defer cache.Delete(cache.Session, cache.CODEXCACHE)
+
+	status := `{
+		"type": "token_count",
+		"thread_id": "thread-from-file-after-cache-miss",
+		"model": "gpt-5.5"
+	}`
+
+	env := new(mock.Environment)
+	env.On("Getenv", defaultCodexStatusFileEnv).Return("/tmp/codex-status.json")
+	env.On("FileContent", "/tmp/codex-status.json").Return(status)
+
+	segment := &Codex{
+		Base: Base{
+			env: env,
+			options: options.Map{
+				discoverLocalStatus: false,
+			},
+		},
+	}
+
+	require.True(t, segment.Enabled())
+	assert.Equal(t, "thread-from-file-after-cache-miss", segment.ThreadID)
+	assert.Equal(t, "gpt-5.5", segment.Model.DisplayName)
+
+	_, found := cache.Get[CodexData](cache.Session, cache.CODEXCACHE)
+	assert.False(t, found)
+}
+
+func TestCodexSegmentInvalidStatusFileFallsBackToStatusEnv(t *testing.T) {
+	cache.Delete(cache.Session, cache.CODEXCACHE)
+
+	status := `{
+		"type": "token_count",
+		"thread_id": "thread-from-env-after-file-miss",
+		"model": "gpt-5.5"
+	}`
+
+	env := new(mock.Environment)
+	env.On("Getenv", defaultCodexStatusFileEnv).Return("/tmp/codex-status.json")
+	env.On("FileContent", "/tmp/codex-status.json").Return(`{"type":"token_count"}`)
+	env.On("Getenv", defaultCodexStatusJSONEnv).Return(status)
+
+	segment := &Codex{
+		Base: Base{
+			env:     env,
+			options: options.Map{},
+		},
+	}
+
+	require.True(t, segment.Enabled())
+	assert.Equal(t, "thread-from-env-after-file-miss", segment.ThreadID)
+	assert.Equal(t, "gpt-5.5", segment.Model.DisplayName)
+}
+
+func TestCodexSegmentEmptyRateLimitsDisabled(t *testing.T) {
+	cache.Set(cache.Session, cache.CODEXCACHE, CodexData{
+		RateLimits: &CodexRateLimits{},
+	}, cache.INFINITE)
+	defer cache.Delete(cache.Session, cache.CODEXCACHE)
+
+	env := new(mock.Environment)
+	env.On("Getenv", defaultCodexStatusFileEnv).Return("")
+	env.On("Getenv", defaultCodexStatusJSONEnv).Return("")
+
+	segment := &Codex{
+		Base: Base{
+			env: env,
+			options: options.Map{
+				discoverLocalStatus: false,
+			},
+		},
+	}
+
+	assert.False(t, segment.Enabled())
+}
+
+func TestCodexFormattedTextUsesOptionsWithoutEnabled(t *testing.T) {
+	primary := 12.5
+	secondary := 26.0
+	segment := &Codex{
+		Base: Base{
+			options: options.Map{
+				displayFiveHourLimit: true,
+				displayReasoning:     true,
+				displayTokens:        true,
+				gaugeMarkedChar:      "#",
+				gaugeUnmarkedChar:    "-",
+			},
+		},
+		CodexData: CodexData{
+			ReasoningEffort: "high",
+			Model: CodexModel{
+				ID:          "gpt-5.5",
+				DisplayName: "GPT-5.5",
+			},
+			Info: CodexTokenInfo{
+				TotalTokenUsage: CodexTokenUsage{
+					TotalTokens: 1200,
+				},
+				ModelContextWindow: 10000,
+			},
+			RateLimits: &CodexRateLimits{
+				Primary: &CodexRateLimitWindow{
+					UsedPercent: &primary,
+				},
+				Secondary: &CodexRateLimitWindow{
+					UsedPercent: &secondary,
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, "\ue7cf GPT-5.5 (high) \uf2d0 ####- tok 1.2K \uf017 5h 87% 7d 74%", segment.FormattedText())
+}
+
+func TestCodexFormattedTextOmitsUnknownContext(t *testing.T) {
+	segment := &Codex{
+		CodexData: CodexData{
+			Model: CodexModel{
+				DisplayName: "GPT-5.5",
+			},
+			Info: CodexTokenInfo{
+				TotalTokenUsage: CodexTokenUsage{
+					TotalTokens: 1200,
+				},
+			},
+		},
+	}
+
+	assert.Empty(t, segment.TokenGauge())
+	assert.Empty(t, segment.TokenGaugeUsed())
+	assert.Equal(t, "\ue7cf GPT-5.5", segment.FormattedText())
+}
+
+func TestCodexTokenUsagePercent(t *testing.T) {
+	cases := []struct {
+		Case            string
+		Info            CodexTokenInfo
+		ExpectedPercent text.Percentage
+	}{
+		{
+			Case:            "No data",
+			Info:            CodexTokenInfo{},
+			ExpectedPercent: 0,
+		},
+		{
+			Case: "Rounded usage",
+			Info: CodexTokenInfo{
+				TotalTokenUsage: CodexTokenUsage{
+					TotalTokens: 1300,
+				},
+				ModelContextWindow: 10000,
+			},
+			ExpectedPercent: 13,
+		},
+		{
+			Case: "Usage capped",
+			Info: CodexTokenInfo{
+				TotalTokenUsage: CodexTokenUsage{
+					TotalTokens: 12000,
+				},
+				ModelContextWindow: 10000,
+			},
+			ExpectedPercent: 100,
+		},
+		{
+			Case: "Last usage preferred over cumulative total",
+			Info: CodexTokenInfo{
+				TotalTokenUsage: CodexTokenUsage{
+					TotalTokens: 12000,
+				},
+				LastTokenUsage: CodexTokenUsage{
+					TotalTokens: 2500,
+				},
+				ModelContextWindow: 10000,
+			},
+			ExpectedPercent: 25,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Case, func(t *testing.T) {
+			segment := &Codex{
+				CodexData: CodexData{
+					Info: tc.Info,
+				},
+			}
+			assert.Equal(t, tc.ExpectedPercent, segment.TokenUsagePercent())
+		})
+	}
+}
+
+func TestCodexFormattedTokens(t *testing.T) {
+	segment := &Codex{
+		CodexData: CodexData{
+			Info: CodexTokenInfo{
+				TotalTokenUsage: CodexTokenUsage{
+					InputTokens:           1200,
+					CachedInputTokens:     400,
+					OutputTokens:          500000,
+					ReasoningOutputTokens: 42,
+					TotalTokens:           1500000,
+				},
+				LastTokenUsage: CodexTokenUsage{
+					TotalTokens: 987,
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, "1.5M", segment.FormattedTokens())
+	assert.Equal(t, "1.2K", segment.FormattedInputTokens())
+	assert.Equal(t, "500.0K", segment.FormattedOutputTokens())
+	assert.Equal(t, "42", segment.FormattedReasoningTokens())
+	assert.Equal(t, "400", segment.FormattedCachedInputTokens())
+	assert.Equal(t, "987", segment.FormattedLastTokens())
+}
+
+func TestCodexRemainingContext(t *testing.T) {
+	segment := &Codex{
+		CodexData: CodexData{
+			Info: CodexTokenInfo{
+				TotalTokenUsage: CodexTokenUsage{
+					TotalTokens: 250000,
+				},
+				LastTokenUsage: CodexTokenUsage{
+					TotalTokens: 25000,
+				},
+				ModelContextWindow: 100000,
+			},
+		},
+	}
+
+	assert.Equal(t, text.Percentage(75), segment.RemainingPercent())
+	assert.Equal(t, 75000, segment.RemainingTokensCount())
+}
+
+func TestCodexRateLimitUsage(t *testing.T) {
+	primary := 12.5
+	secondary := 26.0
+	reset := int64(1781137565)
+	segment := &Codex{
+		Base: Base{
+			options: options.Map{},
+		},
+		CodexData: CodexData{
+			RateLimits: &CodexRateLimits{
+				Primary: &CodexRateLimitWindow{
+					UsedPercent: &primary,
+				},
+				Secondary: &CodexRateLimitWindow{
+					UsedPercent: &secondary,
+					ResetsAt:    &reset,
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, text.Percentage(13), segment.FiveHourUsage())
+	assert.Equal(t, text.Percentage(26), segment.WeeklyUsage())
+	assert.Equal(t, text.Percentage(87), segment.FiveHourRemaining())
+	assert.Equal(t, text.Percentage(74), segment.WeeklyRemaining())
+	assert.Equal(t, "74%", segment.FormattedWeeklyRemaining())
+	assert.Equal(t, "7d 74%", segment.FormattedLimits())
+	assert.Equal(t, time.Unix(reset, 0), segment.WeeklyResetsAt())
+}
+
+func TestCodexFormattedLimitsOmitsUnknownWindows(t *testing.T) {
+	primary := 12.5
+	segment := &Codex{
+		Base: Base{
+			options: options.Map{
+				displayFiveHourLimit: true,
+			},
+		},
+		CodexData: CodexData{
+			RateLimits: &CodexRateLimits{
+				Primary: &CodexRateLimitWindow{
+					UsedPercent: &primary,
+				},
+				Secondary: &CodexRateLimitWindow{},
+			},
+		},
+	}
+
+	assert.Equal(t, "5h 87%", segment.FormattedLimits())
+	assert.Equal(t, "87%", segment.FormattedFiveHourRemaining())
+	assert.Empty(t, segment.FormattedWeeklyRemaining())
+	assert.NotEmpty(t, segment.FiveHourGauge())
+	assert.NotEmpty(t, segment.FiveHourRemainingGauge())
+	assert.Empty(t, segment.WeeklyGauge())
+	assert.Empty(t, segment.WeeklyRemainingGauge())
+}
+
+func TestCodexFormattedLimitsEmptyWhenUsageUnknown(t *testing.T) {
+	segment := &Codex{
+		Base: Base{
+			options: options.Map{
+				displayFiveHourLimit: true,
+			},
+		},
+		CodexData: CodexData{
+			RateLimits: &CodexRateLimits{},
+		},
+	}
+
+	assert.Empty(t, segment.FormattedLimits())
+	assert.Empty(t, segment.FormattedFiveHourRemaining())
+	assert.Empty(t, segment.FormattedWeeklyRemaining())
+	assert.Empty(t, segment.FiveHourGauge())
+	assert.Empty(t, segment.WeeklyGauge())
+	assert.Empty(t, segment.FiveHourRemainingGauge())
+	assert.Empty(t, segment.WeeklyRemainingGauge())
+}
+
+func TestCodexTokenGaugeCustomChars(t *testing.T) {
+	data := CodexData{
+		Info: CodexTokenInfo{
+			TotalTokenUsage: CodexTokenUsage{
+				TotalTokens: 60000,
+			},
+			ModelContextWindow: 100000,
+		},
+	}
+	cache.Set(cache.Session, cache.CODEXCACHE, data, cache.INFINITE)
+	defer cache.Delete(cache.Session, cache.CODEXCACHE)
+
+	segment := &Codex{
+		Base: Base{
+			env: new(mock.Environment),
+			options: options.Map{
+				gaugeMarkedChar:   "█",
+				gaugeUnmarkedChar: "░",
+			},
+		},
+	}
+
+	require.True(t, segment.Enabled())
+	assert.Contains(t, segment.TokenGaugeUsed(), "█")
+	assert.Contains(t, segment.TokenGauge(), "░")
+}
+
+func TestCodexDisplayOptions(t *testing.T) {
+	primary := 12.5
+	secondary := 26.0
+	data := CodexData{
+		ThreadID:        "thread-1",
+		ReasoningEffort: "high",
+		Model: CodexModel{
+			ID:          "gpt-5.5",
+			DisplayName: "GPT-5.5",
+		},
+		Info: CodexTokenInfo{
+			TotalTokenUsage: CodexTokenUsage{
+				TotalTokens: 1200,
+			},
+			ModelContextWindow: 10000,
+		},
+		RateLimits: &CodexRateLimits{
+			Primary: &CodexRateLimitWindow{
+				UsedPercent: &primary,
+			},
+			Secondary: &CodexRateLimitWindow{
+				UsedPercent: &secondary,
+			},
+		},
+	}
+	cache.Set(cache.Session, cache.CODEXCACHE, data, cache.INFINITE)
+	defer cache.Delete(cache.Session, cache.CODEXCACHE)
+
+	cases := []struct {
+		Case              string
+		Options           options.Map
+		ExpectedModel     bool
+		ExpectedReason    bool
+		ExpectedContext   bool
+		ExpectedTokens    bool
+		ExpectedFiveHour  bool
+		ExpectedWeekly    bool
+		ExpectedModelText string
+		ExpectedLimits    string
+	}{
+		{
+			Case:              "Defaults",
+			Options:           options.Map{},
+			ExpectedModel:     true,
+			ExpectedReason:    false,
+			ExpectedContext:   true,
+			ExpectedTokens:    false,
+			ExpectedFiveHour:  false,
+			ExpectedWeekly:    true,
+			ExpectedModelText: "GPT-5.5",
+			ExpectedLimits:    "7d 74%",
+		},
+		{
+			Case: "Everything enabled",
+			Options: options.Map{
+				displayFiveHourLimit: true,
+				displayReasoning:     true,
+				displayTokens:        true,
+			},
+			ExpectedModel:     true,
+			ExpectedReason:    true,
+			ExpectedContext:   true,
+			ExpectedTokens:    true,
+			ExpectedFiveHour:  true,
+			ExpectedWeekly:    true,
+			ExpectedModelText: "GPT-5.5 (high)",
+			ExpectedLimits:    "5h 87% 7d 74%",
+		},
+		{
+			Case: "Minimal limits only",
+			Options: options.Map{
+				displayModel:         false,
+				displayContext:       false,
+				displayWeeklyLimit:   false,
+				displayFiveHourLimit: true,
+			},
+			ExpectedModel:     false,
+			ExpectedReason:    false,
+			ExpectedContext:   false,
+			ExpectedTokens:    false,
+			ExpectedFiveHour:  true,
+			ExpectedWeekly:    false,
+			ExpectedModelText: "",
+			ExpectedLimits:    "5h 87%",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Case, func(t *testing.T) {
+			segment := &Codex{
+				Base: Base{
+					env:     new(mock.Environment),
+					options: tc.Options,
+				},
+			}
+
+			require.True(t, segment.Enabled())
+			assert.Equal(t, tc.ExpectedModel, segment.DisplayModel())
+			assert.Equal(t, tc.ExpectedReason, segment.DisplayReasoning())
+			assert.Equal(t, tc.ExpectedContext, segment.DisplayContext())
+			assert.Equal(t, tc.ExpectedTokens, segment.DisplayTokens())
+			assert.Equal(t, tc.ExpectedFiveHour, segment.DisplayFiveHourLimit())
+			assert.Equal(t, tc.ExpectedWeekly, segment.DisplayWeeklyLimit())
+			assert.Equal(t, tc.ExpectedModelText, segment.FormattedModel())
+			assert.Equal(t, tc.ExpectedLimits, segment.FormattedLimits())
+		})
+	}
+}

--- a/src/shell/constants.go
+++ b/src/shell/constants.go
@@ -11,5 +11,6 @@ const (
 	ELVISH     = "elvish"
 	XONSH      = "xonsh"
 	CLAUDE     = "claude"
+	CODEX      = "codex"
 	COPILOTCLI = "copilot-cli"
 )

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -383,6 +383,7 @@
             "cf",
             "cftarget",
             "claude",
+            "codex",
             "clojure",
             "cmake",
             "copilot",
@@ -1317,6 +1318,113 @@
             "properties": {
               "options": {
                 "properties": {
+                  "gauge_marked_char": {
+                    "type": "string",
+                    "title": "Gauge marked character",
+                    "description": "The character used for the filled part of the token usage gauge",
+                    "default": "▰"
+                  },
+                  "gauge_unmarked_char": {
+                    "type": "string",
+                    "title": "Gauge unmarked character",
+                    "description": "The character used for the empty part of the token usage gauge",
+                    "default": "▱"
+                  }
+                },
+                "unevaluatedProperties": false
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "codex"
+              }
+            }
+          },
+          "then": {
+            "title": "OpenAI Codex Segment",
+            "description": "https://ohmyposh.dev/docs/segments/cli/codex",
+            "properties": {
+              "options": {
+                "type": "object",
+                "properties": {
+                  "display_model": {
+                    "type": "boolean",
+                    "title": "Display model",
+                    "description": "Display the Codex model name in the .FormattedText preset",
+                    "default": true
+                  },
+                  "display_reasoning": {
+                    "type": "boolean",
+                    "title": "Display reasoning",
+                    "description": "Display the Codex reasoning level in the .FormattedText preset",
+                    "default": false
+                  },
+                  "display_context": {
+                    "type": "boolean",
+                    "title": "Display context",
+                    "description": "Display context window usage in the .FormattedText preset",
+                    "default": true
+                  },
+                  "display_tokens": {
+                    "type": "boolean",
+                    "title": "Display tokens",
+                    "description": "Display total token usage in the .FormattedText preset",
+                    "default": false
+                  },
+                  "display_five_hour_limit": {
+                    "type": "boolean",
+                    "title": "Display five-hour limit",
+                    "description": "Display the primary 5-hour rolling limit in the .FormattedText preset",
+                    "default": false
+                  },
+                  "display_weekly_limit": {
+                    "type": "boolean",
+                    "title": "Display weekly limit",
+                    "description": "Display the secondary 7-day rolling limit in the .FormattedText preset",
+                    "default": true
+                  },
+                  "discover_local_status": {
+                    "type": "boolean",
+                    "title": "Discover local status",
+                    "description": "Discover Codex status from local session transcripts when no explicit status data is available",
+                    "default": true
+                  },
+                  "codex_home": {
+                    "type": "string",
+                    "title": "Codex home",
+                    "description": "Codex home directory; defaults to CODEX_HOME or ~/.codex"
+                  },
+                  "session_root": {
+                    "type": "string",
+                    "title": "Session root",
+                    "description": "Codex sessions directory; defaults to <codex_home>/sessions"
+                  },
+                  "session_id": {
+                    "type": "string",
+                    "title": "Session ID",
+                    "description": "Codex session/thread ID to render; defaults to the newest session with token usage"
+                  },
+                  "status_file": {
+                    "type": "string",
+                    "title": "Status file",
+                    "description": "Path to a JSON file containing Codex status data"
+                  },
+                  "status_file_env": {
+                    "type": "string",
+                    "title": "Status file environment variable",
+                    "description": "Environment variable containing the Codex status file path",
+                    "default": "POSH_CODEX_STATUS_FILE"
+                  },
+                  "status_json_env": {
+                    "type": "string",
+                    "title": "Status JSON environment variable",
+                    "description": "Environment variable containing Codex status JSON",
+                    "default": "POSH_CODEX_STATUS"
+                  },
                   "gauge_marked_char": {
                     "type": "string",
                     "title": "Gauge marked character",

--- a/website/docs/installation/prompt.mdx
+++ b/website/docs/installation/prompt.mdx
@@ -87,45 +87,11 @@ For more information about the Claude segment properties and customization optio
 To render OpenAI Codex session information with Oh My Posh, add the `codex` segment to your
 prompt config. The segment reads the latest Codex `token_count` event from local Codex session
 transcripts under `$CODEX_HOME/sessions`, or `~/.codex/sessions` when `CODEX_HOME` is not set.
-Use the standard segment `cache` setting to control how often local discovery refreshes.
-Set `discover_local_status` to `false` when you only want to render explicit status data from
-a file or environment variable, for example when a Codex hook updates a status file.
+Use the standard segment `cache` setting to control how often local discovery refreshes. Without
+a segment cache, local discovery runs whenever the segment renders.
 
-You can also use the `oh-my-posh codex` command to render a dedicated Codex statusline prompt:
-
-```bash
-oh-my-posh codex
-```
-
-:::tip
-You can use the `--config` flag to point to a tailored Oh My Posh config just for Codex:
-
-```bash
-oh-my-posh codex --config /path/to/codex.omp.json
-```
-
-:::
-
-To render a specific Codex session, pass its thread ID:
-
-```bash
-oh-my-posh codex --session 019e9eac-83ec-7393-ae18-cc2e566394d5
-```
-
-The Codex segment and command do not authenticate to Codex, call Codex APIs, or read Codex auth
-files. They only read local session metadata and `token_count` events. If status JSON is provided
-to the command on standard input, standard input takes precedence over local session discovery.
-This is useful for manual testing or scripts that emit Codex status data:
-
-```bash
-cat codex-status.json | oh-my-posh codex
-```
-
-For regular shell prompts, explicit status data takes precedence over local session discovery. You
-can write a Codex status payload to a file and point the segment at it with `status_file`, set
-`POSH_CODEX_STATUS_FILE` to the file path, or set `POSH_CODEX_STATUS` directly to the JSON payload.
-Codex hooks can use that file-based path by running a command on `Stop` that updates the status
-file after each turn.
+The Codex segment does not authenticate to Codex, call Codex APIs, or read Codex auth files. It only
+reads local session metadata and `token_count` events.
 
 For more information about the Codex segment properties and customization options, see the
 [Codex segment documentation].

--- a/website/docs/installation/prompt.mdx
+++ b/website/docs/installation/prompt.mdx
@@ -87,8 +87,8 @@ For more information about the Claude segment properties and customization optio
 To render OpenAI Codex session information with Oh My Posh, add the `codex` segment to your
 prompt config. The segment reads the latest Codex `token_count` event from local Codex session
 transcripts under `$CODEX_HOME/sessions`, or `~/.codex/sessions` when `CODEX_HOME` is not set.
-Use the standard segment `cache` setting to control how often local discovery refreshes. Without
-a segment cache, local discovery runs whenever the segment renders.
+Use the standard segment `cache` setting to control how often local discovery refreshes. A
+minutes-scale cache, such as `15m`, avoids scanning local session files on every prompt render.
 
 The Codex segment does not authenticate to Codex, call Codex APIs, or read Codex auth files. It only
 reads local session metadata and `token_count` events.

--- a/website/docs/installation/prompt.mdx
+++ b/website/docs/installation/prompt.mdx
@@ -23,6 +23,7 @@ oh-my-posh get shell
     { label: 'bash', value: 'bash', },
     { label: 'claude', value: 'claude', },
     { label: 'cmd', value: 'cmd', },
+    { label: 'codex', value: 'codex', },
     { label: 'copilot', value: 'copilot', },
     { label: 'elvish', value: 'elvish', },
     { label: 'fish', value: 'fish', },
@@ -79,6 +80,55 @@ oh-my-posh claude --config /path/to/claude.omp.json
 :::
 
 For more information about the Claude segment properties and customization options, see the [Claude segment documentation](/docs/segments/cli/claude).
+
+</TabItem>
+<TabItem value="codex">
+
+To render OpenAI Codex session information with Oh My Posh, add the `codex` segment to your
+prompt config. The segment reads the latest Codex `token_count` event from local Codex session
+transcripts under `$CODEX_HOME/sessions`, or `~/.codex/sessions` when `CODEX_HOME` is not set.
+Use the standard segment `cache` setting to control how often local discovery refreshes.
+Set `discover_local_status` to `false` when you only want to render explicit status data from
+a file or environment variable, for example when a Codex hook updates a status file.
+
+You can also use the `oh-my-posh codex` command to render a dedicated Codex statusline prompt:
+
+```bash
+oh-my-posh codex
+```
+
+:::tip
+You can use the `--config` flag to point to a tailored Oh My Posh config just for Codex:
+
+```bash
+oh-my-posh codex --config /path/to/codex.omp.json
+```
+
+:::
+
+To render a specific Codex session, pass its thread ID:
+
+```bash
+oh-my-posh codex --session 019e9eac-83ec-7393-ae18-cc2e566394d5
+```
+
+The Codex segment and command do not authenticate to Codex, call Codex APIs, or read Codex auth
+files. They only read local session metadata and `token_count` events. If status JSON is provided
+to the command on standard input, standard input takes precedence over local session discovery.
+This is useful for manual testing or scripts that emit Codex status data:
+
+```bash
+cat codex-status.json | oh-my-posh codex
+```
+
+For regular shell prompts, explicit status data takes precedence over local session discovery. You
+can write a Codex status payload to a file and point the segment at it with `status_file`, set
+`POSH_CODEX_STATUS_FILE` to the file path, or set `POSH_CODEX_STATUS` directly to the JSON payload.
+Codex hooks can use that file-based path by running a command on `Stop` that updates the status
+file after each turn.
+
+For more information about the Codex segment properties and customization options, see the
+[Codex segment documentation].
 
 </TabItem>
 <TabItem value="copilot">
@@ -281,6 +331,7 @@ exec zsh
 </Tabs>
 
 [Copilot CLI segment documentation]: /docs/segments/cli/copilot-cli
+[Codex segment documentation]: /docs/segments/cli/codex
 [clink]: https://chrisant996.github.io/clink/
 [iterm2]: https://iterm2.com/
 [sign]: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_signing?view=powershell-7.3#methods-of-signing-scripts

--- a/website/docs/segments/cli/codex.mdx
+++ b/website/docs/segments/cli/codex.mdx
@@ -29,7 +29,7 @@ import Config from "@site/src/components/Config.js";
     foreground: "#111111",
     background: "#10A37F",
     template:
-      " \ue7cf {{ .ModelName }} \uf2d0 {{ .TokenGauge }}{{ if .FormattedWeeklyRemaining }} \uf017 7d {{ .FormattedWeeklyRemaining }}{{ end }} ",
+      " \ue7cf {{ .ModelName }} \uf2d0 {{ .TokenGauge }}{{ if .FormattedWeeklyRemaining }} \uf017 {{ .WeeklyLimitLabel }} {{ .FormattedWeeklyRemaining }}{{ end }} ",
     cache: {
       duration: "15m",
       strategy: "device",
@@ -42,7 +42,7 @@ import Config from "@site/src/components/Config.js";
 :::note default template
 
 ```template
- {{ if .ModelName }} {{ .ModelName }}{{ end }}{{ if .TokenGauge }}  {{ .TokenGauge }}{{ end }}{{ if .FormattedWeeklyRemaining }}  7d {{ .FormattedWeeklyRemaining }}{{ end }}
+ {{ if .ModelName }} {{ .ModelName }}{{ end }}{{ if .TokenGauge }}  {{ .TokenGauge }}{{ end }}{{ if .FormattedWeeklyRemaining }}  {{ .WeeklyLimitLabel }} {{ .FormattedWeeklyRemaining }}{{ end }}
 ```
 
 :::
@@ -125,6 +125,8 @@ segment renders.
 | `.WeeklyRemainingGauge` | `string` | Gauge showing weekly quota remaining; empty when unavailable |
 | `.FormattedFiveHourRemaining` | `string` | Primary rolling window remaining with a percent sign; empty when unavailable |
 | `.FormattedWeeklyRemaining` | `string` | Weekly rolling window remaining with a percent sign; empty when unavailable |
+| `.FiveHourLimitLabel` | `string` | Primary rolling window label derived from `WindowMinutes`, falling back to `5h` |
+| `.WeeklyLimitLabel` | `string` | Secondary rolling window label derived from `WindowMinutes`, falling back to `7d` |
 | `.FormattedLimits` | `string` | Default remaining-limit text, controlled by available limit data and display options |
 | `.FiveHourResetsAt` | `time.Time` | Reset time for the primary rolling window, or zero when unavailable |
 | `.WeeklyResetsAt` | `time.Time` | Reset time for the weekly rolling window, or zero when unavailable |

--- a/website/docs/segments/cli/codex.mdx
+++ b/website/docs/segments/cli/codex.mdx
@@ -1,0 +1,410 @@
+---
+id: codex
+title: OpenAI Codex
+sidebar_label: OpenAI Codex
+---
+
+## What
+
+Display OpenAI Codex session information including the current model, token usage,
+context window usage, and available rate-limit data. Shows visual gauges for context
+usage, five-hour usage, and weekly usage.
+
+The segment reads the latest Codex `token_count` event from local Codex session
+transcripts under `$CODEX_HOME/sessions`, or `~/.codex/sessions` when `CODEX_HOME`
+is not set. It does not read Codex auth files or call Codex APIs.
+
+For setup instructions, see [Change your prompt](/docs/installation/prompt?shell=codex).
+
+## Sample Configuration
+
+import Config from "@site/src/components/Config.js";
+
+<Config
+  data={{
+    type: "codex",
+    style: "diamond",
+    leading_diamond: "\ue0b6",
+    trailing_diamond: "\ue0b4",
+    foreground: "#111111",
+    background: "#10A37F",
+    template:
+      " \ue7cf {{ .ModelName }} \uf2d0 {{ .TokenGauge }}{{ if .FormattedWeeklyRemaining }} \uf017 7d {{ .FormattedWeeklyRemaining }}{{ end }} ",
+    cache: {
+      duration: "30s",
+      strategy: "device",
+    },
+  }}
+/>
+
+## Template ([info][templates])
+
+:::note default template
+
+```template
+ {{ if .ModelName }} {{ .ModelName }}{{ end }}{{ if .TokenGauge }}  {{ .TokenGauge }}{{ end }}{{ if .FormattedWeeklyRemaining }}  7d {{ .FormattedWeeklyRemaining }}{{ end }}
+```
+
+:::
+
+:::tip preset helper
+
+Use `{{ .FormattedText }}` if you want a compact preset controlled by the
+`display_*` options. The default template uses explicit template fields so it
+matches other CLI status segments and remains easy to customize directly.
+
+:::
+
+## Status Payload
+
+The segment discovers this payload from local Codex JSONL session transcripts by
+default. It also accepts either a direct `token_count` payload or a Codex rollout
+`event_msg` wrapper whose `payload.type` is `token_count`.
+
+```json
+{
+  "type": "token_count",
+  "thread_id": "019e9eac-83ec-7393-ae18-cc2e566394d5",
+  "version": "0.137.0",
+  "reasoning_effort": "high",
+  "model": {
+    "id": "gpt-5",
+    "display_name": "gpt-5"
+  },
+  "info": {
+    "total_token_usage": {
+      "input_tokens": 420000,
+      "cached_input_tokens": 300000,
+      "output_tokens": 24000,
+      "reasoning_output_tokens": 8000,
+      "total_tokens": 444000
+    },
+    "last_token_usage": {
+      "input_tokens": 150000,
+      "cached_input_tokens": 120000,
+      "output_tokens": 4000,
+      "reasoning_output_tokens": 1500,
+      "total_tokens": 154000
+    },
+    "model_context_window": 258000
+  },
+  "rate_limits": {
+    "primary": {
+      "used_percent": 12,
+      "window_minutes": 300,
+      "resets_at": 1780794869
+    },
+    "secondary": {
+      "used_percent": 28,
+      "window_minutes": 10080,
+      "resets_at": 1781137565
+    },
+    "plan_type": "pro"
+  }
+}
+```
+
+## Options
+
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| `display_model` | `boolean` | `true` | Display the model name in the `.FormattedText` preset |
+| `display_reasoning` | `boolean` | `false` | Display the reasoning level in the `.FormattedText` preset |
+| `display_context` | `boolean` | `true` | Display context window usage in the `.FormattedText` preset |
+| `display_tokens` | `boolean` | `false` | Display total token usage in the `.FormattedText` preset |
+| `display_five_hour_limit` | `boolean` | `false` | Display the 5-hour limit in the `.FormattedText` preset |
+| `display_weekly_limit` | `boolean` | `true` | Display the 7-day limit in the `.FormattedText` preset |
+| `discover_local_status` | `boolean` | `true` | Discover Codex status from local session transcripts when no explicit status data is available |
+| `codex_home` | `string` | `CODEX_HOME` or `~/.codex` | Codex home directory |
+| `session_root` | `string` | `<codex_home>/sessions` | Codex sessions directory |
+| `session_id` | `string` | `""` | Codex session/thread ID to render; defaults to the newest session with token usage |
+| `status_file` | `string` | `""` | Path to a JSON file containing Codex status data |
+| `status_file_env` | `string` | `POSH_CODEX_STATUS_FILE` | Environment variable containing a Codex status file path |
+| `status_json_env` | `string` | `POSH_CODEX_STATUS` | Environment variable containing Codex status JSON |
+| `gauge_marked_char` | `string` | `▰` | Character used for filled blocks in gauge visualizations |
+| `gauge_unmarked_char` | `string` | `▱` | Character used for empty blocks in gauge visualizations |
+
+## Command Options
+
+| Name | Description |
+| ---- | ----------- |
+| `--session <id>` | Render a specific Codex session/thread ID instead of the newest session with token usage |
+| `--codex-home <path>` | Override the Codex home directory; defaults to `CODEX_HOME` or `~/.codex` |
+| `--session-root <path>` | Override the Codex sessions directory; defaults to `<codex-home>/sessions` |
+
+### Properties
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `.Type` | `string` | Codex event type, commonly `token_count` |
+| `.ThreadID` | `string` | Unique identifier for the Codex thread |
+| `.CWD` | `string` | Current working directory |
+| `.Version` | `string` | Codex CLI version |
+| `.ReasoningEffort` | `string` | Configured reasoning effort |
+| `.ApprovalMode` | `string` | Active approval mode |
+| `.SandboxPolicy` | `string` | Active sandbox policy |
+| `.Model` | `Model` | AI model information |
+| `.Info` | `TokenInfo` | Token usage information |
+| `.RateLimits` | `RateLimits` | Rate limit information; `nil` when Codex does not provide it |
+| `.DisplayModel` | `boolean` | Whether the `.FormattedText` preset displays the model name |
+| `.DisplayReasoning` | `boolean` | Whether the `.FormattedText` preset displays the reasoning level |
+| `.DisplayContext` | `boolean` | Whether the `.FormattedText` preset displays context usage |
+| `.DisplayTokens` | `boolean` | Whether the `.FormattedText` preset displays total tokens |
+| `.DisplayFiveHourLimit` | `boolean` | Whether the `.FormattedText` preset displays the 5-hour limit |
+| `.DisplayWeeklyLimit` | `boolean` | Whether the `.FormattedText` preset displays the 7-day limit |
+| `.FormattedText` | `string` | Preset Codex segment text assembled from display options |
+| `.ModelName` | `string` | Model display name, falling back to the model ID |
+| `.FormattedModel` | `string` | Model text assembled from `display_model` and `display_reasoning`; useful with the `.FormattedText` preset |
+| `.TokenUsagePercent` | `Percentage` | Percentage of model context window used by the latest token usage snapshot (0-100) |
+| `.TokenGauge` | `string` | Gauge showing remaining context capacity; empty when context usage is unavailable |
+| `.TokenGaugeUsed` | `string` | Gauge showing used context capacity; empty when context usage is unavailable |
+| `.RemainingPercent` | `Percentage` | Percentage of model context window remaining (0-100) |
+| `.RemainingTokensCount` | `int` | Number of remaining context window tokens; 0 when unavailable |
+| `.FormattedTokens` | `string` | Human-readable total token count |
+| `.FormattedInputTokens` | `string` | Human-readable input token count |
+| `.FormattedOutputTokens` | `string` | Human-readable output token count |
+| `.FormattedReasoningTokens` | `string` | Human-readable reasoning output token count |
+| `.FormattedCachedInputTokens` | `string` | Human-readable cached input token count |
+| `.FormattedLastTokens` | `string` | Human-readable token count for the latest response |
+| `.FiveHourUsage` | `Percentage` | Primary rolling window usage percentage (0-100) |
+| `.WeeklyUsage` | `Percentage` | Secondary rolling window usage percentage (0-100) |
+| `.FiveHourRemaining` | `Percentage` | Primary rolling window remaining percentage (0-100) |
+| `.WeeklyRemaining` | `Percentage` | Secondary rolling window remaining percentage (0-100) |
+| `.FiveHourGauge` | `string` | Gauge showing primary rolling window usage; empty when unavailable |
+| `.WeeklyGauge` | `string` | Gauge showing weekly rolling window usage; empty when unavailable |
+| `.FiveHourRemainingGauge` | `string` | Gauge showing primary rolling quota remaining; empty when unavailable |
+| `.WeeklyRemainingGauge` | `string` | Gauge showing weekly quota remaining; empty when unavailable |
+| `.FormattedFiveHourRemaining` | `string` | Primary rolling window remaining with a percent sign; empty when unavailable |
+| `.FormattedWeeklyRemaining` | `string` | Weekly rolling window remaining with a percent sign; empty when unavailable |
+| `.FormattedLimits` | `string` | Default remaining-limit text, controlled by available limit data and display options |
+| `.FiveHourResetsAt` | `time.Time` | Reset time for the primary rolling window, or zero when unavailable |
+| `.WeeklyResetsAt` | `time.Time` | Reset time for the weekly rolling window, or zero when unavailable |
+| `.FiveHourResetsIn` | `time.Duration` | Time until the primary rolling window resets; 0 when unavailable |
+| `.WeeklyResetsIn` | `time.Duration` | Time until the weekly rolling window resets; 0 when unavailable |
+
+#### Model Properties
+
+| Name           | Type     | Description                 |
+| -------------- | -------- | --------------------------- |
+| `.ID`          | `string` | Technical model identifier  |
+| `.DisplayName` | `string` | Human-readable model name   |
+
+#### TokenInfo Properties
+
+| Name                  | Type         | Description                       |
+| --------------------- | ------------ | --------------------------------- |
+| `.TotalTokenUsage`    | `TokenUsage` | Total token usage for the session |
+| `.LastTokenUsage`     | `TokenUsage` | Token usage for the latest call   |
+| `.ModelContextWindow` | `int`        | Active model context window size  |
+
+#### TokenUsage Properties
+
+| Name                     | Type  | Description                   |
+| ------------------------ | ----- | ----------------------------- |
+| `.InputTokens`           | `int` | Input tokens                  |
+| `.CachedInputTokens`     | `int` | Cached input tokens           |
+| `.OutputTokens`          | `int` | Output tokens                 |
+| `.ReasoningOutputTokens` | `int` | Reasoning output tokens       |
+| `.TotalTokens`           | `int` | Total tokens                  |
+
+#### RateLimits Properties
+
+| Name                    | Type              | Description                                   |
+| ----------------------- | ----------------- | --------------------------------------------- |
+| `.LimitID`              | `string`          | Rate limit identifier                         |
+| `.LimitName`            | `string`          | Human-readable rate limit name                |
+| `.Primary`              | `RateLimitWindow` | Primary rolling limit window                  |
+| `.Secondary`            | `RateLimitWindow` | Secondary rolling limit window, usually weekly |
+| `.PlanType`             | `string`          | Active plan type                              |
+| `.RateLimitReachedType` | `string`          | Reached limit type; empty when not limited    |
+
+#### RateLimitWindow Properties
+
+| Name             | Type       | Description                                       |
+| ---------------- | ---------- | ------------------------------------------------- |
+| `.UsedPercent`   | `*float64` | Percentage used (0-100); `nil` when unavailable   |
+| `.WindowMinutes` | `int`      | Window size in minutes                            |
+| `.ResetsAt`      | `*int64`   | Unix timestamp when the window resets             |
+
+### Percentage Methods
+
+The `Percentage` type provides additional methods for direct use in templates:
+
+| Method       | Returns  | Description                                                               |
+| ------------ | -------- | ------------------------------------------------------------------------- |
+| `.Gauge`     | `string` | Visual gauge showing remaining capacity using hardcoded `▰`/`▱` characters |
+| `.GaugeUsed` | `string` | Visual gauge showing used capacity using hardcoded `▰`/`▱` characters     |
+| `.String`    | `string` | Numeric percentage value (e.g., "75")                                     |
+
+:::tip Custom gauge characters
+Use the segment gauge methods instead of raw `.Percentage` methods when you want
+the `gauge_marked_char` and `gauge_unmarked_char` options to apply.
+:::
+
+## How it works
+
+When the segment is added to a normal Oh My Posh config, it first checks the session cache,
+then `status_file`, then the file path in `POSH_CODEX_STATUS_FILE`, then the JSON payload in
+`POSH_CODEX_STATUS`. If none of those sources provide usable status data, it automatically
+reads the latest local Codex session `token_count` event.
+
+Use the standard segment `cache` setting to control how often local discovery refreshes. Without
+a segment cache, local discovery runs whenever the segment renders.
+
+Set `discover_local_status` to `false` when you only want to render explicit status data
+from `status_file`, `POSH_CODEX_STATUS_FILE`, or `POSH_CODEX_STATUS`. This is useful when
+a Codex hook updates a status file and you do not want Oh My Posh to scan local transcripts
+as a fallback.
+
+The `oh-my-posh codex` command uses the same local discovery logic, caches the parsed data,
+then renders your configured statusline prompt. Standard input takes precedence when a
+payload is piped to the command. This is mostly useful for manual testing or for scripts
+that already emit a Codex `token_count` payload:
+
+```bash
+oh-my-posh codex --config ~/.config/ohmyposh/codex.omp.json < codex-status.json
+```
+
+The segment is only visible when Codex status data is available.
+
+The parser accepts either a direct Codex token-count payload or a Codex rollout
+`event_msg` wrapper whose `payload.type` is `token_count`.
+
+## Hook-updated Status File
+
+Codex hooks can run commands on lifecycle events such as `Stop`. A hook can update
+a status file after each turn, and the segment can read that file instead of scanning
+session transcripts itself.
+
+```json title="~/.codex/hooks.json"
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh ~/.codex/hooks/export-codex-status.sh",
+            "commandWindows": "pwsh -NoProfile -File \"$HOME/.codex/hooks/Export-CodexStatus.ps1\"",
+            "timeout": 10,
+            "statusMessage": "Updating Codex status"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Configure the segment to read that status file and skip automatic local discovery:
+
+```json
+{
+  "type": "codex",
+  "template": "  {{ .ModelName }}  {{ .TokenGauge }}{{ if .FormattedWeeklyRemaining }}  7d {{ .FormattedWeeklyRemaining }}{{ end }} ",
+  "cache": {
+    "duration": "30s",
+    "strategy": "device"
+  },
+  "options": {
+    "status_file": "~/.codex/oh-my-posh-codex-status.json",
+    "discover_local_status": false
+  }
+}
+```
+
+The standard segment cache still applies. If the hook updates the file on every
+turn but the segment cache duration is `30s`, Oh My Posh can continue showing
+the cached segment data until that cache entry expires. Omit the segment cache
+or use a shorter duration when you want hook updates to appear immediately.
+
+```sh title="~/.codex/hooks/export-codex-status.sh"
+#!/usr/bin/env sh
+set -eu
+
+codex_home="${CODEX_HOME:-"$HOME/.codex"}"
+out_file="${POSH_CODEX_STATUS_FILE:-"$codex_home/oh-my-posh-codex-status.json"}"
+
+CODEX_HOME_DIR="$codex_home" OUT_FILE="$out_file" python3 <<'PY'
+import json
+import os
+from pathlib import Path
+
+root = Path(os.environ["CODEX_HOME_DIR"]) / "sessions"
+out_file = Path(os.environ["OUT_FILE"])
+
+if not root.exists():
+    raise SystemExit(0)
+
+for path in sorted(root.rglob("*.jsonl"), reverse=True)[:250]:
+    latest = None
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        continue
+
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        payload = event.get("payload") if event.get("type") == "event_msg" else event
+        if isinstance(payload, dict) and payload.get("type") == "token_count":
+            latest = payload
+
+    if latest is not None:
+        out_file.parent.mkdir(parents=True, exist_ok=True)
+        out_file.write_text(json.dumps(latest, separators=(",", ":")), encoding="utf-8")
+        break
+PY
+```
+
+```powershell title="~/.codex/hooks/Export-CodexStatus.ps1"
+$codexHome = if ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $HOME '.codex' }
+$outFile = if ($env:POSH_CODEX_STATUS_FILE) {
+    $env:POSH_CODEX_STATUS_FILE
+} else {
+    Join-Path $codexHome 'oh-my-posh-codex-status.json'
+}
+
+$sessionRoot = Join-Path $codexHome 'sessions'
+if (-not (Test-Path -LiteralPath $sessionRoot)) {
+    exit 0
+}
+
+$files = Get-ChildItem -LiteralPath $sessionRoot -Recurse -Filter '*.jsonl' -File -ErrorAction SilentlyContinue |
+    Sort-Object -Property FullName -Descending |
+    Select-Object -First 250
+
+foreach ($file in $files) {
+    $latest = $null
+
+    foreach ($line in Get-Content -LiteralPath $file.FullName -ErrorAction SilentlyContinue) {
+        if ([string]::IsNullOrWhiteSpace($line)) {
+            continue
+        }
+
+        try {
+            $event = $line | ConvertFrom-Json -ErrorAction Stop
+        } catch {
+            continue
+        }
+
+        if ($event.type -eq 'event_msg' -and $event.payload.type -eq 'token_count') {
+            $latest = $event.payload
+        } elseif ($event.type -eq 'token_count') {
+            $latest = $event
+        }
+    }
+
+    if ($null -ne $latest) {
+        New-Item -ItemType Directory -Force -Path (Split-Path -Parent $outFile) | Out-Null
+        $latest | ConvertTo-Json -Depth 20 -Compress | Set-Content -LiteralPath $outFile -Encoding utf8
+        break
+    }
+}
+```
+
+[templates]: /docs/configuration/templates

--- a/website/docs/segments/cli/codex.mdx
+++ b/website/docs/segments/cli/codex.mdx
@@ -126,6 +126,10 @@ default. It also accepts either a direct `token_count` payload or a Codex rollou
 
 ## Command Options
 
+These options apply to the standalone `oh-my-posh codex` command, which is primarily useful for
+testing and scripts that already emit Codex status data. Regular shell prompts only need the segment
+configuration above.
+
 | Name | Description |
 | ---- | ----------- |
 | `--session <id>` | Render a specific Codex session/thread ID instead of the newest session with token usage |
@@ -243,168 +247,29 @@ the `gauge_marked_char` and `gauge_unmarked_char` options to apply.
 
 ## How it works
 
-When the segment is added to a normal Oh My Posh config, it first checks the session cache,
-then `status_file`, then the file path in `POSH_CODEX_STATUS_FILE`, then the JSON payload in
-`POSH_CODEX_STATUS`. If none of those sources provide usable status data, it automatically
-reads the latest local Codex session `token_count` event.
+When the segment is added to a normal Oh My Posh config, it automatically reads the latest local
+Codex session `token_count` event.
 
 Use the standard segment `cache` setting to control how often local discovery refreshes. Without
 a segment cache, local discovery runs whenever the segment renders.
 
-Set `discover_local_status` to `false` when you only want to render explicit status data
-from `status_file`, `POSH_CODEX_STATUS_FILE`, or `POSH_CODEX_STATUS`. This is useful when
-a Codex hook updates a status file and you do not want Oh My Posh to scan local transcripts
-as a fallback.
-
-The `oh-my-posh codex` command uses the same local discovery logic, caches the parsed data,
-then renders your configured statusline prompt. Standard input takes precedence when a
-payload is piped to the command. This is mostly useful for manual testing or for scripts
-that already emit a Codex `token_count` payload:
-
-```bash
-oh-my-posh codex --config ~/.config/ohmyposh/codex.omp.json < codex-status.json
-```
+Explicit status data from `status_file`, `POSH_CODEX_STATUS_FILE`, or `POSH_CODEX_STATUS` takes
+precedence over local discovery. Set `discover_local_status` to `false` when you only want to render
+those explicit sources.
 
 The segment is only visible when Codex status data is available.
 
 The parser accepts either a direct Codex token-count payload or a Codex rollout
 `event_msg` wrapper whose `payload.type` is `token_count`.
 
-## Hook-updated Status File
+:::note advanced integrations
 
-Codex hooks can run commands on lifecycle events such as `Stop`. A hook can update
-a status file after each turn, and the segment can read that file instead of scanning
-session transcripts itself.
+Codex hooks can run commands on lifecycle events, but they should not be used to update Oh My Posh's
+internal segment cache directly. That cache is implementation-specific and scoped to Oh My Posh's
+runtime/session. If a hook or another script already emits Codex status data, write it to a file and
+point `status_file` or `POSH_CODEX_STATUS_FILE` at that file. The normal local-discovery path does not
+require this.
 
-```json title="~/.codex/hooks.json"
-{
-  "hooks": {
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "sh ~/.codex/hooks/export-codex-status.sh",
-            "commandWindows": "pwsh -NoProfile -File \"$HOME/.codex/hooks/Export-CodexStatus.ps1\"",
-            "timeout": 10,
-            "statusMessage": "Updating Codex status"
-          }
-        ]
-      }
-    ]
-  }
-}
-```
-
-Configure the segment to read that status file and skip automatic local discovery:
-
-```json
-{
-  "type": "codex",
-  "template": "  {{ .ModelName }}  {{ .TokenGauge }}{{ if .FormattedWeeklyRemaining }}  7d {{ .FormattedWeeklyRemaining }}{{ end }} ",
-  "cache": {
-    "duration": "30s",
-    "strategy": "device"
-  },
-  "options": {
-    "status_file": "~/.codex/oh-my-posh-codex-status.json",
-    "discover_local_status": false
-  }
-}
-```
-
-The standard segment cache still applies. If the hook updates the file on every
-turn but the segment cache duration is `30s`, Oh My Posh can continue showing
-the cached segment data until that cache entry expires. Omit the segment cache
-or use a shorter duration when you want hook updates to appear immediately.
-
-```sh title="~/.codex/hooks/export-codex-status.sh"
-#!/usr/bin/env sh
-set -eu
-
-codex_home="${CODEX_HOME:-"$HOME/.codex"}"
-out_file="${POSH_CODEX_STATUS_FILE:-"$codex_home/oh-my-posh-codex-status.json"}"
-
-CODEX_HOME_DIR="$codex_home" OUT_FILE="$out_file" python3 <<'PY'
-import json
-import os
-from pathlib import Path
-
-root = Path(os.environ["CODEX_HOME_DIR"]) / "sessions"
-out_file = Path(os.environ["OUT_FILE"])
-
-if not root.exists():
-    raise SystemExit(0)
-
-for path in sorted(root.rglob("*.jsonl"), reverse=True)[:250]:
-    latest = None
-    try:
-        lines = path.read_text(encoding="utf-8").splitlines()
-    except OSError:
-        continue
-
-    for line in lines:
-        if not line.strip():
-            continue
-        try:
-            event = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        payload = event.get("payload") if event.get("type") == "event_msg" else event
-        if isinstance(payload, dict) and payload.get("type") == "token_count":
-            latest = payload
-
-    if latest is not None:
-        out_file.parent.mkdir(parents=True, exist_ok=True)
-        out_file.write_text(json.dumps(latest, separators=(",", ":")), encoding="utf-8")
-        break
-PY
-```
-
-```powershell title="~/.codex/hooks/Export-CodexStatus.ps1"
-$codexHome = if ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $HOME '.codex' }
-$outFile = if ($env:POSH_CODEX_STATUS_FILE) {
-    $env:POSH_CODEX_STATUS_FILE
-} else {
-    Join-Path $codexHome 'oh-my-posh-codex-status.json'
-}
-
-$sessionRoot = Join-Path $codexHome 'sessions'
-if (-not (Test-Path -LiteralPath $sessionRoot)) {
-    exit 0
-}
-
-$files = Get-ChildItem -LiteralPath $sessionRoot -Recurse -Filter '*.jsonl' -File -ErrorAction SilentlyContinue |
-    Sort-Object -Property FullName -Descending |
-    Select-Object -First 250
-
-foreach ($file in $files) {
-    $latest = $null
-
-    foreach ($line in Get-Content -LiteralPath $file.FullName -ErrorAction SilentlyContinue) {
-        if ([string]::IsNullOrWhiteSpace($line)) {
-            continue
-        }
-
-        try {
-            $event = $line | ConvertFrom-Json -ErrorAction Stop
-        } catch {
-            continue
-        }
-
-        if ($event.type -eq 'event_msg' -and $event.payload.type -eq 'token_count') {
-            $latest = $event.payload
-        } elseif ($event.type -eq 'token_count') {
-            $latest = $event
-        }
-    }
-
-    if ($null -ne $latest) {
-        New-Item -ItemType Directory -Force -Path (Split-Path -Parent $outFile) | Out-Null
-        $latest | ConvertTo-Json -Depth 20 -Compress | Set-Content -LiteralPath $outFile -Encoding utf8
-        break
-    }
-}
-```
+:::
 
 [templates]: /docs/configuration/templates

--- a/website/docs/segments/cli/codex.mdx
+++ b/website/docs/segments/cli/codex.mdx
@@ -31,7 +31,7 @@ import Config from "@site/src/components/Config.js";
     template:
       " \ue7cf {{ .ModelName }} \uf2d0 {{ .TokenGauge }}{{ if .FormattedWeeklyRemaining }} \uf017 7d {{ .FormattedWeeklyRemaining }}{{ end }} ",
     cache: {
-      duration: "30s",
+      duration: "15m",
       strategy: "device",
     },
   }}
@@ -55,54 +55,11 @@ matches other CLI status segments and remains easy to customize directly.
 
 :::
 
-## Status Payload
+## Caching
 
-The segment discovers this payload from local Codex JSONL session transcripts by
-default. It also accepts either a direct `token_count` payload or a Codex rollout
-`event_msg` wrapper whose `payload.type` is `token_count`.
-
-```json
-{
-  "type": "token_count",
-  "thread_id": "019e9eac-83ec-7393-ae18-cc2e566394d5",
-  "version": "0.137.0",
-  "reasoning_effort": "high",
-  "model": {
-    "id": "gpt-5",
-    "display_name": "gpt-5"
-  },
-  "info": {
-    "total_token_usage": {
-      "input_tokens": 420000,
-      "cached_input_tokens": 300000,
-      "output_tokens": 24000,
-      "reasoning_output_tokens": 8000,
-      "total_tokens": 444000
-    },
-    "last_token_usage": {
-      "input_tokens": 150000,
-      "cached_input_tokens": 120000,
-      "output_tokens": 4000,
-      "reasoning_output_tokens": 1500,
-      "total_tokens": 154000
-    },
-    "model_context_window": 258000
-  },
-  "rate_limits": {
-    "primary": {
-      "used_percent": 12,
-      "window_minutes": 300,
-      "resets_at": 1780794869
-    },
-    "secondary": {
-      "used_percent": 28,
-      "window_minutes": 10080,
-      "resets_at": 1781137565
-    },
-    "plan_type": "pro"
-  }
-}
-```
+The sample uses Oh My Posh's standard segment `cache` setting with a `15m` duration. The Codex
+segment does not define a separate cache default; without `cache`, local discovery runs whenever the
+segment renders.
 
 ## Options
 
@@ -123,18 +80,6 @@ default. It also accepts either a direct `token_count` payload or a Codex rollou
 | `status_json_env` | `string` | `POSH_CODEX_STATUS` | Environment variable containing Codex status JSON |
 | `gauge_marked_char` | `string` | `▰` | Character used for filled blocks in gauge visualizations |
 | `gauge_unmarked_char` | `string` | `▱` | Character used for empty blocks in gauge visualizations |
-
-## Command Options
-
-These options apply to the standalone `oh-my-posh codex` command, which is primarily useful for
-testing and scripts that already emit Codex status data. Regular shell prompts only need the segment
-configuration above.
-
-| Name | Description |
-| ---- | ----------- |
-| `--session <id>` | Render a specific Codex session/thread ID instead of the newest session with token usage |
-| `--codex-home <path>` | Override the Codex home directory; defaults to `CODEX_HOME` or `~/.codex` |
-| `--session-root <path>` | Override the Codex sessions directory; defaults to `<codex-home>/sessions` |
 
 ### Properties
 
@@ -250,8 +195,8 @@ the `gauge_marked_char` and `gauge_unmarked_char` options to apply.
 When the segment is added to a normal Oh My Posh config, it automatically reads the latest local
 Codex session `token_count` event.
 
-Use the standard segment `cache` setting to control how often local discovery refreshes. Without
-a segment cache, local discovery runs whenever the segment renders.
+Use the standard segment `cache` setting to control how often local discovery refreshes. A
+minutes-scale cache avoids scanning local session files on every prompt render.
 
 Explicit status data from `status_file`, `POSH_CODEX_STATUS_FILE`, or `POSH_CODEX_STATUS` takes
 precedence over local discovery. Set `discover_local_status` to `false` when you only want to render
@@ -262,14 +207,79 @@ The segment is only visible when Codex status data is available.
 The parser accepts either a direct Codex token-count payload or a Codex rollout
 `event_msg` wrapper whose `payload.type` is `token_count`.
 
-:::note advanced integrations
+## Advanced
+
+### Status Payload
+
+The segment discovers this payload from local Codex JSONL session transcripts by default. It also
+accepts either a direct `token_count` payload or a Codex rollout `event_msg` wrapper whose
+`payload.type` is `token_count`.
+
+```json
+{
+  "type": "token_count",
+  "thread_id": "019e9eac-83ec-7393-ae18-cc2e566394d5",
+  "version": "0.137.0",
+  "reasoning_effort": "high",
+  "model": {
+    "id": "gpt-5",
+    "display_name": "gpt-5"
+  },
+  "info": {
+    "total_token_usage": {
+      "input_tokens": 420000,
+      "cached_input_tokens": 300000,
+      "output_tokens": 24000,
+      "reasoning_output_tokens": 8000,
+      "total_tokens": 444000
+    },
+    "last_token_usage": {
+      "input_tokens": 150000,
+      "cached_input_tokens": 120000,
+      "output_tokens": 4000,
+      "reasoning_output_tokens": 1500,
+      "total_tokens": 154000
+    },
+    "model_context_window": 258000
+  },
+  "rate_limits": {
+    "primary": {
+      "used_percent": 12,
+      "window_minutes": 300,
+      "resets_at": 1780794869
+    },
+    "secondary": {
+      "used_percent": 28,
+      "window_minutes": 10080,
+      "resets_at": 1781137565
+    },
+    "plan_type": "pro"
+  }
+}
+```
+
+### Command Options
+
+These options apply to the standalone `oh-my-posh codex` command, which is primarily useful for
+testing and scripts that already emit Codex status data. Regular shell prompts only need the segment
+configuration above.
+
+| Name | Description |
+| ---- | ----------- |
+| `--session <id>` | Render a specific Codex session/thread ID instead of the newest session with token usage |
+| `--codex-home <path>` | Override the Codex home directory; defaults to `CODEX_HOME` or `~/.codex` |
+| `--session-root <path>` | Override the Codex sessions directory; defaults to `<codex-home>/sessions` |
+
+### Hooks and Explicit Status
 
 Codex hooks can run commands on lifecycle events, but they should not be used to update Oh My Posh's
 internal segment cache directly. That cache is implementation-specific and scoped to Oh My Posh's
-runtime/session. If a hook or another script already emits Codex status data, write it to a file and
-point `status_file` or `POSH_CODEX_STATUS_FILE` at that file. The normal local-discovery path does not
-require this.
+runtime/session.
 
-:::
+If a hook or another script already emits Codex status data, write it to a file and point
+`status_file` or `POSH_CODEX_STATUS_FILE` at that file. Keep `discover_local_status` enabled to fall
+back to transcript discovery when the file is missing, invalid, or empty. A valid explicit file wins
+over local discovery, so remove or update stale hook output when you want newer transcript data to
+show. The standard segment cache still controls when the prompt sees either source.
 
 [templates]: /docs/configuration/templates

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -61,6 +61,7 @@ export default {
             "segments/cli/bun",
             "segments/cli/claude",
             "segments/cli/cmake",
+            "segments/cli/codex",
             "segments/cli/copilot",
             "segments/cli/copilot-cli",
             "segments/cli/deno",


### PR DESCRIPTION
## Summary

This replaces #7567 with a clean single-commit branch. The old branch accidentally picked up unrelated workflow changes from one of my local scripts, so I opened this fresh PR with only the Codex segment work.

This adds an OpenAI Codex segment and statusline command that can read Codex usage from local session transcripts. The segment supports normal Oh My Posh rendering, cache settings, templates, color/background templates, and configurable display options for model, reasoning, context, tokens, and rate-limit windows.

## Validation

- `go test ./segments -run TestCodex`
- `go test ./...`
- `npm run build` from `website/`
- `go run . codex`
- `go run . print primary --config <temp codex config> --plain`