### PR TITLE
feat(claude): add repo, PR, and prompt statusline fields

### DIFF
--- a/src/segments/claude.go
+++ b/src/segments/claude.go
@@ -22,25 +22,25 @@ type Claude struct {
 
 // ClaudeData represents the parsed Claude JSON data
 type ClaudeData struct {
+	Effort            *ClaudeEffort       `json:"effort"`
+	Worktree          *ClaudeWorktree     `json:"worktree"`
+	OutputStyle       *ClaudeOutputStyle  `json:"output_style"`
+	Vim               *ClaudeVim          `json:"vim"`
 	RateLimits        *ClaudeRateLimits   `json:"rate_limits"`
-	Worktree          ClaudeWorktree      `json:"worktree"`
-	Model             AIModel             `json:"model"`
-	OutputStyle       ClaudeOutputStyle   `json:"output_style"`
-	Vim               ClaudeVim           `json:"vim"`
-	TranscriptPath    string              `json:"transcript_path"`
-	CWD               string              `json:"cwd"`
-	Version           string              `json:"version"`
-	SessionID         string              `json:"session_id"`
-	PromptID          string              `json:"prompt_id"`
-	Effort            ClaudeEffort        `json:"effort"`
-	SessionName       string              `json:"session_name"`
-	Agent             ClaudeAgent         `json:"agent"`
+	Thinking          *ClaudeThinking     `json:"thinking"`
 	PR                *ClaudePR           `json:"pr"`
+	Agent             *ClaudeAgent        `json:"agent"`
+	Model             AIModel             `json:"model"`
+	TranscriptPath    string              `json:"transcript_path"`
+	PromptID          string              `json:"prompt_id"`
+	SessionName       string              `json:"session_name"`
+	SessionID         string              `json:"session_id"`
+	Version           string              `json:"version"`
+	CWD               string              `json:"cwd"`
 	Workspace         ClaudeWorkspace     `json:"workspace"`
 	ContextWindow     ClaudeContextWindow `json:"context_window"`
 	Cost              ClaudeCost          `json:"cost"`
 	Exceeds200KTokens bool                `json:"exceeds_200k_tokens"`
-	Thinking          ClaudeThinking      `json:"thinking"`
 	FastMode          bool                `json:"fast_mode"`
 }
 
@@ -67,27 +67,31 @@ type ClaudeRepo struct {
 }
 
 // ClaudeOutputStyle represents the current output style.
+// Nil when the statusline payload does not report an output style.
 type ClaudeOutputStyle struct {
 	Name string `json:"name"`
 }
 
 // ClaudeEffort represents reasoning effort information for the current session.
-// Level is empty when the active model does not support reasoning effort.
+// Nil when the active model does not support reasoning effort.
 type ClaudeEffort struct {
 	Level string `json:"level"`
 }
 
 // ClaudeThinking represents extended thinking state for the current session.
+// Nil when the statusline payload does not report thinking state.
 type ClaudeThinking struct {
 	Enabled bool `json:"enabled"`
 }
 
 // ClaudeVim represents vim mode state.
+// Nil when vim mode is disabled.
 type ClaudeVim struct {
 	Mode string `json:"mode"`
 }
 
 // ClaudeAgent represents the active agent.
+// Nil when no agent is active.
 type ClaudeAgent struct {
 	Name string `json:"name"`
 }
@@ -134,6 +138,7 @@ func (p *ClaudePR) UnmarshalJSON(data []byte) error {
 }
 
 // ClaudeWorktree represents Claude Code --worktree session information.
+// Nil when the session is not running inside a Claude Code worktree.
 type ClaudeWorktree struct {
 	Name           string `json:"name"`
 	Path           string `json:"path"`

--- a/src/segments/claude.go
+++ b/src/segments/claude.go
@@ -1,7 +1,9 @@
 package segments
 
 import (
+	"encoding/json"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/cache"
@@ -29,9 +31,11 @@ type ClaudeData struct {
 	CWD               string              `json:"cwd"`
 	Version           string              `json:"version"`
 	SessionID         string              `json:"session_id"`
+	PromptID          string              `json:"prompt_id"`
 	Effort            ClaudeEffort        `json:"effort"`
 	SessionName       string              `json:"session_name"`
 	Agent             ClaudeAgent         `json:"agent"`
+	PR                *ClaudePR           `json:"pr"`
 	Workspace         ClaudeWorkspace     `json:"workspace"`
 	ContextWindow     ClaudeContextWindow `json:"context_window"`
 	Cost              ClaudeCost          `json:"cost"`
@@ -48,10 +52,18 @@ type AIModel struct {
 
 // ClaudeWorkspace represents workspace directory information
 type ClaudeWorkspace struct {
-	CurrentDir  string   `json:"current_dir"`
-	ProjectDir  string   `json:"project_dir"`
-	GitWorktree string   `json:"git_worktree"`
-	AddedDirs   []string `json:"added_dirs"`
+	Repo        *ClaudeRepo `json:"repo"`
+	CurrentDir  string      `json:"current_dir"`
+	ProjectDir  string      `json:"project_dir"`
+	GitWorktree string      `json:"git_worktree"`
+	AddedDirs   []string    `json:"added_dirs"`
+}
+
+// ClaudeRepo represents the repository identity parsed from the origin remote.
+type ClaudeRepo struct {
+	Host  string `json:"host"`
+	Owner string `json:"owner"`
+	Name  string `json:"name"`
 }
 
 // ClaudeOutputStyle represents the current output style.
@@ -78,6 +90,47 @@ type ClaudeVim struct {
 // ClaudeAgent represents the active agent.
 type ClaudeAgent struct {
 	Name string `json:"name"`
+}
+
+// ClaudePR represents the open pull request for the current branch.
+type ClaudePR struct {
+	Number      string `json:"number"`
+	URL         string `json:"url"`
+	ReviewState string `json:"review_state"`
+}
+
+func (p *ClaudePR) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		URL         string          `json:"url"`
+		ReviewState string          `json:"review_state"`
+		Number      json.RawMessage `json:"number"`
+	}
+
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	p.URL = raw.URL
+	p.ReviewState = raw.ReviewState
+
+	if len(raw.Number) == 0 || string(raw.Number) == "null" {
+		return nil
+	}
+
+	var number string
+	if err := json.Unmarshal(raw.Number, &number); err == nil {
+		p.Number = number
+		return nil
+	}
+
+	var numberValue int64
+	if err := json.Unmarshal(raw.Number, &numberValue); err != nil {
+		return err
+	}
+
+	p.Number = strconv.FormatInt(numberValue, 10)
+
+	return nil
 }
 
 // ClaudeWorktree represents Claude Code --worktree session information.

--- a/src/segments/claude_test.go
+++ b/src/segments/claude_test.go
@@ -170,29 +170,29 @@ func TestClaudeEffortAndThinking(t *testing.T) {
 	})
 
 	cases := []struct {
+		Effort           *ClaudeEffort
+		Thinking         *ClaudeThinking
 		Case             string
-		Effort           ClaudeEffort
 		ExpectedLevel    string
-		Thinking         ClaudeThinking
 		ExpectedThinking bool
 	}{
 		{
 			Case:             "Reasoning effort active, thinking enabled",
-			Effort:           ClaudeEffort{Level: "xhigh"},
+			Effort:           &ClaudeEffort{Level: "xhigh"},
 			ExpectedLevel:    "xhigh",
-			Thinking:         ClaudeThinking{Enabled: true},
+			Thinking:         &ClaudeThinking{Enabled: true},
 			ExpectedThinking: true,
 		},
 		{
 			Case:             "Reasoning effort active, thinking disabled",
-			Effort:           ClaudeEffort{Level: "high"},
+			Effort:           &ClaudeEffort{Level: "high"},
 			ExpectedLevel:    "high",
 			ExpectedThinking: false,
 		},
 		{
 			Case:             "Reasoning effort absent, thinking enabled",
 			ExpectedLevel:    "",
-			Thinking:         ClaudeThinking{Enabled: true},
+			Thinking:         &ClaudeThinking{Enabled: true},
 			ExpectedThinking: true,
 		},
 		{
@@ -217,8 +217,19 @@ func TestClaudeEffortAndThinking(t *testing.T) {
 		}
 
 		assert.True(t, claude.Enabled(), tc.Case)
-		assert.Equal(t, tc.ExpectedLevel, claude.Effort.Level, tc.Case)
-		assert.Equal(t, tc.ExpectedThinking, claude.Thinking.Enabled, tc.Case)
+
+		level := ""
+		if claude.Effort != nil {
+			level = claude.Effort.Level
+		}
+
+		thinking := false
+		if claude.Thinking != nil {
+			thinking = claude.Thinking.Enabled
+		}
+
+		assert.Equal(t, tc.ExpectedLevel, level, tc.Case)
+		assert.Equal(t, tc.ExpectedThinking, thinking, tc.Case)
 	}
 }
 
@@ -253,8 +264,19 @@ func TestClaudeEffortAndThinkingJSONShape(t *testing.T) {
 		var data ClaudeData
 		err := json.Unmarshal([]byte(tc.JSON), &data)
 		assert.NoError(t, err, tc.Case)
-		assert.Equal(t, tc.ExpectedLevel, data.Effort.Level, tc.Case)
-		assert.Equal(t, tc.ExpectedThinking, data.Thinking.Enabled, tc.Case)
+
+		level := ""
+		if data.Effort != nil {
+			level = data.Effort.Level
+		}
+
+		thinking := false
+		if data.Thinking != nil {
+			thinking = data.Thinking.Enabled
+		}
+
+		assert.Equal(t, tc.ExpectedLevel, level, tc.Case)
+		assert.Equal(t, tc.ExpectedThinking, thinking, tc.Case)
 	}
 }
 
@@ -315,7 +337,7 @@ func TestClaudeAdditionalStatusLineFieldsJSONShape(t *testing.T) {
 				PromptID:       "prompt-456",
 				TranscriptPath: "/repo/project/.claude/transcript.jsonl",
 				Version:        "2.1.123",
-				OutputStyle:    ClaudeOutputStyle{Name: defaultStr},
+				OutputStyle:    &ClaudeOutputStyle{Name: defaultStr},
 				Workspace: ClaudeWorkspace{
 					AddedDirs: []string{"/repo/shared", "/repo/docs"},
 					Repo: &ClaudeRepo{
@@ -325,14 +347,14 @@ func TestClaudeAdditionalStatusLineFieldsJSONShape(t *testing.T) {
 					},
 				},
 				Exceeds200KTokens: true,
-				Vim:               ClaudeVim{Mode: "NORMAL"},
-				Agent:             ClaudeAgent{Name: "security-reviewer"},
+				Vim:               &ClaudeVim{Mode: "NORMAL"},
+				Agent:             &ClaudeAgent{Name: "security-reviewer"},
 				PR: &ClaudePR{
 					Number:      "1234",
 					URL:         "https://github.com/anthropics/claude-code/pull/1234",
 					ReviewState: "pending",
 				},
-				Worktree: ClaudeWorktree{
+				Worktree: &ClaudeWorktree{
 					Name:           "my-feature",
 					Path:           "/repo/project/.claude/worktrees/my-feature",
 					Branch:         "worktree-my-feature",
@@ -372,7 +394,13 @@ func TestClaudeAdditionalStatusLineFieldsJSONShape(t *testing.T) {
 				"pr": {},
 				"worktree": {}
 			}`,
-			Expected:             ClaudeData{PR: &ClaudePR{}},
+			Expected: ClaudeData{
+				OutputStyle: &ClaudeOutputStyle{},
+				Vim:         &ClaudeVim{},
+				Agent:       &ClaudeAgent{},
+				PR:          &ClaudePR{},
+				Worktree:    &ClaudeWorktree{},
+			},
 			ExpectedAddedDirsNil: true,
 		},
 		{
@@ -388,7 +416,7 @@ func TestClaudeAdditionalStatusLineFieldsJSONShape(t *testing.T) {
 			}`,
 			Expected: ClaudeData{
 				Workspace: ClaudeWorkspace{AddedDirs: []string{"/repo/shared"}},
-				Worktree: ClaudeWorktree{
+				Worktree: &ClaudeWorktree{
 					Name: "review",
 					Path: "/repo/project/.claude/worktrees/review",
 				},
@@ -419,22 +447,18 @@ func TestClaudeAdditionalStatusLineFieldsJSONShape(t *testing.T) {
 		assert.Equal(t, tc.Expected.PromptID, data.PromptID, tc.Case)
 		assert.Equal(t, tc.Expected.TranscriptPath, data.TranscriptPath, tc.Case)
 		assert.Equal(t, tc.Expected.Version, data.Version, tc.Case)
-		assert.Equal(t, tc.Expected.OutputStyle.Name, data.OutputStyle.Name, tc.Case)
+		assert.Equal(t, tc.Expected.OutputStyle, data.OutputStyle, tc.Case)
 		if tc.ExpectedAddedDirsNil {
 			assert.Nil(t, data.Workspace.AddedDirs, tc.Case)
 		} else {
 			assert.Equal(t, tc.Expected.Workspace.AddedDirs, data.Workspace.AddedDirs, tc.Case)
 		}
 		assert.Equal(t, tc.Expected.Exceeds200KTokens, data.Exceeds200KTokens, tc.Case)
-		assert.Equal(t, tc.Expected.Vim.Mode, data.Vim.Mode, tc.Case)
-		assert.Equal(t, tc.Expected.Agent.Name, data.Agent.Name, tc.Case)
+		assert.Equal(t, tc.Expected.Vim, data.Vim, tc.Case)
+		assert.Equal(t, tc.Expected.Agent, data.Agent, tc.Case)
 		assert.Equal(t, tc.Expected.Workspace.Repo, data.Workspace.Repo, tc.Case)
 		assert.Equal(t, tc.Expected.PR, data.PR, tc.Case)
-		assert.Equal(t, tc.Expected.Worktree.Name, data.Worktree.Name, tc.Case)
-		assert.Equal(t, tc.Expected.Worktree.Path, data.Worktree.Path, tc.Case)
-		assert.Equal(t, tc.Expected.Worktree.Branch, data.Worktree.Branch, tc.Case)
-		assert.Equal(t, tc.Expected.Worktree.OriginalCWD, data.Worktree.OriginalCWD, tc.Case)
-		assert.Equal(t, tc.Expected.Worktree.OriginalBranch, data.Worktree.OriginalBranch, tc.Case)
+		assert.Equal(t, tc.Expected.Worktree, data.Worktree, tc.Case)
 		assert.Equal(t, tc.Expected.FastMode, data.FastMode, tc.Case)
 	}
 }

--- a/src/segments/claude_test.go
+++ b/src/segments/claude_test.go
@@ -274,13 +274,19 @@ func TestClaudeAdditionalStatusLineFieldsJSONShape(t *testing.T) {
 			JSON: `{
 				"cwd": "/repo/project",
 				"session_name": "release-check",
+				"prompt_id": "prompt-456",
 				"transcript_path": "/repo/project/.claude/transcript.jsonl",
 				"version": "2.1.123",
 				"output_style": {
 					"name": "default"
 				},
 				"workspace": {
-					"added_dirs": ["/repo/shared", "/repo/docs"]
+					"added_dirs": ["/repo/shared", "/repo/docs"],
+					"repo": {
+						"host": "github.com",
+						"owner": "anthropics",
+						"name": "claude-code"
+					}
 				},
 				"exceeds_200k_tokens": true,
 				"vim": {
@@ -288,6 +294,11 @@ func TestClaudeAdditionalStatusLineFieldsJSONShape(t *testing.T) {
 				},
 				"agent": {
 					"name": "security-reviewer"
+				},
+				"pr": {
+					"number": 1234,
+					"url": "https://github.com/anthropics/claude-code/pull/1234",
+					"review_state": "pending"
 				},
 				"worktree": {
 					"name": "my-feature",
@@ -299,15 +310,28 @@ func TestClaudeAdditionalStatusLineFieldsJSONShape(t *testing.T) {
 				"fast_mode": true
 			}`,
 			Expected: ClaudeData{
-				CWD:               "/repo/project",
-				SessionName:       "release-check",
-				TranscriptPath:    "/repo/project/.claude/transcript.jsonl",
-				Version:           "2.1.123",
-				OutputStyle:       ClaudeOutputStyle{Name: defaultStr},
-				Workspace:         ClaudeWorkspace{AddedDirs: []string{"/repo/shared", "/repo/docs"}},
+				CWD:            "/repo/project",
+				SessionName:    "release-check",
+				PromptID:       "prompt-456",
+				TranscriptPath: "/repo/project/.claude/transcript.jsonl",
+				Version:        "2.1.123",
+				OutputStyle:    ClaudeOutputStyle{Name: defaultStr},
+				Workspace: ClaudeWorkspace{
+					AddedDirs: []string{"/repo/shared", "/repo/docs"},
+					Repo: &ClaudeRepo{
+						Host:  "github.com",
+						Owner: "anthropics",
+						Name:  "claude-code",
+					},
+				},
 				Exceeds200KTokens: true,
 				Vim:               ClaudeVim{Mode: "NORMAL"},
 				Agent:             ClaudeAgent{Name: "security-reviewer"},
+				PR: &ClaudePR{
+					Number:      "1234",
+					URL:         "https://github.com/anthropics/claude-code/pull/1234",
+					ReviewState: "pending",
+				},
 				Worktree: ClaudeWorktree{
 					Name:           "my-feature",
 					Path:           "/repo/project/.claude/worktrees/my-feature",
@@ -325,15 +349,30 @@ func TestClaudeAdditionalStatusLineFieldsJSONShape(t *testing.T) {
 			ExpectedAddedDirsNil: true,
 		},
 		{
+			Case: "PR number provided as string",
+			JSON: `{"pr":{"number":"1234"}}`,
+			Expected: ClaudeData{
+				PR: &ClaudePR{Number: "1234"},
+			},
+			ExpectedAddedDirsNil: true,
+		},
+		{
+			Case:                 "PR number explicitly null",
+			JSON:                 `{"pr":{"number":null}}`,
+			Expected:             ClaudeData{PR: &ClaudePR{}},
+			ExpectedAddedDirsNil: true,
+		},
+		{
 			Case: "Nested objects empty",
 			JSON: `{
 				"output_style": {},
 				"workspace": {},
 				"vim": {},
 				"agent": {},
+				"pr": {},
 				"worktree": {}
 			}`,
-			Expected:             ClaudeData{},
+			Expected:             ClaudeData{PR: &ClaudePR{}},
 			ExpectedAddedDirsNil: true,
 		},
 		{
@@ -377,6 +416,7 @@ func TestClaudeAdditionalStatusLineFieldsJSONShape(t *testing.T) {
 		assert.NoError(t, err, tc.Case)
 		assert.Equal(t, tc.Expected.CWD, data.CWD, tc.Case)
 		assert.Equal(t, tc.Expected.SessionName, data.SessionName, tc.Case)
+		assert.Equal(t, tc.Expected.PromptID, data.PromptID, tc.Case)
 		assert.Equal(t, tc.Expected.TranscriptPath, data.TranscriptPath, tc.Case)
 		assert.Equal(t, tc.Expected.Version, data.Version, tc.Case)
 		assert.Equal(t, tc.Expected.OutputStyle.Name, data.OutputStyle.Name, tc.Case)
@@ -388,6 +428,8 @@ func TestClaudeAdditionalStatusLineFieldsJSONShape(t *testing.T) {
 		assert.Equal(t, tc.Expected.Exceeds200KTokens, data.Exceeds200KTokens, tc.Case)
 		assert.Equal(t, tc.Expected.Vim.Mode, data.Vim.Mode, tc.Case)
 		assert.Equal(t, tc.Expected.Agent.Name, data.Agent.Name, tc.Case)
+		assert.Equal(t, tc.Expected.Workspace.Repo, data.Workspace.Repo, tc.Case)
+		assert.Equal(t, tc.Expected.PR, data.PR, tc.Case)
 		assert.Equal(t, tc.Expected.Worktree.Name, data.Worktree.Name, tc.Case)
 		assert.Equal(t, tc.Expected.Worktree.Path, data.Worktree.Path, tc.Case)
 		assert.Equal(t, tc.Expected.Worktree.Branch, data.Worktree.Branch, tc.Case)

--- a/website/docs/segments/cli/claude.mdx
+++ b/website/docs/segments/cli/claude.mdx
@@ -53,6 +53,7 @@ import Config from "@site/src/components/Config.js";
 | `.CWD`                  | `string`        | Current working directory; same value as `.Workspace.CurrentDir`                     |
 | `.SessionID`            | `string`        | Unique identifier for the Claude session                                             |
 | `.SessionName`          | `string`        | Custom session name; empty when absent                                               |
+| `.PromptID`             | `string`        | User prompt identifier for event correlation; empty when absent                      |
 | `.TranscriptPath`       | `string`        | Path to the conversation transcript file                                             |
 | `.Model`                | `Model`         | AI model information                                                                 |
 | `.Workspace`            | `Workspace`     | Workspace directory information                                                      |
@@ -65,6 +66,7 @@ import Config from "@site/src/components/Config.js";
 | `.Exceeds200KTokens`    | `bool`          | Whether the most recent API response exceeded 200K total tokens                      |
 | `.Vim`                  | `Vim`           | Vim mode information; empty when absent                                              |
 | `.Agent`                | `Agent`         | Agent information; empty when absent                                                 |
+| `.PR`                   | `PR`            | Pull request information for the current branch; nil when absent                     |
 | `.Worktree`             | `Worktree`      | Claude Code worktree information; empty when absent                                  |
 | `.FastMode`             | `bool`          | Whether fast mode is enabled; `false` when absent or unsupported                     |
 | `.TokenUsagePercent`    | `Percentage`    | Percentage of context window used (0-100)                                            |
@@ -98,6 +100,15 @@ import Config from "@site/src/components/Config.js";
 | `.ProjectDir`  | `string`   | Directory where Claude Code was launched; may differ from `.CurrentDir`      |
 | `.AddedDirs`   | `[]string` | Additional directories added via `/add-dir` or `--add-dir`                   |
 | `.GitWorktree` | `string`   | Path to the linked git worktree, empty when not inside a linked git worktree |
+| `.Repo`        | `Repo`     | Repository identity parsed from the `origin` remote; nil when absent         |
+
+#### Repo Properties
+
+| Name     | Type     | Description                                                  |
+| -------- | -------- | ------------------------------------------------------------ |
+| `.Host`  | `string` | Repository host, for example `github.com`; empty when absent |
+| `.Owner` | `string` | Repository owner or organization; empty when absent          |
+| `.Name`  | `string` | Repository name; empty when absent                           |
 
 #### OutputStyle Properties
 
@@ -128,6 +139,14 @@ import Config from "@site/src/components/Config.js";
 | Name    | Type     | Description                               |
 | ------- | -------- | ----------------------------------------- |
 | `.Name` | `string` | Agent name; empty when no agent is active |
+
+#### PR Properties
+
+| Name           | Type          | Description                                                                                   |
+| -------------- | ------------- | --------------------------------------------------------------------------------------------- |
+| `.Number`      | `string`      | Open pull request number for the current branch; empty when absent                            |
+| `.URL`         | `string`      | Open pull request URL for the current branch; empty when absent                               |
+| `.ReviewState` | `string`      | Review status (`approved`, `pending`, `changes_requested`, or `draft`); empty when unavailable |
 
 #### Worktree Properties
 

--- a/website/docs/segments/cli/claude.mdx
+++ b/website/docs/segments/cli/claude.mdx
@@ -58,16 +58,16 @@ import Config from "@site/src/components/Config.js";
 | `.Model`                | `Model`         | AI model information                                                                 |
 | `.Workspace`            | `Workspace`     | Workspace directory information                                                      |
 | `.Version`              | `string`        | Claude Code version                                                                  |
-| `.OutputStyle`          | `OutputStyle`   | Current output style information                                                     |
-| `.Effort`               | `Effort`        | Reasoning effort information                                                         |
-| `.Thinking`             | `Thinking`      | Extended thinking state                                                              |
+| `.OutputStyle`          | `OutputStyle`   | Current output style information; nil when absent                                   |
+| `.Effort`               | `Effort`        | Reasoning effort information; nil when absent or unsupported                         |
+| `.Thinking`             | `Thinking`      | Extended thinking state; nil when absent                                            |
 | `.Cost`                 | `Cost`          | Cost and duration information                                                        |
 | `.ContextWindow`        | `ContextWindow` | Token usage information                                                              |
 | `.Exceeds200KTokens`    | `bool`          | Whether the most recent API response exceeded 200K total tokens                      |
-| `.Vim`                  | `Vim`           | Vim mode information; empty when absent                                              |
-| `.Agent`                | `Agent`         | Agent information; empty when absent                                                 |
+| `.Vim`                  | `Vim`           | Vim mode information; nil when absent                                                |
+| `.Agent`                | `Agent`         | Agent information; nil when absent                                                   |
 | `.PR`                   | `PR`            | Pull request information for the current branch; nil when absent                     |
-| `.Worktree`             | `Worktree`      | Claude Code worktree information; empty when absent                                  |
+| `.Worktree`             | `Worktree`      | Claude Code worktree information; nil when absent                                    |
 | `.FastMode`             | `bool`          | Whether fast mode is enabled; `false` when absent or unsupported                     |
 | `.TokenUsagePercent`    | `Percentage`    | Percentage of context window used (0-100)                                            |
 | `.TokenGauge`           | `string`        | Gauge showing remaining context capacity using configured characters (e.g., `▰▰▰▱▱`) |
@@ -109,6 +109,12 @@ import Config from "@site/src/components/Config.js";
 | `.Host`  | `string` | Repository host, for example `github.com`; empty when absent |
 | `.Owner` | `string` | Repository owner or organization; empty when absent          |
 | `.Name`  | `string` | Repository name; empty when absent                           |
+
+:::tip nil pointer fields
+`.OutputStyle`, `.Effort`, `.Thinking`, `.Vim`, `.Agent`, `.PR`, `.Worktree`, and `.Workspace.Repo`
+are all `nil` when the underlying data is absent. Guard direct field access with
+`{{if .Effort}}{{.Effort.Level}}{{end}}` to avoid template errors.
+:::
 
 #### OutputStyle Properties
 


### PR DESCRIPTION
This PR adds Claude Code statusline fields that are currently exposed by Claude but were not available in the oh-my-posh `claude` segment:

- `prompt_id` as `.PromptID`
- `workspace.repo.host`, `workspace.repo.owner`, and `workspace.repo.name` as `.Workspace.Repo.*`
- `pr.number`, `pr.url`, and `pr.review_state` as `.PR.*`

Statusline docs source: https://code.claude.com/docs/en/statusline.md