### PR TITLE
spotify

### DIFF
--- a/src/runtime/environment.go
+++ b/src/runtime/environment.go
@@ -51,6 +51,7 @@ type Environment interface {
 	Flags() *Flags
 	BatteryState() (*battery.Info, error)
 	QueryWindowTitles(processName, windowTitleRegex string) (string, error)
+	QuerySpotifySMTC() (string, error)
 	WindowsRegistryKeyValue(key string) (*WindowsRegistryValue, error)
 	HTTPRequest(url string, body io.Reader, timeout int, requestModifiers ...http.RequestModifier) ([]byte, error)
 	IsWsl() bool

--- a/src/runtime/environment.go
+++ b/src/runtime/environment.go
@@ -22,6 +22,18 @@ const (
 	PRIMARY = "primary"
 )
 
+// MediaInfo holds a single media session read from the OS media-transport
+// layer (e.g. Windows System Media Transport Controls). It is player-agnostic:
+// the SMTC mechanism can surface any app that publishes a session.
+type MediaInfo struct {
+	// Status is the lowercased playback status: playing/paused/stopped/closed/opened/changing.
+	Status      string
+	Title       string
+	Artist      string
+	Album       string
+	TrackNumber int
+}
+
 type Environment interface {
 	Getenv(key string) string
 	Pwd() string
@@ -51,7 +63,7 @@ type Environment interface {
 	Flags() *Flags
 	BatteryState() (*battery.Info, error)
 	QueryWindowTitles(processName, windowTitleRegex string) (string, error)
-	QuerySpotifySMTC() (string, error)
+	QueryMediaPlayer(player string) (*MediaInfo, error)
 	WindowsRegistryKeyValue(key string) (*WindowsRegistryValue, error)
 	HTTPRequest(url string, body io.Reader, timeout int, requestModifiers ...http.RequestModifier) ([]byte, error)
 	IsWsl() bool

--- a/src/runtime/mock/environment.go
+++ b/src/runtime/mock/environment.go
@@ -135,6 +135,11 @@ func (env *Environment) QueryWindowTitles(processName, windowTitleRegex string) 
 	return args.String(0), args.Error(1)
 }
 
+func (env *Environment) QuerySpotifySMTC() (string, error) {
+	args := env.Called()
+	return args.String(0), args.Error(1)
+}
+
 func (env *Environment) WindowsRegistryKeyValue(path string) (*runtime.WindowsRegistryValue, error) {
 	args := env.Called(path)
 	return args.Get(0).(*runtime.WindowsRegistryValue), args.Error(1)

--- a/src/runtime/mock/environment.go
+++ b/src/runtime/mock/environment.go
@@ -135,9 +135,12 @@ func (env *Environment) QueryWindowTitles(processName, windowTitleRegex string) 
 	return args.String(0), args.Error(1)
 }
 
-func (env *Environment) QuerySpotifySMTC() (string, error) {
-	args := env.Called()
-	return args.String(0), args.Error(1)
+func (env *Environment) QueryMediaPlayer(player string) (*runtime.MediaInfo, error) {
+	args := env.Called(player)
+	if info, ok := args.Get(0).(*runtime.MediaInfo); ok {
+		return info, args.Error(1)
+	}
+	return nil, args.Error(1)
 }
 
 func (env *Environment) WindowsRegistryKeyValue(path string) (*runtime.WindowsRegistryValue, error) {

--- a/src/runtime/smtc_windows.go
+++ b/src/runtime/smtc_windows.go
@@ -1,0 +1,380 @@
+//go:build windows
+
+package runtime
+
+import (
+	"errors"
+	"fmt"
+	goruntime "runtime"
+	"strings"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// querySpotifySMTC reads the active Spotify session from the Windows System
+// Media Transport Controls (SMTC) using a minimal in-tree WinRT binding —
+// `combase.dll` exports + COM vtable dispatch. It returns the line
+//
+//	"<status>|<title>|<artist>|<album>|<trackNumber>"
+//
+// which the segment-side parseSMTCOutput already understands, including the
+// `playing && album=="" && trackNumber=="0"` ad-detection heuristic.
+//
+// Vtable indices and IIDs were verified by .NET reflection against
+// Windows.Media.Control.winmd on Windows 11 (see the table in the const
+// blocks below). All WinRT interfaces inherit from IInspectable, which sits
+// on top of IUnknown:
+//
+//	IUnknown      [0] QueryInterface  [1] AddRef  [2] Release
+//	IInspectable  [3] GetIids  [4] GetRuntimeClassName  [5] GetTrustLevel
+//
+// so interface-specific methods always start at slot 6.
+
+// COM vtable layout. The actual object in memory starts with a pointer to
+// its vtable; the vtable starts with N function pointers. Modelling both as
+// Go structs keeps `go vet`'s unsafe rules satisfied — we navigate by struct
+// field access rather than uintptr arithmetic.
+type comVTable struct {
+	methods [64]uintptr
+}
+
+type comObj struct {
+	vtable *comVTable
+}
+
+const (
+	iunknownQueryInterface = 0
+	iunknownRelease        = 2
+
+	staticsRequestAsync = 6 // IGlobalSystemMediaTransportControlsSessionManagerStatics
+
+	managerGetSessions = 7 // IGlobalSystemMediaTransportControlsSessionManager
+
+	vectorViewGetAt   = 6 // IVectorView<T>
+	vectorViewGetSize = 7
+
+	sessionGetSourceAppUserModelID    = 6 // IGlobalSystemMediaTransportControlsSession
+	sessionTryGetMediaPropertiesAsync = 7
+	sessionGetPlaybackInfo            = 9
+
+	playbackInfoGetPlaybackStatus = 7 // IGlobalSystemMediaTransportControlsSessionPlaybackInfo
+
+	mediaPropsGetTitle       = 6 // IGlobalSystemMediaTransportControlsSessionMediaProperties
+	mediaPropsGetArtist      = 9
+	mediaPropsGetAlbumTitle  = 10
+	mediaPropsGetTrackNumber = 11
+
+	asyncOpGetResults  = 8 // IAsyncOperation<T>
+	asyncInfoGetStatus = 7 // IAsyncInfo
+)
+
+// GlobalSystemMediaTransportControlsSessionPlaybackStatus enum values.
+const (
+	smtcStatusClosed   = 0
+	smtcStatusOpened   = 1
+	smtcStatusChanging = 2
+	smtcStatusStopped  = 3
+	smtcStatusPlaying  = 4
+	smtcStatusPaused   = 5
+)
+
+// Windows.Foundation.AsyncStatus enum values.
+const (
+	asyncStatusCompleted = 1
+	asyncStatusCanceled  = 2
+	asyncStatusError     = 3
+)
+
+const (
+	smtcAsyncTimeout      = 5 * time.Second
+	smtcAsyncPollInterval = 5 * time.Millisecond
+)
+
+var (
+	// IGlobalSystemMediaTransportControlsSessionManagerStatics
+	iidSpotifySessionManagerStatics = windows.GUID{
+		Data1: 0x2050c4ee,
+		Data2: 0x11a0,
+		Data3: 0x57de,
+		Data4: [8]byte{0xae, 0xd7, 0xc9, 0x7c, 0x70, 0x33, 0x82, 0x45},
+	}
+	// IAsyncInfo
+	iidSpotifyAsyncInfo = windows.GUID{
+		Data1: 0x00000036,
+		Data2: 0x0000,
+		Data3: 0x0000,
+		Data4: [8]byte{0xc0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46},
+	}
+)
+
+var (
+	combase                       = windows.NewLazySystemDLL("combase.dll")
+	procRoInitialize              = combase.NewProc("RoInitialize")
+	procRoUninitialize            = combase.NewProc("RoUninitialize")
+	procRoGetActivationFactory    = combase.NewProc("RoGetActivationFactory")
+	procWindowsCreateString       = combase.NewProc("WindowsCreateString")
+	procWindowsDeleteString       = combase.NewProc("WindowsDeleteString")
+	procWindowsGetStringRawBuffer = combase.NewProc("WindowsGetStringRawBuffer")
+
+	// kernel32 is declared in win32_windows.go.
+	procRtlMoveMemory = kernel32.NewProc("RtlMoveMemory")
+)
+
+// hstring is a WinRT HSTRING handle. Pointer-sized opaque value — must be
+// freed with WindowsDeleteString once the consumer is done with it.
+type hstring uintptr
+
+func newHString(s string) (hstring, error) {
+	utf16, err := syscall.UTF16FromString(s)
+	if err != nil {
+		return 0, err
+	}
+	var hs hstring
+	r1, _, _ := procWindowsCreateString.Call(
+		uintptr(unsafe.Pointer(&utf16[0])),
+		uintptr(len(utf16)-1),
+		uintptr(unsafe.Pointer(&hs)),
+	)
+	if r1 != 0 {
+		return 0, fmt.Errorf("WindowsCreateString: 0x%08x", r1)
+	}
+	return hs, nil
+}
+
+func (hs hstring) String() string {
+	if hs == 0 {
+		return ""
+	}
+	var length uint32
+	ptr, _, _ := procWindowsGetStringRawBuffer.Call(uintptr(hs), uintptr(unsafe.Pointer(&length)))
+	if ptr == 0 || length == 0 {
+		return ""
+	}
+	// Copy WinRT-owned UTF-16 into a Go-owned slice via RtlMoveMemory so we
+	// never construct an unsafe.Pointer from the raw buffer's uintptr.
+	out := make([]uint16, length)
+	_, _, _ = procRtlMoveMemory.Call(
+		uintptr(unsafe.Pointer(&out[0])),
+		ptr,
+		uintptr(length)*2, // UTF-16 = 2 bytes per code unit
+	)
+	return syscall.UTF16ToString(out)
+}
+
+func (hs hstring) Close() {
+	if hs == 0 {
+		return
+	}
+	_, _, _ = procWindowsDeleteString.Call(uintptr(hs))
+}
+
+// comCall invokes vtable[idx] on the COM object at ptr, with `this` and the
+// given arguments.
+func comCall(ptr unsafe.Pointer, idx uintptr, args ...uintptr) uintptr {
+	fn := (*comObj)(ptr).vtable.methods[idx]
+	all := make([]uintptr, 0, 1+len(args))
+	all = append(all, uintptr(ptr))
+	all = append(all, args...)
+	ret, _, _ := syscall.SyscallN(fn, all...)
+	return ret
+}
+
+func comRelease(ptr unsafe.Pointer) {
+	if ptr == nil {
+		return
+	}
+	comCall(ptr, iunknownRelease)
+}
+
+// awaitAsync polls IAsyncInfo::Status until the async operation reaches a
+// terminal state. We poll instead of registering a Completed handler to
+// avoid implementing a COM callback object in Go.
+func awaitAsync(asyncOp unsafe.Pointer) error {
+	var asyncInfo unsafe.Pointer
+	hr := comCall(asyncOp, iunknownQueryInterface,
+		uintptr(unsafe.Pointer(&iidSpotifyAsyncInfo)),
+		uintptr(unsafe.Pointer(&asyncInfo)),
+	)
+	if hr != 0 {
+		return fmt.Errorf("QueryInterface IAsyncInfo: 0x%08x", hr)
+	}
+	defer comRelease(asyncInfo)
+
+	deadline := time.Now().Add(smtcAsyncTimeout)
+	for {
+		var status uint32
+		comCall(asyncInfo, asyncInfoGetStatus, uintptr(unsafe.Pointer(&status)))
+		switch status {
+		case asyncStatusCompleted:
+			return nil
+		case asyncStatusCanceled:
+			return errors.New("async cancelled")
+		case asyncStatusError:
+			return errors.New("async failed")
+		}
+		if time.Now().After(deadline) {
+			return errors.New("async timed out")
+		}
+		time.Sleep(smtcAsyncPollInterval)
+	}
+}
+
+func querySpotifySMTC() (string, error) {
+	// RoInitialize / RoUninitialize update thread-local state, so we have to
+	// pin the goroutine to one OS thread for the duration of this call.
+	goruntime.LockOSThread()
+	defer goruntime.UnlockOSThread()
+
+	// RO_INIT_MULTITHREADED = 1. S_FALSE (1) means already initialised on
+	// this thread, which is fine — we still pair with RoUninitialize.
+	hr, _, _ := procRoInitialize.Call(1)
+	if hr != 0 && hr != 1 {
+		return "", fmt.Errorf("RoInitialize: 0x%08x", hr)
+	}
+	defer func() { _, _, _ = procRoUninitialize.Call() }()
+
+	classID, err := newHString("Windows.Media.Control.GlobalSystemMediaTransportControlsSessionManager")
+	if err != nil {
+		return "", err
+	}
+	defer classID.Close()
+
+	var factory unsafe.Pointer
+	hr, _, _ = procRoGetActivationFactory.Call(
+		uintptr(classID),
+		uintptr(unsafe.Pointer(&iidSpotifySessionManagerStatics)),
+		uintptr(unsafe.Pointer(&factory)),
+	)
+	if hr != 0 {
+		return "", fmt.Errorf("RoGetActivationFactory: 0x%08x", hr)
+	}
+	defer comRelease(factory)
+
+	var asyncOp unsafe.Pointer
+	if hr := comCall(factory, staticsRequestAsync, uintptr(unsafe.Pointer(&asyncOp))); hr != 0 {
+		return "", fmt.Errorf("RequestAsync: 0x%08x", hr)
+	}
+	defer comRelease(asyncOp)
+
+	if err := awaitAsync(asyncOp); err != nil {
+		return "", fmt.Errorf("await RequestAsync: %w", err)
+	}
+
+	var manager unsafe.Pointer
+	if hr := comCall(asyncOp, asyncOpGetResults, uintptr(unsafe.Pointer(&manager))); hr != 0 {
+		return "", fmt.Errorf("GetResults manager: 0x%08x", hr)
+	}
+	defer comRelease(manager)
+
+	var sessions unsafe.Pointer
+	if hr := comCall(manager, managerGetSessions, uintptr(unsafe.Pointer(&sessions))); hr != 0 {
+		return "", fmt.Errorf("GetSessions: 0x%08x", hr)
+	}
+	defer comRelease(sessions)
+
+	var size uint32
+	if hr := comCall(sessions, vectorViewGetSize, uintptr(unsafe.Pointer(&size))); hr != 0 {
+		return "", fmt.Errorf("get_Size: 0x%08x", hr)
+	}
+
+	for i := uint32(0); i < size; i++ {
+		var session unsafe.Pointer
+		if hr := comCall(sessions, vectorViewGetAt, uintptr(i), uintptr(unsafe.Pointer(&session))); hr != 0 {
+			continue
+		}
+		result, ok := readSpotifySession(session)
+		comRelease(session)
+		if ok {
+			return result, nil
+		}
+	}
+
+	// No Spotify session in the SMTC list — match the contract the existing
+	// PowerShell script returns when the manager has nothing matching.
+	return "closed||||0", nil
+}
+
+func readSpotifySession(session unsafe.Pointer) (string, bool) {
+	var appHS hstring
+	if hr := comCall(session, sessionGetSourceAppUserModelID, uintptr(unsafe.Pointer(&appHS))); hr != 0 {
+		return "", false
+	}
+	appID := appHS.String()
+	appHS.Close()
+
+	if !strings.Contains(strings.ToLower(appID), "spotify") {
+		return "", false
+	}
+
+	var playbackInfo unsafe.Pointer
+	if hr := comCall(session, sessionGetPlaybackInfo, uintptr(unsafe.Pointer(&playbackInfo))); hr != 0 {
+		return "", false
+	}
+	defer comRelease(playbackInfo)
+
+	var status int32
+	if hr := comCall(playbackInfo, playbackInfoGetPlaybackStatus, uintptr(unsafe.Pointer(&status))); hr != 0 {
+		return "", false
+	}
+
+	statusStr := smtcStatusString(status)
+
+	// Title/artist/album/trackNumber are best-effort; if the async op fails
+	// we still return the status so the segment can hide cleanly.
+	title, artist, album, trackNumber := readMediaProperties(session)
+	return fmt.Sprintf("%s|%s|%s|%s|%d", statusStr, title, artist, album, trackNumber), true
+}
+
+func smtcStatusString(s int32) string {
+	switch s {
+	case smtcStatusPlaying:
+		return "playing"
+	case smtcStatusPaused:
+		return "paused"
+	case smtcStatusStopped:
+		return "stopped"
+	case smtcStatusOpened:
+		return "opened"
+	case smtcStatusChanging:
+		return "changing"
+	default:
+		return "closed"
+	}
+}
+
+func readMediaProperties(session unsafe.Pointer) (title, artist, album string, trackNumber int32) {
+	var asyncOp unsafe.Pointer
+	if hr := comCall(session, sessionTryGetMediaPropertiesAsync, uintptr(unsafe.Pointer(&asyncOp))); hr != 0 {
+		return
+	}
+	defer comRelease(asyncOp)
+
+	if err := awaitAsync(asyncOp); err != nil {
+		return
+	}
+
+	var props unsafe.Pointer
+	if hr := comCall(asyncOp, asyncOpGetResults, uintptr(unsafe.Pointer(&props))); hr != 0 {
+		return
+	}
+	defer comRelease(props)
+
+	title = readHStringMethod(props, mediaPropsGetTitle)
+	artist = readHStringMethod(props, mediaPropsGetArtist)
+	album = readHStringMethod(props, mediaPropsGetAlbumTitle)
+	comCall(props, mediaPropsGetTrackNumber, uintptr(unsafe.Pointer(&trackNumber)))
+	return
+}
+
+func readHStringMethod(obj unsafe.Pointer, slot uintptr) string {
+	var hs hstring
+	if hr := comCall(obj, slot, uintptr(unsafe.Pointer(&hs))); hr != 0 {
+		return ""
+	}
+	s := hs.String()
+	hs.Close()
+	return s
+}

--- a/src/runtime/smtc_windows.go
+++ b/src/runtime/smtc_windows.go
@@ -14,14 +14,13 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-// querySpotifySMTC reads the active Spotify session from the Windows System
-// Media Transport Controls (SMTC) using a minimal in-tree WinRT binding —
-// `combase.dll` exports + COM vtable dispatch. It returns the line
-//
-//	"<status>|<title>|<artist>|<album>|<trackNumber>"
-//
-// which the segment-side parseSMTCOutput already understands, including the
-// `playing && album=="" && trackNumber=="0"` ad-detection heuristic.
+// queryMediaPlayer reads the media session for the given player (matched by a
+// case-insensitive substring of its SourceAppUserModelId, e.g. "spotify") from
+// the Windows System Media Transport Controls (SMTC) using a minimal in-tree
+// WinRT binding — `combase.dll` exports + COM vtable dispatch. SMTC is
+// player-agnostic, so the same path serves any app that publishes a session.
+// It returns a *MediaInfo, leaving status mapping and the
+// `playing && album=="" && trackNumber==0` ad-detection heuristic to the caller.
 //
 // Vtable indices and IIDs were verified by .NET reflection against
 // Windows.Media.Control.winmd on Windows 11 (see the table in the const
@@ -95,14 +94,14 @@ const (
 
 var (
 	// IGlobalSystemMediaTransportControlsSessionManagerStatics
-	iidSpotifySessionManagerStatics = windows.GUID{
+	iidSMTCSessionManagerStatics = windows.GUID{
 		Data1: 0x2050c4ee,
 		Data2: 0x11a0,
 		Data3: 0x57de,
 		Data4: [8]byte{0xae, 0xd7, 0xc9, 0x7c, 0x70, 0x33, 0x82, 0x45},
 	}
 	// IAsyncInfo
-	iidSpotifyAsyncInfo = windows.GUID{
+	iidAsyncInfo = windows.GUID{
 		Data1: 0x00000036,
 		Data2: 0x0000,
 		Data3: 0x0000,
@@ -195,7 +194,7 @@ func comRelease(ptr unsafe.Pointer) {
 func awaitAsync(asyncOp unsafe.Pointer) error {
 	var asyncInfo unsafe.Pointer
 	hr := comCall(asyncOp, iunknownQueryInterface,
-		uintptr(unsafe.Pointer(&iidSpotifyAsyncInfo)),
+		uintptr(unsafe.Pointer(&iidAsyncInfo)),
 		uintptr(unsafe.Pointer(&asyncInfo)),
 	)
 	if hr != 0 {
@@ -222,7 +221,7 @@ func awaitAsync(asyncOp unsafe.Pointer) error {
 	}
 }
 
-func querySpotifySMTC() (string, error) {
+func queryMediaPlayer(player string) (*MediaInfo, error) {
 	// RoInitialize / RoUninitialize update thread-local state, so we have to
 	// pin the goroutine to one OS thread for the duration of this call.
 	goruntime.LockOSThread()
@@ -232,52 +231,52 @@ func querySpotifySMTC() (string, error) {
 	// this thread, which is fine — we still pair with RoUninitialize.
 	hr, _, _ := procRoInitialize.Call(1)
 	if hr != 0 && hr != 1 {
-		return "", fmt.Errorf("RoInitialize: 0x%08x", hr)
+		return nil, fmt.Errorf("RoInitialize: 0x%08x", hr)
 	}
 	defer func() { _, _, _ = procRoUninitialize.Call() }()
 
 	classID, err := newHString("Windows.Media.Control.GlobalSystemMediaTransportControlsSessionManager")
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer classID.Close()
 
 	var factory unsafe.Pointer
 	hr, _, _ = procRoGetActivationFactory.Call(
 		uintptr(classID),
-		uintptr(unsafe.Pointer(&iidSpotifySessionManagerStatics)),
+		uintptr(unsafe.Pointer(&iidSMTCSessionManagerStatics)),
 		uintptr(unsafe.Pointer(&factory)),
 	)
 	if hr != 0 {
-		return "", fmt.Errorf("RoGetActivationFactory: 0x%08x", hr)
+		return nil, fmt.Errorf("RoGetActivationFactory: 0x%08x", hr)
 	}
 	defer comRelease(factory)
 
 	var asyncOp unsafe.Pointer
 	if hr := comCall(factory, staticsRequestAsync, uintptr(unsafe.Pointer(&asyncOp))); hr != 0 {
-		return "", fmt.Errorf("RequestAsync: 0x%08x", hr)
+		return nil, fmt.Errorf("RequestAsync: 0x%08x", hr)
 	}
 	defer comRelease(asyncOp)
 
 	if err := awaitAsync(asyncOp); err != nil {
-		return "", fmt.Errorf("await RequestAsync: %w", err)
+		return nil, fmt.Errorf("await RequestAsync: %w", err)
 	}
 
 	var manager unsafe.Pointer
 	if hr := comCall(asyncOp, asyncOpGetResults, uintptr(unsafe.Pointer(&manager))); hr != 0 {
-		return "", fmt.Errorf("GetResults manager: 0x%08x", hr)
+		return nil, fmt.Errorf("GetResults manager: 0x%08x", hr)
 	}
 	defer comRelease(manager)
 
 	var sessions unsafe.Pointer
 	if hr := comCall(manager, managerGetSessions, uintptr(unsafe.Pointer(&sessions))); hr != 0 {
-		return "", fmt.Errorf("GetSessions: 0x%08x", hr)
+		return nil, fmt.Errorf("GetSessions: 0x%08x", hr)
 	}
 	defer comRelease(sessions)
 
 	var size uint32
 	if hr := comCall(sessions, vectorViewGetSize, uintptr(unsafe.Pointer(&size))); hr != 0 {
-		return "", fmt.Errorf("get_Size: 0x%08x", hr)
+		return nil, fmt.Errorf("get_Size: 0x%08x", hr)
 	}
 
 	for i := uint32(0); i < size; i++ {
@@ -285,47 +284,51 @@ func querySpotifySMTC() (string, error) {
 		if hr := comCall(sessions, vectorViewGetAt, uintptr(i), uintptr(unsafe.Pointer(&session))); hr != 0 {
 			continue
 		}
-		result, ok := readSpotifySession(session)
+		info, ok := readMediaSession(session, player)
 		comRelease(session)
 		if ok {
-			return result, nil
+			return info, nil
 		}
 	}
 
-	// No Spotify session in the SMTC list — match the contract the existing
-	// PowerShell script returns when the manager has nothing matching.
-	return "closed||||0", nil
+	// No matching session in the SMTC list — surface a closed status so the
+	// caller hides cleanly, mirroring the PowerShell script's contract.
+	return &MediaInfo{Status: "closed"}, nil
 }
 
-func readSpotifySession(session unsafe.Pointer) (string, bool) {
+func readMediaSession(session unsafe.Pointer, player string) (*MediaInfo, bool) {
 	var appHS hstring
 	if hr := comCall(session, sessionGetSourceAppUserModelID, uintptr(unsafe.Pointer(&appHS))); hr != 0 {
-		return "", false
+		return nil, false
 	}
 	appID := appHS.String()
 	appHS.Close()
 
-	if !strings.Contains(strings.ToLower(appID), "spotify") {
-		return "", false
+	if !strings.Contains(strings.ToLower(appID), strings.ToLower(player)) {
+		return nil, false
 	}
 
 	var playbackInfo unsafe.Pointer
 	if hr := comCall(session, sessionGetPlaybackInfo, uintptr(unsafe.Pointer(&playbackInfo))); hr != 0 {
-		return "", false
+		return nil, false
 	}
 	defer comRelease(playbackInfo)
 
 	var status int32
 	if hr := comCall(playbackInfo, playbackInfoGetPlaybackStatus, uintptr(unsafe.Pointer(&status))); hr != 0 {
-		return "", false
+		return nil, false
 	}
-
-	statusStr := smtcStatusString(status)
 
 	// Title/artist/album/trackNumber are best-effort; if the async op fails
 	// we still return the status so the segment can hide cleanly.
 	title, artist, album, trackNumber := readMediaProperties(session)
-	return fmt.Sprintf("%s|%s|%s|%s|%d", statusStr, title, artist, album, trackNumber), true
+	return &MediaInfo{
+		Status:      smtcStatusString(status),
+		Title:       title,
+		Artist:      artist,
+		Album:       album,
+		TrackNumber: int(trackNumber),
+	}, true
 }
 
 func smtcStatusString(s int32) string {

--- a/src/runtime/terminal_unix.go
+++ b/src/runtime/terminal_unix.go
@@ -25,6 +25,10 @@ func (term *Terminal) QueryWindowTitles(_, _ string) (string, error) {
 	return "", &NotImplemented{}
 }
 
+func (term *Terminal) QuerySpotifySMTC() (string, error) {
+	return "", &NotImplemented{}
+}
+
 func (term *Terminal) IsWsl() bool {
 	defer log.Trace(time.Now())
 	const key = "is_wsl"

--- a/src/runtime/terminal_unix.go
+++ b/src/runtime/terminal_unix.go
@@ -25,8 +25,8 @@ func (term *Terminal) QueryWindowTitles(_, _ string) (string, error) {
 	return "", &NotImplemented{}
 }
 
-func (term *Terminal) QuerySpotifySMTC() (string, error) {
-	return "", &NotImplemented{}
+func (term *Terminal) QueryMediaPlayer(_ string) (*MediaInfo, error) {
+	return nil, &NotImplemented{}
 }
 
 func (term *Terminal) IsWsl() bool {

--- a/src/runtime/terminal_windows.go
+++ b/src/runtime/terminal_windows.go
@@ -60,6 +60,15 @@ func (term *Terminal) QueryWindowTitles(processName, windowTitleRegex string) (s
 	return title, err
 }
 
+func (term *Terminal) QuerySpotifySMTC() (string, error) {
+	defer log.Trace(time.Now())
+	output, err := querySpotifySMTC()
+	if err != nil {
+		log.Error(err)
+	}
+	return output, err
+}
+
 func (term *Terminal) IsWsl() bool {
 	defer log.Trace(time.Now())
 	return false

--- a/src/runtime/terminal_windows.go
+++ b/src/runtime/terminal_windows.go
@@ -60,13 +60,13 @@ func (term *Terminal) QueryWindowTitles(processName, windowTitleRegex string) (s
 	return title, err
 }
 
-func (term *Terminal) QuerySpotifySMTC() (string, error) {
+func (term *Terminal) QueryMediaPlayer(player string) (*MediaInfo, error) {
 	defer log.Trace(time.Now())
-	output, err := querySpotifySMTC()
+	info, err := queryMediaPlayer(player)
 	if err != nil {
 		log.Error(err)
 	}
-	return output, err
+	return info, err
 }
 
 func (term *Terminal) IsWsl() bool {

--- a/src/segments/spotify.go
+++ b/src/segments/spotify.go
@@ -39,12 +39,12 @@ func (s *Spotify) resolveIcon() {
 	switch s.Status {
 	case stopped:
 		// in this case, no artist or track info
-		s.Icon = s.options.String(StoppedIcon, "\uf04d ")
+		s.Icon = s.options.String(StoppedIcon, " ")
 	case paused:
-		s.Icon = s.options.String(PausedIcon, "\uf04c ")
+		s.Icon = s.options.String(PausedIcon, " ")
 	case playing:
-		s.Icon = s.options.String(PlayingIcon, "\ue602 ")
+		s.Icon = s.options.String(PlayingIcon, " ")
 	case ad:
-		s.Icon = s.options.String(AdIcon, "\ueebb ")
+		s.Icon = s.options.String(AdIcon, " ")
 	}
 }

--- a/src/segments/spotify.go
+++ b/src/segments/spotify.go
@@ -28,6 +28,7 @@ const (
 	playing = "playing"
 	stopped = "stopped"
 	paused  = "paused"
+	ad      = "ad"
 )
 
 func (s *Spotify) Template() string {
@@ -43,5 +44,7 @@ func (s *Spotify) resolveIcon() {
 		s.Icon = s.options.String(PausedIcon, "\uf04c ")
 	case playing:
 		s.Icon = s.options.String(PlayingIcon, "\ue602 ")
+	case ad:
+		s.Icon = s.options.String(AdIcon, "\ueebb ")
 	}
 }

--- a/src/segments/spotify_linux.go
+++ b/src/segments/spotify_linux.go
@@ -45,37 +45,9 @@ func (s *Spotify) runLinuxScriptCommand(command string) string {
 	return val
 }
 
+// enabledWsl reads the Windows host's SMTC sessions through the WSL Windows
+// interop powershell.exe. The Linux side sees the same data the native
+// Windows segment does (playing/paused/stopped/ad).
 func (s *Spotify) enabledWsl() bool {
-	psCommand := `[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; (Get-Process Spotify -ErrorAction SilentlyContinue | Where-Object {$_.MainWindowTitle -ne ""} | Select-Object -First 1).MainWindowTitle` //nolint: lll
-
-	windowName, err := s.env.RunCommand("powershell.exe", "-NoProfile", "-NonInteractive", "-Command", psCommand)
-	if err != nil {
-		s.Status = stopped
-		return false
-	}
-
-	title := strings.TrimSpace(windowName)
-	if title == "" || !strings.Contains(title, " - ") {
-		s.Status = stopped
-		return false
-	}
-
-	artist, track, found := strings.Cut(title, " - ")
-	if !found {
-		s.Status = stopped
-		return false
-	}
-
-	s.Artist = strings.TrimSpace(artist)
-	s.Track = strings.TrimSpace(track)
-
-	if s.Artist == "" || s.Track == "" {
-		s.Status = stopped
-		return false
-	}
-
-	s.Status = playing
-	s.resolveIcon()
-
-	return true
+	return s.querySMTC()
 }

--- a/src/segments/spotify_linux_test.go
+++ b/src/segments/spotify_linux_test.go
@@ -50,22 +50,55 @@ func TestSpotifyLinux(t *testing.T) {
 
 func TestSpotifyWSL(t *testing.T) {
 	cases := []struct {
-		Case            string
 		Error           error
-		Title           string
+		Case            string
+		Output          string
 		Expected        string
 		ExpectedEnabled bool
 	}{
-		{Case: "nothing"},
-		{Case: "error", Error: errors.New("oops")},
-		{Case: "title", ExpectedEnabled: true, Expected: "\ue602 Xzibit - Crash (ft. Royce Da 5'9\" K.A.A.N.)", Title: `Xzibit - Crash (ft. Royce Da 5'9" K.A.A.N.)`},
+		{
+			Case:            "playing",
+			Output:          "playing|Spellbreaker|Candlemass|Nightfall|3",
+			Expected:        "\ue602 Candlemass - Spellbreaker",
+			ExpectedEnabled: true,
+		},
+		{
+			Case:            "paused",
+			Output:          "paused|Spellbreaker|Candlemass|Nightfall|3",
+			Expected:        "\uf04c Candlemass - Spellbreaker",
+			ExpectedEnabled: true,
+		},
+		{
+			Case:            "ad (empty album, track number 0)",
+			Output:          "playing|Try Premium for free|Spotify||0",
+			Expected:        "\ueebb Spotify - Try Premium for free",
+			ExpectedEnabled: true,
+		},
+		{
+			Case:            "stopped",
+			Output:          "stopped||||0",
+			ExpectedEnabled: false,
+		},
+		{
+			Case:            "closed (no Spotify session)",
+			Output:          "closed||||0",
+			ExpectedEnabled: false,
+		},
+		{
+			Case:            "powershell error",
+			Error:           errors.New("oops"),
+			ExpectedEnabled: false,
+		},
+		{
+			Case:            "malformed output",
+			Output:          "garbage",
+			ExpectedEnabled: false,
+		},
 	}
 	for _, tc := range cases {
 		env := new(mock.Environment)
 		env.On("IsWsl").Return(true)
-
-		psCommand := `[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; (Get-Process Spotify -ErrorAction SilentlyContinue | Where-Object {$_.MainWindowTitle -ne ""} | Select-Object -First 1).MainWindowTitle` //nolint: lll
-		env.On("RunCommand", "powershell.exe", []string{"-NoProfile", "-NonInteractive", "-Command", psCommand}).Return(tc.Title, tc.Error)
+		env.On("RunCommand", "powershell.exe", []string{"-NoProfile", "-NonInteractive", "-Command", spotifySMTCScript}).Return(tc.Output, tc.Error)
 
 		s := &Spotify{}
 		s.Init(options.Map{}, env)

--- a/src/segments/spotify_smtc.go
+++ b/src/segments/spotify_smtc.go
@@ -1,0 +1,80 @@
+//go:build windows || (linux && !darwin)
+
+package segments
+
+import "strings"
+
+// PowerShell script that queries the Spotify session from the Windows
+// System Media Transport Controls (SMTC). Output is a single line of
+// "<status>|<title>|<artist>|<album>|<trackNumber>" where <status> is the
+// lowercased PlaybackStatus enum value (playing/paused/stopped/closed/
+// opened/changing), or "closed||||0" when no Spotify SMTC session exists.
+//
+// Works for both the native Win32 Spotify client and the Microsoft Store
+// version (SourceAppUserModelId starts with "SpotifyAB.SpotifyMusic_").
+// On WSL, the same script is invoked via the Windows interop powershell.exe
+// so the Linux side reads the same SMTC sessions as the Windows host.
+const spotifySMTCScript = `[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$null = [Windows.Media.Control.GlobalSystemMediaTransportControlsSessionManager,Windows.Media.Control,ContentType=WindowsRuntime]
+Add-Type -AssemblyName System.Runtime.WindowsRuntime
+$asTaskGeneric = [System.WindowsRuntimeSystemExtensions].GetMethods() |
+    Where-Object { $_.Name -eq 'AsTask' -and $_.IsGenericMethodDefinition -and $_.GetGenericArguments().Length -eq 1 -and $_.GetParameters().Length -eq 1 } |
+    Select-Object -First 1
+function Await($t, $rt) {
+    $netTask = $asTaskGeneric.MakeGenericMethod($rt).Invoke($null, @($t))
+    $netTask.Wait(-1) | Out-Null
+    $netTask.Result
+}
+$mgrType = [Windows.Media.Control.GlobalSystemMediaTransportControlsSessionManager,Windows.Media.Control,ContentType=WindowsRuntime]
+$mgr = Await ($mgrType::RequestAsync()) ([Windows.Media.Control.GlobalSystemMediaTransportControlsSessionManager])
+$session = $mgr.GetSessions() | Where-Object { $_.SourceAppUserModelId -match 'Spotify' } | Select-Object -First 1
+if (-not $session) { Write-Output 'closed||||0'; return }
+$status = $session.GetPlaybackInfo().PlaybackStatus.ToString().ToLower()
+$props = Await ($session.TryGetMediaPropertiesAsync()) ([Windows.Media.Control.GlobalSystemMediaTransportControlsSessionMediaProperties])
+'{0}|{1}|{2}|{3}|{4}' -f $status, $props.Title, $props.Artist, $props.AlbumTitle, $props.TrackNumber`
+
+// querySMTC invokes the SMTC PowerShell script and stores the result in s.
+// Returns true when the segment should be displayed.
+func (s *Spotify) querySMTC() bool {
+	output, err := s.env.RunCommand("powershell.exe", "-NoProfile", "-NonInteractive", "-Command", spotifySMTCScript)
+	if err != nil {
+		return false
+	}
+	return s.parseSMTCOutput(output)
+}
+
+func (s *Spotify) parseSMTCOutput(output string) bool {
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return false
+	}
+
+	parts := strings.SplitN(output, "|", 5)
+	if len(parts) != 5 {
+		return false
+	}
+
+	switch parts[0] {
+	case playing:
+		s.Status = playing
+	case paused:
+		s.Status = paused
+	default:
+		// stopped, closed, opened, changing — segment hidden, matching macOS/Linux behavior.
+		s.Status = stopped
+		return false
+	}
+
+	s.Track = parts[1]
+	s.Artist = parts[2]
+
+	// Spotify ads expose the campaign as a regular "Music" SMTC entry but with no
+	// AlbumTitle and TrackNumber=0 — neither is true for real tracks. Use the pair
+	// to flag ads (single condition would false-positive on Spotify Singles etc.).
+	if s.Status == playing && parts[3] == "" && parts[4] == "0" {
+		s.Status = ad
+	}
+
+	s.resolveIcon()
+	return true
+}

--- a/src/segments/spotify_smtc.go
+++ b/src/segments/spotify_smtc.go
@@ -1,8 +1,6 @@
-//go:build windows || (linux && !darwin)
+//go:build linux && !darwin
 
 package segments
-
-import "strings"
 
 // PowerShell script that queries the Spotify session from the Windows
 // System Media Transport Controls (SMTC). Output is a single line of
@@ -10,10 +8,10 @@ import "strings"
 // lowercased PlaybackStatus enum value (playing/paused/stopped/closed/
 // opened/changing), or "closed||||0" when no Spotify SMTC session exists.
 //
-// Works for both the native Win32 Spotify client and the Microsoft Store
-// version (SourceAppUserModelId starts with "SpotifyAB.SpotifyMusic_").
-// On WSL, the same script is invoked via the Windows interop powershell.exe
-// so the Linux side reads the same SMTC sessions as the Windows host.
+// Used from WSL: the Linux binary cannot call WinRT directly, so it shells
+// out to the Windows interop powershell.exe to read the host's SMTC list.
+// On native Windows the binary instead calls combase.dll directly via
+// runtime.QuerySpotifySMTC — see runtime/smtc_windows.go.
 const spotifySMTCScript = `[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 $null = [Windows.Media.Control.GlobalSystemMediaTransportControlsSessionManager,Windows.Media.Control,ContentType=WindowsRuntime]
 Add-Type -AssemblyName System.Runtime.WindowsRuntime
@@ -41,40 +39,4 @@ func (s *Spotify) querySMTC() bool {
 		return false
 	}
 	return s.parseSMTCOutput(output)
-}
-
-func (s *Spotify) parseSMTCOutput(output string) bool {
-	output = strings.TrimSpace(output)
-	if output == "" {
-		return false
-	}
-
-	parts := strings.SplitN(output, "|", 5)
-	if len(parts) != 5 {
-		return false
-	}
-
-	switch parts[0] {
-	case playing:
-		s.Status = playing
-	case paused:
-		s.Status = paused
-	default:
-		// stopped, closed, opened, changing — segment hidden, matching macOS/Linux behavior.
-		s.Status = stopped
-		return false
-	}
-
-	s.Track = parts[1]
-	s.Artist = parts[2]
-
-	// Spotify ads expose the campaign as a regular "Music" SMTC entry but with no
-	// AlbumTitle and TrackNumber=0 — neither is true for real tracks. Use the pair
-	// to flag ads (single condition would false-positive on Spotify Singles etc.).
-	if s.Status == playing && parts[3] == "" && parts[4] == "0" {
-		s.Status = ad
-	}
-
-	s.resolveIcon()
-	return true
 }

--- a/src/segments/spotify_smtc.go
+++ b/src/segments/spotify_smtc.go
@@ -2,6 +2,13 @@
 
 package segments
 
+import (
+	"strconv"
+	"strings"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
+)
+
 // PowerShell script that queries the Spotify session from the Windows
 // System Media Transport Controls (SMTC). Output is a single line of
 // "<status>|<title>|<artist>|<album>|<trackNumber>" where <status> is the
@@ -11,7 +18,7 @@ package segments
 // Used from WSL: the Linux binary cannot call WinRT directly, so it shells
 // out to the Windows interop powershell.exe to read the host's SMTC list.
 // On native Windows the binary instead calls combase.dll directly via
-// runtime.QuerySpotifySMTC — see runtime/smtc_windows.go.
+// runtime.QueryMediaPlayer — see runtime/smtc_windows.go.
 const spotifySMTCScript = `[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 $null = [Windows.Media.Control.GlobalSystemMediaTransportControlsSessionManager,Windows.Media.Control,ContentType=WindowsRuntime]
 Add-Type -AssemblyName System.Runtime.WindowsRuntime
@@ -38,5 +45,32 @@ func (s *Spotify) querySMTC() bool {
 	if err != nil {
 		return false
 	}
-	return s.parseSMTCOutput(output)
+	info, ok := parseSMTCLine(output)
+	if !ok {
+		return false
+	}
+	return s.applyMediaInfo(info)
+}
+
+// parseSMTCLine turns the PowerShell script's
+// "<status>|<title>|<artist>|<album>|<trackNumber>" line into a *MediaInfo.
+func parseSMTCLine(output string) (*runtime.MediaInfo, bool) {
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return nil, false
+	}
+
+	parts := strings.SplitN(output, "|", 5)
+	if len(parts) != 5 {
+		return nil, false
+	}
+
+	trackNumber, _ := strconv.Atoi(strings.TrimSpace(parts[4]))
+	return &runtime.MediaInfo{
+		Status:      parts[0],
+		Title:       parts[1],
+		Artist:      parts[2],
+		Album:       parts[3],
+		TrackNumber: trackNumber,
+	}, true
 }

--- a/src/segments/spotify_smtc_parser.go
+++ b/src/segments/spotify_smtc_parser.go
@@ -1,0 +1,45 @@
+//go:build windows || (linux && !darwin)
+
+package segments
+
+import "strings"
+
+// parseSMTCOutput consumes a "<status>|<title>|<artist>|<album>|<trackNumber>"
+// line produced by either the WSL PowerShell script (spotify_smtc.go) or the
+// native Windows WinRT path (runtime/smtc_windows.go), applies it to s, and
+// returns whether the segment should be displayed.
+func (s *Spotify) parseSMTCOutput(output string) bool {
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return false
+	}
+
+	parts := strings.SplitN(output, "|", 5)
+	if len(parts) != 5 {
+		return false
+	}
+
+	switch parts[0] {
+	case playing:
+		s.Status = playing
+	case paused:
+		s.Status = paused
+	default:
+		// stopped, closed, opened, changing — segment hidden, matching macOS/Linux behavior.
+		s.Status = stopped
+		return false
+	}
+
+	s.Track = parts[1]
+	s.Artist = parts[2]
+
+	// Spotify ads expose the campaign as a regular "Music" SMTC entry but with no
+	// AlbumTitle and TrackNumber=0 — neither is true for real tracks. Use the pair
+	// to flag ads (single condition would false-positive on Spotify Singles etc.).
+	if s.Status == playing && parts[3] == "" && parts[4] == "0" {
+		s.Status = ad
+	}
+
+	s.resolveIcon()
+	return true
+}

--- a/src/segments/spotify_smtc_parser.go
+++ b/src/segments/spotify_smtc_parser.go
@@ -2,24 +2,17 @@
 
 package segments
 
-import "strings"
+import "github.com/jandedobbeleer/oh-my-posh/src/runtime"
 
-// parseSMTCOutput consumes a "<status>|<title>|<artist>|<album>|<trackNumber>"
-// line produced by either the WSL PowerShell script (spotify_smtc.go) or the
-// native Windows WinRT path (runtime/smtc_windows.go), applies it to s, and
-// returns whether the segment should be displayed.
-func (s *Spotify) parseSMTCOutput(output string) bool {
-	output = strings.TrimSpace(output)
-	if output == "" {
+// applyMediaInfo maps a media session read from SMTC (native WinRT on Windows
+// via runtime.QueryMediaPlayer, or the WSL PowerShell script in spotify_smtc.go)
+// onto s and returns whether the segment should be displayed.
+func (s *Spotify) applyMediaInfo(info *runtime.MediaInfo) bool {
+	if info == nil {
 		return false
 	}
 
-	parts := strings.SplitN(output, "|", 5)
-	if len(parts) != 5 {
-		return false
-	}
-
-	switch parts[0] {
+	switch info.Status {
 	case playing:
 		s.Status = playing
 	case paused:
@@ -30,13 +23,13 @@ func (s *Spotify) parseSMTCOutput(output string) bool {
 		return false
 	}
 
-	s.Track = parts[1]
-	s.Artist = parts[2]
+	s.Track = info.Title
+	s.Artist = info.Artist
 
 	// Spotify ads expose the campaign as a regular "Music" SMTC entry but with no
 	// AlbumTitle and TrackNumber=0 — neither is true for real tracks. Use the pair
 	// to flag ads (single condition would false-positive on Spotify Singles etc.).
-	if s.Status == playing && parts[3] == "" && parts[4] == "0" {
+	if s.Status == playing && info.Album == "" && info.TrackNumber == 0 {
 		s.Status = ad
 	}
 

--- a/src/segments/spotify_smtc_parser_test.go
+++ b/src/segments/spotify_smtc_parser_test.go
@@ -1,0 +1,109 @@
+//go:build linux && !darwin
+
+package segments
+
+import (
+	"testing"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestParseSMTCLineAndApply exercises the WSL PowerShell path: a
+// "<status>|<title>|<artist>|<album>|<trackNumber>" line is parsed into a
+// *runtime.MediaInfo and applied to the segment. The expected strings carry
+// the default Nerd Font icons resolveIcon assigns (playing , paused
+// , ad ).
+func TestParseSMTCLineAndApply(t *testing.T) {
+	cases := []struct {
+		Case            string
+		Output          string
+		ExpectedString  string
+		ExpectedStatus  string
+		ExpectedEnabled bool
+		ExpectedParseOK bool
+	}{
+		{
+			Case:            "playing",
+			Output:          "playing|Spellbreaker|Candlemass|Nightfall|3",
+			ExpectedString:  " Candlemass - Spellbreaker",
+			ExpectedStatus:  playing,
+			ExpectedEnabled: true,
+			ExpectedParseOK: true,
+		},
+		{
+			Case:            "paused",
+			Output:          "paused|Spellbreaker|Candlemass|Nightfall|3",
+			ExpectedString:  " Candlemass - Spellbreaker",
+			ExpectedStatus:  paused,
+			ExpectedEnabled: true,
+			ExpectedParseOK: true,
+		},
+		{
+			Case:            "ad (empty album, track number 0)",
+			Output:          "playing|君のこころが観たいもの　プライムビデオ|プライムビデオ||0",
+			ExpectedString:  " プライムビデオ - 君のこころが観たいもの　プライムビデオ",
+			ExpectedStatus:  ad,
+			ExpectedEnabled: true,
+			ExpectedParseOK: true,
+		},
+		{
+			Case:            "track with parentheses and quotes",
+			Output:          `playing|Collapsing (feat. Björn "Speed" Strid)|Demon Hunter|The World Is a Thorn|9`,
+			ExpectedString:  " Demon Hunter - Collapsing (feat. Björn \"Speed\" Strid)",
+			ExpectedStatus:  playing,
+			ExpectedEnabled: true,
+			ExpectedParseOK: true,
+		},
+		{
+			Case:            "stopped",
+			Output:          "stopped||||0",
+			ExpectedEnabled: false,
+			ExpectedParseOK: true,
+		},
+		{
+			Case:            "closed (no session)",
+			Output:          "closed||||0",
+			ExpectedEnabled: false,
+			ExpectedParseOK: true,
+		},
+		{
+			Case:            "malformed (too few fields)",
+			Output:          "playing|only|three|fields",
+			ExpectedEnabled: false,
+			ExpectedParseOK: false,
+		},
+		{
+			Case:            "malformed (no separators)",
+			Output:          "garbage",
+			ExpectedEnabled: false,
+			ExpectedParseOK: false,
+		},
+		{
+			Case:            "empty",
+			Output:          "",
+			ExpectedEnabled: false,
+			ExpectedParseOK: false,
+		},
+	}
+
+	for _, tc := range cases {
+		info, ok := parseSMTCLine(tc.Output)
+		assert.Equal(t, tc.ExpectedParseOK, ok, tc.Case)
+		if !ok {
+			continue
+		}
+
+		env := new(mock.Environment)
+		s := &Spotify{}
+		s.Init(options.Map{}, env)
+
+		assert.Equal(t, tc.ExpectedEnabled, s.applyMediaInfo(info), tc.Case)
+		if tc.ExpectedEnabled {
+			assert.Equal(t, tc.ExpectedStatus, s.Status, tc.Case)
+			assert.Equal(t, tc.ExpectedString, renderTemplate(env, s.Template(), s), tc.Case)
+		}
+	}
+}

--- a/src/segments/spotify_windows.go
+++ b/src/segments/spotify_windows.go
@@ -2,38 +2,19 @@
 
 package segments
 
-import (
-	"strings"
-)
+import "strings"
 
 func (s *Spotify) Enabled() bool {
-	// search for spotify window to retrieve the title
-	// Can be either "Spotify xxx" or the song name "Candlemass - Spellbreaker"
-	windowTitle, err := s.env.QueryWindowTitles("spotify.exe", `^(Spotify.*)|(.*\s-\s.*)$`)
-	if err == nil {
-		return s.parseNativeTitle(windowTitle)
+	if s.querySMTC() {
+		return true
 	}
-	windowTitle, err = s.env.QueryWindowTitles("msedge.exe", `^(Spotify.*)`)
+
+	// Fall back to scraping the Edge window title for the Spotify Web Player PWA.
+	windowTitle, err := s.env.QueryWindowTitles("msedge.exe", `^(Spotify.*)`)
 	if err != nil {
 		return false
 	}
 	return s.parseWebTitle(windowTitle)
-}
-
-func (s *Spotify) parseNativeTitle(windowTitle string) bool {
-	separator := " - "
-
-	if !strings.Contains(windowTitle, separator) {
-		s.Status = stopped
-		return false
-	}
-
-	before, after, _ := strings.Cut(windowTitle, separator)
-	s.Artist = before
-	s.Track = after
-	s.Status = playing
-	s.resolveIcon()
-	return true
 }
 
 func (s *Spotify) parseWebTitle(windowTitle string) bool {

--- a/src/segments/spotify_windows.go
+++ b/src/segments/spotify_windows.go
@@ -5,11 +5,16 @@ package segments
 import "strings"
 
 func (s *Spotify) Enabled() bool {
-	if s.querySMTC() {
+	// Primary path: native WinRT call into SMTC. See runtime/smtc_windows.go
+	// for the combase.dll binding. PowerShell startup latency made the
+	// previous approach unsuitable for per-prompt rendering.
+	if output, err := s.env.QuerySpotifySMTC(); err == nil && s.parseSMTCOutput(output) {
 		return true
 	}
 
-	// Fall back to scraping the Edge window title for the Spotify Web Player PWA.
+	// Fall back to scraping the Edge window title for the Spotify Web Player PWA,
+	// whose SMTC entry surfaces under "Microsoft.MicrosoftEdge_*" rather than
+	// "Spotify*", so the SMTC walker above skips it.
 	windowTitle, err := s.env.QueryWindowTitles("msedge.exe", `^(Spotify.*)`)
 	if err != nil {
 		return false

--- a/src/segments/spotify_windows.go
+++ b/src/segments/spotify_windows.go
@@ -8,7 +8,7 @@ func (s *Spotify) Enabled() bool {
 	// Primary path: native WinRT call into SMTC. See runtime/smtc_windows.go
 	// for the combase.dll binding. PowerShell startup latency made the
 	// previous approach unsuitable for per-prompt rendering.
-	if output, err := s.env.QuerySpotifySMTC(); err == nil && s.parseSMTCOutput(output) {
+	if info, err := s.env.QueryMediaPlayer("spotify"); err == nil && s.applyMediaInfo(info) {
 		return true
 	}
 

--- a/src/segments/spotify_windows_test.go
+++ b/src/segments/spotify_windows_test.go
@@ -3,6 +3,7 @@
 package segments
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
@@ -12,43 +13,76 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSpotifyWindowsNative(t *testing.T) {
+func TestSpotifyWindowsSMTC(t *testing.T) {
 	cases := []struct {
 		Error           error
 		Case            string
+		Output          string
 		ExpectedString  string
-		Title           string
 		ExpectedEnabled bool
 	}{
 		{
-			Case:            "Playing",
-			ExpectedString:  "\ue602 Candlemass - Spellbreaker",
+			Case:            "playing",
+			Output:          "playing|Spellbreaker|Candlemass|Nightfall|3",
+			ExpectedString:  " Candlemass - Spellbreaker",
 			ExpectedEnabled: true,
-			Title:           "Candlemass - Spellbreaker",
 		},
 		{
-			Case:            "Stopped",
+			Case:            "paused",
+			Output:          "paused|Spellbreaker|Candlemass|Nightfall|3",
+			ExpectedString:  " Candlemass - Spellbreaker",
+			ExpectedEnabled: true,
+		},
+		{
+			Case:            "ad (empty album, track number 0)",
+			Output:          "playing|君のこころが観たいもの　プライムビデオ|プライムビデオ||0",
+			ExpectedString:  " プライムビデオ - 君のこころが観たいもの　プライムビデオ",
+			ExpectedEnabled: true,
+		},
+		{
+			Case:            "stopped",
+			Output:          "stopped||||0",
 			ExpectedEnabled: false,
-			Title:           "Spotify premium",
 		},
 		{
-			Case:            "Playing - new",
-			ExpectedString:  "\ue602 Demon Hunter - Collapsing (feat. Björn \"Speed\" Strid)",
+			Case:            "closed (no Spotify session)",
+			Output:          "closed||||0",
+			ExpectedEnabled: false,
+		},
+		{
+			Case:            "track with parentheses and quotes",
+			Output:          `playing|Collapsing (feat. Björn "Speed" Strid)|Demon Hunter|The World Is a Thorn|9`,
+			ExpectedString:  " Demon Hunter - Collapsing (feat. Björn \"Speed\" Strid)",
 			ExpectedEnabled: true,
-			Title:           `Demon Hunter - Collapsing (feat. Björn "Speed" Strid)`,
+		},
+		{
+			Case:            "powershell error",
+			Error:           errors.New("oops"),
+			ExpectedEnabled: false,
+		},
+		{
+			Case:            "malformed output (too few fields)",
+			Output:          "playing|only|three|fields",
+			ExpectedEnabled: false,
+		},
+		{
+			Case:            "malformed output (no separators)",
+			Output:          "garbage",
+			ExpectedEnabled: false,
 		},
 	}
 	for _, tc := range cases {
 		env := new(mock.Environment)
-		env.On("QueryWindowTitles", "spotify.exe", `^(Spotify.*)|(.*\s-\s.*)$`).Return(tc.Title, tc.Error)
+		env.On("RunCommand", "powershell.exe", []string{"-NoProfile", "-NonInteractive", "-Command", spotifySMTCScript}).Return(tc.Output, tc.Error)
+		// Edge PWA fallback never matches in this group of tests.
 		env.On("QueryWindowTitles", "msedge.exe", `^(Spotify.*)`).Return("", &runtime.NotImplemented{})
 
 		s := &Spotify{}
 		s.Init(options.Map{}, env)
 
-		assert.Equal(t, tc.ExpectedEnabled, s.Enabled())
+		assert.Equal(t, tc.ExpectedEnabled, s.Enabled(), tc.Case)
 		if tc.ExpectedEnabled {
-			assert.Equal(t, tc.ExpectedString, renderTemplate(env, s.Template(), s))
+			assert.Equal(t, tc.ExpectedString, renderTemplate(env, s.Template(), s), tc.Case)
 		}
 	}
 }
@@ -62,34 +96,29 @@ func TestSpotifyWindowsPWA(t *testing.T) {
 		ExpectedEnabled bool
 	}{
 		{
-			Case:            "Playing",
-			ExpectedString:  "\ue602 Sarah, the Illstrumentalist - Snow in Stockholm",
+			Case:            "playing",
+			ExpectedString:  " Sarah, the Illstrumentalist - Snow in Stockholm",
 			ExpectedEnabled: true,
 			Title:           "Spotify - Snow in Stockholm • Sarah, the Illstrumentalist",
 		},
 		{
-			Case:            "Playing",
-			ExpectedString:  "\ue602 Main one - Bring the drama",
-			ExpectedEnabled: true,
-			Title:           "Spotify - Bring the drama • Main one",
-		},
-		{
-			Case:            "Stopped",
+			Case:            "stopped",
 			ExpectedEnabled: false,
 			Title:           "Spotify - Web Player",
 		},
 	}
 	for _, tc := range cases {
 		env := new(mock.Environment)
-		env.On("QueryWindowTitles", "spotify.exe", "^(Spotify.*)|(.*\\s-\\s.*)$").Return("", &runtime.NotImplemented{})
-		env.On("QueryWindowTitles", "msedge.exe", "^(Spotify.*)").Return(tc.Title, tc.Error)
+		// SMTC unavailable — falls back to Edge PWA window title parsing.
+		env.On("RunCommand", "powershell.exe", []string{"-NoProfile", "-NonInteractive", "-Command", spotifySMTCScript}).Return("", errors.New("smtc unavailable"))
+		env.On("QueryWindowTitles", "msedge.exe", `^(Spotify.*)`).Return(tc.Title, tc.Error)
 
 		s := &Spotify{}
 		s.Init(options.Map{}, env)
 
-		assert.Equal(t, tc.ExpectedEnabled, s.Enabled())
+		assert.Equal(t, tc.ExpectedEnabled, s.Enabled(), tc.Case)
 		if tc.ExpectedEnabled {
-			assert.Equal(t, tc.ExpectedString, renderTemplate(env, s.Template(), s))
+			assert.Equal(t, tc.ExpectedString, renderTemplate(env, s.Template(), s), tc.Case)
 		}
 	}
 }

--- a/src/segments/spotify_windows_test.go
+++ b/src/segments/spotify_windows_test.go
@@ -73,7 +73,7 @@ func TestSpotifyWindowsSMTC(t *testing.T) {
 	}
 	for _, tc := range cases {
 		env := new(mock.Environment)
-		env.On("RunCommand", "powershell.exe", []string{"-NoProfile", "-NonInteractive", "-Command", spotifySMTCScript}).Return(tc.Output, tc.Error)
+		env.On("QuerySpotifySMTC").Return(tc.Output, tc.Error)
 		// Edge PWA fallback never matches in this group of tests.
 		env.On("QueryWindowTitles", "msedge.exe", `^(Spotify.*)`).Return("", &runtime.NotImplemented{})
 
@@ -110,7 +110,7 @@ func TestSpotifyWindowsPWA(t *testing.T) {
 	for _, tc := range cases {
 		env := new(mock.Environment)
 		// SMTC unavailable — falls back to Edge PWA window title parsing.
-		env.On("RunCommand", "powershell.exe", []string{"-NoProfile", "-NonInteractive", "-Command", spotifySMTCScript}).Return("", errors.New("smtc unavailable"))
+		env.On("QuerySpotifySMTC").Return("", errors.New("smtc unavailable"))
 		env.On("QueryWindowTitles", "msedge.exe", `^(Spotify.*)`).Return(tc.Title, tc.Error)
 
 		s := &Spotify{}

--- a/src/segments/spotify_windows_test.go
+++ b/src/segments/spotify_windows_test.go
@@ -15,65 +15,55 @@ import (
 
 func TestSpotifyWindowsSMTC(t *testing.T) {
 	cases := []struct {
+		Info            *runtime.MediaInfo
 		Error           error
 		Case            string
-		Output          string
 		ExpectedString  string
 		ExpectedEnabled bool
 	}{
 		{
 			Case:            "playing",
-			Output:          "playing|Spellbreaker|Candlemass|Nightfall|3",
+			Info:            &runtime.MediaInfo{Status: "playing", Title: "Spellbreaker", Artist: "Candlemass", Album: "Nightfall", TrackNumber: 3},
 			ExpectedString:  " Candlemass - Spellbreaker",
 			ExpectedEnabled: true,
 		},
 		{
 			Case:            "paused",
-			Output:          "paused|Spellbreaker|Candlemass|Nightfall|3",
+			Info:            &runtime.MediaInfo{Status: "paused", Title: "Spellbreaker", Artist: "Candlemass", Album: "Nightfall", TrackNumber: 3},
 			ExpectedString:  " Candlemass - Spellbreaker",
 			ExpectedEnabled: true,
 		},
 		{
 			Case:            "ad (empty album, track number 0)",
-			Output:          "playing|君のこころが観たいもの　プライムビデオ|プライムビデオ||0",
+			Info:            &runtime.MediaInfo{Status: "playing", Title: "君のこころが観たいもの　プライムビデオ", Artist: "プライムビデオ", Album: "", TrackNumber: 0},
 			ExpectedString:  " プライムビデオ - 君のこころが観たいもの　プライムビデオ",
 			ExpectedEnabled: true,
 		},
 		{
 			Case:            "stopped",
-			Output:          "stopped||||0",
+			Info:            &runtime.MediaInfo{Status: "stopped"},
 			ExpectedEnabled: false,
 		},
 		{
 			Case:            "closed (no Spotify session)",
-			Output:          "closed||||0",
+			Info:            &runtime.MediaInfo{Status: "closed"},
 			ExpectedEnabled: false,
 		},
 		{
 			Case:            "track with parentheses and quotes",
-			Output:          `playing|Collapsing (feat. Björn "Speed" Strid)|Demon Hunter|The World Is a Thorn|9`,
+			Info:            &runtime.MediaInfo{Status: "playing", Title: `Collapsing (feat. Björn "Speed" Strid)`, Artist: "Demon Hunter", Album: "The World Is a Thorn", TrackNumber: 9},
 			ExpectedString:  " Demon Hunter - Collapsing (feat. Björn \"Speed\" Strid)",
 			ExpectedEnabled: true,
 		},
 		{
-			Case:            "powershell error",
+			Case:            "smtc error",
 			Error:           errors.New("oops"),
-			ExpectedEnabled: false,
-		},
-		{
-			Case:            "malformed output (too few fields)",
-			Output:          "playing|only|three|fields",
-			ExpectedEnabled: false,
-		},
-		{
-			Case:            "malformed output (no separators)",
-			Output:          "garbage",
 			ExpectedEnabled: false,
 		},
 	}
 	for _, tc := range cases {
 		env := new(mock.Environment)
-		env.On("QuerySpotifySMTC").Return(tc.Output, tc.Error)
+		env.On("QueryMediaPlayer", "spotify").Return(tc.Info, tc.Error)
 		// Edge PWA fallback never matches in this group of tests.
 		env.On("QueryWindowTitles", "msedge.exe", `^(Spotify.*)`).Return("", &runtime.NotImplemented{})
 
@@ -110,7 +100,7 @@ func TestSpotifyWindowsPWA(t *testing.T) {
 	for _, tc := range cases {
 		env := new(mock.Environment)
 		// SMTC unavailable — falls back to Edge PWA window title parsing.
-		env.On("QuerySpotifySMTC").Return("", errors.New("smtc unavailable"))
+		env.On("QueryMediaPlayer", "spotify").Return((*runtime.MediaInfo)(nil), errors.New("smtc unavailable"))
 		env.On("QueryWindowTitles", "msedge.exe", `^(Spotify.*)`).Return(tc.Title, tc.Error)
 
 		s := &Spotify{}

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -4245,6 +4245,12 @@
                     "title": "Stopped Icon",
                     "description": "Text/icon to show when stopped",
                     "default": "\uf04d "
+                  },
+                  "ad_icon": {
+                    "type": "string",
+                    "title": "Advertisement Icon",
+                    "description": "Text/icon to show when an advertisement is playing (Windows/WSL)",
+                    "default": "\ueebb "
                   }
                 },
                 "unevaluatedProperties": false

--- a/website/docs/segments/music/spotify.mdx
+++ b/website/docs/segments/music/spotify.mdx
@@ -11,10 +11,11 @@ Show the currently playing song in the [Spotify][spotify] client.
 :::caution
 Be aware this can make the prompt a tad bit slower as it needs to get a response from the Spotify player.
 
-On _macOS & Linux_, all states are supported (playing/paused/stopped).
-
-On _Windows/WSL_, **only the playing state is supported** (no information when paused/stopped). It supports
-fetching information from the native Spotify application and Edge PWA.
+All playback states are supported on every platform (playing/paused/stopped, and an optional `ad` state on
+Windows and WSL). On _Windows_ the data is read from the [System Media Transport Controls][smtc], which
+covers both the native Spotify client and the Microsoft Store version, with a fall-back to scraping the
+Edge PWA window title. On _WSL_ the same SMTC session is queried via the Windows interop `powershell.exe`,
+so the Linux side sees the same information the Windows host does.
 :::
 
 ## Sample Configuration
@@ -31,18 +32,20 @@ import Config from "@site/src/components/Config.js";
     options: {
       playing_icon: "\ue602 ",
       paused_icon: "\uf04c ",
-      stopped_icon: "\uf04d "
+      stopped_icon: "\uf04d ",
+      ad_icon: "\ueebb "
     }
   }}
 />
 
 ## Options
 
-| Name           |   Type   |  Default  | Description                    |
-| -------------- | :------: | :-------: | ------------------------------ |
-| `playing_icon` | `string` | `\ue602 ` | text/icon to show when playing |
-| `paused_icon`  | `string` | `\uf04c ` | text/icon to show when paused  |
-| `stopped_icon` | `string` | `\uf04d ` | text/icon to show when stopped |
+| Name           |   Type   |  Default  | Description                                                      |
+| -------------- | :------: | :-------: | ---------------------------------------------------------------- |
+| `playing_icon` | `string` | `\ue602 ` | text/icon to show when playing                                   |
+| `paused_icon`  | `string` | `\uf04c ` | text/icon to show when paused                                    |
+| `stopped_icon` | `string` | `\uf04d ` | text/icon to show when stopped                                   |
+| `ad_icon`      | `string` | `\ueebb ` | text/icon to show when an advertisement is playing (Windows/WSL) |
 
 ## Template ([info][templates])
 
@@ -56,12 +59,13 @@ import Config from "@site/src/components/Config.js";
 
 ### Properties
 
-| Name      | Type     | Description                                    |
-| --------- | -------- | ---------------------------------------------- |
-| `.Status` | `string` | player status (`playing`, `paused`, `stopped`) |
-| `.Artist` | `string` | current artist                                 |
-| `.Track`  | `string` | current track                                  |
-| `.Icon`   | `string` | icon (based on `.Status`)                      |
+| Name      | Type     | Description                                          |
+| --------- | -------- | ---------------------------------------------------- |
+| `.Status` | `string` | player status (`playing`, `paused`, `stopped`, `ad`) |
+| `.Artist` | `string` | current artist                                       |
+| `.Track`  | `string` | current track                                        |
+| `.Icon`   | `string` | icon (based on `.Status`)                            |
 
 [templates]: /docs/configuration/templates
 [spotify]: https://www.spotify.com
+[smtc]: https://learn.microsoft.com/en-us/windows/apps/develop/media-playback/system-media-transport-controls


### PR DESCRIPTION
- **feat(spotify): switch Windows and WSL to SMTC-based detection**
- **perf(spotify): use native WinRT for SMTC on Windows**
- **refactor(spotify): return *MediaInfo from a generic media-player SMTC seam**

### Prerequisites

- [ ] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [ ] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

<!---

Tips:

If you're not comfortable with working with Git,
we're working on a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D)
as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
