### PR TITLE
feat(segment): detect terraform/tofu version from tenv

### DIFF
--- a/src/segments/terraform.go
+++ b/src/segments/terraform.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/hashicorp/hcl/v2/hclparse"
@@ -47,11 +48,56 @@ func (tf *Terraform) Enabled() bool {
 		return true
 	}
 
+	// tenv (https://github.com/tofuutils/tenv) pins the version through an
+	// environment variable or a version file, which takes precedence over the
+	// version declared in the terraform files or the state file.
+	if tf.setVersionFromTenv() {
+		return true
+	}
+
 	if err := tf.setVersionFromTfFiles(); err == nil {
 		return true
 	}
 
 	tf.setVersionFromTfStateFile()
+	return true
+}
+
+// tenvSources returns the environment variable and version file tenv uses to
+// pin the version, based on whether the segment targets terraform or tofu.
+func (tf *Terraform) tenvSources() (envVar, versionFile string) {
+	cmd := tf.options.String(Command, "terraform")
+	if strings.Contains(cmd, "tofu") {
+		return "TOFUENV_TOFU_VERSION", ".opentofu-version"
+	}
+
+	return "TFENV_TERRAFORM_VERSION", ".terraform-version"
+}
+
+func (tf *Terraform) setVersionFromTenv() bool {
+	envVar, versionFile := tf.tenvSources()
+
+	// the environment variable takes precedence over the version file
+	if version := strings.TrimSpace(tf.env.Getenv(envVar)); version != "" {
+		tf.Version = &version
+		return true
+	}
+
+	if !tf.env.HasFiles(versionFile) {
+		return false
+	}
+
+	version := strings.TrimSpace(tf.env.FileContent(versionFile))
+	// a version file holds a single version reference, guard against trailing content
+	if line, _, found := strings.Cut(version, "\n"); found {
+		version = strings.TrimSpace(line)
+	}
+
+	if version == "" {
+		return false
+	}
+
+	tf.Version = &version
 	return true
 }
 
@@ -71,7 +117,8 @@ func (tf *Terraform) inContext(fetchVersion bool) bool {
 		return false
 	}
 
-	versionFiles := []string{"versions.tf", "main.tf", "terraform.tfstate"}
+	_, tenvVersionFile := tf.tenvSources()
+	versionFiles := []string{"versions.tf", "main.tf", "terraform.tfstate", tenvVersionFile}
 	return slices.ContainsFunc(versionFiles, tf.env.HasFiles)
 }
 

--- a/src/segments/terraform_test.go
+++ b/src/segments/terraform_test.go
@@ -14,7 +14,11 @@ func TestTerraform(t *testing.T) {
 	cases := []struct {
 		Case              string
 		Template          string
+		Command           string
 		WorkspaceName     string
+		TenvEnv           string
+		TenvFile          string
+		TenvFileContent   string
 		ExpectedString    string
 		HasTfCommand      bool
 		HasTfFolder       bool
@@ -79,21 +83,120 @@ func TestTerraform(t *testing.T) {
 			HasTfFiles:      true,
 			HasTfCommand:    true,
 		},
+		{
+			Case:            "terraform version from .terraform-version file",
+			ExpectedString:  "1.7.0",
+			ExpectedEnabled: true,
+			WorkspaceName:   "default",
+			Template:        "{{ .Version }}",
+			HasTfFolder:     true,
+			HasTfCommand:    true,
+			FetchVersion:    true,
+			TenvFile:        ".terraform-version",
+			TenvFileContent: "1.7.0\n",
+		},
+		{
+			Case:            "terraform version from TFENV_TERRAFORM_VERSION env",
+			ExpectedString:  "1.8.0",
+			ExpectedEnabled: true,
+			WorkspaceName:   "default",
+			Template:        "{{ .Version }}",
+			HasTfFolder:     true,
+			HasTfCommand:    true,
+			FetchVersion:    true,
+			TenvEnv:         "1.8.0",
+		},
+		{
+			Case:            "env takes precedence over .terraform-version file",
+			ExpectedString:  "1.8.0",
+			ExpectedEnabled: true,
+			WorkspaceName:   "default",
+			Template:        "{{ .Version }}",
+			HasTfFolder:     true,
+			HasTfCommand:    true,
+			FetchVersion:    true,
+			TenvEnv:         "1.8.0",
+			TenvFile:        ".terraform-version",
+			TenvFileContent: "1.7.0",
+		},
+		{
+			Case:              "tenv file takes precedence over terraform files",
+			ExpectedString:    "1.7.0",
+			ExpectedEnabled:   true,
+			WorkspaceName:     "default",
+			Template:          "{{ .Version }}",
+			HasTfVersionFiles: true,
+			HasTfCommand:      true,
+			FetchVersion:      true,
+			TenvFile:          ".terraform-version",
+			TenvFileContent:   "1.7.0",
+		},
+		{
+			Case:            "enabled by .terraform-version alone",
+			ExpectedString:  "1.7.0",
+			ExpectedEnabled: true,
+			WorkspaceName:   "default",
+			Template:        "{{ .Version }}",
+			HasTfCommand:    true,
+			FetchVersion:    true,
+			TenvFile:        ".terraform-version",
+			TenvFileContent: "1.7.0",
+		},
+		{
+			Case:            "tofu version from .opentofu-version file",
+			ExpectedString:  "1.8.5",
+			ExpectedEnabled: true,
+			WorkspaceName:   "default",
+			Template:        "{{ .Version }}",
+			Command:         "tofu",
+			HasTfFolder:     true,
+			HasTfCommand:    true,
+			FetchVersion:    true,
+			TenvFile:        ".opentofu-version",
+			TenvFileContent: "1.8.5",
+		},
+		{
+			Case:            "tofu version from TOFUENV_TOFU_VERSION env",
+			ExpectedString:  "1.9.0",
+			ExpectedEnabled: true,
+			WorkspaceName:   "default",
+			Template:        "{{ .Version }}",
+			Command:         "tofu",
+			HasTfFolder:     true,
+			HasTfCommand:    true,
+			FetchVersion:    true,
+			TenvEnv:         "1.9.0",
+		},
 	}
 
 	for _, tc := range cases {
 		env := new(mock.Environment)
 
-		env.On("HasCommand", "terraform").Return(tc.HasTfCommand)
+		cmd := tc.Command
+		if cmd == "" {
+			cmd = "terraform"
+		}
+
+		tenvEnvVar := "TFENV_TERRAFORM_VERSION"
+		tenvFile := ".terraform-version"
+		if cmd == "tofu" {
+			tenvEnvVar = "TOFUENV_TOFU_VERSION"
+			tenvFile = ".opentofu-version"
+		}
+
+		env.On("HasCommand", cmd).Return(tc.HasTfCommand)
 		env.On("HasFolder", ".terraform").Return(tc.HasTfFolder)
 		env.On("HasFiles", ".tf").Return(tc.HasTfFiles)
 		env.On("HasFiles", ".tfplan").Return(tc.HasTfFiles)
 		env.On("HasFiles", ".tfstate").Return(tc.HasTfFiles)
 		env.On("Pwd").Return("")
-		env.On("RunCommand", "terraform", []string{"workspace", "show"}).Return(tc.WorkspaceName, nil)
+		env.On("RunCommand", cmd, []string{"workspace", "show"}).Return(tc.WorkspaceName, nil)
 		env.On("HasFiles", "versions.tf").Return(tc.HasTfVersionFiles)
 		env.On("HasFiles", "main.tf").Return(tc.HasTfVersionFiles)
 		env.On("HasFiles", "terraform.tfstate").Return(tc.HasTfStateFile)
+		env.On("Getenv", tenvEnvVar).Return(tc.TenvEnv)
+		env.On("HasFiles", tenvFile).Return(tc.TenvFile == tenvFile)
+		env.On("FileContent", tenvFile).Return(tc.TenvFileContent)
 		if tc.HasTfVersionFiles {
 			content, _ := os.ReadFile("../test/versions.tf")
 			env.On("FileContent", "versions.tf").Return(string(content))
@@ -105,6 +208,7 @@ func TestTerraform(t *testing.T) {
 
 		props := options.Map{
 			options.FetchVersion: tc.FetchVersion,
+			Command:              cmd,
 		}
 
 		tf := &Terraform{}

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -4698,7 +4698,7 @@
                   "fetch_version": {
                     "type": "boolean",
                     "title": "Fetch Version",
-                    "description": "Fetch the version number",
+                    "description": "Fetch the version number from tenv (TFENV_TERRAFORM_VERSION / TOFUENV_TOFU_VERSION or .terraform-version / .opentofu-version), versions.tf, main.tf or terraform.tfstate",
                     "default": false
                   }
                 },

--- a/website/docs/segments/cli/terraform.mdx
+++ b/website/docs/segments/cli/terraform.mdx
@@ -25,10 +25,27 @@ import Config from "@site/src/components/Config.js";
 
 ## Options
 
-| Name            |   Type    |   Default   | Description                                                                        |
-| --------------- | :-------: | :---------: | ---------------------------------------------------------------------------------- |
-| `fetch_version` | `boolean` |   `false`   | fetch the version information from `versions.tf`, `main.tf` or `terraform.tfstate` |
-| `command`       | `string`  | `terraform` | the command(s) to run, allows support for `tofu`                                   |
+| Name            |   Type    |   Default   | Description                                                                                                          |
+| --------------- | :-------: | :---------: | ------------------------------------------------------------------------------------------------------------------ |
+| `fetch_version` | `boolean` |   `false`   | fetch the version information, see [Version detection](#version-detection) for the sources and their priority       |
+| `command`       | `string`  | `terraform` | the command(s) to run, allows support for `tofu`                                                                    |
+
+### Version detection
+
+When `fetch_version` is enabled, the version is resolved from the first source
+that yields a value, in this order:
+
+1. the [tenv][tenv] environment variable — `TFENV_TERRAFORM_VERSION` (or
+   `TOFUENV_TOFU_VERSION` when `command` is `tofu`)
+2. the [tenv][tenv] version file — `.terraform-version` (or `.opentofu-version`
+   when `command` is `tofu`)
+3. the `required_version` declared in `versions.tf` or `main.tf`
+4. the `terraform_version` stored in `terraform.tfstate`
+
+The tenv sources let the segment show the pinned version even when you don't use
+`main.tf` / `versions.tf`. The environment variable and version file are only
+used to read the version; a project file (a `.terraform` folder or one of the
+files above) is still required for the segment to activate.
 
 ## Template ([info][templates])
 
@@ -49,3 +66,4 @@ import Config from "@site/src/components/Config.js";
 
 [templates]: /docs/configuration/templates
 [terraform]: https://developer.hashicorp.com/terraform
+[tenv]: https://github.com/tofuutils/tenv

--- a/website/docs/segments/cli/terraform.mdx
+++ b/website/docs/segments/cli/terraform.mdx
@@ -27,7 +27,7 @@ import Config from "@site/src/components/Config.js";
 
 | Name            |   Type    |   Default   | Description                                                                                                          |
 | --------------- | :-------: | :---------: | ------------------------------------------------------------------------------------------------------------------ |
-| `fetch_version` | `boolean` |   `false`   | fetch the version information, see [Version detection](#version-detection) for the sources and their priority       |
+| `fetch_version` | `boolean` |   `false`   | fetch the version information, see [Version detection][version-detection] for the sources and their priority        |
 | `command`       | `string`  | `terraform` | the command(s) to run, allows support for `tofu`                                                                    |
 
 ### Version detection
@@ -67,3 +67,4 @@ files above) is still required for the segment to activate.
 [templates]: /docs/configuration/templates
 [terraform]: https://developer.hashicorp.com/terraform
 [tenv]: https://github.com/tofuutils/tenv
+[version-detection]: #version-detection


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Closes #7168.

The terraform segment could only read the version from `versions.tf` / `main.tf` (`required_version`) or `terraform.tfstate`. Setups that manage the Terraform/OpenTofu version with [tenv][tenv] — and therefore don't use those files — showed no version at all.

This adds version detection from the tenv sources, taking precedence over the terraform files, and following tenv's own precedence (environment variable over version file):

| `command` | env var | version file |
| --------- | ------- | ------------ |
| `terraform` (default) | `TFENV_TERRAFORM_VERSION` | `.terraform-version` |
| `tofu` | `TOFUENV_TOFU_VERSION` | `.opentofu-version` |

Resolution order when `fetch_version` is enabled:

1. tenv environment variable
2. tenv version file
3. `required_version` in `versions.tf` / `main.tf`
4. `terraform_version` in `terraform.tfstate`

Notes:

- The source pair is picked from the existing `command` option (no new option).
- The version file is added to the activation check so a tenv-only project (no `versions.tf` / `main.tf`) still shows the segment. The **environment variable is only used to read the version** — it never activates the segment on its own, so a globally-exported `TFENV_TERRAFORM_VERSION` won't make the segment appear everywhere.
- `.tool-versions` (asdf/mise), `.tfswitchrc` and terragrunt are intentionally out of scope here.

#### Validation

- `go build ./...`, `go test ./segments/`, `golangci-lint run ./segments/...`, `go vet` — all pass
- Verified end-to-end against the real `tenv` (4.14.8) with `tofu` / `terraform`:
  - `.terraform-version` / `.opentofu-version` → `.Version` shows the pinned version
  - `TFENV_TERRAFORM_VERSION` / `TOFUENV_TOFU_VERSION` override the version file
  - a tenv version file takes precedence over `main.tf`'s `required_version`
  - an env var alone (no project files) does **not** activate the segment
  - `command: tofu` uses the OpenTofu sources

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[tenv]: https://github.com/tofuutils/tenv

🤖 Generated with [Claude Code](https://claude.com/claude-code)
