### PR TITLE
feat(zvm): add ZVM segment

### DIFF
--- a/src/config/segment_types.go
+++ b/src/config/segment_types.go
@@ -389,6 +389,8 @@ const (
 	YTM SegmentType = "ytm"
 	// ZIG writes the active zig version
 	ZIG SegmentType = "zig"
+	// ZVM writes the active zig version used in the zvm environment
+	ZVM SegmentType = "zvm"
 )
 
 // Segments contains all available prompt segment writers.
@@ -506,6 +508,7 @@ var Segments = map[SegmentType]func() SegmentWriter{
 	YARN:            func() SegmentWriter { return &segments.Yarn{} },
 	YTM:             func() SegmentWriter { return &segments.Ytm{} },
 	ZIG:             func() SegmentWriter { return &segments.Zig{} },
+	ZVM:             func() SegmentWriter { return &segments.Zvm{} },
 }
 
 func (segment *Segment) MapSegmentWithWriter(env runtime.Environment) error {

--- a/src/segments/zvm.go
+++ b/src/segments/zvm.go
@@ -1,0 +1,53 @@
+package segments
+
+import (
+	"strings"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+)
+
+// ZigIcon is the icon displayed before the version.
+const ZigIcon options.Option = "zigicon"
+
+// Zvm represents the Zig Version Manager (zvm) segment.
+type Zvm struct {
+	Base
+
+	Version string
+	ZigIcon string
+}
+
+func (z *Zvm) Template() string {
+	return " {{ if .ZigIcon }}{{ .ZigIcon }} {{ end }}{{ .Version }} "
+}
+
+func (z *Zvm) Enabled() bool {
+	if !z.env.HasCommand("zvm") {
+		return false
+	}
+
+	z.ZigIcon = z.options.String(ZigIcon, "ZVM")
+
+	// Disable colors so the output has no ANSI escape codes to parse.
+	output, err := z.env.RunCommand("zvm", "--color=false", "list")
+	if err != nil {
+		return false
+	}
+
+	z.Version = parseActiveZvmVersion(output)
+
+	return z.Version != ""
+}
+
+// parseActiveZvmVersion extracts the active version, marked with "[x]", from `zvm list` output.
+func parseActiveZvmVersion(output string) string {
+	for line := range strings.SplitSeq(output, "\n") {
+		if !strings.Contains(line, "[x]") {
+			continue
+		}
+
+		return strings.TrimSpace(strings.ReplaceAll(line, "[x]", ""))
+	}
+
+	return ""
+}

--- a/src/segments/zvm_test.go
+++ b/src/segments/zvm_test.go
@@ -1,0 +1,78 @@
+package segments
+
+import (
+	"testing"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestZvm(t *testing.T) {
+	cases := []struct {
+		Options         options.Map
+		Case            string
+		ListOutput      string
+		ExpectedString  string
+		HasCommand      bool
+		ExpectedEnabled bool
+	}{
+		{
+			Case:            "no zvm command",
+			HasCommand:      false,
+			ExpectedEnabled: false,
+		},
+		{
+			Case:            "active version",
+			HasCommand:      true,
+			ListOutput:      "0.11.0\n[x]0.13.0\n0.12.0",
+			ExpectedString:  "ZVM 0.13.0",
+			ExpectedEnabled: true,
+		},
+		{
+			Case:            "active version with spaced marker",
+			HasCommand:      true,
+			ListOutput:      "0.11.0\n[x] 0.13.0\n0.12.0",
+			ExpectedString:  "ZVM 0.13.0",
+			ExpectedEnabled: true,
+		},
+		{
+			Case:            "custom icon",
+			HasCommand:      true,
+			ListOutput:      "0.11.0\n[x]0.13.0\n0.12.0",
+			Options:         options.Map{ZigIcon: "⚡"},
+			ExpectedString:  "⚡ 0.13.0",
+			ExpectedEnabled: true,
+		},
+		{
+			Case:            "no active version",
+			HasCommand:      true,
+			ListOutput:      "0.11.0\n0.12.0",
+			ExpectedEnabled: false,
+		},
+	}
+
+	for _, tc := range cases {
+		env := new(mock.Environment)
+		env.On("HasCommand", "zvm").Return(tc.HasCommand)
+		if tc.HasCommand {
+			env.On("RunCommand", "zvm", []string{"--color=false", "list"}).Return(tc.ListOutput, nil)
+		}
+
+		props := tc.Options
+		if props == nil {
+			props = options.Map{}
+		}
+
+		zvm := &Zvm{}
+		zvm.Init(props, env)
+
+		assert.Equal(t, tc.ExpectedEnabled, zvm.Enabled(), tc.Case)
+
+		if tc.ExpectedEnabled {
+			assert.Equal(t, tc.ExpectedString, renderTemplate(env, zvm.Template(), zvm), tc.Case)
+		}
+
+		env.AssertExpectations(t)
+	}
+}

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -476,7 +476,8 @@
             "xmake",
             "yarn",
             "ytm",
-            "zig"
+            "zig",
+            "zvm"
           ]
         },
         "style": {
@@ -5146,6 +5147,31 @@
                     "default": [
                       "zig"
                     ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "zvm"
+              }
+            }
+          },
+          "then": {
+            "title": "ZVM Segment",
+            "description": "https://ohmyposh.dev/docs/segments/cli/zvm",
+            "properties": {
+              "options": {
+                "properties": {
+                  "zigicon": {
+                    "type": "string",
+                    "title": "Zig Icon",
+                    "description": "icon to display before the version",
+                    "default": "ZVM"
                   }
                 }
               }

--- a/website/docs/segments/cli/zvm.mdx
+++ b/website/docs/segments/cli/zvm.mdx
@@ -1,0 +1,55 @@
+---
+id: zvm
+title: ZVM
+sidebar_label: ZVM
+---
+
+## What
+
+Display the active Zig version reported by [ZVM][zvm] (Zig Version Manager).
+
+The segment is only enabled when the `zvm` command is available and a version is currently in use.
+
+## Sample Configuration
+
+import Config from "@site/src/components/Config.js";
+
+<Config
+  data={{
+    type: "zvm",
+    style: "powerline",
+    powerline_symbol: "\uE0B0",
+    foreground: "#F7A41D",
+    background: "#193549",
+    template: " {{ if .ZigIcon }}{{ .ZigIcon }} {{ end }}{{ .Version }} ",
+    options: {
+      zigicon: "ZVM - "
+    }
+  }}
+/>
+
+## Options
+
+| Name      | Type     | Default | Description                            |
+| --------- | -------- | :-----: | -------------------------------------- |
+| `zigicon` | `string` |  `ZVM`  | the icon to display before the version |
+
+## Template ([info][templates])
+
+:::note default template
+
+```template
+ {{ if .ZigIcon }}{{ .ZigIcon }} {{ end }}{{ .Version }}
+```
+
+:::
+
+### Properties
+
+| Name       | Type     | Description                          |
+| ---------- | -------- | ------------------------------------ |
+| `.Version` | `string` | the active Zig version used by `zvm` |
+| `.ZigIcon` | `string` | the configured `zigicon`             |
+
+[zvm]: https://github.com/tristanisham/zvm
+[templates]: configuration/templates.mdx

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -89,6 +89,7 @@ export default {
             "segments/cli/unity",
             "segments/cli/xmake",
             "segments/cli/yarn",
+            "segments/cli/zvm",
           ]
         },
         {


### PR DESCRIPTION
### Description

Adds a segment for [ZVM](https://github.com/tristanisham/zvm) (Zig Version Manager) that displays the Zig version currently in use, similar to how nvm works for Node.

This revives [#5990](https://github.com/JanDeDobbeleer/oh-my-posh/pull/5990) by @ggottemo, re-implemented on the current segment API and incorporating the review feedback from that PR:

- **Inherits from `Base`** instead of `language`, so the `SegmentWriter` boilerplate (`Init`/`Text`/`SetText`/`Template`) is not duplicated (per the review comment on the original PR).
- **Reads the version via `zvm --color=false list`** to get ANSI-free output, replacing the original PR's stateful color-toggling logic (which the maintainer flagged as undesirable).
- Exposes the active version — the entry marked with `[x]` in `zvm list` — and a configurable `zigicon` through the template.

It also follows the current conventions throughout: the `options` package (the old `properties` package is gone), the `options`-based schema block, and an `options:`-based docs sample.

### Files

- `src/segments/zvm.go` — the segment
- `src/segments/zvm_test.go` — table-driven tests (command present/absent, active/no-active version, custom icon)
- `src/config/segment_types.go` — register the `zvm` type
- `themes/schema.json` — add `zvm` to the type enum and an options block for `zigicon`
- `website/docs/segments/cli/zvm.mdx` + `website/sidebars.js` — docs

### Validation

- `go build ./...`, `go test ./segments/ ./config/` pass.
- `gofmt`, `go vet`, `fieldalignment`, and `modernize` are clean for the new code.
- Built the binary and confirmed `oh-my-posh config export` round-trips a `zvm` config, the segment renders ` ZVM -  0.13.0 ` against a stubbed `zvm`, and it is disabled when `zvm` is absent.

Credit to @ggottemo for the original work.