### PR TITLE
fix(config): recover theme from cache when session config is lost

### DIFF
--- a/src/config/gob.go
+++ b/src/config/gob.go
@@ -34,23 +34,66 @@ func Get(configFile string, reload bool) *Config {
 		}
 	}
 
-	base64String, found := cache.Get[string](cache.Session, configKey)
-	if !found {
-		log.Debug("no cached config found")
-		cfg := Load(configFile)
-		cfg.Store()
-		return cfg
-	}
+	if base64String, found := cache.Get[string](cache.Session, configKey); found {
+		var cfg Config
+		if err := cfg.Restore(base64String); err == nil {
+			return &cfg
+		}
 
-	var cfg Config
-	if err := cfg.Restore(base64String); err != nil {
 		log.Debug("failed to restore config from cache")
-		loaded := Load(configFile)
-		loaded.Store()
-		return loaded
+	} else {
+		log.Debug("no cached config found")
 	}
 
-	return &cfg
+	// A prompt render relies on the session cache for its configuration: it's
+	// invoked without an explicit --config, so configFile is empty here. When the
+	// session cache is missing or corrupt - the file got purged (e.g. under disk
+	// pressure) or clobbered by a concurrent writer sharing the session - falling
+	// back to Load("") silently renders the default theme for the rest of the
+	// session. Recover the previously initialized source first so the configured
+	// theme keeps rendering and the session cache self-heals.
+	if configFile == "" {
+		if source := recoverSource(); source != "" {
+			if cfg, err := Parse(source); err == nil {
+				log.Debug("recovered configuration from source: ", source)
+				cfg.Store()
+				return cfg
+			}
+
+			log.Debug("failed to recover configuration from source: ", source)
+		}
+	}
+
+	cfg := Load(configFile)
+	cfg.Store()
+	return cfg
+}
+
+// recoverSource locates the most recently initialized configuration source when
+// the session config cache is unavailable. It first checks the session source,
+// which survives when only the config blob is corrupt, then falls back to the
+// device-level DSC, which persists across sessions with an infinite TTL and is
+// populated on every init (where --config is required).
+func recoverSource() string {
+	defer log.Trace(time.Now())
+
+	if source, OK := cache.Get[string](cache.Session, SourceKey); OK && source != "" {
+		return source
+	}
+
+	resource := DSC()
+	resource.Load()
+
+	if len(resource.States) == 0 {
+		return ""
+	}
+
+	// the last added state reflects the most recent init.
+	if last := resource.States[len(resource.States)-1]; last != nil {
+		return last.Source
+	}
+
+	return ""
 }
 
 func (cfg *Config) Base64() string {

--- a/src/config/gob.go
+++ b/src/config/gob.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/gob"
+	"os"
 	"time"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/cache"
@@ -13,6 +14,13 @@ import (
 const (
 	configKey = "CONFIG"
 	SourceKey = "CONFIG_SOURCE"
+
+	// envKey is resolved into the --config flag by the root command when no
+	// explicit flag is given. The shell's init script pins it to the session's
+	// resolved configuration source so the configuration can be recovered when
+	// the session cache is lost or corrupted. A healthy session cache always
+	// wins, so it can not be used to change the configuration mid-session.
+	envKey = "POSH_CONFIG"
 )
 
 func (cfg *Config) Store() {
@@ -45,55 +53,30 @@ func Get(configFile string, reload bool) *Config {
 		log.Debug("no cached config found")
 	}
 
-	// A prompt render relies on the session cache for its configuration: it's
-	// invoked without an explicit --config, so configFile is empty here. When the
-	// session cache is missing or corrupt - the file got purged (e.g. under disk
-	// pressure) or clobbered by a concurrent writer sharing the session - falling
-	// back to Load("") silently renders the default theme for the rest of the
-	// session. Recover the previously initialized source first so the configured
-	// theme keeps rendering and the session cache self-heals.
-	if configFile == "" {
-		if source := recoverSource(); source != "" {
-			if cfg, err := Parse(source); err == nil {
-				log.Debug("recovered configuration from source: ", source)
-				cfg.Store()
-				return cfg
-			}
-
-			log.Debug("failed to recover configuration from source: ", source)
+	// A prompt render is invoked without an explicit --config and relies on the
+	// session cache for its configuration. When that cache is missing or corrupt
+	// - the file got purged (e.g. under disk pressure) or clobbered by a
+	// concurrent writer sharing the session - the shell session still knows its
+	// source: init exported it as POSH_CONFIG, and the root command resolved it
+	// into configFile. Store the parsed result again so the session cache
+	// self-heals. When the source is unavailable, return the default without
+	// caching it so the next render retries the recovery instead of pinning
+	// the default theme for the rest of the session.
+	if configFile != "" && configFile == os.Getenv(envKey) {
+		cfg, err := Parse(configFile)
+		if err == nil {
+			log.Debug("recovered configuration from environment: ", configFile)
+			cfg.Store()
+			return cfg
 		}
+
+		log.Debug("failed to recover configuration from environment: ", configFile)
+		return Default(err)
 	}
 
 	cfg := Load(configFile)
 	cfg.Store()
 	return cfg
-}
-
-// recoverSource locates the most recently initialized configuration source when
-// the session config cache is unavailable. It first checks the session source,
-// which survives when only the config blob is corrupt, then falls back to the
-// device-level DSC, which persists across sessions with an infinite TTL and is
-// populated on every init (where --config is required).
-func recoverSource() string {
-	defer log.Trace(time.Now())
-
-	if source, OK := cache.Get[string](cache.Session, SourceKey); OK && source != "" {
-		return source
-	}
-
-	resource := DSC()
-	resource.Load()
-
-	if len(resource.States) == 0 {
-		return ""
-	}
-
-	// the last added state reflects the most recent init.
-	if last := resource.States[len(resource.States)-1]; last != nil {
-		return last.Source
-	}
-
-	return ""
 }
 
 func (cfg *Config) Base64() string {

--- a/src/config/gob_test.go
+++ b/src/config/gob_test.go
@@ -1,0 +1,77 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/cache"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func writeTestConfig(t *testing.T) string {
+	t.Helper()
+
+	file := filepath.Join(t.TempDir(), "theme.omp.json")
+	if err := os.WriteFile(file, []byte(`{"version": 3, "final_space": true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	return file
+}
+
+func TestGetRecoversFromDSCWhenSessionCacheLost(t *testing.T) {
+	defer func() {
+		cache.DeleteAll(cache.Device)
+		cache.DeleteAll(cache.Session)
+	}()
+
+	file := writeTestConfig(t)
+
+	// Simulate a prior init: the source is tracked in the device-level DSC, which
+	// survives the loss of the session cache.
+	resource := DSC()
+	resource.Add(file)
+	resource.Save()
+
+	// A prompt render: no --config, and the session cache no longer holds the config.
+	cfg := Get("", false)
+
+	assert.NotNil(t, cfg)
+	assert.Equal(t, file, cfg.Source, "should recover the configured theme instead of the default")
+
+	// Recovery should self-heal the session cache so subsequent renders are fast.
+	_, found := cache.Get[string](cache.Session, configKey)
+	assert.True(t, found, "recovery should repopulate the session config cache")
+}
+
+func TestGetRecoversFromSessionSourceWhenConfigBlobMissing(t *testing.T) {
+	defer func() {
+		cache.DeleteAll(cache.Device)
+		cache.DeleteAll(cache.Session)
+	}()
+
+	file := writeTestConfig(t)
+
+	// The session source survives even when the config blob is corrupt or absent.
+	cache.Set(cache.Session, SourceKey, file, cache.INFINITE)
+
+	cfg := Get("", false)
+
+	assert.NotNil(t, cfg)
+	assert.Equal(t, file, cfg.Source)
+}
+
+func TestGetFallsBackToDefaultWithoutSource(t *testing.T) {
+	defer func() {
+		cache.DeleteAll(cache.Device)
+		cache.DeleteAll(cache.Session)
+	}()
+
+	// No --config, no session cache, and no DSC: there is nothing to recover.
+	cfg := Get("", false)
+
+	assert.NotNil(t, cfg)
+	assert.Empty(t, cfg.Source, "should fall back to the default built-in config")
+}

--- a/src/config/gob_test.go
+++ b/src/config/gob_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func writeTestConfig(t *testing.T) string {
+func writeTestConfig(t *testing.T, name string) string {
 	t.Helper()
 
-	file := filepath.Join(t.TempDir(), "theme.omp.json")
+	file := filepath.Join(t.TempDir(), name)
 	if err := os.WriteFile(file, []byte(`{"version": 3, "final_space": true}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -21,57 +21,80 @@ func writeTestConfig(t *testing.T) string {
 	return file
 }
 
-func TestGetRecoversFromDSCWhenSessionCacheLost(t *testing.T) {
-	defer func() {
-		cache.DeleteAll(cache.Device)
+func resetCache(t *testing.T) {
+	t.Helper()
+
+	reset := func() {
 		cache.DeleteAll(cache.Session)
-	}()
+		cache.DeleteAll(cache.Device)
+	}
 
-	file := writeTestConfig(t)
+	reset()
+	t.Cleanup(reset)
+}
 
-	// Simulate a prior init: the source is tracked in the device-level DSC, which
-	// survives the loss of the session cache.
-	resource := DSC()
-	resource.Add(file)
-	resource.Save()
+func TestGetRecoversFromEnvironmentWhenSessionCacheLost(t *testing.T) {
+	resetCache(t)
 
-	// A prompt render: no --config, and the session cache no longer holds the config.
-	cfg := Get("", false)
+	file := writeTestConfig(t, "theme.omp.json")
+
+	// Simulate a prompt render after the session cache is lost: init pinned the
+	// source in POSH_CONFIG and the root command resolved it into the config flag.
+	t.Setenv(envKey, file)
+
+	cfg := Get(file, false)
 
 	assert.NotNil(t, cfg)
-	assert.Equal(t, file, cfg.Source, "should recover the configured theme instead of the default")
+	assert.Equal(t, file, cfg.Source, "should render the configured theme instead of the default")
 
 	// Recovery should self-heal the session cache so subsequent renders are fast.
 	_, found := cache.Get[string](cache.Session, configKey)
 	assert.True(t, found, "recovery should repopulate the session config cache")
 }
 
-func TestGetRecoversFromSessionSourceWhenConfigBlobMissing(t *testing.T) {
-	defer func() {
-		cache.DeleteAll(cache.Device)
-		cache.DeleteAll(cache.Session)
-	}()
+func TestGetPrefersSessionCacheOverEnvironment(t *testing.T) {
+	resetCache(t)
 
-	file := writeTestConfig(t)
+	cached := writeTestConfig(t, "cached.omp.json")
+	other := writeTestConfig(t, "other.omp.json")
 
-	// The session source survives even when the config blob is corrupt or absent.
-	cache.Set(cache.Session, SourceKey, file, cache.INFINITE)
+	Load(cached).Store()
 
-	cfg := Get("", false)
+	// POSH_CONFIG can not change the configuration mid-session:
+	// a healthy session cache always wins.
+	t.Setenv(envKey, other)
+
+	cfg := Get(other, false)
 
 	assert.NotNil(t, cfg)
-	assert.Equal(t, file, cfg.Source)
+	assert.Equal(t, cached, cfg.Source)
 }
 
-func TestGetFallsBackToDefaultWithoutSource(t *testing.T) {
-	defer func() {
-		cache.DeleteAll(cache.Device)
-		cache.DeleteAll(cache.Session)
-	}()
+func TestGetFallsBackToDefaultWithoutRecoverySource(t *testing.T) {
+	resetCache(t)
 
-	// No --config, no session cache, and no DSC: there is nothing to recover.
+	// No --config, no session cache, and no environment: there is nothing to recover.
+	t.Setenv(envKey, "")
+
 	cfg := Get("", false)
 
 	assert.NotNil(t, cfg)
 	assert.Empty(t, cfg.Source, "should fall back to the default built-in config")
+}
+
+func TestGetFallsBackToDefaultWhenRecoverySourceInvalid(t *testing.T) {
+	resetCache(t)
+
+	file := filepath.Join(t.TempDir(), "missing.omp.json")
+	t.Setenv(envKey, file)
+
+	cfg := Get(file, false)
+
+	assert.NotNil(t, cfg)
+	assert.Empty(t, cfg.Source, "should fall back to the default built-in config")
+
+	// The source may only be temporarily unavailable: the default must not be
+	// cached, otherwise the next render can no longer retry the recovery.
+	_, found := cache.Get[string](cache.Session, configKey)
+	assert.False(t, found, "a failed recovery should not pin the default in the session cache")
 }

--- a/src/shell/init.go
+++ b/src/shell/init.go
@@ -71,7 +71,7 @@ func Init(env runtime.Environment, feats Features) string {
 // This is used by the --print flag to output the script to stdout.
 func Script(env runtime.Environment, feats Features) string {
 	script := generateScript(env, feats)
-	return fmt.Sprintf("%s\n%s", sessionScript(env.Flags().Shell), script)
+	return fmt.Sprintf("%s\n%s", sessionScript(env), script)
 }
 
 // Debug writes the init script and returns debug information.
@@ -165,6 +165,11 @@ func generateScript(env runtime.Environment, feats Features) string {
 
 	bashBLEsession = len(env.Getenv("BLE_SESSION_ID")) != 0
 
+	// Only nu consumes ::CONFIG::: it has no eval'd session script to export
+	// POSH_CONFIG from, so the value is baked into its init script instead.
+	// All other shells get it via sessionScript.
+	var config string
+
 	var script string
 
 	switch env.Flags().Shell {
@@ -185,6 +190,7 @@ func generateScript(env runtime.Environment, feats Features) string {
 		script = cmdInit
 	case NU:
 		executable = quoteNuStr(executable)
+		config = quoteNuStr(env.Flags().ConfigPath)
 		script = nuInit
 	case ELVISH:
 		executable = quotePwshOrElvishStr(executable)
@@ -202,6 +208,7 @@ func generateScript(env runtime.Environment, feats Features) string {
 	init := strings.NewReplacer(
 		"::OMP::", executable,
 		"::SESSION_ID::", cache.SessionID(),
+		"::CONFIG::", config,
 	).Replace(script)
 
 	return feats.Lines(env.Flags().Shell).String(init)
@@ -219,6 +226,7 @@ func generateNuScript(env runtime.Environment, feats Features) string {
 	init := strings.NewReplacer(
 		"::OMP::", executable,
 		"::SESSION_ID::", cache.SessionID(),
+		"::CONFIG::", quoteNuStr(env.Flags().ConfigPath),
 	).Replace(nuInit)
 
 	return feats.Lines(NU).String(init)
@@ -235,7 +243,7 @@ func sourceCommand(env runtime.Environment, scriptPath string, async bool) strin
 		}
 	}
 
-	script := sessionScript(env.Flags().Shell)
+	script := sessionScript(env)
 
 	if async {
 		return script + sourceCommandAsync(env.Flags().Shell, scriptPath)
@@ -289,20 +297,28 @@ func printDebugInfo(env runtime.Environment, startTime *time.Time) string {
 	return builder.String()
 }
 
-func sessionScript(shell string) string {
-	switch shell {
+// sessionScript exports the session's environment variables: POSH_SESSION_ID
+// identifies the session cache, and POSH_CONFIG is pinned to the session's
+// resolved configuration source so it can be recovered when the session cache
+// is lost. A healthy session cache always wins, so POSH_CONFIG can not be used
+// to change the configuration mid-session.
+func sessionScript(env runtime.Environment) string {
+	sessionID := cache.SessionID()
+	config := env.Flags().ConfigPath
+
+	switch env.Flags().Shell {
 	case PWSH:
-		return fmt.Sprintf("$env:POSH_SESSION_ID = \"%s\";", cache.SessionID())
+		return fmt.Sprintf("$env:POSH_SESSION_ID = \"%s\"; $env:POSH_CONFIG = %s;", sessionID, quotePwshOrElvishStr(config))
 	case ZSH, BASH:
-		return fmt.Sprintf("export POSH_SESSION_ID=\"%s\";", cache.SessionID())
+		return fmt.Sprintf("export POSH_SESSION_ID=\"%s\"; export POSH_CONFIG=%s;", sessionID, QuotePosixStr(config))
 	case XONSH:
-		return fmt.Sprintf("$POSH_SESSION_ID = \"%s\";", cache.SessionID())
+		return fmt.Sprintf("$POSH_SESSION_ID = \"%s\"; $POSH_CONFIG = %s;", sessionID, quotePythonStr(config))
 	case FISH:
-		return fmt.Sprintf("set --export --global POSH_SESSION_ID \"%s\";", cache.SessionID())
+		return fmt.Sprintf("set --export --global POSH_SESSION_ID \"%s\"; set --export --global POSH_CONFIG %s;", sessionID, quoteFishStr(config))
 	case ELVISH:
-		return fmt.Sprintf("set-env POSH_SESSION_ID \"%s\";", cache.SessionID())
+		return fmt.Sprintf("set-env POSH_SESSION_ID \"%s\"; set-env POSH_CONFIG %s;", sessionID, quotePwshOrElvishStr(config))
 	case CMD:
-		return fmt.Sprintf(`os.setenv('POSH_SESSION_ID', '%s');`, cache.SessionID())
+		return fmt.Sprintf(`os.setenv('POSH_SESSION_ID', '%s'); os.setenv('POSH_CONFIG', '%s');`, sessionID, escapeLuaStr(config))
 	}
 	return ""
 }

--- a/src/shell/scripts/omp.nu
+++ b/src/shell/scripts/omp.nu
@@ -18,6 +18,8 @@ if ($env.config? | is-not-empty) {
 $env.POWERLINE_COMMAND = 'oh-my-posh'
 $env.PROMPT_INDICATOR = ""
 $env.POSH_SESSION_ID = "::SESSION_ID::"
+# pinned to the session's configuration so it can be recovered when the session cache is lost
+$env.POSH_CONFIG = ::CONFIG::
 $env.POSH_SHELL = "nu"
 $env.POSH_SHELL_VERSION = (version | get version)
 


### PR DESCRIPTION
## What

When the per-session config cache is lost mid-session, the prompt silently falls back to the **default built-in theme** for the rest of that shell. This recovers the configured theme (and self-heals the cache) instead.

## Why / root cause

A prompt render calls `oh-my-posh print` **without** `--config`, so config resolution depends entirely on the session cache (`zsh.$POSH_SESSION_ID.omp.cache` → `CONFIG`/`CONFIG_SOURCE`).

- Only `init` ever writes those keys; `print --save-cache` only *preserves* them.
- If that session cache file is lost mid-session — purged under disk pressure (e.g. macOS `com.apple.cache_delete`), or **corrupted by a concurrent writer that inherited the same `$POSH_SESSION_ID`** (the gob file is read‑modify‑written without locking) — the next `print` rebuilds the file without the config.
- `config.Get("", false)` then hits the cache miss and calls `Load("")` → `Parse("")` → `ErrNoConfig` → `Default()`, i.e. the default theme. It stays default until a new shell re-runs `init`.

This presents as a random "my theme reverted mid-session" that a new terminal fixes. It's easy to hit when a second process shares the session id (multiplexers, subshells, agent tooling, etc.).

### Reproduction
```sh
eval "$(oh-my-posh init zsh --config ~/path/theme.omp.json)"   # theme renders
rm ~/.cache/oh-my-posh/zsh.$POSH_SESSION_ID.omp.cache          # purge / simulate a corrupt concurrent write
# press Enter -> prompt is now the DEFAULT theme for the rest of the session
```
`oh-my-posh debug` in that state shows `no --config set, using default built-in configuration`, `(session) key not found: CONFIG`, `no cached config found`.

## How

In `config.Get`, when no explicit `--config` was provided and the session cache is missing/corrupt, recover the source before falling back to the default:

1. session `CONFIG_SOURCE` — still present when only the config *blob* is corrupt;
2. device-level **DSC** (`Resource[*Configuration]`) — persists across sessions with an infinite TTL and is populated on every `init`. Since `init` *requires* `--config` (`MarkPersistentFlagRequired("config")`), the DSC always reflects a real, user-chosen theme, so this introduces no "resurrect an unwanted theme" path. The most recently added state is used.

On recovery the config is re-parsed and `Store`d again, so the session cache self-heals and subsequent renders stay on the fast path. Behaviour is unchanged when `--config` is supplied or when the cache is valid.

## Tests

Added `src/config/gob_test.go`:
- recovery from the device DSC when the session cache is gone (+ asserts the session cache is repopulated);
- recovery from the session source when only the config blob is missing;
- fallback to the default when there is genuinely nothing to recover.

Verified end-to-end against a release build: before, `debug` reports the default theme after the cache is removed; after, it reports `recovered configuration from source: …` and renders the configured theme.