### PR TITLE
Next

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,3 +65,23 @@ PowerShell helper scripts live in `packages/` and `build/`. Follow the `powershe
 Themes are plain JSON files in `themes/`. New themes must validate against
 `website/static/schema.json`. Do not introduce breaking schema changes without updating the
 schema file.
+
+## Pull Request Reviews
+
+Whenever any agent performs or addresses a pull request review, follow this process at all
+times, regardless of previous instructions:
+
+1. Stay within the scope of the pull request: only address feedback on changes it introduces.
+2. Investigate every review comment and reach a conclusion: a code fix, a clarification, or a
+   reasoned rejection.
+3. Fold each fix into the commit it belongs to. When the change semantically belongs to a
+   commit the pull request introduces (any commit not yet on main), create a fixup commit
+   (`git commit --fixup <sha>`), squash it (`git rebase --autosquash`), and force-push the
+   pull request branch. This preserves the atomicity of the pull request's commits instead
+   of stacking review-fix commits on top. Rewriting the pull request branch is fine; main
+   history must never be rewritten.
+4. Only when a change does not semantically fit any existing commit in the pull request does
+   it become its own commit on top, following the commit conventions.
+5. Reply to each review comment with the conclusion, referencing the commit that addresses it
+   when there is one.
+6. Resolve each review thread once its answer and/or fix has been provided.

--- a/src/config/gob.go
+++ b/src/config/gob.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/gob"
+	"os"
 	"time"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/cache"
@@ -13,6 +14,13 @@ import (
 const (
 	configKey = "CONFIG"
 	SourceKey = "CONFIG_SOURCE"
+
+	// envKey is resolved into the --config flag by the root command when no
+	// explicit flag is given. The shell's init script pins it to the session's
+	// resolved configuration source so the configuration can be recovered when
+	// the session cache is lost or corrupted. A healthy session cache always
+	// wins, so it can not be used to change the configuration mid-session.
+	envKey = "POSH_CONFIG"
 )
 
 func (cfg *Config) Store() {
@@ -34,23 +42,44 @@ func Get(configFile string, reload bool) *Config {
 		}
 	}
 
-	base64String, found := cache.Get[string](cache.Session, configKey)
-	if !found {
-		log.Debug("no cached config found")
-		cfg := Load(configFile)
-		cfg.Store()
-		return cfg
-	}
+	if base64String, found := cache.Get[string](cache.Session, configKey); found {
+		var cfg Config
+		if err := cfg.Restore(base64String); err == nil {
+			return &cfg
+		}
 
-	var cfg Config
-	if err := cfg.Restore(base64String); err != nil {
 		log.Debug("failed to restore config from cache")
-		loaded := Load(configFile)
-		loaded.Store()
-		return loaded
+		// the entry is corrupted beyond repair, drop it so subsequent renders
+		// skip the decode attempt and go straight to recovery
+		cache.Delete(cache.Session, configKey)
+	} else {
+		log.Debug("no cached config found")
 	}
 
-	return &cfg
+	// A prompt render is invoked without an explicit --config and relies on the
+	// session cache for its configuration. When that cache is missing or corrupt
+	// - the file got purged (e.g. under disk pressure) or clobbered by a
+	// concurrent writer sharing the session - the shell session still knows its
+	// source: init exported it as POSH_CONFIG, and the root command resolved it
+	// into configFile. Store the parsed result again so the session cache
+	// self-heals. When the source is unavailable, return the default without
+	// caching it so the next render retries the recovery instead of pinning
+	// the default theme for the rest of the session.
+	if configFile != "" && configFile == os.Getenv(envKey) {
+		cfg, err := Parse(configFile)
+		if err == nil {
+			log.Debug("recovered configuration from environment: ", configFile)
+			cfg.Store()
+			return cfg
+		}
+
+		log.Debug("failed to recover configuration from environment: ", configFile)
+		return Default(err)
+	}
+
+	cfg := Load(configFile)
+	cfg.Store()
+	return cfg
 }
 
 func (cfg *Config) Base64() string {

--- a/src/config/gob_test.go
+++ b/src/config/gob_test.go
@@ -1,0 +1,121 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/cache"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func writeTestConfig(t *testing.T, name string) string {
+	t.Helper()
+
+	file := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(file, []byte(`{"version": 3, "final_space": true}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	return file
+}
+
+func resetCache(t *testing.T) {
+	t.Helper()
+
+	// pin the config source resolution: with OSTYPE set (as in Git Bash),
+	// Windows keeps forward-slash paths instead of resolving native ones
+	t.Setenv("OSTYPE", "")
+
+	reset := func() {
+		cache.DeleteAll(cache.Session)
+		cache.DeleteAll(cache.Device)
+	}
+
+	reset()
+	t.Cleanup(reset)
+}
+
+func TestGetRecoversFromEnvironmentWhenSessionCacheLost(t *testing.T) {
+	resetCache(t)
+
+	file := writeTestConfig(t, "theme.omp.json")
+
+	// Simulate a prompt render after the session cache is lost: init pinned the
+	// source in POSH_CONFIG and the root command resolved it into the config flag.
+	t.Setenv(envKey, file)
+
+	cfg := Get(file, false)
+
+	assert.NotNil(t, cfg)
+	assert.Equal(t, file, cfg.Source, "should render the configured theme instead of the default")
+
+	// Recovery should self-heal the session cache so subsequent renders are fast.
+	_, found := cache.Get[string](cache.Session, configKey)
+	assert.True(t, found, "recovery should repopulate the session config cache")
+}
+
+func TestGetPrefersSessionCacheOverEnvironment(t *testing.T) {
+	resetCache(t)
+
+	cached := writeTestConfig(t, "cached.omp.json")
+	other := writeTestConfig(t, "other.omp.json")
+
+	Load(cached).Store()
+
+	// POSH_CONFIG can not change the configuration mid-session:
+	// a healthy session cache always wins.
+	t.Setenv(envKey, other)
+
+	cfg := Get(other, false)
+
+	assert.NotNil(t, cfg)
+	assert.Equal(t, cached, cfg.Source)
+}
+
+func TestGetFallsBackToDefaultWithoutRecoverySource(t *testing.T) {
+	resetCache(t)
+
+	// No --config, no session cache, and no environment: there is nothing to recover.
+	t.Setenv(envKey, "")
+
+	cfg := Get("", false)
+
+	assert.NotNil(t, cfg)
+	assert.Empty(t, cfg.Source, "should fall back to the default built-in config")
+}
+
+func TestGetDropsCorruptedSessionCacheEntry(t *testing.T) {
+	resetCache(t)
+
+	// valid base64, but not a gob-encoded Config
+	cache.Set(cache.Session, configKey, "Y29ycnVwdGVkIGVudHJ5", cache.INFINITE)
+
+	file := filepath.Join(t.TempDir(), "missing.omp.json")
+	t.Setenv(envKey, file)
+
+	cfg := Get(file, false)
+
+	assert.NotNil(t, cfg)
+
+	_, found := cache.Get[string](cache.Session, configKey)
+	assert.False(t, found, "a corrupted session config entry should be dropped after a failed restore")
+}
+
+func TestGetFallsBackToDefaultWhenRecoverySourceInvalid(t *testing.T) {
+	resetCache(t)
+
+	file := filepath.Join(t.TempDir(), "missing.omp.json")
+	t.Setenv(envKey, file)
+
+	cfg := Get(file, false)
+
+	assert.NotNil(t, cfg)
+	assert.Empty(t, cfg.Source, "should fall back to the default built-in config")
+
+	// The source may only be temporarily unavailable: the default must not be
+	// cached, otherwise the next render can no longer retry the recovery.
+	_, found := cache.Get[string](cache.Session, configKey)
+	assert.False(t, found, "a failed recovery should not pin the default in the session cache")
+}

--- a/src/segments/project.go
+++ b/src/segments/project.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"io/fs"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -15,6 +16,11 @@ import (
 
 	toml "github.com/pelletier/go-toml/v2"
 	yaml "go.yaml.in/yaml/v3"
+)
+
+const (
+	ResolveTargetFromSolution options.Option = "resolve_target_from_solution"
+	SolutionSearchDepth       options.Option = "solution_search_depth"
 )
 
 type ProjectItem struct {
@@ -309,6 +315,16 @@ func (n *Project) getDotnetProject(item ProjectItem) *ProjectData {
 		target = values["TFM"]
 	}
 
+	if target == "" && (extension == ".sln" || extension == ".slnx") && n.options.Bool(ResolveTargetFromSolution, true) {
+		maxDepth := n.options.Int(SolutionSearchDepth, 2)
+		if projContent := n.findProjectFile(files, maxDepth); projContent != "" {
+			values = regex.FindNamedRegexMatch(tag, projContent)
+			if len(values) != 0 {
+				target = values["TFM"]
+			}
+		}
+	}
+
 	if target == "" {
 		log.Error(fmt.Errorf("cannot extract TFM from %s project file", name))
 	}
@@ -317,6 +333,49 @@ func (n *Project) getDotnetProject(item ProjectItem) *ProjectData {
 		Target: target,
 		Name:   name,
 	}
+}
+
+// findProjectFile scans rootEntries and their subdirectories breadth-first,
+// up to maxDepth levels deep, and returns the content of the first
+// .csproj/.fsproj/.vbproj file found. Paths are kept relative to pwd so
+// FileContent resolves them the same way the caller does.
+func (n *Project) findProjectFile(rootEntries []fs.DirEntry, maxDepth int) string {
+	projectExts := []string{".csproj", ".fsproj", ".vbproj"}
+	pwd := n.env.Pwd()
+
+	var dirs []string
+	for _, entry := range rootEntries {
+		if entry.IsDir() {
+			dirs = append(dirs, entry.Name())
+			continue
+		}
+
+		// a project file can live next to the solution
+		if slices.Contains(projectExts, filepath.Ext(entry.Name())) {
+			return n.env.FileContent(entry.Name())
+		}
+	}
+
+	for depth := 1; depth <= maxDepth && len(dirs) > 0; depth++ {
+		var next []string
+
+		for _, dir := range dirs {
+			for _, entry := range n.env.LsDir(filepath.Join(pwd, dir)) {
+				if entry.IsDir() {
+					next = append(next, filepath.Join(dir, entry.Name()))
+					continue
+				}
+
+				if slices.Contains(projectExts, filepath.Ext(entry.Name())) {
+					return n.env.FileContent(filepath.Join(dir, entry.Name()))
+				}
+			}
+		}
+
+		dirs = next
+	}
+
+	return ""
 }
 
 func (n *Project) getPowerShellModuleData(_ ProjectItem) *ProjectData {

--- a/src/segments/project_test.go
+++ b/src/segments/project_test.go
@@ -651,6 +651,204 @@ func TestDotnetProject(t *testing.T) {
 	}
 }
 
+func TestDotnetSolutionResolvesTargetFramework(t *testing.T) {
+	cases := []struct {
+		Case            string
+		SolutionFile    string
+		SubDirs         map[string][]fs.DirEntry // path -> entries returned by LsDir
+		FileContents    map[string]string        // path -> file content
+		Options         options.Map
+		ExpectedString  string
+		ExpectedEnabled bool
+	}{
+		{
+			Case:         ".sln with .csproj one level deep",
+			SolutionFile: "MyApp.sln",
+			SubDirs: map[string][]fs.DirEntry{
+				"posh": {
+					&MockDirEntry{name: "MyApp.sln"},
+					&MockDirEntry{name: "App", isDir: true},
+				},
+				filepath.Join("posh", "App"): {
+					&MockDirEntry{name: "App.csproj"},
+				},
+			},
+			FileContents: map[string]string{
+				"MyApp.sln":                        "",
+				filepath.Join("App", "App.csproj"): "<Project><PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>",
+			},
+			ExpectedEnabled: true,
+			ExpectedString:  "MyApp \uf4de net8.0",
+		},
+		{
+			Case:         ".sln with .csproj next to it",
+			SolutionFile: "MyApp.sln",
+			SubDirs: map[string][]fs.DirEntry{
+				"posh": {
+					&MockDirEntry{name: "MyApp.sln"},
+					&MockDirEntry{name: "App.csproj"},
+				},
+			},
+			FileContents: map[string]string{
+				"MyApp.sln":  "",
+				"App.csproj": "<Project><PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>",
+			},
+			ExpectedEnabled: true,
+			ExpectedString:  "MyApp \uf4de net8.0",
+		},
+		{
+			Case:         ".sln with .csproj at depth 2",
+			SolutionFile: "MyApp.sln",
+			SubDirs: map[string][]fs.DirEntry{
+				"posh": {
+					&MockDirEntry{name: "MyApp.sln"},
+					&MockDirEntry{name: "src", isDir: true},
+				},
+				filepath.Join("posh", "src"): {
+					&MockDirEntry{name: "App", isDir: true},
+				},
+				filepath.Join("posh", "src", "App"): {
+					&MockDirEntry{name: "App.csproj"},
+				},
+			},
+			FileContents: map[string]string{
+				"MyApp.sln": "",
+				filepath.Join("src", "App", "App.csproj"): "<Project><PropertyGroup><TargetFramework>net8.0</TargetFramework></PropertyGroup></Project>",
+			},
+			ExpectedEnabled: true,
+			ExpectedString:  "MyApp \uf4de net8.0",
+		},
+		{
+			Case:         "depth limit exceeded - .csproj at depth 3, max depth 2",
+			SolutionFile: "MyApp.sln",
+			SubDirs: map[string][]fs.DirEntry{
+				"posh": {
+					&MockDirEntry{name: "MyApp.sln"},
+					&MockDirEntry{name: "src", isDir: true},
+				},
+				filepath.Join("posh", "src"): {
+					&MockDirEntry{name: "nested", isDir: true},
+				},
+				filepath.Join("posh", "src", "nested"): {
+					&MockDirEntry{name: "deep", isDir: true},
+				},
+				filepath.Join("posh", "src", "nested", "deep"): {
+					&MockDirEntry{name: "App.csproj"},
+				},
+			},
+			FileContents: map[string]string{
+				"MyApp.sln": "",
+			},
+			Options:         options.Map{SolutionSearchDepth: 2},
+			ExpectedEnabled: true,
+			ExpectedString:  "MyApp",
+		},
+		{
+			Case:         "opt-out with resolve_target_from_solution=false",
+			SolutionFile: "MyApp.sln",
+			SubDirs: map[string][]fs.DirEntry{
+				"posh": {
+					&MockDirEntry{name: "MyApp.sln"},
+					&MockDirEntry{name: "App", isDir: true},
+				},
+			},
+			FileContents: map[string]string{
+				"MyApp.sln": "",
+			},
+			Options:         options.Map{ResolveTargetFromSolution: false},
+			ExpectedEnabled: true,
+			ExpectedString:  "MyApp",
+		},
+		{
+			Case:         ".slnx triggers scanning - resolves TFM from .fsproj",
+			SolutionFile: "MyApp.slnx",
+			SubDirs: map[string][]fs.DirEntry{
+				"posh": {
+					&MockDirEntry{name: "MyApp.slnx"},
+					&MockDirEntry{name: "Lib", isDir: true},
+				},
+				filepath.Join("posh", "Lib"): {
+					&MockDirEntry{name: "Lib.fsproj"},
+				},
+			},
+			FileContents: map[string]string{
+				"MyApp.slnx":                       "",
+				filepath.Join("Lib", "Lib.fsproj"): "<Project><PropertyGroup><TargetFramework>net9.0</TargetFramework></PropertyGroup></Project>",
+			},
+			ExpectedEnabled: true,
+			ExpectedString:  "MyApp \uf4de net9.0",
+		},
+		{
+			Case:         ".slnf does NOT trigger scanning",
+			SolutionFile: "MyApp.slnf",
+			SubDirs: map[string][]fs.DirEntry{
+				"posh": {
+					&MockDirEntry{name: "MyApp.slnf"},
+					&MockDirEntry{name: "App", isDir: true},
+				},
+			},
+			FileContents: map[string]string{
+				"MyApp.slnf": "",
+			},
+			ExpectedEnabled: true,
+			ExpectedString:  "MyApp",
+		},
+		{
+			Case:         "no project files in subdirs",
+			SolutionFile: "MyApp.sln",
+			SubDirs: map[string][]fs.DirEntry{
+				"posh": {
+					&MockDirEntry{name: "MyApp.sln"},
+					&MockDirEntry{name: "docs", isDir: true},
+				},
+				filepath.Join("posh", "docs"): {
+					&MockDirEntry{name: "README.md"},
+				},
+			},
+			FileContents: map[string]string{
+				"MyApp.sln": "",
+			},
+			ExpectedEnabled: true,
+			ExpectedString:  "MyApp",
+		},
+	}
+
+	for _, tc := range cases {
+		env := new(mock.Environment)
+		env.On(hasFiles, testify_.Anything).Run(func(args testify_.Arguments) {
+			for _, c := range env.ExpectedCalls {
+				if c.Method == hasFiles {
+					pattern := "*" + filepath.Ext(tc.SolutionFile)
+					c.ReturnArguments = testify_.Arguments{args.Get(0).(string) == pattern}
+				}
+			}
+		})
+		env.On("Pwd").Return("posh")
+
+		// Set up LsDir mocks for all paths
+		for path, entries := range tc.SubDirs {
+			env.On("LsDir", path).Return(entries)
+		}
+
+		// Set up FileContent mocks
+		for path, content := range tc.FileContents {
+			env.On("FileContent", path).Return(content)
+		}
+
+		opts := tc.Options
+		if opts == nil {
+			opts = options.Map{}
+		}
+
+		pkg := &Project{}
+		pkg.Init(opts, env)
+		assert.Equal(t, tc.ExpectedEnabled, pkg.Enabled(), tc.Case)
+		if tc.ExpectedEnabled {
+			assert.Equal(t, tc.ExpectedString, renderTemplate(env, pkg.Template(), pkg), tc.Case)
+		}
+	}
+}
+
 func TestPowerShellModuleProject(t *testing.T) {
 	cases := []struct {
 		Case            string

--- a/src/shell/filesystem.go
+++ b/src/shell/filesystem.go
@@ -1,11 +1,13 @@
 package shell
 
 import (
+	"bytes"
 	"fmt"
 	"hash/fnv"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/build"
 	"github.com/jandedobbeleer/oh-my-posh/src/cache"
@@ -43,13 +45,66 @@ func hasScript(env runtime.Environment) (string, bool) {
 	return path, true
 }
 
+func filesEqual(name string, data []byte) bool {
+	existing, err := os.ReadFile(name)
+	return err == nil && bytes.Equal(existing, data)
+}
+
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	if filesEqual(path, data) {
+		return nil
+	}
+
+	// the temp file must be in the same directory as the target,
+	// os.Rename is only atomic within the same volume
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+
+	defer os.Remove(tmp.Name())
+
+	if _, err = tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+
+	// CreateTemp creates the file with 0600
+	if err = tmp.Chmod(perm); err != nil {
+		tmp.Close()
+		return err
+	}
+
+	if err = tmp.Close(); err != nil {
+		return err
+	}
+
+	return os.Rename(tmp.Name(), path)
+}
+
 func writeScript(env runtime.Environment, script string) (string, error) {
 	path, err := scriptPath(env)
 	if err != nil {
 		return "", err
 	}
 
-	err = os.WriteFile(path, []byte(script), 0o644)
+	data := []byte(script)
+
+	// another process can hold the script (or its target) open on Windows,
+	// making the rename fail with a sharing violation; retry with backoff
+	// until it lets go — all other errors are persistent, fail fast
+	const attempts = 8
+	wait := 50 * time.Millisecond
+
+	for attempt := 1; ; attempt++ {
+		if err = writeFileAtomic(path, data, 0o644); !canRetryWrite(err) || attempt == attempts {
+			break
+		}
+
+		time.Sleep(wait)
+		wait = min(wait*2, time.Second)
+	}
+
 	if err != nil {
 		log.Error(err)
 		return "", err

--- a/src/shell/filesystem_other.go
+++ b/src/shell/filesystem_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package shell
+
+// only Windows knows transient file-sharing violations worth retrying,
+// on other platforms a write error is always persistent
+func canRetryWrite(_ error) bool {
+	return false
+}

--- a/src/shell/filesystem_windows.go
+++ b/src/shell/filesystem_windows.go
@@ -1,0 +1,20 @@
+package shell
+
+import (
+	"errors"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// canRetryWrite reports whether the write failed because another process
+// temporarily holds the file (or its rename target) open, making a retry
+// worthwhile. All other errors are considered persistent.
+func canRetryWrite(err error) bool {
+	var errno syscall.Errno
+	if !errors.As(err, &errno) {
+		return false
+	}
+
+	return errno == windows.ERROR_SHARING_VIOLATION || errno == windows.ERROR_LOCK_VIOLATION
+}

--- a/src/shell/init.go
+++ b/src/shell/init.go
@@ -71,7 +71,7 @@ func Init(env runtime.Environment, feats Features) string {
 // This is used by the --print flag to output the script to stdout.
 func Script(env runtime.Environment, feats Features) string {
 	script := generateScript(env, feats)
-	return fmt.Sprintf("%s\n%s", sessionScript(env.Flags().Shell), script)
+	return fmt.Sprintf("%s\n%s", sessionScript(env), script)
 }
 
 // Debug writes the init script and returns debug information.
@@ -165,6 +165,11 @@ func generateScript(env runtime.Environment, feats Features) string {
 
 	bashBLEsession = len(env.Getenv("BLE_SESSION_ID")) != 0
 
+	// Only nu consumes the ::CONFIG:: placeholder: it has no eval'd session
+	// script to export POSH_CONFIG from, so the value is baked into its init
+	// script instead. All other shells get it via sessionScript.
+	var config string
+
 	var script string
 
 	switch env.Flags().Shell {
@@ -185,6 +190,7 @@ func generateScript(env runtime.Environment, feats Features) string {
 		script = cmdInit
 	case NU:
 		executable = quoteNuStr(executable)
+		config = quoteNuStr(env.Flags().ConfigPath)
 		script = nuInit
 	case ELVISH:
 		executable = quotePwshOrElvishStr(executable)
@@ -202,6 +208,7 @@ func generateScript(env runtime.Environment, feats Features) string {
 	init := strings.NewReplacer(
 		"::OMP::", executable,
 		"::SESSION_ID::", cache.SessionID(),
+		"::CONFIG::", config,
 	).Replace(script)
 
 	return feats.Lines(env.Flags().Shell).String(init)
@@ -219,6 +226,7 @@ func generateNuScript(env runtime.Environment, feats Features) string {
 	init := strings.NewReplacer(
 		"::OMP::", executable,
 		"::SESSION_ID::", cache.SessionID(),
+		"::CONFIG::", quoteNuStr(env.Flags().ConfigPath),
 	).Replace(nuInit)
 
 	return feats.Lines(NU).String(init)
@@ -235,7 +243,7 @@ func sourceCommand(env runtime.Environment, scriptPath string, async bool) strin
 		}
 	}
 
-	script := sessionScript(env.Flags().Shell)
+	script := sessionScript(env)
 
 	if async {
 		return script + sourceCommandAsync(env.Flags().Shell, scriptPath)
@@ -289,20 +297,28 @@ func printDebugInfo(env runtime.Environment, startTime *time.Time) string {
 	return builder.String()
 }
 
-func sessionScript(shell string) string {
-	switch shell {
+// sessionScript exports the session's environment variables: POSH_SESSION_ID
+// identifies the session cache, and POSH_CONFIG is pinned to the session's
+// resolved configuration source so it can be recovered when the session cache
+// is lost. A healthy session cache always wins, so POSH_CONFIG can not be used
+// to change the configuration mid-session.
+func sessionScript(env runtime.Environment) string {
+	sessionID := cache.SessionID()
+	config := env.Flags().ConfigPath
+
+	switch env.Flags().Shell {
 	case PWSH:
-		return fmt.Sprintf("$env:POSH_SESSION_ID = \"%s\";", cache.SessionID())
+		return fmt.Sprintf("$env:POSH_SESSION_ID = \"%s\"; $env:POSH_CONFIG = %s;", sessionID, quotePwshOrElvishStr(config))
 	case ZSH, BASH:
-		return fmt.Sprintf("export POSH_SESSION_ID=\"%s\";", cache.SessionID())
+		return fmt.Sprintf("export POSH_SESSION_ID=\"%s\"; export POSH_CONFIG=%s;", sessionID, QuotePosixStr(config))
 	case XONSH:
-		return fmt.Sprintf("$POSH_SESSION_ID = \"%s\";", cache.SessionID())
+		return fmt.Sprintf("$POSH_SESSION_ID = \"%s\"; $POSH_CONFIG = %s;", sessionID, quotePythonStr(config))
 	case FISH:
-		return fmt.Sprintf("set --export --global POSH_SESSION_ID \"%s\";", cache.SessionID())
+		return fmt.Sprintf("set --export --global POSH_SESSION_ID \"%s\"; set --export --global POSH_CONFIG %s;", sessionID, quoteFishStr(config))
 	case ELVISH:
-		return fmt.Sprintf("set-env POSH_SESSION_ID \"%s\";", cache.SessionID())
+		return fmt.Sprintf("set-env POSH_SESSION_ID \"%s\"; set-env POSH_CONFIG %s;", sessionID, quotePwshOrElvishStr(config))
 	case CMD:
-		return fmt.Sprintf(`os.setenv('POSH_SESSION_ID', '%s');`, cache.SessionID())
+		return fmt.Sprintf(`os.setenv('POSH_SESSION_ID', '%s'); os.setenv('POSH_CONFIG', '%s');`, sessionID, escapeLuaStr(config))
 	}
 	return ""
 }

--- a/src/shell/scripts/omp.nu
+++ b/src/shell/scripts/omp.nu
@@ -18,6 +18,8 @@ if ($env.config? | is-not-empty) {
 $env.POWERLINE_COMMAND = 'oh-my-posh'
 $env.PROMPT_INDICATOR = ""
 $env.POSH_SESSION_ID = "::SESSION_ID::"
+# pinned to the session's configuration so it can be recovered when the session cache is lost
+$env.POSH_CONFIG = ::CONFIG::
 $env.POSH_SHELL = "nu"
 $env.POSH_SHELL_VERSION = (version | get version)
 

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -3871,6 +3871,19 @@
                     "title": "Always Enabled",
                     "description": "Always show the segment",
                     "default": false
+                  },
+                  "resolve_target_from_solution": {
+                    "type": "boolean",
+                    "title": "Resolve Target from Solution",
+                    "description": "When a .sln/.slnx is matched, scan subdirectories for project files to extract TargetFramework",
+                    "default": true
+                  },
+                  "solution_search_depth": {
+                    "type": "integer",
+                    "title": "Solution Search Depth",
+                    "description": "Maximum directory depth to scan for project files when resolving from a solution",
+                    "default": 2,
+                    "minimum": 1
                   }
                 }
               }

--- a/website/docs/segments/system/project.mdx
+++ b/website/docs/segments/system/project.mdx
@@ -42,10 +42,12 @@ import Config from "@site/src/components/Config.js";
 
 ## Options
 
-| Name             |   Type    | Default | Description                                                                                                         |
-| ---------------- | :-------: | :-----: | ------------------------------------------------------------------------------------------------------------------- |
-| `always_enabled` | `boolean` | `false` | always show the segment                                                                                             |
-| `<type>_files`   |  `array`  |  `[]`   | override the project's files to validate for. Use the `.Type` values listed below to override (e.g. `dotnet_files`) |
+| Name                            |   Type    | Default | Description                                                                                                         |
+| ------------------------------- | :-------: | :-----: | ------------------------------------------------------------------------------------------------------------------- |
+| `always_enabled`                | `boolean` | `false` | always show the segment                                                                                             |
+| `<type>_files`                  |  `array`  |  `[]`   | override the project's files to validate for. Use the `.Type` values listed below to override (e.g. `dotnet_files`) |
+| `resolve_target_from_solution`  | `boolean` | `true`  | when a `.sln`/`.slnx` is matched, scan subdirectories for project files to extract `TargetFramework`               |
+| `solution_search_depth`         |   `int`   |  `2`    | maximum directory depth to scan for project files when resolving from a solution                                    |
 
 ## Template ([info][templates])
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

<!---

Tips:

If you're not comfortable with working with Git,
we're working on a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D)
as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core config loading and init behavior for every shell; incorrect recovery logic could briefly show the wrong theme or skip caching, while init write retries affect startup on Windows.
> 
> **Overview**
> Adds **session config recovery** when the session cache is missing or corrupt: init now exports **`POSH_CONFIG`** (alongside `POSH_SESSION_ID`) with the resolved theme path, and **`config.Get`** re-parses that source when it matches the active `--config` / env resolution, repopulates the cache, and **does not cache the default theme** if recovery fails so later renders can retry. A healthy session cache still wins over `POSH_CONFIG`.
> 
> **Init script writing** uses **atomic rename** (skip write if unchanged) with **retries/backoff** on Windows when another process holds the file open.
> 
> The **project segment** can infer **TargetFramework** for **`.sln` / `.slnx`** by breadth-first scanning subfolders for **`.csproj`/`.fsproj`/`.vbproj`** (options **`resolve_target_from_solution`**, **`solution_search_depth`**), with schema/docs/tests updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b377b612da9308b523eebcb56c0e08e56a0c07ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->