### PR TITLE
feat(shell): support vimode segment in PowerShell

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -204,7 +204,7 @@ func (cfg *Config) Features(env runtime.Environment) shell.Features {
 				}
 			}
 
-			if segment.Type == VIMODE && env.Shell() == shell.ZSH {
+			if segment.Type == VIMODE && slices.Contains([]string{shell.ZSH, shell.PWSH}, env.Shell()) {
 				log.Debug("vi mode tracking enabled")
 				feats |= shell.VIMode
 			}

--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -165,6 +165,56 @@ func TestFeaturesShellIntegration(t *testing.T) {
 	}
 }
 
+func TestFeaturesVIMode(t *testing.T) {
+	cases := []struct {
+		Case          string
+		Shell         string
+		ExpectedFeats shell.Features
+	}{
+		{
+			Case:          "zsh enables vi mode tracking",
+			Shell:         shell.ZSH,
+			ExpectedFeats: shell.VIMode,
+		},
+		{
+			Case:          "pwsh enables vi mode tracking",
+			Shell:         shell.PWSH,
+			ExpectedFeats: shell.VIMode,
+		},
+		{
+			Case:          "bash does not enable vi mode tracking",
+			Shell:         shell.BASH,
+			ExpectedFeats: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		env := &mock.Environment{}
+		env.On("Shell").Return(tc.Shell)
+
+		template.Cache = &cache.Template{
+			SimpleTemplate: cache.SimpleTemplate{
+				Shell: tc.Shell,
+			},
+		}
+		template.Init(env, nil, nil)
+
+		cfg := &Config{
+			Upgrade: &upgrade.Config{},
+			Blocks: []*Block{
+				{
+					Segments: []*Segment{
+						{Type: VIMODE},
+					},
+				},
+			},
+		}
+
+		got := cfg.Features(env)
+		assert.Equal(t, tc.ExpectedFeats, got, tc.Case)
+	}
+}
+
 func TestUpgradeFeatures(t *testing.T) {
 	cases := []struct {
 		Case                  string

--- a/src/config/segment_types.go
+++ b/src/config/segment_types.go
@@ -374,7 +374,7 @@ const (
 	V SegmentType = "v"
 	// VALA writes the active vala version
 	VALA SegmentType = "vala"
-	// VIMODE writes the active ZSH Vi mode (insert/normal/visual)
+	// VIMODE writes the active Vi mode (insert/normal/visual)
 	VIMODE SegmentType = "vimode"
 	// WAKATIME writes tracked time spend in dev editors
 	WAKATIME SegmentType = "wakatime"

--- a/src/shell/pwsh.go
+++ b/src/shell/pwsh.go
@@ -33,7 +33,9 @@ func (f Features) Pwsh() Code {
 		return "$global:_ompStreaming = $true"
 	case KeyHandlers:
 		return "Enable-KeyHandlers"
-	case PromptMark, RPrompt, CursorPositioning, Async, VIMode:
+	case VIMode:
+		return "Enable-PoshVIMode"
+	case PromptMark, RPrompt, CursorPositioning, Async:
 		fallthrough
 	default:
 		return ""

--- a/src/shell/pwsh_test.go
+++ b/src/shell/pwsh_test.go
@@ -7,7 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var allFeatures = Tooltips | LineError | Transient | Jobs | Azure | PoshGit | FTCSMarks | Upgrade | Notice | PromptMark | RPrompt | CursorPositioning | KeyHandlers | Streaming
+var allFeatures = Tooltips | LineError | Transient | Jobs | Azure | PoshGit | FTCSMarks |
+	Upgrade | Notice | PromptMark | RPrompt | CursorPositioning | KeyHandlers | Streaming | VIMode
 
 func TestPwshFeatures(t *testing.T) {
 	got := allFeatures.Lines(PWSH).String("")
@@ -23,7 +24,8 @@ $global:_ompFTCSMarks = $true
 & $global:_ompExecutable upgrade --auto
 & $global:_ompExecutable notice
 $global:_ompStreaming = $true
-Enable-KeyHandlers`
+Enable-KeyHandlers
+Enable-PoshVIMode`
 
 	assert.Equal(t, want, got)
 }

--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -32,8 +32,11 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
 
     # Prompt related backup.
     $script:OriginalPromptFunction = $Function:prompt
-    $script:OriginalContinuationPrompt = (Get-PSReadLineOption).ContinuationPrompt
-    $script:OriginalPromptText = (Get-PSReadLineOption).PromptText
+    $originalPSReadLineOptions = Get-PSReadLineOption
+    $script:OriginalContinuationPrompt = $originalPSReadLineOptions.ContinuationPrompt
+    $script:OriginalPromptText = $originalPSReadLineOptions.PromptText
+    $script:OriginalViModeIndicator = $originalPSReadLineOptions.ViModeIndicator
+    $script:OriginalViModeChangeHandler = $originalPSReadLineOptions.ViModeChangeHandler
 
     $script:NoExitCode = $true
     $script:ErrorCode = 0
@@ -672,6 +675,44 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
         Set-PSReadLineOption -PromptText $validLine, $errorLine
     }
 
+    function Enable-PoshVIMode {
+        if ($script:ConstrainedLanguageMode) {
+            return
+        }
+
+        if ((Get-PSReadLineOption).EditMode -ne "Vi") {
+            return
+        }
+
+        if (-not (Get-Command Set-PSReadLineOption).Parameters.ContainsKey('ViModeChangeHandler')) {
+            return
+        }
+
+        $env:POSH_VI_MODE = "viins"
+        Set-PSReadLineOption -ViModeIndicator Script -ViModeChangeHandler {
+            param($mode)
+
+            if ($mode -eq "Command") {
+                $env:POSH_VI_MODE = "vicmd"
+            }
+            else {
+                $env:POSH_VI_MODE = "viins"
+            }
+
+            $previousOutputEncoding = [Console]::OutputEncoding
+            try {
+                $script:Streaming.State = 'NEW'
+                [Console]::OutputEncoding = [Text.Encoding]::UTF8
+                [Microsoft.PowerShell.PSConsoleReadLine]::InvokePrompt()
+            }
+            catch {
+            }
+            finally {
+                [Console]::OutputEncoding = $previousOutputEncoding
+            }
+        }
+    }
+
     # perform cleanup on removal so a new initialization in current session works
     if (!$script:ConstrainedLanguageMode) {
         $ExecutionContext.SessionState.Module.OnRemove += {
@@ -695,6 +736,12 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
 
             (Get-PSReadLineOption).ContinuationPrompt = $script:OriginalContinuationPrompt
             (Get-PSReadLineOption).PromptText = $script:OriginalPromptText
+
+            if ((Get-Command Set-PSReadLineOption).Parameters.ContainsKey('ViModeChangeHandler')) {
+                Set-PSReadLineOption -ViModeIndicator $script:OriginalViModeIndicator -ViModeChangeHandler $script:OriginalViModeChangeHandler
+            }
+
+            Remove-Item Env:POSH_VI_MODE -ErrorAction Ignore
 
             if ((Get-PSReadLineKeyHandler Spacebar).Function -eq 'OhMyPoshSpaceKeyHandler') {
                 Remove-PSReadLineKeyHandler Spacebar
@@ -721,6 +768,7 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
         "Enable-PoshTooltips"
         "Enable-KeyHandlers"
         "Enable-PoshLineError"
+        "Enable-PoshVIMode"
         "Set-TransientPrompt"
         "prompt"
     )

--- a/src/shell/zsh_test.go
+++ b/src/shell/zsh_test.go
@@ -16,7 +16,8 @@ _omp_ftcs_marks=1
 "$_omp_executable" upgrade --auto
 "$_omp_executable" notice
 _omp_cursor_positioning=1
-_omp_enable_streaming=1`
+_omp_enable_streaming=1
+_omp_enable_vimode`
 
 	assert.Equal(t, want, got)
 }

--- a/website/docs/segments/system/vimode.mdx
+++ b/website/docs/segments/system/vimode.mdx
@@ -6,14 +6,20 @@ sidebar_label: Vi mode
 
 ## What
 
-Display the current ZSH [Vi mode][zsh-vi-mode] (insert / normal / visual …) in
-the prompt. Useful when using `bindkey -v` so you can tell at a glance which
-mode you are in.
+Display the current Vi mode (insert / normal / visual …) in the prompt. Useful
+when using ZSH [keymaps][zsh-vi-mode] via `bindkey -v` or PowerShell PSReadLine
+`-EditMode Vi` so you can tell at a glance which mode you are in.
 
-:::caution
-This segment is currently only supported in **ZSH**. Adding it to your
-configuration will automatically register a `zle-keymap-select` hook that
-re-renders the prompt every time the keymap changes.
+In ZSH, adding this segment automatically registers a `zle-keymap-select` hook.
+In PowerShell, it registers a PSReadLine [Vi mode change handler][pwsh-vi-mode].
+Both re-render the prompt every time the active mode changes.
+
+:::caution PowerShell cursor indicator
+
+PowerShell support sets PSReadLine's `ViModeIndicator` to `Script`, replacing
+cursor-shape mode indicators such as `Cursor`. The mode is then shown by this
+segment in the prompt instead.
+
 :::
 
 ## Sample Configuration
@@ -42,11 +48,12 @@ import Config from "@site/src/components/Config.js";
 
 ### Properties
 
-| Name      |   Type   | Description                                                                                              |
-| --------- | :------: | -------------------------------------------------------------------------------------------------------- |
-| `.Mode`   | `string` | the normalized mode: `insert`, `normal`, `visual`, `viopp`, `replace`, or the raw keymap when unmapped   |
-| `.Keymap` | `string` | the raw [`$KEYMAP`][zsh-keymap] value reported by ZSH (e.g. `main`, `viins`, `vicmd`, `visual`, `viopp`) |
+| Name      |   Type   | Description                                                                                                                                    |
+| --------- | :------: | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `.Mode`   | `string` | the normalized mode: `insert`, `normal`, `visual`, `viopp`, `replace`, or the raw keymap when unmapped                                         |
+| `.Keymap` | `string` | the raw mode value ([`$KEYMAP`][zsh-keymap] in ZSH, e.g. `main`, `viins`, `vicmd`, `visual`, `viopp`; `viins` or `vicmd` in PowerShell PSReadLine) |
 
 [templates]: /docs/configuration/templates
 [zsh-vi-mode]: https://zsh.sourceforge.io/Doc/Release/Zsh-Line-Editor.html#Keymaps
 [zsh-keymap]: https://zsh.sourceforge.io/Doc/Release/Zsh-Line-Editor.html#index-KEYMAP
+[pwsh-vi-mode]: https://learn.microsoft.com/en-us/powershell/module/psreadline/set-psreadlineoption#-vimodechangehandler


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Adds PowerShell PSReadLine Vi edit mode support for the existing `vimode` segment.

This keeps the segment implementation unchanged and extends the shell integration path instead: when a config contains `vimode` in PowerShell, Oh My Posh now enables a PSReadLine `ViModeChangeHandler`, maps Insert/Command mode to the existing `POSH_VI_MODE` values (`viins` / `vicmd`), and re-renders the prompt on mode changes.

The PowerShell module cleanup now restores the previous PSReadLine Vi mode indicator/change handler and clears `POSH_VI_MODE`. The docs now describe PowerShell support and call out that enabling this segment replaces cursor-shape Vi mode indicators with the prompt segment display.

Closes #7622.

Validation:

- `gofmt -w src/config/config.go src/config/config_test.go src/config/segment_types.go src/shell/pwsh.go src/shell/pwsh_test.go src/shell/zsh_test.go`
- `GOMAXPROCS=2 go test -p 1 ./...` from `src/`
- PowerShell smoke test for `Enable-PoshVIMode`: confirmed `POSH_VI_MODE=viins`, `ViModeIndicator=Script`, handler registered, and `POSH_VI_MODE` cleared on module removal

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
