### PR TITLE
chore(release): sign checksums with cosign

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,11 +60,16 @@ jobs:
       run:
         shell: pwsh
         working-directory: ${{ github.workspace }}/build
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout code 👋
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Install Go 🗳
         uses: ./.github/workflows/composite/bootstrap-go
+      - name: Install Cosign 🗳
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6
       - name: Pre Build 😸
         env:
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}

--- a/src/.goreleaser.yml
+++ b/src/.goreleaser.yml
@@ -54,5 +54,14 @@ signs:
       - "-c"
       - "& '{{ .Env.OPENSSL }}' pkeyutl -sign -inkey '{{ .Env.SHA_SIGNING_KEY_LOCATION }}' -out '${artifact}.sig' -rawin -in '${artifact}'"
     artifacts: checksum
+  - cmd: cosign
+    args:
+      - sign-blob
+      - --bundle=${signature}
+      - --yes
+      - ${artifact}
+    artifacts: checksum
+    signature: ${artifact}.sigstore.json
+
 changelog:
   disable: true


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

<!---
proejcts
Tips:

If you're not comfortable with working with Git,
we're working on a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D)
as your preferred cross platform Git GUI power tool.

-->

Refs
- https://www.sigstore.dev
- https://docs.sigstore.dev/cosign/signing/overview/
- https://github.com/sigstore/cosign

This yields a checksums.txt.sigstore.json in release assets, which can be used to verify the checksums file and thus transitively files listed in it. This can be done manually using cosign, and software such as [aqua](https://aquaproj.github.io/) and [mise](https://mise.jdx.dev/) can do it automatically on install.

Note: with this, one likely wants to use `--skip=sign` if running `goreleaser release --snapshot` to test (other) things locally.

Caveat: untested, but have set up this for multiple projects previously, could work.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
