### PR TITLE
fix(runtime): close Windows job objects when segments complete

### DIFF
--- a/src/config/segment.go
+++ b/src/config/segment.go
@@ -205,6 +205,16 @@ func (segment *Segment) Execute(env runtime.Environment) {
 		if err := runjobs.CreateJobForGoroutine(segment.Name()); err != nil {
 			log.Errorf("failed to create job for goroutine (segment: %s): %v", segment.Name(), err)
 		}
+
+		// Release the Job object (Windows) once this goroutine is done
+		// spawning/waiting on children. cmd.Run blocks until its child exits,
+		// so by the time Execute returns - on any path below, including a
+		// panic unwind - no process we intended to keep alive is still
+		// assigned to the job, making it safe to close despite
+		// JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE. If the timeout path already
+		// terminated/closed the job concurrently, this is a no-op; see the
+		// ownership invariant documented on jobs.CloseGoroutineJob.
+		defer runjobs.CloseGoroutineJob()
 	}
 
 	segment.Enabled = segment.writer.Enabled()

--- a/src/runtime/jobs/jobs_other.go
+++ b/src/runtime/jobs/jobs_other.go
@@ -18,6 +18,11 @@ var (
 func CreateJobForGoroutine(_ string) error { return nil }
 func AssignPidToGoroutineJob(_ int) error  { return nil }
 
+// CloseGoroutineJob is a no-op on non-Windows platforms; there is no Job
+// object to release. It exists so callers (e.g. config.Segment.Execute) can
+// unconditionally defer the close without platform-specific branching.
+func CloseGoroutineJob() {}
+
 // setProcessGroup ensures the child process runs in its own process group so
 // it can be killed with a group kill (negative pid).
 func SetProcessGroup(cmd *exec.Cmd) {

--- a/src/runtime/jobs/jobs_windows.go
+++ b/src/runtime/jobs/jobs_windows.go
@@ -115,6 +115,52 @@ func UnregisterProcess(pid int) {
 	processesMu.Unlock()
 }
 
+// CloseGoroutineJob releases the Job object (if any) created for the current
+// goroutine via CreateJobForGoroutine, along with its recorded pids.
+//
+// Ownership invariant: a map entry in `jobs` represents an open handle that
+// nobody else has closed yet. Removal from the map and closing the handle
+// must happen atomically from the caller's perspective, and whichever of
+// CloseGoroutineJob/KillGoroutineChildren deletes the entry first is the sole
+// owner of the handle from that point on - the other side, finding the entry
+// already gone, does nothing further. This guarantees exactly one
+// windows.CloseHandle/TerminateJobObject call per handle, so a segment that
+// finishes normally right as its timeout fires can never race a double-close
+// or have its handle closed out from under a concurrent kill.
+//
+// This must only be called from the same goroutine that created the job
+// (i.e. after the segment's Execute body has returned), since by then any
+// child processes started via cmd.Run have already exited - JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+// only affects processes still assigned to the job at close time.
+func CloseGoroutineJob() {
+	gid := CurrentGID()
+
+	jobsMu.Lock()
+	job, hasJob := jobs[gid]
+	if hasJob {
+		delete(jobs, gid)
+	}
+	jobsMu.Unlock()
+
+	processesMu.Lock()
+	delete(processes, gid)
+	processesMu.Unlock()
+
+	if !hasJob {
+		// Either no job was ever created for this goroutine, or
+		// KillGoroutineChildren already won the race and took ownership of
+		// the handle (and already closed it via TerminateJobObject).
+		return
+	}
+
+	if err := windows.CloseHandle(job); err != nil {
+		log.Error(err)
+		return
+	}
+
+	log.Debugf("closed job object for goroutine: %d", gid)
+}
+
 // KillGoroutineChildren will first try to terminate a Job if present, and
 // otherwise will fall back to taskkill for each recorded pid.
 func KillGoroutineChildren(gid uint64) error {
@@ -126,8 +172,18 @@ func KillGoroutineChildren(gid uint64) error {
 	}
 	jobsMu.Unlock()
 	if hasJob {
-		// Terminate the job which kills all processes in it
-		if err := windows.TerminateJobObject(job, 1); err == nil {
+		// Terminate the job which kills all processes in it. This also
+		// closes/invalidates the handle's usefulness; TerminateJobObject
+		// does not itself close the handle, but since we've already removed
+		// it from the map, CloseGoroutineJob running concurrently (e.g. the
+		// original goroutine finishing right as the timeout fires) will see
+		// no entry and skip closing it here, so we're the sole owner and
+		// must close it ourselves to avoid leaking the handle.
+		terminated := windows.TerminateJobObject(job, 1) == nil
+		if err := windows.CloseHandle(job); err != nil {
+			log.Error(err)
+		}
+		if terminated {
 			// cleanup recorded pids as well
 			processesMu.Lock()
 			delete(processes, gid)

--- a/src/runtime/jobs/jobs_windows_test.go
+++ b/src/runtime/jobs/jobs_windows_test.go
@@ -1,0 +1,58 @@
+//go:build windows
+
+package jobs
+
+import "testing"
+
+// TestCloseGoroutineJob verifies that CloseGoroutineJob removes both the job
+// and its recorded pids for the current goroutine, closes the underlying
+// handle exactly once, and is a safe no-op if called again (e.g. because
+// KillGoroutineChildren already won the race and closed it first).
+func TestCloseGoroutineJob(t *testing.T) {
+	if err := CreateJobForGoroutine("test"); err != nil {
+		t.Fatalf("CreateJobForGoroutine returned error: %v", err)
+	}
+
+	gid := CurrentGID()
+
+	jobsMu.Lock()
+	_, hasJob := jobs[gid]
+	jobsMu.Unlock()
+
+	if !hasJob {
+		t.Fatalf("expected job to be registered for gid %d", gid)
+	}
+
+	// register a fake pid entry to exercise the processes map cleanup
+	processesMu.Lock()
+	processes[gid] = map[int]struct{}{1234: {}}
+	processesMu.Unlock()
+
+	CloseGoroutineJob()
+
+	jobsMu.Lock()
+	_, hasJob = jobs[gid]
+	jobsMu.Unlock()
+
+	if hasJob {
+		t.Fatalf("expected job to be removed for gid %d after close", gid)
+	}
+
+	processesMu.Lock()
+	_, hasProcesses := processes[gid]
+	processesMu.Unlock()
+
+	if hasProcesses {
+		t.Fatalf("expected processes entry to be removed for gid %d after close", gid)
+	}
+
+	// calling again must be a safe no-op (no double-close panic/error)
+	CloseGoroutineJob()
+}
+
+// TestCloseGoroutineJobNoJob verifies calling CloseGoroutineJob without a
+// prior CreateJobForGoroutine call (e.g. a segment with no timeout) is a
+// harmless no-op.
+func TestCloseGoroutineJobNoJob(t *testing.T) {
+	CloseGoroutineJob()
+}


### PR DESCRIPTION
## Summary

Follow-up to #7626 (stacked on `perf/rendering-engine` — retarget to `main` once that merges). Fixes the pre-existing Windows job-handle leak that #7626 deliberately left out of scope.

Job objects created for timeout-enabled segments were never closed on the happy path, and `KillGoroutineChildren` never closed the handle even on the kill path (it only terminated the job). The per-gid `processes` map entries leaked the same way. Mostly relevant for streaming mode and long-lived processes.

## Design

- **Ownership invariant:** a `jobs` map entry *is* the open handle. Both `CloseGoroutineJob` (new) and `KillGoroutineChildren` delete the entry under `jobsMu` before acting; whichever deletes first owns the one-and-only close. A segment finishing normally exactly as its timeout fires can never double-close or have the handle closed out from under a concurrent kill.
- **`KILL_ON_JOB_CLOSE` safety:** the close runs via `defer` in the same goroutine as `Execute`, after `cmd.Run` has waited for children — so no surviving process is still assigned at close time. This matches the existing end-of-process behavior, just earlier.
- Non-Windows platforms get a no-op `CloseGoroutineJob`; new Windows-only unit tests cover create→close map cleanup and idempotent double-close.

## Validation

- Full `go test ./...` green; new `TestCloseGoroutineJob`/`TestCloseGoroutineJobNoJob` pass
- Cross-compiles: linux, darwin, windows/amd64
- Smoke: `print primary` renders normally with a crafted config containing `timeout`-enabled segments (exercises create→close)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Windows process/job lifecycle and concurrent timeout vs normal completion; mistakes could double-close handles or affect child termination, though the PR documents and tests the ownership race.
> 
> **Overview**
> Fixes a **Windows handle leak** for timeout-enabled segments: job objects and per-goroutine `processes` map entries were never released on the normal completion path, and the timeout kill path terminated jobs without closing handles.
> 
> **`CloseGoroutineJob`** is added and **`defer`’d from `Segment.Execute`** when `Timeout > 0`, so the job is released after segment work finishes (including panic unwind), once child processes from `cmd.Run` have exited—safe with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`. Non-Windows builds get a no-op so callers need no `#ifdef` branching.
> 
> On Windows, **`KillGoroutineChildren`** now **`CloseHandle`s** after `TerminateJobObject`. An **ownership invariant** ensures whichever of `CloseGoroutineJob` or `KillGoroutineChildren` removes the `jobs` map entry first performs the single close, avoiding double-close when a segment finishes as its timeout fires.
> 
> New **Windows-only tests** cover map cleanup, idempotent second close, and no-op when no job exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df5ad16e191b1e081a9c0b4878661deb28e1d880. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->