### PR TITLE
feat(bubblesextra): add dotnet segment

### DIFF
--- a/themes/bubblesextra.omp.json
+++ b/themes/bubblesextra.omp.json
@@ -50,6 +50,19 @@
         },
         {
           "background": "#29315A",
+          "foreground": "#caa6f7",
+          "leading_diamond": " \ue0b6",
+          "options": {
+            "fetch_version": true
+          },
+          "style": "diamond",
+          "trailing_diamond": "\ue0b4",
+          "powerline_symbol": "\ue0b0",
+          "template": " \ue77f {{ if .Unsupported }}\uf071{{ else }}{{ .Full }}{{ end }} ",
+          "type": "dotnet"
+        },
+        {
+          "background": "#29315A",
           "foreground": "#7FD5EA",
           "leading_diamond": " \ue0b6",
           "options": {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [ ] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

Added the `dotnet` segment to the `bubblesextra` theme using the same diamond style and color palette as the existing language segments. It displays the .NET icon and SDK version when inside a .NET project directory. This is my favourite theme!.