### PR TITLE
Next

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -204,7 +204,7 @@ func (cfg *Config) Features(env runtime.Environment) shell.Features {
 				}
 			}
 
-			if segment.Type == VIMODE && env.Shell() == shell.ZSH {
+			if segment.Type == VIMODE && slices.Contains([]string{shell.ZSH, shell.PWSH}, env.Shell()) {
 				log.Debug("vi mode tracking enabled")
 				feats |= shell.VIMode
 			}

--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -165,6 +165,56 @@ func TestFeaturesShellIntegration(t *testing.T) {
 	}
 }
 
+func TestFeaturesVIMode(t *testing.T) {
+	cases := []struct {
+		Case          string
+		Shell         string
+		ExpectedFeats shell.Features
+	}{
+		{
+			Case:          "zsh enables vi mode tracking",
+			Shell:         shell.ZSH,
+			ExpectedFeats: shell.VIMode,
+		},
+		{
+			Case:          "pwsh enables vi mode tracking",
+			Shell:         shell.PWSH,
+			ExpectedFeats: shell.VIMode,
+		},
+		{
+			Case:          "bash does not enable vi mode tracking",
+			Shell:         shell.BASH,
+			ExpectedFeats: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		env := &mock.Environment{}
+		env.On("Shell").Return(tc.Shell)
+
+		template.Cache = &cache.Template{
+			SimpleTemplate: cache.SimpleTemplate{
+				Shell: tc.Shell,
+			},
+		}
+		template.Init(env, nil, nil)
+
+		cfg := &Config{
+			Upgrade: &upgrade.Config{},
+			Blocks: []*Block{
+				{
+					Segments: []*Segment{
+						{Type: VIMODE},
+					},
+				},
+			},
+		}
+
+		got := cfg.Features(env)
+		assert.Equal(t, tc.ExpectedFeats, got, tc.Case)
+	}
+}
+
 func TestUpgradeFeatures(t *testing.T) {
 	cases := []struct {
 		Case                  string

--- a/src/config/segment_types.go
+++ b/src/config/segment_types.go
@@ -374,7 +374,7 @@ const (
 	V SegmentType = "v"
 	// VALA writes the active vala version
 	VALA SegmentType = "vala"
-	// VIMODE writes the active ZSH Vi mode (insert/normal/visual)
+	// VIMODE writes the active Vi mode (insert/normal/visual)
 	VIMODE SegmentType = "vimode"
 	// WAKATIME writes tracked time spend in dev editors
 	WAKATIME SegmentType = "wakatime"

--- a/src/shell/pwsh.go
+++ b/src/shell/pwsh.go
@@ -33,7 +33,9 @@ func (f Features) Pwsh() Code {
 		return "$global:_ompStreaming = $true"
 	case KeyHandlers:
 		return "Enable-KeyHandlers"
-	case PromptMark, RPrompt, CursorPositioning, Async, VIMode:
+	case VIMode:
+		return "Enable-PoshVIMode"
+	case PromptMark, RPrompt, CursorPositioning, Async:
 		fallthrough
 	default:
 		return ""

--- a/src/shell/pwsh_test.go
+++ b/src/shell/pwsh_test.go
@@ -7,7 +7,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var allFeatures = Tooltips | LineError | Transient | Jobs | Azure | PoshGit | FTCSMarks | Upgrade | Notice | PromptMark | RPrompt | CursorPositioning | KeyHandlers | Streaming
+var allFeatures = Tooltips | LineError | Transient | Jobs | Azure | PoshGit | FTCSMarks |
+	Upgrade | Notice | PromptMark | RPrompt | CursorPositioning | KeyHandlers | Streaming | VIMode
 
 func TestPwshFeatures(t *testing.T) {
 	got := allFeatures.Lines(PWSH).String("")
@@ -23,7 +24,8 @@ $global:_ompFTCSMarks = $true
 & $global:_ompExecutable upgrade --auto
 & $global:_ompExecutable notice
 $global:_ompStreaming = $true
-Enable-KeyHandlers`
+Enable-KeyHandlers
+Enable-PoshVIMode`
 
 	assert.Equal(t, want, got)
 }

--- a/src/shell/scripts/omp.bash
+++ b/src/shell/scripts/omp.bash
@@ -23,7 +23,7 @@ _omp_cursor_positioning=0
 _omp_ftcs_marks=0
 
 # start timer on command start
-PS0='${_omp_start_time:0:$((_omp_start_time="$(_omp_start_timer)",0))}$(_omp_ftcs_command_start)'
+PS0='${_omp_start_time:0:$((_omp_start_time="$(_omp_milliseconds)",0))}$(_omp_ftcs_command_start)'
 
 # set secondary prompt
 _omp_secondary_prompt=$(
@@ -52,7 +52,16 @@ function _omp_set_cursor_position() {
     export POSH_CURSOR_COLUMN=${COL}
 }
 
-function _omp_start_timer() {
+function _omp_milliseconds() {
+    if ((BASH_VERSINFO[0] >= 5)); then
+        # EPOCHREALTIME is epoch time with microsecond precision and a
+        # locale-dependent decimal separator, strip anything but the digits
+        local epoch_micros=${EPOCHREALTIME//[!0-9]/}
+        echo $((epoch_micros / 1000))
+        return
+    fi
+
+    # EPOCHREALTIME requires bash 5.0 or newer
     "$_omp_executable" get millis
 }
 
@@ -122,7 +131,7 @@ function _omp_hook() {
 
     _omp_execution_time=-1
     if [[ $_omp_start_time ]]; then
-        local omp_now=$("$_omp_executable" get millis)
+        local omp_now=$(_omp_milliseconds)
         _omp_execution_time=$((omp_now - _omp_start_time))
         _omp_no_status=false
     fi

--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -32,8 +32,11 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
 
     # Prompt related backup.
     $script:OriginalPromptFunction = $Function:prompt
-    $script:OriginalContinuationPrompt = (Get-PSReadLineOption).ContinuationPrompt
-    $script:OriginalPromptText = (Get-PSReadLineOption).PromptText
+    $originalPSReadLineOptions = Get-PSReadLineOption
+    $script:OriginalContinuationPrompt = $originalPSReadLineOptions.ContinuationPrompt
+    $script:OriginalPromptText = $originalPSReadLineOptions.PromptText
+    $script:OriginalViModeIndicator = $originalPSReadLineOptions.ViModeIndicator
+    $script:OriginalViModeChangeHandler = $originalPSReadLineOptions.ViModeChangeHandler
 
     $script:NoExitCode = $true
     $script:ErrorCode = 0
@@ -672,6 +675,44 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
         Set-PSReadLineOption -PromptText $validLine, $errorLine
     }
 
+    function Enable-PoshVIMode {
+        if ($script:ConstrainedLanguageMode) {
+            return
+        }
+
+        if ((Get-PSReadLineOption).EditMode -ne "Vi") {
+            return
+        }
+
+        if (-not (Get-Command Set-PSReadLineOption).Parameters.ContainsKey('ViModeChangeHandler')) {
+            return
+        }
+
+        $env:POSH_VI_MODE = "viins"
+        Set-PSReadLineOption -ViModeIndicator Script -ViModeChangeHandler {
+            param($mode)
+
+            if ($mode -eq "Command") {
+                $env:POSH_VI_MODE = "vicmd"
+            }
+            else {
+                $env:POSH_VI_MODE = "viins"
+            }
+
+            $previousOutputEncoding = [Console]::OutputEncoding
+            try {
+                $script:Streaming.State = 'NEW'
+                [Console]::OutputEncoding = [Text.Encoding]::UTF8
+                [Microsoft.PowerShell.PSConsoleReadLine]::InvokePrompt()
+            }
+            catch {
+            }
+            finally {
+                [Console]::OutputEncoding = $previousOutputEncoding
+            }
+        }
+    }
+
     # perform cleanup on removal so a new initialization in current session works
     if (!$script:ConstrainedLanguageMode) {
         $ExecutionContext.SessionState.Module.OnRemove += {
@@ -695,6 +736,12 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
 
             (Get-PSReadLineOption).ContinuationPrompt = $script:OriginalContinuationPrompt
             (Get-PSReadLineOption).PromptText = $script:OriginalPromptText
+
+            if ((Get-Command Set-PSReadLineOption).Parameters.ContainsKey('ViModeChangeHandler')) {
+                Set-PSReadLineOption -ViModeIndicator $script:OriginalViModeIndicator -ViModeChangeHandler $script:OriginalViModeChangeHandler
+            }
+
+            Remove-Item Env:POSH_VI_MODE -ErrorAction Ignore
 
             if ((Get-PSReadLineKeyHandler Spacebar).Function -eq 'OhMyPoshSpaceKeyHandler') {
                 Remove-PSReadLineKeyHandler Spacebar
@@ -721,6 +768,7 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
         "Enable-PoshTooltips"
         "Enable-KeyHandlers"
         "Enable-PoshLineError"
+        "Enable-PoshVIMode"
         "Set-TransientPrompt"
         "prompt"
     )

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -12,6 +12,9 @@ export PYENV_VIRTUALENV_DISABLE_PROMPT=1
 _omp_executable=::OMP::
 _omp_tooltip_command=''
 
+# zsh/datetime provides the epochtime array for native millisecond timestamps
+zmodload zsh/datetime 2>/dev/null
+
 # switches to enable/disable features
 _omp_cursor_positioning=0
 _omp_ftcs_marks=0
@@ -132,12 +135,27 @@ function _omp_exit_handler() {
 # register exit handler
 zshexit_functions+=(_omp_exit_handler)
 
+# sets _omp_millis instead of printing to avoid forking a subshell
+function _omp_milliseconds() {
+  if (( ${+epochtime} )); then
+    # copy first: every expansion of epochtime reads the clock again,
+    # so referencing it twice in one expression can straddle a second boundary
+    local -a now=("${epochtime[@]}")
+    _omp_millis=$((now[1] * 1000 + now[2] / 1000000))
+    return
+  fi
+
+  # zsh/datetime is unavailable
+  _omp_millis=$($_omp_executable get millis)
+}
+
 function _omp_preexec() {
   if [[ $_omp_ftcs_marks == 1 ]]; then
     printf '\033]133;C\007'
   fi
 
-  _omp_start_time=$($_omp_executable get millis)
+  _omp_milliseconds
+  _omp_start_time=$_omp_millis
 }
 
 function _omp_precmd() {
@@ -150,8 +168,8 @@ function _omp_precmd() {
   _omp_tooltip_command=''
 
   if [[ -n $_omp_start_time ]]; then
-    local omp_now=$($_omp_executable get millis)
-    _omp_execution_time=$(($omp_now - $_omp_start_time))
+    _omp_milliseconds
+    _omp_execution_time=$(($_omp_millis - $_omp_start_time))
     _omp_no_status=false
   fi
 

--- a/src/shell/zsh_test.go
+++ b/src/shell/zsh_test.go
@@ -16,7 +16,8 @@ _omp_ftcs_marks=1
 "$_omp_executable" upgrade --auto
 "$_omp_executable" notice
 _omp_cursor_positioning=1
-_omp_enable_streaming=1`
+_omp_enable_streaming=1
+_omp_enable_vimode`
 
 	assert.Equal(t, want, got)
 }

--- a/website/docs/segments/system/vimode.mdx
+++ b/website/docs/segments/system/vimode.mdx
@@ -6,14 +6,20 @@ sidebar_label: Vi mode
 
 ## What
 
-Display the current ZSH [Vi mode][zsh-vi-mode] (insert / normal / visual …) in
-the prompt. Useful when using `bindkey -v` so you can tell at a glance which
-mode you are in.
+Display the current Vi mode (insert / normal / visual …) in the prompt. Useful
+when using ZSH [keymaps][zsh-vi-mode] via `bindkey -v` or PowerShell PSReadLine
+`-EditMode Vi` so you can tell at a glance which mode you are in.
 
-:::caution
-This segment is currently only supported in **ZSH**. Adding it to your
-configuration will automatically register a `zle-keymap-select` hook that
-re-renders the prompt every time the keymap changes.
+In ZSH, adding this segment automatically registers a `zle-keymap-select` hook.
+In PowerShell, it registers a PSReadLine [Vi mode change handler][pwsh-vi-mode].
+Both re-render the prompt every time the active mode changes.
+
+:::caution PowerShell cursor indicator
+
+PowerShell support sets PSReadLine's `ViModeIndicator` to `Script`, replacing
+cursor-shape mode indicators such as `Cursor`. The mode is then shown by this
+segment in the prompt instead.
+
 :::
 
 ## Sample Configuration
@@ -42,11 +48,12 @@ import Config from "@site/src/components/Config.js";
 
 ### Properties
 
-| Name      |   Type   | Description                                                                                              |
-| --------- | :------: | -------------------------------------------------------------------------------------------------------- |
-| `.Mode`   | `string` | the normalized mode: `insert`, `normal`, `visual`, `viopp`, `replace`, or the raw keymap when unmapped   |
-| `.Keymap` | `string` | the raw [`$KEYMAP`][zsh-keymap] value reported by ZSH (e.g. `main`, `viins`, `vicmd`, `visual`, `viopp`) |
+| Name      |   Type   | Description                                                                                                                                    |
+| --------- | :------: | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `.Mode`   | `string` | the normalized mode: `insert`, `normal`, `visual`, `viopp`, `replace`, or the raw keymap when unmapped                                         |
+| `.Keymap` | `string` | the raw mode value ([`$KEYMAP`][zsh-keymap] in ZSH, e.g. `main`, `viins`, `vicmd`, `visual`, `viopp`; `viins` or `vicmd` in PowerShell PSReadLine) |
 
 [templates]: /docs/configuration/templates
 [zsh-vi-mode]: https://zsh.sourceforge.io/Doc/Release/Zsh-Line-Editor.html#Keymaps
 [zsh-keymap]: https://zsh.sourceforge.io/Doc/Release/Zsh-Line-Editor.html#index-KEYMAP
+[pwsh-vi-mode]: https://learn.microsoft.com/en-us/powershell/module/psreadline/set-psreadlineoption#-vimodechangehandler


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).


<!---

Tips:

If you're not comfortable with working with Git,
we're working on a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D)
as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> PowerShell changes hook PSReadLine vi-mode behavior and prompt redraws; bash/zsh timing changes affect execution-time accuracy on older shells that still use the fallback path.
> 
> **Overview**
> Extends the **vimode** prompt segment to **PowerShell** (alongside ZSH): when the segment is present, config enables `shell.VIMode`, init runs `Enable-PoshVIMode`, and PSReadLine’s `ViModeChangeHandler` updates `POSH_VI_MODE` and redraws the prompt. Module teardown restores prior Vi indicator/handler settings.
> 
> **Bash** and **ZSH** now measure command duration with native clocks (`EPOCHREALTIME` on Bash 5+, `zsh/datetime`’s `epochtime`) via `_omp_milliseconds`, falling back to `oh-my-posh get millis` only when needed—reducing subprocess forks for execution-time segments.
> 
> Docs for the vimode segment describe PowerShell usage and the trade-off of switching `ViModeIndicator` to `Script`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 906635d35f81a2134d91dbcec42c9297aec58134. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->