### PR TITLE
feat(shell): support vimode segment in fish

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -204,7 +204,7 @@ func (cfg *Config) Features(env runtime.Environment) shell.Features {
 				}
 			}
 
-			if segment.Type == VIMODE && slices.Contains([]string{shell.ZSH, shell.PWSH}, env.Shell()) {
+			if segment.Type == VIMODE && slices.Contains([]string{shell.ZSH, shell.PWSH, shell.FISH}, env.Shell()) {
 				log.Debug("vi mode tracking enabled")
 				feats |= shell.VIMode
 			}

--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -182,6 +182,11 @@ func TestFeaturesVIMode(t *testing.T) {
 			ExpectedFeats: shell.VIMode,
 		},
 		{
+			Case:          "fish enables vi mode tracking",
+			Shell:         shell.FISH,
+			ExpectedFeats: shell.VIMode,
+		},
+		{
 			Case:          "bash does not enable vi mode tracking",
 			Shell:         shell.BASH,
 			ExpectedFeats: 0,

--- a/src/shell/fish.go
+++ b/src/shell/fish.go
@@ -27,7 +27,9 @@ func (f Features) Fish() Code {
 		return unixUpgrade
 	case Notice:
 		return unixNotice
-	case RPrompt, PoshGit, Azure, LineError, Jobs, Async, KeyHandlers, VIMode:
+	case VIMode:
+		return "_omp_enable_vimode"
+	case RPrompt, PoshGit, Azure, LineError, Jobs, Async, KeyHandlers:
 		fallthrough
 	default:
 		return ""

--- a/src/shell/fish_test.go
+++ b/src/shell/fish_test.go
@@ -18,7 +18,8 @@ set --global _omp_ftcs_marks 1
 "$_omp_executable" notice
 set --global _omp_prompt_mark 1
 set --global _omp_cursor_positioning 1
-set --global _omp_enable_streaming 1`
+set --global _omp_enable_streaming 1
+_omp_enable_vimode`
 
 	assert.Equal(t, want, got)
 }

--- a/src/shell/scripts/omp.fish
+++ b/src/shell/scripts/omp.fish
@@ -733,3 +733,38 @@ function omp_repaint_prompt
     set --global _omp_new_prompt 1
     commandline --function repaint
 end
+
+# vi mode tracking — mirror the active fish bind mode into POSH_VI_MODE and
+# re-render the prompt whenever it changes. Enabled through the vimode segment.
+function _omp_enable_vimode
+    # only track when vi (or hybrid) key bindings are active
+    contains -- "$fish_key_bindings" fish_vi_key_bindings fish_hybrid_key_bindings
+    or return
+
+    # translate fish's bind mode into the keymap names the vimode segment expects
+    function _omp_set_vimode
+        switch $fish_bind_mode
+            case default
+                set --global --export POSH_VI_MODE vicmd
+            case replace replace_one
+                set --global --export POSH_VI_MODE replace
+            case insert
+                set --global --export POSH_VI_MODE viins
+            case '*'
+                set --global --export POSH_VI_MODE $fish_bind_mode
+        end
+    end
+
+    # re-render the prompt on every mode change
+    function _omp_render_vimode --on-variable fish_bind_mode
+        _omp_set_vimode
+        omp_repaint_prompt
+    end
+
+    # oh-my-posh renders the mode through the vimode segment, so silence fish's
+    # built-in mode indicator to avoid a duplicate
+    function fish_mode_prompt
+    end
+
+    _omp_set_vimode
+end

--- a/website/docs/segments/system/vimode.mdx
+++ b/website/docs/segments/system/vimode.mdx
@@ -7,18 +7,30 @@ sidebar_label: Vi mode
 ## What
 
 Display the current Vi mode (insert / normal / visual …) in the prompt. Useful
-when using ZSH [keymaps][zsh-vi-mode] via `bindkey -v` or PowerShell PSReadLine
-`-EditMode Vi` so you can tell at a glance which mode you are in.
+when using ZSH [keymaps][zsh-vi-mode] via `bindkey -v`, PowerShell PSReadLine
+`-EditMode Vi`, or fish [vi key bindings][fish-vi-mode] so you can tell at a
+glance which mode you are in.
 
 In ZSH, adding this segment automatically registers a `zle-keymap-select` hook.
 In PowerShell, it registers a PSReadLine [Vi mode change handler][pwsh-vi-mode].
-Both re-render the prompt every time the active mode changes.
+In fish, it registers an [`--on-variable fish_bind_mode`][fish-bind-mode] handler
+(only when vi or hybrid key bindings are active). All of them re-render the
+prompt every time the active mode changes.
 
 :::caution PowerShell cursor indicator
 
 PowerShell support sets PSReadLine's `ViModeIndicator` to `Script`, replacing
 cursor-shape mode indicators such as `Cursor`. The mode is then shown by this
 segment in the prompt instead.
+
+:::
+
+:::caution fish mode prompt
+
+fish support overrides `fish_mode_prompt` with an empty function so fish's
+built-in `[N]` / `[I]` mode indicator does not show up next to the mode
+rendered by this segment. Make sure vi key bindings are enabled (e.g.
+`fish_vi_key_bindings`) for the segment to display.
 
 :::
 
@@ -51,9 +63,11 @@ import Config from "@site/src/components/Config.js";
 | Name      |   Type   | Description                                                                                                                                    |
 | --------- | :------: | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | `.Mode`   | `string` | the normalized mode: `insert`, `normal`, `visual`, `viopp`, `replace`, or the raw keymap when unmapped                                         |
-| `.Keymap` | `string` | the raw mode value ([`$KEYMAP`][zsh-keymap] in ZSH, e.g. `main`, `viins`, `vicmd`, `visual`, `viopp`; `viins` or `vicmd` in PowerShell PSReadLine) |
+| `.Keymap` | `string` | the raw mode value ([`$KEYMAP`][zsh-keymap] in ZSH, e.g. `main`, `viins`, `vicmd`, `visual`, `viopp`; `viins` or `vicmd` in PowerShell PSReadLine; `viins`, `vicmd`, `visual` or `replace` in fish) |
 
 [templates]: /docs/configuration/templates
 [zsh-vi-mode]: https://zsh.sourceforge.io/Doc/Release/Zsh-Line-Editor.html#Keymaps
 [zsh-keymap]: https://zsh.sourceforge.io/Doc/Release/Zsh-Line-Editor.html#index-KEYMAP
 [pwsh-vi-mode]: https://learn.microsoft.com/en-us/powershell/module/psreadline/set-psreadlineoption#-vimodechangehandler
+[fish-vi-mode]: https://fishshell.com/docs/current/interactive.html#vi-mode-commands
+[fish-bind-mode]: https://fishshell.com/docs/current/language.html#the-fish-bind-mode-variable


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Extends the existing `vimode` segment (ZSH #7500, PowerShell #7633) to **fish**, continuing the cross-shell work tracked in #5438.

The segment implementation is unchanged — only the fish shell-integration path is added. When a config contains a `vimode` segment and the active shell is fish, Oh My Posh enables an `_omp_enable_vimode` hook that:

- registers an `--on-variable fish_bind_mode` handler that mirrors fish's bind mode into `POSH_VI_MODE` and re-renders the prompt on every mode change (via the existing `omp_repaint_prompt`);
- translates fish's mode names to the keymap names the segment already understands: `default` → `vicmd` (normal), `insert` → `viins`, `replace`/`replace_one` → `replace`, `visual` passthrough;
- only activates when vi or hybrid key bindings are in use (`fish_vi_key_bindings` / `fish_hybrid_key_bindings`), so non-vi fish sessions are unaffected;
- overrides fish's built-in `fish_mode_prompt` with an empty function so the mode is shown solely by the segment (mirrors the PowerShell `ViModeIndicator` behaviour).

#### Files changed

| File | Purpose |
| ---- | ------- |
| `src/shell/fish.go` | Map the `VIMode` feature to `_omp_enable_vimode` |
| `src/shell/scripts/omp.fish` | `_omp_enable_vimode` / `_omp_render_vimode` runtime functions |
| `src/config/config.go` | Enable the `VIMode` feature when a `vimode` segment is configured in fish |
| `src/shell/fish_test.go` | Assert the fish feature line is emitted |
| `src/config/config_test.go` | Assert fish enables vi mode tracking |
| `website/docs/segments/system/vimode.mdx` | Document fish support |

#### Validation

- `go build ./...`, `go test ./shell/... ./config/... ./segments/...`, `golangci-lint run` (all pass)
- fish 4.8 smoke test: `oh-my-posh init fish` appends `_omp_enable_vimode`; the `--on-variable fish_bind_mode` handler fires on mode changes, sets `POSH_VI_MODE` (`insert`→`viins`, `default`→`vicmd`, `visual`, `replace`), and repaints; non-vi sessions early-return and leave the segment disabled

#### Scope

Fish only. bash / nushell / elvish / xonsh remain out of scope (bash's readline has no clean keymap-change hook for live redraws), so this is linked as `Related` rather than closing #5438.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)
