### PR TITLE
feat(os): add native Artix Linux support

### DIFF
--- a/src/runtime/terminal_unix.go
+++ b/src/runtime/terminal_unix.go
@@ -117,14 +117,20 @@ func (term *Terminal) Platform() string {
 func (term *Terminal) getSpecialLinuxDistros(platform string) string {
 	lsbInfo := term.FileContent("/etc/lsb-release")
 
-	if platform == "arch" && strings.Contains(strings.ToLower(lsbInfo), "manjaro") {
-		// validate for Manjaro
+	if platform == "debian" && strings.Contains(strings.ToLower(lsbInfo), "zorin") {
+		return "zorin"
+	}
+
+	if platform != "arch" {
+		return platform
+	}
+
+	if strings.Contains(strings.ToLower(lsbInfo), "manjaro") {
 		return "manjaro"
 	}
 
-	if platform == "debian" && strings.Contains(strings.ToLower(lsbInfo), "zorin") {
-		// validate for Zorin OS
-		return "zorin"
+	if strings.Contains(strings.ToLower(lsbInfo), "artix") {
+		return "artix"
 	}
 
 	return platform

--- a/src/segments/os.go
+++ b/src/segments/os.go
@@ -60,6 +60,7 @@ func (oi *Os) getDistroIcon(distro string) string {
 		"android":             "\ue70e",
 		"aosc":                "\uf301",
 		"arch":                "\uf303",
+		"artix":               "\uf31f",
 		"centos":              "\uf304",
 		"coreos":              "\uf305",
 		"debian":              "\uf306",


### PR DESCRIPTION
### Prerequisites

* [x] I have read and understood the [contributing guide](https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md).
* [x] The commit message follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/%23summary) guidelines.
* [ ] Tests for the changes have been added (for bug fixes / features).
* [ ] Docs have been added/updated (for bug fixes / features).

### Description

**What does this PR do?**
Adds native OS icon support for Artix Linux.

**Why is this necessary?**
Currently, Oh My Posh renders the parent Arch Linux logo (`\uf303`) for Artix systems. It behaves like Manjaro and I believe this happens because `gopsutil` groups Artix under the `"arch"` family based on the `ID_LIKE` fallback, returning `"arch"` to the engine instead of `"artix"`.

**How does it fix it?**

1. **`src/runtime/terminal_unix.go`**: Added a quick interception check in `getSpecialLinuxDistros`. Since Artix populates `/etc/lsb-release` with `DISTRIB_ID="Artix"`, the function now catches `"artix"` and returns it cleanly before it gets miscategorized as Arch (mirroring the existing logic for Manjaro and Zorin).
2. **`src/segments/os.go`**: Added `"artix": "\uf31f"` to the `iconMap` to correctly map the established Nerd Font glyph for Artix.

*(Tested locally on an Artix system running pwsh; cache was cleared and the correct glyph renders natively).*