### PR TITLE
feat(segments): add DVC source control support

### DIFF
--- a/src/config/segment_types.go
+++ b/src/config/segment_types.go
@@ -55,6 +55,8 @@ func init() {
 	gob.Register(&segments.Deno{})
 	gob.Register(&segments.Docker{})
 	gob.Register(&segments.Dotnet{})
+	gob.Register(&segments.Dvc{})
+	gob.Register(&segments.DvcStatus{})
 	gob.Register(&segments.Elixir{})
 	gob.Register(&segments.Executiontime{})
 	gob.Register(&segments.Status{})
@@ -222,6 +224,8 @@ const (
 	DOCKER SegmentType = "docker"
 	// DOTNET writes which dotnet version is currently active
 	DOTNET SegmentType = "dotnet"
+	// DVC writes the dvc status
+	DVC SegmentType = "dvc"
 	// ELIXIR writes the elixir version
 	ELIXIR SegmentType = "elixir"
 	// EXECUTIONTIME writes the execution time of the last run command
@@ -427,6 +431,7 @@ var Segments = map[SegmentType]func() SegmentWriter{
 	DENO:            func() SegmentWriter { return &segments.Deno{} },
 	DOCKER:          func() SegmentWriter { return &segments.Docker{} },
 	DOTNET:          func() SegmentWriter { return &segments.Dotnet{} },
+	DVC:             func() SegmentWriter { return &segments.Dvc{} },
 	ELIXIR:          func() SegmentWriter { return &segments.Elixir{} },
 	EXECUTIONTIME:   func() SegmentWriter { return &segments.Executiontime{} },
 	EXIT:            func() SegmentWriter { return &segments.Status{} },

--- a/src/segments/dvc.go
+++ b/src/segments/dvc.go
@@ -1,0 +1,92 @@
+package segments
+
+import "encoding/json"
+
+// DvcStatus represents the status of a DVC repository
+type DvcStatus struct {
+	ScmStatus
+}
+
+func (s *DvcStatus) add(code string) {
+	switch code {
+	case "not in cache":
+		s.Missing++
+	case "deleted":
+		s.Deleted++
+	case "new":
+		s.Added++
+	case "modified":
+		s.Modified++
+	}
+}
+
+const (
+	DVCCOMMAND = "dvc"
+)
+
+type Dvc struct {
+	Status *DvcStatus
+	Scm
+}
+
+func (d *Dvc) Template() string {
+	return "  {{ .Status.String }} "
+}
+
+func (d *Dvc) Enabled() bool {
+	if !d.hasCommand(DVCCOMMAND) {
+		return false
+	}
+
+	// only display when we're actually inside a DVC repository
+	if _, err := d.env.HasParentFilePath(".dvc", false); err != nil {
+		return false
+	}
+
+	statusFormats := d.options.KeyValueMap(StatusFormats, map[string]string{})
+	d.Status = &DvcStatus{ScmStatus: ScmStatus{Formats: statusFormats}}
+
+	output, err := d.env.RunCommand(d.command, "status", "--json")
+	if err != nil {
+		return false
+	}
+
+	d.setStatus(output)
+
+	return true
+}
+
+func (d *Dvc) CacheKey() (string, bool) {
+	dir, err := d.env.HasParentFilePath(".dvc", true)
+	if err != nil {
+		return "", false
+	}
+
+	return dir.Path, true
+}
+
+// setStatus parses the output of `dvc status --json`, which has the shape:
+//
+//	{"<stage>": [{"changed outs": {"<file>": "<state>"}}, {"changed deps": {"<file>": "<state>"}}], ...}
+//
+// a clean workspace returns an empty object ({}). Unknown states are ignored.
+func (d *Dvc) setStatus(output string) {
+	if output == "" {
+		return
+	}
+
+	var status map[string][]map[string]map[string]string
+	if err := json.Unmarshal([]byte(output), &status); err != nil {
+		return
+	}
+
+	for _, sections := range status {
+		for _, section := range sections {
+			for _, files := range section {
+				for _, state := range files {
+					d.Status.add(state)
+				}
+			}
+		}
+	}
+}

--- a/src/segments/dvc_test.go
+++ b/src/segments/dvc_test.go
@@ -1,0 +1,130 @@
+package segments
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDvcStatus(t *testing.T) {
+	cases := []struct {
+		OutputError      error
+		Case             string
+		Output           string
+		ExpectedStatus   string
+		HasCommand       bool
+		HasDvcDir        bool
+		ExpectedDisabled bool
+	}{
+		{
+			Case:             "not installed",
+			HasCommand:       false,
+			ExpectedDisabled: true,
+		},
+		{
+			Case:             "not in DVC repo",
+			HasCommand:       true,
+			HasDvcDir:        false,
+			ExpectedDisabled: true,
+		},
+		{
+			Case:             "command error",
+			HasCommand:       true,
+			HasDvcDir:        true,
+			OutputError:      fmt.Errorf("error"),
+			ExpectedDisabled: true,
+		},
+		{
+			Case:           "clean status",
+			HasCommand:     true,
+			HasDvcDir:      true,
+			Output:         "{}",
+			ExpectedStatus: "",
+		},
+		{
+			Case:           "invalid json is ignored",
+			HasCommand:     true,
+			HasDvcDir:      true,
+			Output:         "not json",
+			ExpectedStatus: "",
+		},
+		{
+			Case:           "modified files",
+			HasCommand:     true,
+			HasDvcDir:      true,
+			Output:         `{"data.xml.dvc": [{"changed outs": {"data.xml": "modified"}}], "model.pkl.dvc": [{"changed outs": {"model.pkl": "modified"}}]}`,
+			ExpectedStatus: "~2",
+		},
+		{
+			Case:           "new files",
+			HasCommand:     true,
+			HasDvcDir:      true,
+			Output:         `{"data.dvc": [{"changed outs": {"data/new.csv": "new"}}], "test.dvc": [{"changed outs": {"data/test.csv": "new"}}]}`,
+			ExpectedStatus: "+2",
+		},
+		{
+			Case:           "deleted files",
+			HasCommand:     true,
+			HasDvcDir:      true,
+			Output:         `{"data.xml.dvc": [{"changed outs": {"data.xml": "deleted"}}]}`,
+			ExpectedStatus: "-1",
+		},
+		{
+			Case:           "not in cache",
+			HasCommand:     true,
+			HasDvcDir:      true,
+			Output:         `{"data.dvc": [{"changed outs": {"data": "not in cache"}}]}`,
+			ExpectedStatus: "!1",
+		},
+		{
+			Case:           "mixed status",
+			HasCommand:     true,
+			HasDvcDir:      true,
+			Output:         `{"a.dvc": [{"changed outs": {"a": "new"}}], "b.dvc": [{"changed outs": {"b": "modified"}}], "c.dvc": [{"changed outs": {"c": "deleted"}}], "d.dvc": [{"changed outs": {"d": "not in cache"}}]}`, //nolint:lll
+			ExpectedStatus: "+1 ~1 -1 !1",
+		},
+		{
+			// real `dvc status --json` output from a pipeline: a file can show up
+			// as both a changed dep and a changed out across stages.
+			Case:           "pipeline with changed deps and outs",
+			HasCommand:     true,
+			HasDvcDir:      true,
+			Output:         `{"other.txt.dvc": [{"changed outs": {"other.txt": "modified"}}], "build": [{"changed deps": {"input.txt": "modified"}}, {"changed outs": {"output.txt": "modified"}}], "input.txt.dvc": [{"changed outs": {"input.txt": "modified"}}]}`, //nolint:lll
+			ExpectedStatus: "~4",
+		},
+	}
+
+	for _, tc := range cases {
+		env := new(mock.Environment)
+		env.On("GOOS").Return("unix")
+		env.On("IsWsl").Return(false)
+		env.On("InWSLSharedDrive").Return(false)
+		env.On("HasCommand", DVCCOMMAND).Return(tc.HasCommand)
+
+		if tc.HasDvcDir {
+			env.On("HasParentFilePath", ".dvc", false).Return(&runtime.FileInfo{}, nil)
+		} else {
+			env.On("HasParentFilePath", ".dvc", false).Return(&runtime.FileInfo{}, errors.New("not found"))
+		}
+
+		env.On("RunCommand", DVCCOMMAND, []string{"status", "--json"}).Return(tc.Output, tc.OutputError)
+
+		d := &Dvc{}
+		d.Init(options.Map{}, env)
+
+		got := d.Enabled()
+
+		assert.Equal(t, !tc.ExpectedDisabled, got, tc.Case)
+		if tc.ExpectedDisabled {
+			continue
+		}
+
+		assert.Equal(t, tc.ExpectedStatus, d.Status.String(), tc.Case)
+	}
+}

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -394,6 +394,7 @@
             "deno",
             "docker",
             "dotnet",
+            "dvc",
             "elixir",
             "executiontime",
             "firebase",
@@ -1699,6 +1700,32 @@
                     "default": false
                   }
                 }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "dvc"
+              }
+            }
+          },
+          "then": {
+            "title": "DVC Segment",
+            "description": "https://ohmyposh.dev/docs/segments/scm/dvc",
+            "properties": {
+              "options": {
+                "properties": {
+                  "status_formats": {
+                    "$ref": "#/definitions/status_formats"
+                  },
+                  "native_fallback": {
+                    "$ref": "#/definitions/native_fallback"
+                  }
+                },
+                "unevaluatedProperties": false
               }
             }
           }

--- a/website/docs/segments/scm/dvc.mdx
+++ b/website/docs/segments/scm/dvc.mdx
@@ -1,0 +1,71 @@
+---
+id: dvc
+title: DVC
+sidebar_label: DVC
+---
+
+## What
+
+Display [DVC][dvc] (Data Version Control) information when in a DVC repository.
+
+The segment is displayed when the `dvc` executable is available and a `.dvc`
+directory is found in the current or any parent directory. The status is
+retrieved using `dvc status --json`.
+
+## Sample Configuration
+
+import Config from '@site/src/components/Config.js';
+
+<Config data={{
+  "type": "dvc",
+  "style": "powerline",
+  "powerline_symbol": "\uE0B0",
+  "foreground": "#193549",
+  "background": "#945dd6"
+}}/>
+
+## Options
+
+| Name              |        Type         | Default | Description                                                                                                                                                                                                                                                     |
+| ----------------- | :-----------------: | :-----: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `native_fallback` |      `boolean`      | `false` | when set to `true` and `dvc.exe` is not available when inside a WSL2 shared Windows drive, we will fallback to the native `dvc` executable to fetch data. Not all information can be displayed in this case                                                       |
+| `status_formats`  | `map[string]string` |         | a key, value map allowing to override how individual status items are displayed. For example, `"status_formats": { "Added": "Added: %d" }` will display the added count as `Added: 1` instead of `+1`. See the [DvcStatus](#dvcstatus) section for the keys      |
+
+## Template ([info][templates])
+
+:::note default template
+
+```template
+ \ue8d1 {{.Status.String}}
+```
+
+:::
+
+### Properties
+
+| Name      | Type        | Description                         |
+| --------- | ----------- | ----------------------------------- |
+| `.Status` | `DvcStatus` | changes in the worktree (see below) |
+
+### DvcStatus
+
+| Name        | Type      | Description                                  |
+| ----------- | --------- | -------------------------------------------- |
+| `.Added`    | `int`     | number of new files                          |
+| `.Modified` | `int`     | number of modified files                     |
+| `.Deleted`  | `int`     | number of deleted files                      |
+| `.Missing`  | `int`     | number of files not in cache                 |
+| `.Changed`  | `boolean` | if the status contains changes or not        |
+| `.String`   | `string`  | a string representation of the changes above |
+
+Local changes use the following syntax:
+
+| Icon | Description            |
+| ---- | ---------------------- |
+| `+`  | added                  |
+| `~`  | modified               |
+| `-`  | deleted                |
+| `!`  | not in cache (missing) |
+
+[dvc]: https://dvc.org
+[templates]: /docs/configuration/templates

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -170,6 +170,7 @@ export default {
           label: "🗂️ Source control",
           collapsed: true,
           items: [
+            "segments/scm/dvc",
             "segments/scm/fossil",
             "segments/scm/git",
             "segments/scm/jujutsu",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Add a `dvc` segment that displays [Data Version Control (DVC)][dvc] repository status in the prompt.

The segment is enabled when the `dvc` executable is available and a `.dvc` directory is found in the current or any parent directory. It parses the machine-readable output of `dvc status --json` and counts new, modified, deleted and not-in-cache outputs, reusing the shared `ScmStatus` (rendered as `+`, `~`, `-` and `!` respectively).

A `CacheKey` scoped to the `.dvc` directory is provided so the status can be cached per repository, and `status_formats` / `native_fallback` are supported like the other SCM segments.

Resolves #6822

#### Supersedes #7048

This builds on the earlier attempt in #7048, with the following differences:

- **Reliable status source.** #7048 runs `dvc status -q` and parses stdout, but `-q`/`--quiet` suppresses all output and only sets an exit code, so nothing is ever parsed on a real DVC repository. This PR uses `dvc status --json` and parses the actual (nested) output structure instead.
- **Full registration.** The segment is wired up end to end — `gob.Register`, the `SegmentType` constant, the writer map, the JSON schema and the docs sidebar — so it works at runtime rather than failing silently.
- **Caching.** A `CacheKey` scoped to the `.dvc` directory allows the status to be cached per repository.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[dvc]: https://dvc.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)
