### PR TITLE
fix(theme): improve atomic theme rendering and segment styles

### DIFF
--- a/themes/atomic.omp.json
+++ b/themes/atomic.omp.json
@@ -29,7 +29,7 @@
             "style": "folder"
           },
           "style": "powerline",
-          "template": " \uf07b\uea9c {{ .Path }} ",
+          "template": "\uf07b\u200b\uea9c\u200b{{ .Path }}",
           "type": "path"
         },
         {
@@ -59,7 +59,7 @@
             "threshold": 0
           },
           "style": "diamond",
-          "template": " \ueba2 {{ .FormattedMs }} ",
+          "template": " \ueba2\u200b{{ .FormattedMs }}\u2800",
           "trailing_diamond": "\ue0b4",
           "type": "executiontime"
         }
@@ -147,15 +147,6 @@
           "type": "angular"
         },
         {
-          "background": "#ffffff",
-          "foreground": "#de1f84",
-          "leading_diamond": " \ue0b6",
-          "style": "diamond",
-          "template": "\u03b1 {{ if .Error }}{{ .Error }}{{ else }}{{ .Full }}{{ end }}",
-          "trailing_diamond": "\ue0b4 ",
-          "type": "aurelia"
-        },
-        {
           "background": "#1e293b",
           "foreground": "#ffffff",
           "leading_diamond": " \ue0b6",
@@ -213,7 +204,6 @@
           "background": "#b2bec3",
           "foreground": "#222222",
           "leading_diamond": "\ue0b6",
-          "trailing_diamond": "<transparent,background>\ue0b2</>",
           "options": {
             "linux": "\ue712",
             "macos": "\ue711",
@@ -231,21 +221,19 @@
             "{{if eq \"Full\" .State.String}}#33DD2D{{end}}"
           ],
           "foreground": "#262626",
-          "invert_powerline": true,
-          "powerline_symbol": "\ue0b2",
+          "leading_diamond": "\ue0b2",
           "options": {
             "charged_icon": "\uf240 ",
             "charging_icon": "\uf1e6 ",
             "discharging_icon": "\ue234 "
           },
-          "style": "powerline",
-          "template": " {{ if not .Error }}{{ .Icon }}{{ .Percentage }}{{ end }}{{ .Error }}\uf295 ",
+          "style": "diamond",
+          "template": " {{ if not .Error }}{{ .Icon }}{{ .Percentage }}{{ end }}{{ .Error }}\uf295 <#262626>\ue0b2</>",
           "type": "battery"
         },
         {
           "background": "#40c4ff",
           "foreground": "#ffffff",
-          "invert_powerline": true,
           "leading_diamond": "\ue0b2",
           "options": {
             "time_format": "_2,15:04"


### PR DESCRIPTION
### Description

This revives [#5975](https://github.com/JanDeDobbeleer/oh-my-posh/pull/5975) by @kevinShogun, which targeted the older v3 schema and could no longer be merged. The visual intent is re-applied on the current **v4** schema, dropping the obsolete bits from the original PR.

Changes to `themes/atomic.omp.json`:

- **path / executiontime**: insert zero-width separators so the glyphs no longer visually collide with the surrounding text (the original rendering fix).
- **battery**: convert from `powerline` to `diamond` style for a consistent look with the neighbouring `os`/`time` segments; the closing diamond is folded into the template.
- **os**: drop the trailing diamond now that `battery` provides the joining leading diamond.
- **time**: drop the no-op `invert_powerline` left over from the powerline style.
- **aurelia**: remove the unused segment.

Intentionally **not** carried over from the original PR:

- the per-segment `cache_duration: "none"` (deprecated and equal to the default) — no deprecated options are introduced, `properties` stays as `options`, and the theme keeps `version: 4`;
- a malformed trailing `node` block (invalid as a block, duplicated the existing node segment);
- an extra `newline: true` on the right-aligned block (would have changed the layout).

### Validation

- `oh-my-posh config export --config themes/atomic.omp.json` round-trips cleanly.
- `oh-my-posh debug` renders every segment (path, executiontime, os, battery, time) without errors.
- Prettier formatting check passes.

Credit to @kevinShogun for the original work.