### PR TITLE
fix(nush): nushell 0.114 compatibily

### DIFF
--- a/src/shell/scripts/omp.nu
+++ b/src/shell/scripts/omp.nu
@@ -38,16 +38,18 @@ def --wrapped _omp_get_prompt [
         $ms => { $ms | into int }
     }
 
-    ^$_omp_executable print $type
-        --save-cache
-        --shell=nu
-        $"--shell-version=($env.POSH_SHELL_VERSION)"
-        $"--status=($env.LAST_EXIT_CODE)"
-        $"--no-status=($execution_time < 0)"
-        $"--execution-time=($execution_time)"
-        $"--terminal-width=((term size).columns)"
-        $"--job-count=(job list | length)"
-        ...$args
+    (
+        ^$_omp_executable print $type
+            --save-cache
+            --shell=nu
+            $"--shell-version=($env.POSH_SHELL_VERSION)"
+            $"--status=($env.LAST_EXIT_CODE)"
+            $"--no-status=($execution_time < 0)"
+            $"--execution-time=($execution_time)"
+            $"--terminal-width=((term size).columns)"
+            $"--job-count=(job list | length)"
+            ...$args
+    )
 }
 
 $env.PROMPT_MULTILINE_INDICATOR = (

--- a/src/shell/scripts/omp.nu
+++ b/src/shell/scripts/omp.nu
@@ -31,27 +31,23 @@ def --wrapped _omp_get_prompt [
     type: string,
     ...args: string
 ] {
-    mut execution_time = -1
-    mut no_status = true
     # We have to do this because the initial value of `$env.CMD_DURATION_MS` is always `0823`, which is an official setting.
     # See https://github.com/nushell/nushell/discussions/6402#discussioncomment-3466687.
-    if $env.CMD_DURATION_MS != '0823' {
-        $execution_time = $env.CMD_DURATION_MS | into int
-        $no_status = false
+    let execution_time = match $env.CMD_DURATION_MS {
+        '0823' => -1
+        $ms => { $ms | into int }
     }
 
-    (
-        ^$_omp_executable print $type
-            --save-cache
-            --shell=nu
-            $"--shell-version=($env.POSH_SHELL_VERSION)"
-            $"--status=($env.LAST_EXIT_CODE)"
-            $"--no-status=($no_status)"
-            $"--execution-time=($execution_time)"
-            $"--terminal-width=((term size).columns)"
-            $"--job-count=(job list | length)"
-            ...$args
-    )
+    ^$_omp_executable print $type
+        --save-cache
+        --shell=nu
+        $"--shell-version=($env.POSH_SHELL_VERSION)"
+        $"--status=($env.LAST_EXIT_CODE)"
+        $"--no-status=($execution_time < 0)"
+        $"--execution-time=($execution_time)"
+        $"--terminal-width=((term size).columns)"
+        $"--job-count=(job list | length)"
+        ...$args
 }
 
 $env.PROMPT_MULTILINE_INDICATOR = (
@@ -63,10 +59,10 @@ $env.PROMPT_MULTILINE_INDICATOR = (
 $env.PROMPT_COMMAND = {||
     # hack to set the cursor line to 1 when the user clears the screen
     # this obviously isn't bulletproof, but it's a start
-    mut clear = false
-    if $nu.history-enabled {
-        $clear = (history | is-empty) or ((history | last 1 | get 0.command) == "clear")
-    }
+    let clear = $nu.history-enabled and (
+        (history | is-empty)
+        or (history | last | get command?) == "clear"
+    )
 
     if ($env.SET_POSHCONTEXT? | is-not-empty) {
         do --env $env.SET_POSHCONTEXT

--- a/src/shell/scripts/omp.nu
+++ b/src/shell/scripts/omp.nu
@@ -36,7 +36,7 @@ def --wrapped _omp_get_prompt [
     # We have to do this because the initial value of `$env.CMD_DURATION_MS` is always `0823`, which is an official setting.
     # See https://github.com/nushell/nushell/discussions/6402#discussioncomment-3466687.
     if $env.CMD_DURATION_MS != '0823' {
-        $execution_time = $env.CMD_DURATION_MS
+        $execution_time = $env.CMD_DURATION_MS | into int
         $no_status = false
     }
 


### PR DESCRIPTION
### Prerequisites

- [X] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [X] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

fixes `omp.nu` to support nushell 0.114 - https://github.com/nushell/nushell/pull/18430 breaks assigning stringly typed `$env.CMD_DURATION_MS` to what was an integer before
also nuked some mutable vars in the same script, they're considered undesirable in nu

<!---

Tips:

If you're not comfortable with working with Git,
we're working on a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D)
as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
