### PR TITLE
fix(transient): cancel transient newlines as with primary newlines

### DIFF
--- a/src/prompt/engine.go
+++ b/src/prompt/engine.go
@@ -541,6 +541,11 @@ func (e *Engine) rectifyTerminalWidth(diff int) {
 	e.Env.Flags().TerminalWidth += diff
 }
 
+func (e *Engine) cancelNewline() bool {
+	row, _ := e.Env.CursorPosition()
+	return e.Env.Flags().Cleared || e.Env.Flags().PromptCount == 1 || row == 1
+}
+
 // New returns a prompt engine initialized with the
 // given configuration options, and is ready to print any
 // of the prompt components.

--- a/src/prompt/extra.go
+++ b/src/prompt/extra.go
@@ -61,7 +61,7 @@ func (e *Engine) ExtraPrompt(promptType ExtraPromptType) string {
 		promptText = err.Error()
 	}
 
-	if promptType == Transient && prompt.Newline {
+	if promptType == Transient && prompt.Newline && !e.cancelNewline() {
 		promptText = fmt.Sprintf("%s%s", e.getNewline(), promptText)
 	}
 

--- a/src/prompt/primary.go
+++ b/src/prompt/primary.go
@@ -73,8 +73,7 @@ func (e *Engine) writePrimaryPromptInternal(needsPrimaryRPrompt, fromCache bool)
 	for i, block := range blocks {
 		// do not print a leading newline when we're at the first row and the prompt is cleared
 		if i == 0 {
-			row, _ := e.Env.CursorPosition()
-			cancelNewline = e.Env.Flags().Cleared || e.Env.Flags().PromptCount == 1 || row == 1
+			cancelNewline = e.cancelNewline()
 		}
 
 		// skip setting a newline when we didn't print anything yet

--- a/website/docs/configuration/transient.mdx
+++ b/website/docs/configuration/transient.mdx
@@ -49,7 +49,7 @@ You need to extend or create a custom theme with your transient prompt. For exam
 | `background_templates` | `array`   | [color templates][color-templates]                                                                                                             |
 | `template`             | `string`  | a go [text/template][go-text-template] template extended with [sprig][sprig] utilizing the properties below - defaults to `{{ .Shell }}> `     |
 | `filler`               | `string`  | when you want to create a line with a repeated set of characters spanning the width of the terminal. Will be added _after_ the `template` text |
-| `newline`              | `boolean` | add a newline before the prompt                                                                                                                |
+| `newline`              | `boolean` | add a newline before the prompt. The newline will not be printed under the same conditions as for primary prompt [newlines][block-newline].    |
 
 ## Enable the feature
 
@@ -67,3 +67,4 @@ clink set prompt.transient always
 [templates]: /docs/configuration/templates
 [color-templates]: /docs/configuration/colors#color-templates
 [cstp]: /docs/configuration/templates#cross-segment-template-properties
+[block-newline]: /docs/configuration/block#newline


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Currently, if a prompt has `newline` set to `true`, the newline will be omitted in several sensible cases. However this behaviour isn't followed if `transient_prompt` has `newline` set to `true`, meaning the positioning of the transient prompt relative to the primary one differs depending on whether the cancellation criteria are met and the primary prompt has had its newline removed.

This PR makes sure that both prompt types use the same cancellation logic.

NB: this PR is a re-submission of #7577 as per @JanDeDobbeleer's [suggestion](https://github.com/JanDeDobbeleer/oh-my-posh/pull/7577#issuecomment-4756713876).

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
