### PR TITLE
fix (resubmitted): `Failed to write init script` when multiple instances of OMP are started simultaneously

### DIFF
--- a/src/shell/filesystem.go
+++ b/src/shell/filesystem.go
@@ -1,11 +1,13 @@
 package shell
 
 import (
+	"bytes"
 	"fmt"
 	"hash/fnv"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/build"
 	"github.com/jandedobbeleer/oh-my-posh/src/cache"
@@ -43,13 +45,63 @@ func hasScript(env runtime.Environment) (string, bool) {
 	return path, true
 }
 
+func filesEqual(name string, data []byte) bool {
+	existing, err := os.ReadFile(name)
+	return err == nil && bytes.Equal(existing, data)
+}
+
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	if filesEqual(path, data) {
+		return nil
+	}
+
+	// the temp file must be in the same directory as the target,
+	// os.Rename is only atomic within the same volume
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+
+	defer os.Remove(tmp.Name())
+
+	if _, err = tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+
+	// CreateTemp creates the file with 0600
+	if err = tmp.Chmod(perm); err != nil {
+		tmp.Close()
+		return err
+	}
+
+	if err = tmp.Close(); err != nil {
+		return err
+	}
+
+	return os.Rename(tmp.Name(), path)
+}
+
 func writeScript(env runtime.Environment, script string) (string, error) {
 	path, err := scriptPath(env)
 	if err != nil {
 		return "", err
 	}
 
-	err = os.WriteFile(path, []byte(script), 0o644)
+	data := []byte(script)
+	wait := 50 * time.Millisecond
+
+	// another process can hold the script (or its target) open on Windows,
+	// making the rename fail; retry with backoff until it lets go
+	for range 8 {
+		if err = writeFileAtomic(path, data, 0o644); err == nil {
+			break
+		}
+
+		time.Sleep(wait)
+		wait = min(wait*2, time.Second)
+	}
+
 	if err != nil {
 		log.Error(err)
 		return "", err


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description
i'm resubmitting #7220 because searching the commit history, and looking at the code in `main` it doesn't seem that any fix was ever made

### Original description
i was getting an error when i was using oh-my-posh with a terminal that restores all the tabs on startup:
```
Failed to write init script: open C:\Users\irlname\AppData\Local\oh-my-posh\init.16695873114097618080.ps1: The process cannot access the file because it is being used by another process.
```

i implemented a function that only writes a file if it's different from the one on disk already and made the `writeScript` function retry until a deadline is reached

<!---

Tips:

If you're not comfortable with working with Git,
we're working on a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D)
as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
