### PR TITLE
fix(git): update no_commits_icon default to Nerd Fonts v3 glyph

### DIFF
--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -1063,7 +1063,7 @@ func (g *Git) resolveDetachedHEAD() {
 
 	// fallback to no commits found
 	if g.ShortHash == "" {
-		g.HEAD = g.options.String(NoCommitsIcon, "\uF594 ")
+		g.HEAD = g.options.String(NoCommitsIcon, "\U000F0095 ")
 		return
 	}
 

--- a/website/docs/segments/scm/git.mdx
+++ b/website/docs/segments/scm/git.mdx
@@ -89,7 +89,7 @@ You can set the following options to `true` to enable fetching additional inform
 | `cherry_pick_icon` | `string` | `\uE29B` | icon/text to display before the context when doing a cherry-pick |
 | `revert_icon`      | `string` | `\uF0E2` | icon/text to display before the context when doing a revert      |
 | `merge_icon`       | `string` | `\uE727` | icon/text to display before the merge context                    |
-| `no_commits_icon`  | `string` | `\U000F0095` | icon/text to display when there are no commits in the repo       |
+| `no_commits_icon`  | `string` | `\U000F0095` | icon/text to display when there are no commits in the repo (in JSON use `\uDB80\uDC95`)       |
 
 #### Upstream
 

--- a/website/docs/segments/scm/git.mdx
+++ b/website/docs/segments/scm/git.mdx
@@ -89,7 +89,7 @@ You can set the following options to `true` to enable fetching additional inform
 | `cherry_pick_icon` | `string` | `\uE29B` | icon/text to display before the context when doing a cherry-pick |
 | `revert_icon`      | `string` | `\uF0E2` | icon/text to display before the context when doing a revert      |
 | `merge_icon`       | `string` | `\uE727` | icon/text to display before the merge context                    |
-| `no_commits_icon`  | `string` | `\uF594` | icon/text to display when there are no commits in the repo       |
+| `no_commits_icon`  | `string` | `\U000F0095` | icon/text to display when there are no commits in the repo       |
 
 #### Upstream
 


### PR DESCRIPTION
The default `no_commits_icon` in the git segment used `\uF594`, a Nerd Fonts v2 private-use-area glyph removed in v3. Users on current Nerd Fonts builds (e.g., JetBrainsMono from Scoop) see a missing glyph placeholder instead of the intended icon.

This updates the default to `\U000F0095`, the v3 remapped codepoint per the [official migration table](https://ohmyposh.dev/codepoints.csv). The docs default value is updated to match.

Fixes #7554

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude_Sonnet_4.6_(200K)](https://img.shields.io/badge/Claude_Sonnet_4.6_(200K)-D97757?logo=claude&logoColor=white)
