### PR TITLE
feat: render prompts from a template data file

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,6 @@ on:
   workflow_dispatch:
 
 permissions:
-  id-token: write
   contents: read
 
 jobs:
@@ -28,23 +27,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 20.9.0
-        # Create Kind cluster to have a Kubernetes context for cloud-native-azure theme
-        # Images are defined on every Kind release
-        # See https://github.com/kubernetes-sigs/kind/releases
-      - name: Create k8s v1.23 Kind Cluster
-        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc
-        with:
-          node_image: kindest/node:v1.23.4@sha256:0e34f0d0fd448aa2f2819cfd74e99fe5793a6e4938b328f657c8e3f81ee0dfb9
-          cluster_name: posh
-      - name: Create Kubernetes namespace
-        run: |
-          kubectl create ns demo
-      - name: Set default Kubernetes namespace
-        run: |
-          kubectl config set-context posh --namespace demo
-      - uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
       - name: Build oh-my-posh 🔧
         run: |
           cd src

--- a/src/cli/config_export_data.go
+++ b/src/cli/config_export_data.go
@@ -1,0 +1,168 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/cache"
+	"github.com/jandedobbeleer/oh-my-posh/src/config"
+	"github.com/jandedobbeleer/oh-my-posh/src/prompt"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
+	"github.com/jandedobbeleer/oh-my-posh/src/shell"
+	"github.com/jandedobbeleer/oh-my-posh/src/template"
+	"github.com/jandedobbeleer/oh-my-posh/src/terminal"
+
+	"github.com/spf13/cobra"
+)
+
+var outputData string
+
+// dataCmd represents the "config export data" command
+var dataCmd = &cobra.Command{
+	Use:   "data",
+	Short: "Export a template data file for your config",
+	Long: `Export a template data file for your config.
+
+Runs your config's segments against the real environment and records the
+resulting template context and segment data to a file. Feed the recorded
+file back in with --data on print/image to render deterministically,
+without querying the real environment.
+
+Example usage:
+
+> oh-my-posh config export data --config ~/myconfig.omp.json --output ~/myconfig.data.json
+
+Exports the recorded data to ~/myconfig.data.json.
+
+> oh-my-posh config export data --config ~/myconfig.omp.json
+
+Prints the recorded data to stdout.`,
+	Args: cobra.NoArgs,
+	Run: func(_ *cobra.Command, _ []string) {
+		cache.Init(os.Getenv("POSH_SHELL"))
+
+		err := setConfigFlag()
+		if err != nil {
+			exitcode = 666
+			fmt.Println(err.Error())
+			return
+		}
+
+		cfg := config.Load(configFlag)
+
+		flags := &runtime.Flags{
+			ConfigPath:    cfg.Source,
+			Shell:         shell.GENERIC,
+			TerminalWidth: 120,
+		}
+
+		env := &runtime.Terminal{}
+		env.Init(flags)
+
+		template.Init(env, cfg.Var, cfg.Maps)
+
+		defer func() {
+			template.SaveCache()
+			cache.Close()
+		}()
+
+		// set sane defaults for things we don't need while recording
+		cfg.ConsoleTitleTemplate = ""
+		cfg.PWD = ""
+		cfg.ShellIntegration = false
+
+		terminal.Init(shell.GENERIC)
+		terminal.BackgroundColor = cfg.TerminalBackground.ResolveTemplate()
+		terminal.Colors = cfg.MakeColors(env)
+
+		eng := &prompt.Engine{
+			Config: cfg,
+			Env:    env,
+		}
+
+		// Executing the primary prompt runs every segment against the real
+		// environment and populates both the template cache and each
+		// segment's writer, which is what we record below.
+		eng.Primary()
+
+		doc, err := buildDataDocument(cfg)
+		if err != nil {
+			exitcode = 666
+			fmt.Println(err.Error())
+			return
+		}
+
+		if outputData == "" {
+			fmt.Println(string(doc))
+			return
+		}
+
+		if err := os.WriteFile(cleanOutputPath(outputData), doc, 0o644); err != nil {
+			exitcode = 666
+			fmt.Println(err.Error())
+		}
+	},
+}
+
+// buildDataDocument builds the recorder's output document from an
+// already-rendered config: the template cache's simple fields (env) plus
+// every enabled segment's writer, keyed by DataKey (segments). Extracted
+// from dataCmd's Run so it can be unit tested without a real environment.
+func buildDataDocument(cfg *config.Config) ([]byte, error) {
+	envRaw, err := json.Marshal(template.Cache.SimpleTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal template cache: %w", err)
+	}
+
+	var envFields map[string]json.RawMessage
+	if err := json.Unmarshal(envRaw, &envFields); err != nil {
+		return nil, fmt.Errorf("failed to marshal template cache: %w", err)
+	}
+
+	// SegmentsCache is internal cache plumbing, and Var is already covered
+	// by the config's own "var" section - neither belongs in a recorded
+	// data file.
+	delete(envFields, "SegmentsCache")
+	delete(envFields, "Var")
+
+	segments := make(map[string]json.RawMessage)
+
+	for _, block := range cfg.Blocks {
+		for _, segment := range block.Segments {
+			if !segment.Enabled {
+				continue
+			}
+
+			writer := segment.Writer()
+			if writer == nil {
+				continue
+			}
+
+			raw, err := json.Marshal(writer)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal segment %s: %w", segment.DataKey(), err)
+			}
+
+			key := segment.DataKey()
+			if _, exists := segments[key]; exists {
+				fmt.Fprintf(os.Stderr, "warning: multiple segments share the data key %q; the last one wins - add an alias to disambiguate\n", key)
+			}
+
+			segments[key] = raw
+		}
+	}
+
+	doc := map[string]any{
+		"env":      envFields,
+		"segments": segments,
+	}
+
+	return json.MarshalIndent(doc, "", "  ")
+}
+
+func init() {
+	dataCmd.Flags().StringVarP(&outputData, "output", "o", "", "data file to export to")
+
+	exportCmd.AddCommand(dataCmd)
+}

--- a/src/cli/config_export_data_test.go
+++ b/src/cli/config_export_data_test.go
@@ -1,0 +1,152 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/cache"
+	"github.com/jandedobbeleer/oh-my-posh/src/config"
+	"github.com/jandedobbeleer/oh-my-posh/src/maps"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments"
+	"github.com/jandedobbeleer/oh-my-posh/src/template"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newRecordedSessionSegment builds a config.Segment with a real *segments.Session
+// writer attached (via MapSegmentWithWriter, exactly like normal execution
+// does), so buildDataDocument has something concrete to marshal. It does not
+// run Execute/Enabled(), so the caller controls Enabled and the writer's
+// fields directly, keeping the test hermetic (no real environment probing).
+func newRecordedSessionSegment(t *testing.T, alias string) *config.Segment {
+	t.Helper()
+
+	env := new(mock.Environment)
+	env.On("Getenv", "SSH_CONNECTION").Return("")
+	env.On("Getenv", "SSH_CLIENT").Return("")
+
+	segment := &config.Segment{Type: config.SESSION, Alias: alias}
+	require.NoError(t, segment.MapSegmentWithWriter(env))
+	segment.Enabled = true
+
+	return segment
+}
+
+func TestBuildDataDocument_EnvSectionDropsInternalKeysKeepsRest(t *testing.T) {
+	template.Cache = &cache.Template{
+		Segments: maps.NewConcurrent[any](),
+		SimpleTemplate: cache.SimpleTemplate{
+			PWD:      "/home/jan",
+			UserName: "jan",
+			Var:      maps.Simple[any]{"foo": "bar"},
+		},
+	}
+
+	cfg := &config.Config{}
+
+	doc, err := buildDataDocument(cfg)
+	require.NoError(t, err)
+
+	var parsed map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(doc, &parsed))
+
+	require.Contains(t, parsed, "env")
+
+	var env map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(parsed["env"], &env))
+
+	assert.NotContains(t, env, "SegmentsCache", "internal cache plumbing must not be recorded")
+	assert.NotContains(t, env, "Var", "config vars are already covered by the config's own var section")
+	assert.Contains(t, env, "PWD")
+	assert.Contains(t, env, "UserName")
+}
+
+func TestBuildDataDocument_SkipsDisabledAndNilWriterSegments(t *testing.T) {
+	template.Cache = &cache.Template{Segments: maps.NewConcurrent[any]()}
+
+	enabled := newRecordedSessionSegment(t, "")
+	enabled.Writer().(*segments.Session).SSHSession = true
+
+	disabled := newRecordedSessionSegment(t, "disabled-alias")
+	disabled.Enabled = false
+
+	noWriter := &config.Segment{Type: config.TEXT, Alias: "no-writer", Enabled: true}
+
+	cfg := &config.Config{
+		Blocks: []*config.Block{
+			{Segments: []*config.Segment{enabled, disabled, noWriter}},
+		},
+	}
+
+	doc, err := buildDataDocument(cfg)
+	require.NoError(t, err)
+
+	var parsed map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(doc, &parsed))
+
+	var segs map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(parsed["segments"], &segs))
+
+	assert.Contains(t, segs, "session")
+	assert.NotContains(t, segs, "disabled-alias", "disabled segments must not be recorded")
+	assert.NotContains(t, segs, "no-writer", "a segment with a nil writer must be skipped")
+
+	var session map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(segs["session"], &session))
+	assert.JSONEq(t, `true`, string(session["SSHSession"]))
+}
+
+func TestBuildDataDocument_CollisionWarnsAndLastWriterWins(t *testing.T) {
+	template.Cache = &cache.Template{Segments: maps.NewConcurrent[any]()}
+
+	first := newRecordedSessionSegment(t, "")
+	first.Writer().(*segments.Session).SSHSession = false
+
+	second := newRecordedSessionSegment(t, "")
+	second.Writer().(*segments.Session).SSHSession = true
+
+	cfg := &config.Config{
+		Blocks: []*config.Block{
+			{Segments: []*config.Segment{first, second}},
+		},
+	}
+
+	stderrR, stderrW, err := os.Pipe()
+	require.NoError(t, err)
+
+	originalStderr := os.Stderr
+	os.Stderr = stderrW
+
+	doc, docErr := buildDataDocument(cfg)
+
+	os.Stderr = originalStderr
+	require.NoError(t, stderrW.Close())
+
+	var warning []byte
+	buf := make([]byte, 4096)
+	n, _ := stderrR.Read(buf)
+	warning = buf[:n]
+	_ = stderrR.Close()
+
+	require.NoError(t, docErr)
+	assert.Contains(t, string(warning), "session", "collision warning should name the colliding key")
+
+	var parsed map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(doc, &parsed))
+
+	var segs map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(parsed["segments"], &segs))
+
+	var session map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(segs["session"], &session))
+	assert.JSONEq(t, `true`, string(session["SSHSession"]), "the last segment sharing the key should win")
+}
+
+func TestDataCmd_Flags(t *testing.T) {
+	flag := dataCmd.Flags().Lookup("output")
+	require.NotNil(t, flag)
+	assert.Equal(t, "o", flag.Shorthand)
+}

--- a/src/cli/config_export_image.go
+++ b/src/cli/config_export_image.go
@@ -49,7 +49,7 @@ Exports the config to an image file ~/mytheme.png.
 
 Exports the config to an image file using customized output settings.`,
 	Args: cobra.NoArgs,
-	Run: func(_ *cobra.Command, _ []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		cache.Init(os.Getenv("POSH_SHELL"))
 
 		err := setConfigFlag()
@@ -65,6 +65,12 @@ Exports the config to an image file using customized output settings.`,
 			ConfigPath:    cfg.Source,
 			Shell:         shell.GENERIC,
 			TerminalWidth: 120,
+		}
+
+		if err := applyDataFile(flags, cmd.Flags().Changed); err != nil {
+			exitcode = 666
+			fmt.Println(err.Error())
+			return
 		}
 
 		env := &runtime.Terminal{}
@@ -137,6 +143,7 @@ func init() {
 	imageCmd.Flags().StringVar(&bgColor, "background-color", "", "image background color")
 	imageCmd.Flags().StringVarP(&outputImage, "output", "o", "", "image file (.png) to export to")
 	imageCmd.Flags().StringVar(&colorSettingsFile, "settings", "", "color settings file to override ANSI color codes and metadata")
+	imageCmd.Flags().StringVar(&dataPath, "data", "", "path to a template data file (json/yaml/toml) to render with")
 
 	// deprecated flags
 	_ = imageCmd.Flags().MarkHidden("author")

--- a/src/cli/config_export_image.go
+++ b/src/cli/config_export_image.go
@@ -17,10 +17,11 @@ import (
 )
 
 var (
-	author            string
-	colorSettingsFile string
-	bgColor           string
-	outputImage       string
+	author             string
+	colorSettingsFile  string
+	bgColor            string
+	outputImage        string
+	imageTerminalWidth int
 )
 
 // imageCmd represents the image command
@@ -31,9 +32,14 @@ var imageCmd = &cobra.Command{
 
 You can tweak the output by using additional flags:
 
-- cursor-padding: the padding of the prompt cursor
-- rprompt-offset: the offset of the right prompt
-- settings: JSON file with overrides
+- author: name to display as the config's author
+- background-color: background color of the exported image
+- terminal-width: number of columns the image canvas is rendered at; this
+  is also the width the prompt is rendered with, so right-aligned blocks
+  and rprompts line up with the image the same way they would in a real
+  terminal of that width (default 120). Lines that still don't fit either
+  collapse their alignment padding or wrap onto the next row
+- settings: JSON file overriding colors, author, background_color, fonts and cursor
 
 Example usage:
 
@@ -64,7 +70,7 @@ Exports the config to an image file using customized output settings.`,
 		flags := &runtime.Flags{
 			ConfigPath:    cfg.Source,
 			Shell:         shell.GENERIC,
-			TerminalWidth: 120,
+			TerminalWidth: imageTerminalWidth,
 		}
 
 		if err := applyDataFile(flags, cmd.Flags().Changed); err != nil {
@@ -114,6 +120,19 @@ Exports the config to an image file using customized output settings.`,
 			settings.Cursor = "_"
 		}
 
+		// --terminal-width beats the settings file's columns, and the settings
+		// file beats the default.
+		if !cmd.Flags().Changed("terminal-width") && settings.Columns > 0 {
+			imageTerminalWidth = settings.Columns
+		}
+
+		// The engine pads right-aligned blocks/rprompts to TerminalWidth, so the
+		// image must clamp to the same column count or the two disagree on
+		// where content should land. TerminalWidth is read lazily at render
+		// time, so updating the flags here still reaches the engine.
+		flags.TerminalWidth = imageTerminalWidth
+		settings.Columns = imageTerminalWidth
+
 		primaryPrompt := eng.Primary()
 
 		imageCreator := &image.Renderer{
@@ -144,6 +163,7 @@ func init() {
 	imageCmd.Flags().StringVarP(&outputImage, "output", "o", "", "image file (.png) to export to")
 	imageCmd.Flags().StringVar(&colorSettingsFile, "settings", "", "color settings file to override ANSI color codes and metadata")
 	imageCmd.Flags().StringVar(&dataPath, "data", "", "path to a template data file (json/yaml/toml) to render with")
+	imageCmd.Flags().IntVar(&imageTerminalWidth, "terminal-width", 120, "number of columns to render the prompt and image at")
 
 	// deprecated flags
 	_ = imageCmd.Flags().MarkHidden("author")

--- a/src/cli/data.go
+++ b/src/cli/data.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"github.com/jandedobbeleer/oh-my-posh/src/config"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
+)
+
+// dataPath is the shared --data flag value used by printCmd and imageCmd to
+// render deterministically from a recorded template data file instead of
+// the live environment.
+var dataPath string
+
+// applyDataFile loads the template data file referenced by --data (if any)
+// and routes it onto flags. It is a no-op when dataPath is empty.
+//
+// SegmentData and EnvData are copied onto flags verbatim - the rest of the
+// pipeline (segment replay, template cache overlay) consumes them from
+// there. The four env keys that map directly onto runtime.Flags fields
+// (PWD, Code, ExecutionTime, PipeStatus) are routed here explicitly, with
+// precedence explicit CLI flag > data file > live environment: changed
+// reports whether the corresponding CLI flag (by name) was set explicitly,
+// in which case the data file's value is skipped.
+func applyDataFile(flags *runtime.Flags, changed func(name string) bool) error {
+	if dataPath == "" {
+		return nil
+	}
+
+	data, err := config.LoadData(dataPath)
+	if err != nil {
+		return err
+	}
+
+	flags.SegmentData = data.Segments
+	flags.EnvData = data.Env
+
+	envFlags, err := data.EnvFlags()
+	if err != nil {
+		return err
+	}
+
+	if envFlags.PWD != nil && !changed("pwd") {
+		flags.PWD = *envFlags.PWD
+	}
+
+	if envFlags.Code != nil && !changed("status") {
+		flags.ErrorCode = *envFlags.Code
+	}
+
+	if envFlags.ExecutionTime != nil && !changed("execution-time") {
+		flags.ExecutionTime = *envFlags.ExecutionTime
+	}
+
+	if envFlags.PipeStatus != nil && !changed("pipestatus") {
+		flags.PipeStatus = *envFlags.PipeStatus
+	}
+
+	return nil
+}

--- a/src/cli/data_test.go
+++ b/src/cli/data_test.go
@@ -1,0 +1,166 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeDataFile writes a JSON template data file to a temp dir and returns
+// its path.
+func writeDataFile(t *testing.T, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "data.json")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	return path
+}
+
+// withDataPath sets the package-level dataPath var for the duration of the
+// test and restores it afterwards - dataPath is shared with the print/image
+// commands so tests must not leak it across each other.
+func withDataPath(t *testing.T, path string) {
+	t.Helper()
+
+	previous := dataPath
+	dataPath = path
+
+	t.Cleanup(func() { dataPath = previous })
+}
+
+// noneChanged reports that no CLI flag was explicitly set.
+func noneChanged(string) bool { return false }
+
+// changedSet returns a "Changed" func that reports true only for the given
+// flag names, mimicking cmd.Flags().Changed for an explicitly-set flag.
+func changedSet(names ...string) func(string) bool {
+	set := make(map[string]bool, len(names))
+	for _, name := range names {
+		set[name] = true
+	}
+
+	return func(name string) bool { return set[name] }
+}
+
+func TestApplyDataFile_EmptyPathIsNoop(t *testing.T) {
+	withDataPath(t, "")
+
+	flags := &runtime.Flags{PWD: "/live/pwd", ErrorCode: 1, ExecutionTime: 2.5, PipeStatus: "0"}
+
+	err := applyDataFile(flags, noneChanged)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/live/pwd", flags.PWD)
+	assert.Equal(t, 1, flags.ErrorCode)
+	assert.InDelta(t, 2.5, flags.ExecutionTime, 0)
+	assert.Equal(t, "0", flags.PipeStatus)
+	assert.Nil(t, flags.EnvData)
+	assert.Nil(t, flags.SegmentData)
+}
+
+func TestApplyDataFile_MissingFileErrors(t *testing.T) {
+	withDataPath(t, filepath.Join(t.TempDir(), "does-not-exist.json"))
+
+	flags := &runtime.Flags{}
+
+	err := applyDataFile(flags, noneChanged)
+	assert.Error(t, err)
+}
+
+func TestApplyDataFile_UnsupportedExtensionErrors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "data.txt")
+	require.NoError(t, os.WriteFile(path, []byte("{}"), 0o644))
+	withDataPath(t, path)
+
+	flags := &runtime.Flags{}
+
+	err := applyDataFile(flags, noneChanged)
+	assert.Error(t, err)
+}
+
+func TestApplyDataFile_RoutesAllFourKeysWhenNoFlagsChanged(t *testing.T) {
+	path := writeDataFile(t, `{
+		"env": {"PWD": "/data/pwd", "Code": 3, "ExecutionTime": 12.5, "PipeStatus": "0 1"},
+		"segments": {"az": {"Name": "my-sub"}}
+	}`)
+	withDataPath(t, path)
+
+	flags := &runtime.Flags{PWD: "/live/pwd", ErrorCode: 1, ExecutionTime: 2.5, PipeStatus: "0"}
+
+	err := applyDataFile(flags, noneChanged)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/data/pwd", flags.PWD)
+	assert.Equal(t, 3, flags.ErrorCode)
+	assert.InDelta(t, 12.5, flags.ExecutionTime, 0)
+	assert.Equal(t, "0 1", flags.PipeStatus)
+
+	require.NotNil(t, flags.SegmentData)
+	assert.JSONEq(t, `{"Name": "my-sub"}`, string(flags.SegmentData["az"]))
+
+	require.NotNil(t, flags.EnvData)
+
+	var env map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(flags.EnvData, &env))
+	assert.Contains(t, env, "PWD")
+}
+
+func TestApplyDataFile_ExplicitCLIFlagWinsOverDataFile(t *testing.T) {
+	path := writeDataFile(t, `{
+		"env": {"PWD": "/data/pwd", "Code": 3, "ExecutionTime": 12.5, "PipeStatus": "0 1"}
+	}`)
+	withDataPath(t, path)
+
+	flags := &runtime.Flags{PWD: "/live/pwd", ErrorCode: 1, ExecutionTime: 2.5, PipeStatus: "0"}
+
+	err := applyDataFile(flags, changedSet("pwd", "status", "execution-time", "pipestatus"))
+	require.NoError(t, err)
+
+	// Every routed key was explicitly set on the CLI, so the live/flag
+	// value must survive untouched despite the data file providing all four.
+	assert.Equal(t, "/live/pwd", flags.PWD)
+	assert.Equal(t, 1, flags.ErrorCode)
+	assert.InDelta(t, 2.5, flags.ExecutionTime, 0)
+	assert.Equal(t, "0", flags.PipeStatus)
+}
+
+func TestApplyDataFile_PerKeyPrecedence(t *testing.T) {
+	path := writeDataFile(t, `{
+		"env": {"PWD": "/data/pwd", "Code": 3, "ExecutionTime": 12.5, "PipeStatus": "0 1"}
+	}`)
+	withDataPath(t, path)
+
+	flags := &runtime.Flags{PWD: "/live/pwd", ErrorCode: 1, ExecutionTime: 2.5, PipeStatus: "0"}
+
+	// Only "status" is explicitly set on the CLI; the other three keys
+	// should still be routed from the data file.
+	err := applyDataFile(flags, changedSet("status"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "/data/pwd", flags.PWD, "pwd not explicitly set, so the data file value should apply")
+	assert.Equal(t, 1, flags.ErrorCode, "status explicitly set, so it must keep the live/flag value")
+	assert.InDelta(t, 12.5, flags.ExecutionTime, 0, "execution-time not explicitly set, so the data file value should apply")
+	assert.Equal(t, "0 1", flags.PipeStatus, "pipestatus not explicitly set, so the data file value should apply")
+}
+
+func TestApplyDataFile_MissingEnvKeysLeaveFlagsUntouched(t *testing.T) {
+	path := writeDataFile(t, `{"segments": {"az": {"Name": "my-sub"}}}`)
+	withDataPath(t, path)
+
+	flags := &runtime.Flags{PWD: "/live/pwd", ErrorCode: 1, ExecutionTime: 2.5, PipeStatus: "0"}
+
+	err := applyDataFile(flags, noneChanged)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/live/pwd", flags.PWD)
+	assert.Equal(t, 1, flags.ErrorCode)
+	assert.InDelta(t, 2.5, flags.ExecutionTime, 0)
+	assert.Equal(t, "0", flags.PipeStatus)
+}

--- a/src/cli/image/config.go
+++ b/src/cli/image/config.go
@@ -8,6 +8,11 @@ import (
 	"strings"
 )
 
+// defaultColumns is the fixed canvas text width, in columns, used when
+// Settings.Columns is not set (zero value). It matches the default
+// --terminal-width the prompt engine renders with.
+const defaultColumns = 120
+
 // Settings represents the structure for base 16 color overrides and other image settings.
 // Expected JSON format:
 //
@@ -18,7 +23,8 @@ import (
 //	    "green": "#00FF00"
 //	  },
 //	  "author": "Your Name",
-//	  "background_color": "#FFFFFF"
+//	  "background_color": "#FFFFFF",
+//	  "columns": 120
 //	}
 type Settings struct {
 	Colors          Colors `json:"colors"`
@@ -26,6 +32,11 @@ type Settings struct {
 	BackgroundColor string `json:"background_color"`
 	Fonts           *Fonts `json:"fonts"`
 	Cursor          string `json:"cursor,omitempty"`
+	// Columns is the fixed canvas text width, in columns. It should match
+	// the --terminal-width the config was rendered with so alignment
+	// padding produced by the prompt engine lines up with the image.
+	// A zero value falls back to defaultColumns.
+	Columns int `json:"columns,omitempty"`
 }
 
 type Colors map[string]HexColor

--- a/src/cli/image/config_test.go
+++ b/src/cli/image/config_test.go
@@ -104,6 +104,20 @@ func TestLoadSettings(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name: "Valid settings with columns",
+			jsonContent: `{
+				"author": "Grid Author",
+				"columns": 100
+			}`,
+			expectedResult: &Settings{
+				Colors:          nil,
+				Author:          "Grid Author",
+				BackgroundColor: "",
+				Columns:         100,
+			},
+			expectError: false,
+		},
+		{
 			name: "JSON with extended color names",
 			jsonContent: `{
 				"colors": {

--- a/src/cli/image/image.go
+++ b/src/cli/image/image.go
@@ -31,7 +31,6 @@ import (
 	"math"
 	stdOS "os"
 	"path/filepath"
-	"slices"
 	"strconv"
 	"strings"
 
@@ -117,20 +116,18 @@ type Renderer struct {
 	foregroundColor        *RGB
 	defaultBackgroundColor *RGB
 	defaultForegroundColor *RGB
+	AnsiString             string
+	Path                   string
+	shadowBaseColor        string
+	style                  string
 	Settings
-	Path            string
-	AnsiString      string
-	shadowBaseColor string
-	style           string
-	shadowOffsetX   float64
-	margin          float64
-	factor          float64
-	shadowOffsetY   float64
-	rows            int
-	lineSpacing     float64
-	columns         int
-	padding         float64
-	shadowRadius    uint8
+	shadowOffsetX float64
+	margin        float64
+	factor        float64
+	shadowOffsetY float64
+	lineSpacing   float64
+	padding       float64
+	shadowRadius  uint8
 }
 
 func (ir *Renderer) Init(env runtime.Environment) error {
@@ -169,8 +166,6 @@ func (ir *Renderer) initDefaults() {
 	ir.defaultBackgroundColor = &RGB{21, 21, 21}
 
 	ir.factor = 2.0
-	ir.columns = 80
-	ir.rows = 25
 
 	ir.margin = ir.factor * 48
 	ir.padding = ir.factor * 24
@@ -316,6 +311,17 @@ func (ir *Renderer) fontHeight() float64 {
 	return float64(ir.regular.Metrics().Height >> 6)
 }
 
+// resolvedColumns returns the fixed canvas text width, in columns, falling
+// back to defaultColumns when Settings.Columns is unset (zero or negative),
+// e.g. when loading a settings file written before Columns existed.
+func (ir *Renderer) resolvedColumns() int {
+	if ir.Columns <= 0 {
+		return defaultColumns
+	}
+
+	return ir.Columns
+}
+
 type RuneRange struct {
 	Start rune
 	End   rune
@@ -339,11 +345,12 @@ var doubleWidthRunes = []RuneRange{
 	{Start: '\uf400', End: '\uf532'},
 	{Start: '\u2665', End: '\u2665'},
 	{Start: '\u26A1', End: '\u26A1'},
-	// Powerline Extra Symbols (intentionally excluding single width bubbles (e0b4-e0b7) and pixelated (e0c4-e0c7))
+	// Powerline Extra Symbols: only the column-number glyph. The separator
+	// shapes (bubbles e0b4-e0b7, triangles e0b8-e0bf, flames e0c0-e0c3,
+	// pixelated e0c4-e0c7, honeycomb and friends e0c8-e0d4) are designed to
+	// fill exactly one cell, so doubling them adds phantom width that pushes
+	// otherwise-fitting lines across the wrap boundary.
 	{Start: '\ue0a3', End: '\ue0a3'},
-	{Start: '\ue0b4', End: '\ue0c8'},
-	{Start: '\ue0ca', End: '\ue0ca'},
-	{Start: '\ue0cc', End: '\ue0d4'},
 	// IEC Power Symbols
 	{Start: '\u23fb', End: '\u23fe'},
 	{Start: '\u2b58', End: '\u2b58'},
@@ -359,12 +366,6 @@ var doubleWidthRunes = []RuneRange{
 // e.g. for characters that are 2 or more wide. A standard character will return 0
 // Nerd Font glyphs will return 1, since most are double width
 func (ir *Renderer) runeAdditionalWidth(r rune) int {
-	// exclude the round leading diamond
-	singles := []rune{'\ue0b6', '\ue0ba', '\ue0bc'}
-	if slices.Contains(singles, r) {
-		return 0
-	}
-
 	for _, runeRange := range doubleWidthRunes {
 		if runeRange.Start <= r && r <= runeRange.End {
 			return 1
@@ -402,19 +403,69 @@ func (ir *Renderer) cleanContent() {
 	}
 }
 
-func (ir *Renderer) measureContent() (width, height float64) {
-	// Use actual rendering logic for accurate width measurement
-	// This simulates the exact same process as the actual drawing to ensure
-	// the canvas width perfectly matches the rendered content width
-	var maxX float64
-	var x float64
+// glyphPlan is a single positioned, styled rune ready to be measured or drawn.
+// width is the pixel advance the glyph occupies on the canvas, already
+// inflated for double-width Nerd Font glyphs (see runeAdditionalWidth).
+type glyphPlan struct {
+	foreground *RGB
+	background *RGB
+	style      string
+	r          rune
+	width      float64
+}
 
-	// Save original ansi string and style state
+// rowPlan is one physical row of the canvas, i.e. one line as it will
+// actually be drawn after wrapping/collapsing has been applied.
+type rowPlan struct {
+	glyphs []glyphPlan
+}
+
+func (row rowPlan) width() float64 {
+	var w float64
+	for _, g := range row.glyphs {
+		w += g.width
+	}
+	return w
+}
+
+// layoutPlan is the single source of truth for both measurement and
+// drawing: it is built once per render by walking the ANSI string, and both
+// measureContent and SavePNG derive their output from it instead of
+// duplicating the walk.
+type layoutPlan struct {
+	rows         []rowPlan
+	spaceAdvance float64
+}
+
+// minPaddingRun is the minimum length of a run of literal space runes that
+// is treated as alignment padding inserted by the prompt engine for
+// right-aligned blocks/rprompts, as opposed to incidental whitespace in
+// genuine content.
+const minPaddingRun = 5
+
+// buildLayout walks the ANSI string once, resolving styles/colors exactly
+// like processAnsiSequence always has, and produces the logical rows
+// (one per newline in the source). It then fits each logical row to the
+// fixed canvas width: rows that fit are kept as-is, rows that overflow
+// because of a long engine-inserted padding run get that padding collapsed,
+// and any other overflowing row is hard-wrapped, never splitting a glyph.
+func (ir *Renderer) buildLayout() *layoutPlan {
+	// Save/restore so buildLayout is non-destructive and can be called
+	// repeatedly (e.g. once for measurement, once for drawing, or from tests).
 	originalAnsi := ir.AnsiString
 	originalStyle := ir.style
-	ir.style = ""
+	originalFg := ir.foregroundColor
+	originalBg := ir.backgroundColor
 
-	tmpDrawer := &font.Drawer{Face: ir.regular}
+	ir.style = ""
+	ir.foregroundColor = nil
+	ir.backgroundColor = nil
+
+	drawer := &font.Drawer{Face: ir.regular}
+	spaceAdvance := float64(drawer.MeasureString(" ") >> 6)
+
+	var logicalRows []rowPlan
+	var current rowPlan
 
 	for ir.AnsiString != "" {
 		if !ir.processAnsiSequence() {
@@ -426,10 +477,15 @@ func (ir *Renderer) measureContent() (width, height float64) {
 			continue
 		}
 
-		str := string(runes[0:1])
+		r := runes[0]
 		ir.AnsiString = string(runes[1:])
 
-		// Use appropriate font face for measurement
+		if r == '\n' {
+			logicalRows = append(logicalRows, current)
+			current = rowPlan{}
+			continue
+		}
+
 		var face font.Face
 		switch ir.style {
 		case bold:
@@ -440,35 +496,138 @@ func (ir *Renderer) measureContent() (width, height float64) {
 			face = ir.regular
 		}
 
-		tmpDrawer.Face = face
-		advance := tmpDrawer.MeasureString(str)
-		w := float64(advance >> 6)
+		drawer.Face = face
+		advance := float64(drawer.MeasureString(string(r)) >> 6)
+		// Add additional width for Nerd Font glyphs; the gg library returns
+		// a single character width for *all* glyphs in a font, so if we know
+		// the glyph occupies n additional characters of width, allocate it here.
+		advance += advance * float64(ir.runeAdditionalWidth(r))
 
-		// Add additional width for Nerd Font glyphs
-		w += (w * float64(ir.runeAdditionalWidth(runes[0])))
-
-		if str == "\n" {
-			x = 0
-			continue
-		}
-
-		x += w
-		if x > maxX {
-			maxX = x
-		}
+		current.glyphs = append(current.glyphs, glyphPlan{
+			r:          r,
+			width:      advance,
+			foreground: ir.foregroundColor,
+			background: ir.backgroundColor,
+			style:      ir.style,
+		})
 	}
+
+	logicalRows = append(logicalRows, current)
 
 	// Restore original state
 	ir.AnsiString = originalAnsi
 	ir.style = originalStyle
+	ir.foregroundColor = originalFg
+	ir.backgroundColor = originalBg
 
-	// Ensure we have a minimum width for very short content
-	minWidth := tmpDrawer.MeasureString(strings.Repeat(" ", 80))
-	width = math.Max(maxX, float64(minWidth>>6))
+	maxWidth := float64(ir.resolvedColumns()) * spaceAdvance
 
-	// height, lines times font height and line spacing
-	lines := strings.Split(originalAnsi, "\n")
-	height = float64(len(lines)) * ir.fontHeight() * ir.lineSpacing
+	var rows []rowPlan
+	for _, row := range logicalRows {
+		rows = append(rows, fitRow(row, maxWidth, spaceAdvance)...)
+	}
+
+	return &layoutPlan{rows: rows, spaceAdvance: spaceAdvance}
+}
+
+// fitRow fits a single logical row (a line as produced by the prompt
+// engine) to maxWidth pixels, per the approved design:
+//   - a row that already fits is returned unchanged
+//   - a row that overflows because it contains a long (>=minPaddingRun) run
+//     of literal padding spaces has spaces removed from that run until it
+//     fits, keeping right-aligned segments flush against the right edge
+//   - any other overflowing row is hard-wrapped at the column boundary,
+//     never splitting a glyph (glyphs are atomic units here, so this is
+//     structural rather than an extra check)
+func fitRow(row rowPlan, maxWidth, spaceAdvance float64) []rowPlan {
+	if row.width() <= maxWidth {
+		return []rowPlan{row}
+	}
+
+	if start, length, ok := longestPaddingRun(row, minPaddingRun); ok {
+		overflow := row.width() - maxWidth
+		remove := min(int(math.Ceil(overflow/spaceAdvance)), length)
+
+		collapsed := rowPlan{glyphs: make([]glyphPlan, 0, len(row.glyphs)-remove)}
+		collapsed.glyphs = append(collapsed.glyphs, row.glyphs[:start]...)
+		collapsed.glyphs = append(collapsed.glyphs, row.glyphs[start+remove:]...)
+
+		if collapsed.width() <= maxWidth {
+			return []rowPlan{collapsed}
+		}
+
+		// The padding run alone wasn't enough to make it fit (unusual,
+		// e.g. an already very long line); wrap what's left of it.
+		row = collapsed
+	}
+
+	return wrapRow(row, maxWidth)
+}
+
+// longestPaddingRun finds the longest run of consecutive literal space
+// glyphs of at least minLen runes, returning its start index and length.
+func longestPaddingRun(row rowPlan, minLen int) (start, length int, ok bool) {
+	bestStart, bestLen := -1, 0
+	curStart, curLen := -1, 0
+
+	flush := func() {
+		if curLen >= minLen && curLen > bestLen {
+			bestStart, bestLen = curStart, curLen
+		}
+	}
+
+	for i, g := range row.glyphs {
+		if g.r == ' ' {
+			if curLen == 0 {
+				curStart = i
+			}
+			curLen++
+			continue
+		}
+
+		flush()
+		curLen = 0
+	}
+
+	flush()
+
+	if bestLen == 0 {
+		return 0, 0, false
+	}
+
+	return bestStart, bestLen, true
+}
+
+// wrapRow hard-wraps row into as many rows as needed so that each one is at
+// most maxWidth pixels wide, exactly like a real terminal would. Glyphs are
+// never split since they are moved as whole units between rows.
+func wrapRow(row rowPlan, maxWidth float64) []rowPlan {
+	var rows []rowPlan
+	var current rowPlan
+	var width float64
+
+	for _, g := range row.glyphs {
+		if width+g.width > maxWidth && len(current.glyphs) > 0 {
+			rows = append(rows, current)
+			current = rowPlan{}
+			width = 0
+		}
+
+		current.glyphs = append(current.glyphs, g)
+		width += g.width
+	}
+
+	rows = append(rows, current)
+
+	return rows
+}
+
+func (ir *Renderer) measureContent() (width, height float64) {
+	plan := ir.buildLayout()
+
+	width = float64(ir.resolvedColumns()) * plan.spaceAdvance
+	height = float64(len(plan.rows)) * ir.fontHeight() * ir.lineSpacing
+
 	return width, height
 }
 
@@ -481,7 +640,9 @@ func (ir *Renderer) SavePNG() error {
 		distance = scale(25)
 	)
 
-	contentWidth, contentHeight := ir.measureContent()
+	plan := ir.buildLayout()
+	contentWidth := float64(ir.resolvedColumns()) * plan.spaceAdvance
+	contentHeight := float64(len(plan.rows)) * ir.fontHeight() * ir.lineSpacing
 
 	// Make sure the output window is big enough in case no content or very few
 	// content will be rendered. Also account for potential font variations.
@@ -543,78 +704,64 @@ func (ir *Renderer) SavePNG() error {
 		dc.Fill()
 	}
 
-	// Apply the actual text into the prepared content area of the window
-	var x, y = xOffset + paddingX, yOffset + paddingY + titleOffset + ir.fontHeight()
+	// Apply the actual text into the prepared content area of the window,
+	// replaying the layout plan built above instead of re-walking the ANSI
+	// string: measurement and drawing now share a single pass.
+	y := yOffset + paddingY + titleOffset + ir.fontHeight()
 
-	for ir.AnsiString != "" {
-		if !ir.processAnsiSequence() {
-			continue
+	for _, row := range plan.rows {
+		x := xOffset + paddingX
+
+		for _, g := range row.glyphs {
+			switch g.style {
+			case bold:
+				dc.SetFontFace(ir.bold)
+			case italic:
+				dc.SetFontFace(ir.italic)
+			default:
+				dc.SetFontFace(ir.regular)
+			}
+
+			w := g.width
+
+			if g.background != nil {
+				dc.SetRGB255(g.background.r, g.background.g, g.background.b)
+				// Use consistent line height for all background rectangles
+				fontLineHeight := ir.fontHeight() * ir.lineSpacing
+
+				// Center all characters (including powerline glyphs) within the line height
+				// Position background to align properly with text baseline and ensure consistent height
+				bgY := y - fontLineHeight*0.75 // Adjusted for better centering with text
+				bgHeight := fontLineHeight
+
+				dc.DrawRectangle(x, bgY, w, bgHeight)
+				dc.Fill()
+			}
+
+			if g.foreground != nil {
+				dc.SetRGB255(g.foreground.r, g.foreground.g, g.foreground.b)
+			} else {
+				dc.SetRGB255(ir.defaultForegroundColor.r, ir.defaultForegroundColor.g, ir.defaultForegroundColor.b)
+			}
+
+			dc.DrawString(string(g.r), x, y)
+
+			if g.style == underline {
+				dc.DrawLine(x, y+scale(4), x+w, y+scale(4))
+				dc.SetLineWidth(scale(1))
+				dc.Stroke()
+			}
+
+			if g.style == overline {
+				dc.DrawLine(x, y-scale(22), x+w, y-scale(22))
+				dc.SetLineWidth(scale(1))
+				dc.Stroke()
+			}
+
+			x += w
 		}
 
-		runes := []rune(ir.AnsiString)
-		if len(runes) == 0 {
-			continue
-		}
-
-		str := string(runes[0:1])
-		ir.AnsiString = string(runes[1:])
-		switch ir.style {
-		case bold:
-			dc.SetFontFace(ir.bold)
-		case italic:
-			dc.SetFontFace(ir.italic)
-		default:
-			dc.SetFontFace(ir.regular)
-		}
-
-		w, _ := dc.MeasureString(str)
-		// The gg library unfortunately returns a single character width for *all* glyphs in a font.
-		// So if we know the glyph to occupy n additional characters in width, allocate that area
-		// e.g. this will double the space for Nerd Fonts, but some could even be 3 or 4 wide
-		// If there's 0 additional characters of width (the common case), this won't add anything
-		w += (w * float64(ir.runeAdditionalWidth(runes[0])))
-
-		if ir.backgroundColor != nil {
-			dc.SetRGB255(ir.backgroundColor.r, ir.backgroundColor.g, ir.backgroundColor.b)
-			// Use consistent line height for all background rectangles
-			fontLineHeight := ir.fontHeight() * ir.lineSpacing
-
-			// Center all characters (including powerline glyphs) within the line height
-			// Position background to align properly with text baseline and ensure consistent height
-			bgY := y - fontLineHeight*0.75 // Adjusted for better centering with text
-			bgHeight := fontLineHeight
-
-			dc.DrawRectangle(x, bgY, w, bgHeight)
-			dc.Fill()
-		}
-
-		if ir.foregroundColor != nil {
-			dc.SetRGB255(ir.foregroundColor.r, ir.foregroundColor.g, ir.foregroundColor.b)
-		} else {
-			dc.SetRGB255(ir.defaultForegroundColor.r, ir.defaultForegroundColor.g, ir.defaultForegroundColor.b)
-		}
-
-		if str == "\n" {
-			x = xOffset + paddingX
-			y += ir.fontHeight() * ir.lineSpacing // Use consistent line height instead of character height
-			continue
-		}
-
-		dc.DrawString(str, x, y)
-
-		if ir.style == underline {
-			dc.DrawLine(x, y+scale(4), x+w, y+scale(4))
-			dc.SetLineWidth(scale(1))
-			dc.Stroke()
-		}
-
-		if ir.style == overline {
-			dc.DrawLine(x, y-scale(22), x+w, y-scale(22))
-			dc.SetLineWidth(scale(1))
-			dc.Stroke()
-		}
-
-		x += w
+		y += ir.fontHeight() * ir.lineSpacing // Use consistent line height instead of character height
 	}
 
 	return dc.SavePNG(ir.Path)

--- a/src/cli/image/image_test.go
+++ b/src/cli/image/image_test.go
@@ -1,10 +1,194 @@
 package image
 
 import (
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"golang.org/x/image/font"
+	"golang.org/x/image/font/gofont/gomono"
+	"golang.org/x/image/font/opentype"
 )
+
+// loadTestFont returns a font face backed by the Go Mono TTF bundled with
+// golang.org/x/image: monospaced like the real Hack Nerd Font, so a column
+// corresponds to one consistent advance, without needing network access.
+func loadTestFont(t *testing.T) font.Face {
+	t.Helper()
+
+	fnt, err := opentype.Parse(gomono.TTF)
+	if err != nil {
+		t.Fatalf("failed to parse test font: %v", err)
+	}
+
+	face, err := opentype.NewFace(fnt, &opentype.FaceOptions{Size: 24, DPI: 144})
+	if err != nil {
+		t.Fatalf("failed to create test font face: %v", err)
+	}
+
+	return face
+}
+
+// newLayoutTestRenderer builds a Renderer with the given content and column
+// count, wired up with a real (test) font face and the ANSI regex map, but
+// without the file/watermark side effects of Init/cleanContent, so layout
+// tests can assert on exactly the content they provide.
+func newLayoutTestRenderer(t *testing.T, columns int, content string) *Renderer {
+	t.Helper()
+
+	face := loadTestFont(t)
+
+	r := &Renderer{
+		Settings:   Settings{Columns: columns},
+		AnsiString: content,
+	}
+	r.regular, r.bold, r.italic = face, face, face
+	r.initDefaults()
+
+	return r
+}
+
+func testSpaceAdvance(t *testing.T) float64 {
+	t.Helper()
+
+	drawer := &font.Drawer{Face: loadTestFont(t)}
+	return float64(drawer.MeasureString(" ") >> 6)
+}
+
+func glyphString(glyphs []glyphPlan) string {
+	runes := make([]rune, len(glyphs))
+	for i, g := range glyphs {
+		runes[i] = g.r
+	}
+	return string(runes)
+}
+
+func TestMeasureContentIsAlwaysFixedWidth(t *testing.T) {
+	spaceAdvance := testSpaceAdvance(t)
+
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{name: "short content", content: "hi"},
+		{name: "empty content", content: ""},
+		{name: "long content that would have widened the old canvas", content: strings.Repeat("x", 300)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newLayoutTestRenderer(t, 40, tc.content)
+
+			width, _ := r.measureContent()
+
+			assert.Equal(t, float64(40)*spaceAdvance, width, "canvas width must always be exactly Columns x spaceAdvance")
+		})
+	}
+}
+
+func TestLongLineWithoutPaddingWrapsAndAddsARow(t *testing.T) {
+	r := newLayoutTestRenderer(t, 20, strings.Repeat("x", 60))
+
+	plan := r.buildLayout()
+
+	assert.Greater(t, len(plan.rows), 1, "a line with no alignment padding that exceeds the column count must wrap onto extra rows")
+
+	maxWidth := float64(20) * plan.spaceAdvance
+
+	var rebuilt strings.Builder
+	for _, row := range plan.rows {
+		assert.LessOrEqual(t, row.width(), maxWidth+0.001, "no wrapped row may exceed the fixed canvas width")
+		rebuilt.WriteString(glyphString(row.glyphs))
+	}
+
+	assert.Equal(t, strings.Repeat("x", 60), rebuilt.String(), "wrapping must not drop or duplicate runes")
+}
+
+func TestAlignedLineWithPaddingRunCollapsesInsteadOfWrapping(t *testing.T) {
+	left := "left"
+	right := "right"
+	content := left + strings.Repeat(" ", 20) + right
+
+	r := newLayoutTestRenderer(t, 20, content)
+
+	plan := r.buildLayout()
+
+	assert.Len(t, plan.rows, 1, "an engine-aligned line with a long padding run must collapse, not wrap onto a new row")
+
+	maxWidth := float64(20) * plan.spaceAdvance
+	row := plan.rows[0]
+
+	assert.LessOrEqual(t, row.width(), maxWidth, "the collapsed row must fit within the fixed canvas width")
+	assert.Greater(t, row.width(), maxWidth-plan.spaceAdvance, "the collapsed row should end close to the right edge, not far short of it")
+
+	result := glyphString(row.glyphs)
+	assert.True(t, strings.HasPrefix(result, left), "left-aligned content must be preserved")
+	assert.True(t, strings.HasSuffix(result, right), "the right-aligned segment must stay flush against the right edge")
+}
+
+func TestDoubleWidthGlyphNeverSplitsAcrossWrapBoundary(t *testing.T) {
+	icon := '' // Font Awesome range, double width (see doubleWidthRunes)
+	content := strings.Repeat("a", 15) + string(icon) + strings.Repeat("b", 15)
+
+	r := newLayoutTestRenderer(t, 10, content)
+
+	plan := r.buildLayout()
+
+	assert.Greater(t, len(plan.rows), 1, "content this long at 10 columns must wrap")
+
+	maxWidth := float64(10) * plan.spaceAdvance
+
+	var rebuilt strings.Builder
+	iconCount := 0
+
+	for _, row := range plan.rows {
+		assert.LessOrEqual(t, row.width(), maxWidth+0.001, "no wrapped row may exceed the fixed canvas width")
+
+		for _, g := range row.glyphs {
+			if g.r == icon {
+				iconCount++
+			}
+		}
+
+		rebuilt.WriteString(glyphString(row.glyphs))
+	}
+
+	assert.Equal(t, content, rebuilt.String(), "wrapping must not drop or duplicate runes")
+	assert.Equal(t, 1, iconCount, "the double-width glyph must appear exactly once, whole, never split across rows")
+}
+
+func TestResolvedColumnsDefaultsTo120WhenUnset(t *testing.T) {
+	cases := []struct {
+		name     string
+		columns  int
+		expected int
+	}{
+		{name: "unset falls back to default", columns: 0, expected: defaultColumns},
+		{name: "negative falls back to default", columns: -1, expected: defaultColumns},
+		{name: "explicit value is respected", columns: 90, expected: 90},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &Renderer{Settings: Settings{Columns: tc.columns}}
+			assert.Equal(t, tc.expected, r.resolvedColumns())
+		})
+	}
+}
+
+func TestSettingsWithoutColumnsStillLoadsWithDefault120(t *testing.T) {
+	tempFile := createTempFile(t, `{"author": "no columns specified"}`)
+	defer os.Remove(tempFile)
+
+	settings, err := LoadSettings(tempFile)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, settings.Columns, "Columns is the JSON zero value when absent from an older settings file")
+
+	r := &Renderer{Settings: *settings}
+	assert.Equal(t, defaultColumns, r.resolvedColumns(), "a settings file predating Columns must still render at the default width")
+}
 
 func TestSetOutputPath(t *testing.T) {
 	cases := []struct {

--- a/src/cli/print.go
+++ b/src/cli/print.go
@@ -90,6 +90,12 @@ func createPrintCmd() *cobra.Command {
 				Force:         force,
 			}
 
+			if err := applyDataFile(flags, cmd.Flags().Changed); err != nil {
+				exitcode = 666
+				fmt.Println(err.Error())
+				return
+			}
+
 			options := []cache.Option{}
 			if saveCache {
 				options = append(options, cache.Persist)
@@ -147,6 +153,7 @@ func createPrintCmd() *cobra.Command {
 	printCmd.Flags().BoolVar(&saveCache, "save-cache", false, "save updated cache to file")
 	printCmd.Flags().BoolVar(&escape, "escape", true, "escape the ANSI sequences for the shell")
 	printCmd.Flags().BoolVarP(&force, "force", "f", false, "force rendering the segments")
+	printCmd.Flags().StringVar(&dataPath, "data", "", "path to a template data file (json/yaml/toml) to render with")
 
 	// Hide flags that are for internal use only.
 	_ = printCmd.Flags().MarkHidden("save-cache")

--- a/src/config/data.go
+++ b/src/config/data.go
@@ -1,0 +1,157 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gookit/goutil/jsonutil"
+	toml "github.com/pelletier/go-toml/v2"
+	yaml "go.yaml.in/yaml/v3"
+)
+
+// Data holds template data supplied via the --data flag, used to render a
+// prompt deterministically without querying the real runtime.
+type Data struct {
+	Segments map[string]json.RawMessage
+	Env      json.RawMessage
+}
+
+// EnvData holds the subset of the env section that maps directly onto
+// runtime.Flags rather than the template cache. Pointer fields let callers
+// detect whether a key was present in the data file.
+type EnvData struct {
+	PWD           *string
+	Code          *int
+	ExecutionTime *float64
+	PipeStatus    *string
+}
+
+// LoadData reads and parses a template data file. The format is derived
+// from the file extension: .json/.jsonc, .yaml/.yml, or .toml.
+func LoadData(path string) (*Data, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read data file: %w", err)
+	}
+
+	ext := strings.TrimPrefix(strings.ToLower(filepath.Ext(path)), ".")
+
+	var root map[string]json.RawMessage
+
+	switch ext {
+	case JSON, JSONC:
+		raw = []byte(jsonutil.StripComments(string(raw)))
+
+		if err := json.Unmarshal(raw, &root); err != nil {
+			return nil, fmt.Errorf("failed to parse data file: %w", err)
+		}
+	case YAML, YML:
+		var generic map[string]any
+
+		if err := yaml.Unmarshal(raw, &generic); err != nil {
+			return nil, fmt.Errorf("failed to parse data file: %w", err)
+		}
+
+		if root, err = normalize(generic); err != nil {
+			return nil, fmt.Errorf("failed to parse data file: %w", err)
+		}
+	case TOML, TML:
+		var generic map[string]any
+
+		if err := toml.Unmarshal(raw, &generic); err != nil {
+			return nil, fmt.Errorf("failed to parse data file: %w", err)
+		}
+
+		if root, err = normalize(generic); err != nil {
+			return nil, fmt.Errorf("failed to parse data file: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported data file extension: %s", ext)
+	}
+
+	data := &Data{}
+
+	if env, OK := root["env"]; OK {
+		data.Env = env
+	}
+
+	if segmentsRaw, OK := root["segments"]; OK {
+		var segments map[string]json.RawMessage
+
+		if err := json.Unmarshal(segmentsRaw, &segments); err != nil {
+			return nil, fmt.Errorf("failed to parse segments in data file: %w", err)
+		}
+
+		data.Segments = segments
+	}
+
+	return data, nil
+}
+
+// normalize re-marshals a generically decoded section (as produced by the
+// YAML/TOML unmarshalers) to a map of raw JSON so the rest of the pipeline
+// can treat all formats uniformly.
+func normalize(generic map[string]any) (map[string]json.RawMessage, error) {
+	root := make(map[string]json.RawMessage, len(generic))
+
+	for key, value := range generic {
+		b, err := json.Marshal(sanitize(value))
+		if err != nil {
+			return nil, err
+		}
+
+		root[key] = b
+	}
+
+	return root, nil
+}
+
+// sanitize recursively converts map[any]any (which the YAML/TOML decoders
+// may produce for nested maps) into map[string]any so encoding/json can
+// marshal it.
+func sanitize(value any) any {
+	switch v := value.(type) {
+	case map[any]any:
+		m := make(map[string]any, len(v))
+		for key, val := range v {
+			m[fmt.Sprintf("%v", key)] = sanitize(val)
+		}
+
+		return m
+	case map[string]any:
+		m := make(map[string]any, len(v))
+		for key, val := range v {
+			m[key] = sanitize(val)
+		}
+
+		return m
+	case []any:
+		s := make([]any, len(v))
+		for i, val := range v {
+			s[i] = sanitize(val)
+		}
+
+		return s
+	default:
+		return v
+	}
+}
+
+// EnvFlags parses the env section for the properties that route into
+// runtime.Flags instead of the template cache. Unknown keys are ignored.
+func (d *Data) EnvFlags() (*EnvData, error) {
+	env := &EnvData{}
+
+	if len(d.Env) == 0 {
+		return env, nil
+	}
+
+	if err := json.Unmarshal(d.Env, env); err != nil {
+		return nil, fmt.Errorf("failed to parse env data: %w", err)
+	}
+
+	return env, nil
+}

--- a/src/config/data_test.go
+++ b/src/config/data_test.go
@@ -1,0 +1,175 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadDataFormats(t *testing.T) {
+	cases := []struct {
+		name     string
+		file     string
+		contents string
+	}{
+		{
+			name: "json",
+			file: "data.json",
+			contents: `{
+	"env": { "PWD": "~/dev/project", "Code": 1, "ExecutionTime": 341.0, "UserName": "jan" },
+	"segments": {
+		"git": { "HEAD": "main" },
+		"az": { "Name": "posh-subscription", "EnvironmentName": "AzureCloud" }
+	}
+}`,
+		},
+		{
+			name: "jsonc",
+			file: "data.jsonc",
+			contents: `{
+	// deterministic render context
+	"env": { "PWD": "~/dev/project", "Code": 1, "ExecutionTime": 341.0, "UserName": "jan" },
+	"segments": {
+		"git": { "HEAD": "main" }, // replayed, not detected
+		"az": { "Name": "posh-subscription", "EnvironmentName": "AzureCloud" }
+	}
+}`,
+		},
+		{
+			name: "yaml",
+			file: "data.yaml",
+			contents: `env:
+  PWD: ~/dev/project
+  Code: 1
+  ExecutionTime: 341.0
+  UserName: jan
+segments:
+  git:
+    HEAD: main
+  az:
+    Name: posh-subscription
+    EnvironmentName: AzureCloud
+`,
+		},
+		{
+			name: "toml",
+			file: "data.toml",
+			contents: `[env]
+PWD = "~/dev/project"
+Code = 1
+ExecutionTime = 341.0
+UserName = "jan"
+
+[segments.git]
+HEAD = "main"
+
+[segments.az]
+Name = "posh-subscription"
+EnvironmentName = "AzureCloud"
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, tc.file)
+			require.NoError(t, os.WriteFile(path, []byte(tc.contents), 0644))
+
+			data, err := LoadData(path)
+			require.NoError(t, err)
+			require.NotNil(t, data)
+
+			envFlags, err := data.EnvFlags()
+			require.NoError(t, err)
+			require.NotNil(t, envFlags.PWD)
+			assert.Equal(t, "~/dev/project", *envFlags.PWD)
+			require.NotNil(t, envFlags.Code)
+			assert.Equal(t, 1, *envFlags.Code)
+			require.NotNil(t, envFlags.ExecutionTime)
+			assert.InDelta(t, 341.0, *envFlags.ExecutionTime, 0.0001)
+			assert.Nil(t, envFlags.PipeStatus)
+
+			require.Contains(t, data.Segments, "git")
+			require.Contains(t, data.Segments, "az")
+
+			var git struct {
+				HEAD string
+			}
+
+			require.NoError(t, json.Unmarshal(data.Segments["git"], &git))
+			assert.Equal(t, "main", git.HEAD)
+
+			var az struct {
+				Name            string
+				EnvironmentName string
+			}
+
+			require.NoError(t, json.Unmarshal(data.Segments["az"], &az))
+			assert.Equal(t, "posh-subscription", az.Name)
+			assert.Equal(t, "AzureCloud", az.EnvironmentName)
+		})
+	}
+}
+
+func TestEnvFlagsPresence(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "data.json")
+	contents := `{ "env": { "Code": 0 } }`
+	require.NoError(t, os.WriteFile(path, []byte(contents), 0644))
+
+	data, err := LoadData(path)
+	require.NoError(t, err)
+
+	envFlags, err := data.EnvFlags()
+	require.NoError(t, err)
+
+	require.NotNil(t, envFlags.Code)
+	assert.Equal(t, 0, *envFlags.Code)
+
+	assert.Nil(t, envFlags.PWD)
+	assert.Nil(t, envFlags.ExecutionTime)
+	assert.Nil(t, envFlags.PipeStatus)
+}
+
+func TestEnvFlagsAbsent(t *testing.T) {
+	data := &Data{}
+
+	envFlags, err := data.EnvFlags()
+	require.NoError(t, err)
+
+	assert.Nil(t, envFlags.PWD)
+	assert.Nil(t, envFlags.Code)
+	assert.Nil(t, envFlags.ExecutionTime)
+	assert.Nil(t, envFlags.PipeStatus)
+}
+
+func TestLoadDataUnsupportedExtension(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "data.txt")
+	require.NoError(t, os.WriteFile(path, []byte("irrelevant"), 0644))
+
+	data, err := LoadData(path)
+	require.Error(t, err)
+	assert.Nil(t, data)
+}
+
+func TestLoadDataMissingFile(t *testing.T) {
+	data, err := LoadData(filepath.Join(t.TempDir(), "does-not-exist.json"))
+	require.Error(t, err)
+	assert.Nil(t, data)
+}
+
+func TestLoadDataInvalidContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "data.json")
+	require.NoError(t, os.WriteFile(path, []byte("not valid json"), 0644))
+
+	data, err := LoadData(path)
+	require.Error(t, err)
+	assert.Nil(t, data)
+}

--- a/src/config/segment.go
+++ b/src/config/segment.go
@@ -181,6 +181,10 @@ func (segment *Segment) Execute(env runtime.Environment) {
 		return
 	}
 
+	if segment.restoreData() {
+		return
+	}
+
 	cacheRestored := segment.restoreCache()
 	if cacheRestored && !env.Flags().Streaming {
 		return
@@ -325,6 +329,21 @@ func (segment *Segment) hasCache() bool {
 	return segment.Cache != nil && !segment.Cache.Duration.IsEmpty()
 }
 
+// DataKey returns the identity used to look up segment data: the segment's
+// alias if set, falling back to its type.
+func (segment *Segment) DataKey() string {
+	if segment.Alias != "" {
+		return segment.Alias
+	}
+
+	return string(segment.Type)
+}
+
+// Writer returns the segment's underlying SegmentWriter.
+func (segment *Segment) Writer() SegmentWriter {
+	return segment.writer
+}
+
 func (segment *Segment) isToggled() bool {
 	togglesMap, OK := cache.Get[map[string]bool](cache.Session, cache.TOGGLECACHE)
 	if !OK || len(togglesMap) == 0 {
@@ -332,12 +351,7 @@ func (segment *Segment) isToggled() bool {
 		return false
 	}
 
-	segmentName := segment.Alias
-	if segmentName == "" {
-		segmentName = string(segment.Type)
-	}
-
-	if togglesMap[segmentName] {
+	if togglesMap[segment.DataKey()] {
 		log.Debugf("segment toggled off: %s", segment.Name())
 		return true
 	}
@@ -368,6 +382,31 @@ func (segment *Segment) restoreCache() bool {
 	log.Debug("restored segment from cache: ", segment.Name())
 
 	segment.restored = true
+
+	return true
+}
+
+// restoreData replays a segment's writer state from the data file supplied via
+// runtime.Flags.SegmentData, bypassing the real runtime entirely. This lets
+// segments render from a recorded fixture instead of probing the environment.
+func (segment *Segment) restoreData() bool {
+	data, OK := segment.env.Flags().SegmentData[segment.DataKey()]
+	if !OK {
+		return false
+	}
+
+	err := json.Unmarshal(data, &segment.writer)
+	if err != nil {
+		log.Error(err)
+		return false
+	}
+
+	segment.Enabled = true
+	segment.restored = true
+
+	template.Cache.AddSegmentData(segment.Name(), segment.writer)
+
+	log.Debug("restored segment from data: ", segment.Name())
 
 	return true
 }

--- a/src/config/segment_test.go
+++ b/src/config/segment_test.go
@@ -4,13 +4,17 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/jandedobbeleer/oh-my-posh/src/cache"
 	"github.com/jandedobbeleer/oh-my-posh/src/color"
+	"github.com/jandedobbeleer/oh-my-posh/src/maps"
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
 	"github.com/jandedobbeleer/oh-my-posh/src/segments"
+	"github.com/jandedobbeleer/oh-my-posh/src/template"
 
 	toml "github.com/pelletier/go-toml/v2"
 	"github.com/stretchr/testify/assert"
+	testifymock "github.com/stretchr/testify/mock"
 	"go.yaml.in/yaml/v3"
 )
 
@@ -344,4 +348,115 @@ func TestSegment_NoCachingWhenPending(t *testing.T) {
 	segment.setCache() // Should attempt to cache (may fail but shouldn't panic)
 
 	assert.False(t, segment.Pending, "Segment should not be pending")
+}
+
+func TestSegment_DataKey(t *testing.T) {
+	aliased := &Segment{Type: SESSION, Alias: "work"}
+	assert.Equal(t, "work", aliased.DataKey())
+
+	unaliased := &Segment{Type: SESSION}
+	assert.Equal(t, "session", unaliased.DataKey())
+}
+
+// newDataReplayEnv builds a mock environment suitable for driving Segment.Execute
+// through the shouldIncludeFolder/isToggled checks that precede data replay, and
+// initializes template.Cache/template.Init so AddSegmentData doesn't panic.
+func newDataReplayEnv(flags *runtime.Flags) *mock.Environment {
+	env := new(mock.Environment)
+	env.On("Shell").Return("pwsh")
+	env.On("Pwd").Return("/test")
+	env.On("Home").Return("/home")
+	env.On("DirMatchesOneOf", testifymock.Anything, testifymock.Anything).Return(false)
+	env.On("Flags").Return(flags)
+
+	template.Cache = &cache.Template{
+		Segments: maps.NewConcurrent[any](),
+	}
+	template.Init(env, nil, nil)
+
+	return env
+}
+
+func TestSegment_RestoreDataPopulatesWriterAndForcesEnabled(t *testing.T) {
+	flags := &runtime.Flags{
+		SegmentData: map[string]json.RawMessage{
+			"session": json.RawMessage(`{"SSHSession":true}`),
+		},
+	}
+	env := newDataReplayEnv(flags)
+
+	segment := &Segment{Type: SESSION}
+	segment.Execute(env)
+
+	assert.True(t, segment.Enabled, "segment should be forced enabled by data replay")
+	assert.True(t, segment.restored, "restored flag should prevent setCache pollution")
+
+	writer, ok := segment.Writer().(*segments.Session)
+	assert.True(t, ok, "Writer() should expose the concrete writer")
+	assert.True(t, writer.SSHSession)
+
+	segment.Template = "{{ .SSHSession }}"
+	assert.Equal(t, "true", segment.string())
+}
+
+func TestSegment_RestoreDataAliasBeatsType(t *testing.T) {
+	// Only the type-keyed entry exists; the segment has an alias, so DataKey()
+	// resolves to "work" and must NOT match the "text" (type) entry.
+	flags := &runtime.Flags{
+		SegmentData: map[string]json.RawMessage{
+			"text": json.RawMessage(`{}`),
+		},
+	}
+	env := newDataReplayEnv(flags)
+
+	segment := &Segment{Type: TEXT, Alias: "work"}
+	segment.Execute(env)
+
+	assert.False(t, segment.restored, "type-keyed data must not be used for an aliased segment")
+}
+
+func TestSegment_RestoreDataNoEntryFallsThroughToNormalExecution(t *testing.T) {
+	env := newDataReplayEnv(&runtime.Flags{})
+
+	segment := &Segment{Type: TEXT}
+	segment.Execute(env)
+
+	assert.True(t, segment.Enabled, "text segment is always enabled on normal execution")
+	assert.False(t, segment.restored, "no data entry means no replay happened")
+}
+
+func TestSegment_RestoreDataInvalidJSONFallsThrough(t *testing.T) {
+	flags := &runtime.Flags{
+		SegmentData: map[string]json.RawMessage{
+			"text": json.RawMessage(`{invalid`),
+		},
+	}
+	env := newDataReplayEnv(flags)
+
+	segment := &Segment{Type: TEXT}
+
+	assert.NotPanics(t, func() {
+		segment.Execute(env)
+	})
+
+	assert.True(t, segment.Enabled, "should fall through to normal execution")
+	assert.False(t, segment.restored, "a failed replay must not mark the segment as restored")
+}
+
+func TestSegment_RestoreDataToggledOffStaysDisabled(t *testing.T) {
+	cache.Set(cache.Session, cache.TOGGLECACHE, map[string]bool{"text": true}, cache.INFINITE)
+	defer cache.Delete(cache.Session, cache.TOGGLECACHE)
+
+	flags := &runtime.Flags{
+		SegmentData: map[string]json.RawMessage{
+			"text": json.RawMessage(`{}`),
+		},
+	}
+	env := newDataReplayEnv(flags)
+
+	segment := &Segment{Type: TEXT}
+	segment.Execute(env)
+
+	assert.False(t, segment.Enabled, "toggled-off segment must stay disabled even with data available")
+	assert.False(t, segment.restored, "toggle check happens before data replay")
 }

--- a/src/runtime/environment.go
+++ b/src/runtime/environment.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"encoding/json"
 	"io"
 	"io/fs"
 
@@ -82,6 +83,7 @@ type Environment interface {
 }
 
 type Flags struct {
+	SegmentData   map[string]json.RawMessage
 	Type          string
 	PipeStatus    string
 	ConfigPath    string
@@ -90,18 +92,19 @@ type Flags struct {
 	ShellVersion  string
 	PWD           string
 	AbsolutePWD   string
-	ErrorCode     int
+	EnvData       json.RawMessage
+	ExecutionTime float64
 	PromptCount   int
 	Column        int
 	TerminalWidth int
-	ExecutionTime float64
+	ErrorCode     int
 	StackCount    int
 	ConfigHash    uint64
 	JobCount      int
-	HasExtra      bool
+	Cleared       bool
 	Strict        bool
 	Debug         bool
-	Cleared       bool
+	HasExtra      bool
 	NoExitCode    bool
 	Init          bool
 	Migrate       bool

--- a/src/template/cache.go
+++ b/src/template/cache.go
@@ -1,6 +1,7 @@
 package template
 
 import (
+	"encoding/json"
 	"strconv"
 	"strings"
 	"time"
@@ -15,6 +16,14 @@ import (
 
 var (
 	Cache *cache.Template
+
+	// routedEnvDataKeys are env-section keys the CLI layer already routes into
+	// runtime.Flags before Init runs (see runtime.Flags.EnvData), so by the
+	// time loadCache runs, env.Pwd()/StatusCodes()/ExecutionTime() already
+	// reflect the flag-precedence-resolved value (CLI flag > data file >
+	// live). They must never be applied a second time here, or a raw file
+	// value could clobber that resolved value.
+	routedEnvDataKeys = []string{"PWD", "Code", "ExecutionTime", "PipeStatus"}
 )
 
 func loadCache(vars maps.Simple[any], aliases *maps.Config) {
@@ -31,7 +40,7 @@ func loadCache(vars maps.Simple[any], aliases *maps.Config) {
 	tmpl := new(cache.Template)
 
 	tmpl.Root = env.Root()
-	tmpl.Shell = aliases.GetShellName(env.Shell())
+	tmpl.Shell = env.Shell()
 	tmpl.ShellVersion = env.Flags().ShellVersion
 	tmpl.Code, _ = env.StatusCodes()
 	tmpl.WSL = env.IsWsl()
@@ -61,9 +70,9 @@ func loadCache(vars maps.Simple[any], aliases *maps.Config) {
 		tmpl.Folder += `\`
 	}
 
-	tmpl.UserName = aliases.GetUserName(env.User())
+	tmpl.UserName = env.User()
 	if host, err := env.Host(); err == nil {
-		tmpl.HostName = aliases.GetHostName(host)
+		tmpl.HostName = host
 	}
 
 	goos := env.GOOS()
@@ -77,7 +86,55 @@ func loadCache(vars maps.Simple[any], aliases *maps.Config) {
 		tmpl.SHLVL = shlvl
 	}
 
+	overlayEnvData(tmpl)
+
+	// Alias mapping must apply to a data-provided value exactly as it does to
+	// a live one, so it runs after the overlay, on whichever value won.
+	tmpl.Shell = aliases.GetShellName(tmpl.Shell)
+	tmpl.UserName = aliases.GetUserName(tmpl.UserName)
+	tmpl.HostName = aliases.GetHostName(tmpl.HostName)
+
 	Cache = tmpl
+}
+
+// overlayEnvData merges the data file's env section onto an already-built
+// template cache. It only touches keys present in the data, so anything not
+// specified keeps its live value. Keys the CLI layer already routed into
+// runtime.Flags (see routedEnvDataKeys) are stripped first so a raw file
+// value can never clobber the flag-precedence-resolved value. Failures are
+// logged, never fatal - the prompt renders with live values regardless.
+func overlayEnvData(tmpl *cache.Template) {
+	data := env.Flags().EnvData
+	if len(data) == 0 {
+		return
+	}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		log.Error(err)
+		return
+	}
+
+	for _, key := range routedEnvDataKeys {
+		delete(fields, key)
+	}
+
+	// SegmentsCache/Segments are internal cache plumbing, not user-facing
+	// template data; a data file must never be able to overwrite them. Var
+	// (template vars) is left alone - overriding it from the data file is
+	// intentional and useful.
+	delete(fields, "SegmentsCache")
+	delete(fields, "Segments")
+
+	overlay, err := json.Marshal(fields)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	if err := json.Unmarshal(overlay, &tmpl.SimpleTemplate); err != nil {
+		log.Error(err)
+	}
 }
 
 func restoreCache() bool {

--- a/src/template/cache_test.go
+++ b/src/template/cache_test.go
@@ -1,0 +1,131 @@
+package template
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/maps"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// newLoadCacheMockEnv builds a mock environment stubbed with sane live values
+// for every call loadCache makes, so each test only needs to layer on top of
+// it (EnvData, aliases, ...) rather than reconstructing the whole surface.
+func newLoadCacheMockEnv(flags *runtime.Flags) *mock.Environment {
+	flags.IsPrimary = true
+
+	env := new(mock.Environment)
+	env.On("Flags").Return(flags)
+	env.On("Root").Return(false)
+	env.On("Shell").Return("pwsh")
+	env.On("StatusCodes").Return(0, "")
+	env.On("IsWsl").Return(false)
+	env.On("Pwd").Return("/tmp/omp-test/project")
+	env.On("User").Return("jan")
+	env.On("Host").Return("live-host", nil)
+	env.On("GOOS").Return(runtime.DARWIN)
+	env.On("Platform").Return("darwin")
+	env.On("Getenv", "SHLVL").Return("1")
+
+	return env
+}
+
+func TestLoadCacheEnvDataOverlay(t *testing.T) {
+	flags := &runtime.Flags{
+		EnvData: json.RawMessage(`{"UserName":"data-user","HostName":"data-host","Shell":"zsh","Root":true}`),
+	}
+
+	env = newLoadCacheMockEnv(flags)
+
+	loadCache(nil, &maps.Config{})
+
+	assert.Equal(t, "data-user", Cache.UserName)
+	assert.Equal(t, "data-host", Cache.HostName)
+	assert.Equal(t, "zsh", Cache.Shell)
+	assert.True(t, Cache.Root)
+
+	// Untouched fields keep their live values.
+	assert.False(t, Cache.WSL)
+	assert.Equal(t, 1, Cache.SHLVL)
+	assert.Equal(t, 0, Cache.Code)
+}
+
+func TestLoadCacheEnvDataIgnoresRoutedKeys(t *testing.T) {
+	flags := &runtime.Flags{
+		EnvData: json.RawMessage(`{"PWD":"/bogus/path","Code":99,"ExecutionTime":42.5,"PipeStatus":"1 0"}`),
+	}
+
+	env = newLoadCacheMockEnv(flags)
+
+	loadCache(nil, &maps.Config{})
+
+	// The routed keys must be ignored by the overlay: PWD/Code keep the
+	// value already resolved by the CLI layer (here, the live mock values),
+	// never the raw file value.
+	assert.Equal(t, "/tmp/omp-test/project", Cache.PWD)
+	assert.Equal(t, 0, Cache.Code)
+}
+
+func TestLoadCacheEnvDataAliasAppliesToOverlaidValue(t *testing.T) {
+	flags := &runtime.Flags{
+		EnvData: json.RawMessage(`{"UserName":"data-user"}`),
+	}
+
+	env = newLoadCacheMockEnv(flags)
+
+	aliases := &maps.Config{
+		UserName: &maps.Map{"data-user": "aliased-user"},
+	}
+
+	loadCache(nil, aliases)
+
+	assert.Equal(t, "aliased-user", Cache.UserName)
+}
+
+func TestLoadCacheEnvDataFolderOverride(t *testing.T) {
+	flags := &runtime.Flags{
+		EnvData: json.RawMessage(`{"Folder":"custom-folder"}`),
+	}
+
+	env = newLoadCacheMockEnv(flags)
+
+	loadCache(nil, &maps.Config{})
+
+	// Derived from pwd it would be "project"; the explicit override wins.
+	assert.Equal(t, "custom-folder", Cache.Folder)
+}
+
+func TestLoadCacheNoEnvData(t *testing.T) {
+	flags := &runtime.Flags{}
+
+	env = newLoadCacheMockEnv(flags)
+
+	loadCache(nil, &maps.Config{})
+
+	assert.Equal(t, "jan", Cache.UserName)
+	assert.Equal(t, "live-host", Cache.HostName)
+	assert.Equal(t, "pwsh", Cache.Shell)
+	assert.False(t, Cache.Root)
+	assert.Equal(t, "project", Cache.Folder)
+	assert.Equal(t, "/tmp/omp-test/project", Cache.PWD)
+}
+
+func TestLoadCacheInvalidEnvData(t *testing.T) {
+	flags := &runtime.Flags{
+		EnvData: json.RawMessage(`{invalid`),
+	}
+
+	env = newLoadCacheMockEnv(flags)
+
+	assert.NotPanics(t, func() {
+		loadCache(nil, &maps.Config{})
+	})
+
+	// The prompt still renders with the live values.
+	assert.Equal(t, "jan", Cache.UserName)
+	assert.Equal(t, "live-host", Cache.HostName)
+	assert.Equal(t, "pwsh", Cache.Shell)
+}

--- a/themes/chips.omp.json
+++ b/themes/chips.omp.json
@@ -84,7 +84,7 @@
             "http_timeout": 2000
           },
           "style": "diamond",
-          "template": "{{ if and (.Env.WAKATIME_API_KEY) (eq \"False\" (title (default \"False\" .Env.DISABLE_SEGMENT_WAKATIME))) (gt .CumulativeTotal.Seconds 0) }}\uFA19 {{ secondsRound .CumulativeTotal.Seconds }}.{{ end }}",
+          "template": "{{ if and (eq \"False\" (title (default \"False\" .Env.DISABLE_SEGMENT_WAKATIME))) (gt .CumulativeTotal.Seconds 0) }}\uFA19 {{ secondsRound .CumulativeTotal.Seconds }}.{{ end }}",
           "trailing_diamond": "\uE0B4 ",
           "type": "wakatime",
           "cache": {

--- a/themes/cloud-context.omp.json
+++ b/themes/cloud-context.omp.json
@@ -68,6 +68,7 @@
           "type": "az"
         },
         {
+          "alias": "azpwsh",
           "background": "p:background-color",
           "foreground": "p:cloud-text-azure",
           "options": {

--- a/themes/devious-diamonds.omp.yaml
+++ b/themes/devious-diamonds.omp.yaml
@@ -116,7 +116,7 @@ blocks:
         powerline_symbol: 
         background: lightCyan
         foreground: black
-        template: "  {{ if .PackageManagerIcon }}{{ .PackageManagerIcon }} {{ end }}{{ .Full }} "
+        template: "  {{ .Full }} "
       - type: project
         style: powerline
         powerline_symbol: 

--- a/themes/pixelrobots.omp.json
+++ b/themes/pixelrobots.omp.json
@@ -30,6 +30,7 @@
           "type": "az"
         },
         {
+          "alias": "azpwsh",
           "background": "#012456",
           "foreground": "#FFFFFF",
           "powerline_symbol": "\ue0b0",

--- a/themes/tokyo.omp.json
+++ b/themes/tokyo.omp.json
@@ -81,7 +81,7 @@
         {
           "foreground": "#7eb8da",
           "style": "diamond",
-          "template": "[{{ if .Error }}{{ .Error }}{{ else }}<#ffffff>\uf1a0</> <#ffff00>{{ .Project }}</> :: <#ffff00>{{.Account}}</>{{ end }}]",
+          "template": "[<#ffffff>\uf1a0</> <#ffff00>{{ .Project }}</> :: <#ffff00>{{.Account}}</>]",
           "type": "gcp"
         },
         {

--- a/website/docs/configuration/data.mdx
+++ b/website/docs/configuration/data.mdx
@@ -1,0 +1,171 @@
+---
+id: data
+title: Template data
+sidebar_label: Template data
+---
+
+import Config from "@site/src/components/Config.js";
+
+The `--data` flag supplies template properties from a file instead of the live environment. Use it to render
+a prompt deterministically, without the git repository, Azure CLI, kubectl, or any other tooling a segment
+normally detects: take prompt screenshots, build demos, or test a config on a machine that lacks your usual
+setup.
+
+`--data` is available on `oh-my-posh print` (every prompt type) and `oh-my-posh config export image`.
+
+## File format
+
+A data file has two top-level sections: `env` for global template properties and `segments` for
+per-segment template properties. The format is JSON, YAML, or TOML, decided by the file extension.
+
+<Config
+  data={{
+    env: {
+      PWD: "~/dev/oh-my-posh",
+      Code: 1,
+      ExecutionTime: 341.0,
+      UserName: "jan",
+      HostName: "demo",
+      Shell: "pwsh",
+      Root: false,
+    },
+    segments: {
+      git: {
+        HEAD: "main",
+        Working: { Added: 2, Modified: 1 },
+        Staging: {},
+        UpstreamIcon: "",
+      },
+      az: {
+        Name: "posh-subscription",
+        EnvironmentName: "AzureCloud",
+        Origin: "CLI",
+      },
+    },
+  }}
+/>
+
+## The `env` section
+
+Keys are the [global template properties][templates] you already use in templates (`PWD`, `AbsolutePWD`,
+`PSWD`, `Folder`, `UserName`, `HostName`, `Shell`, `ShellVersion`, `Root`, `OS`, `WSL`, `SHLVL`, `Jobs`,
+`Code`, `PromptCount`, `Version`, and `Var`), plus `ExecutionTime` and `PipeStatus`.
+
+A key present in the file overrides the live value. A key left out falls back to the real environment, so
+specify only the properties your config depends on.
+
+`Folder` derives from the effective `PWD` automatically. Set an explicit `Folder` key to override it.
+
+The [`maps`][maps] aliases (`user_name`, `host_name`, `shell_name`) apply to data values as they do to live
+ones.
+
+### Precedence
+
+`PWD`, `Code`, `ExecutionTime`, and `PipeStatus` feed the runtime itself, not just the template context. Live
+segments that compute from them, such as [path][path], [status][status], and [executiontime][executiontime],
+also see the overridden values.
+
+Values are resolved in this order, highest priority first:
+
+1. An explicit CLI flag on `print` (`--pwd`, `--status`, `--execution-time`, ...)
+2. The data file
+3. The live environment
+
+## The `segments` section
+
+Each key is a segment's `alias` if it has one, otherwise its `type` (for example `git` or `az`). The value is
+an object whose keys are that segment's template properties, as documented on the segment's page.
+
+A segment listed here is force-enabled and rendered purely from the supplied data; its runtime detection is
+skipped entirely. A segment left out of the file executes normally against the live environment.
+
+:::caution
+If your config has two segments of the same type, give each an `alias`. Without one, both segments match the
+same `type` key in the `segments` section and can't receive distinct data.
+:::
+
+For example, this config has two `path` segments distinguished by `alias`:
+
+<Config
+  data={{
+    segments: [
+      {
+        type: "path",
+        alias: "PathMain",
+        style: "plain",
+        foreground: "#ffffff",
+      },
+      {
+        type: "path",
+        alias: "PathSecondary",
+        style: "plain",
+        foreground: "#ffffff",
+      },
+    ],
+  }}
+/>
+
+The matching data file targets each segment by its alias:
+
+<Config
+  data={{
+    segments: {
+      PathMain: { Path: "~/dev/oh-my-posh" },
+      PathSecondary: { Path: "~/dev/site" },
+    },
+  }}
+/>
+
+## Template and method fidelity
+
+Templates evaluate over the data you supply, so template methods and functions work as expected.
+`.Working.String` on the [git][git] segment, for example, computes from the `Working` property in the file,
+just as it would from a live repository. Only logic that reads live runtime state at render time can't be
+reproduced this way. This matches how a [cached][cache] segment behaves: it also renders from stored
+properties instead of re-detecting them.
+
+## Recording data
+
+`oh-my-posh config export data` renders your prompt against the real environment and writes a complete data
+file: the `env` section plus every enabled segment. The recorder omits `Var`: the config's own `var` section
+already defines those values, though you can still set `Var` in the file by hand to override them.
+
+```bash
+oh-my-posh config export data --config mytheme.omp.json --output data.json
+```
+
+| Flag       | Description                                    |
+| ---------- | ---------------------------------------------- |
+| `--config` | the configuration to render                    |
+| `--output` | file to write the data to, defaults to stdout  |
+
+The output format is JSON.
+
+This gives you a record-once, replay-forever workflow. Run the command on a machine where everything (git,
+cloud CLIs, language runtimes) is set up the way you want it to look. Then tweak values by hand and replay the
+result anywhere with `--data`, without needing that setup again.
+
+## End-to-end example
+
+Record a data file from a fully configured machine:
+
+```bash
+oh-my-posh config export data --config mytheme.omp.json --output data.json
+```
+
+Edit `data.json` to adjust the values you want to show: the branch name, the exit code, the Azure
+subscription, and so on.
+
+Render an image from the edited data, without touching git, Azure CLI, or anything else the config depends on:
+
+```bash
+oh-my-posh config export image --config mytheme.omp.json --data data.json
+```
+
+[templates]: /docs/configuration/templates#global-properties
+[maps]: /docs/configuration/general#maps
+[path]: /docs/segments/system/path
+[status]: /docs/segments/system/status
+[executiontime]: /docs/segments/system/executiontime
+[git]: /docs/segments/scm/git
+[cache]: /docs/configuration/segment#cache

--- a/website/docs/configuration/data.mdx
+++ b/website/docs/configuration/data.mdx
@@ -76,6 +76,11 @@ Values are resolved in this order, highest priority first:
 Each key is a segment's `alias` if it has one, otherwise its `type` (for example `git` or `az`). The value is
 an object whose keys are that segment's template properties, as documented on the segment's page.
 
+A few segments store a property under a different name than the template exposes. The [wakatime] segment, for
+example, stores `.CumulativeTotal` as `cumulative_total`. When a property you wrote by hand has no effect, run
+[`config export data`](#recording-data) and copy the names from its output: the recorder always uses the
+stored names.
+
 A segment listed here is force-enabled and rendered purely from the supplied data; its runtime detection is
 skipped entirely. A segment left out of the file executes normally against the live environment.
 
@@ -169,3 +174,4 @@ oh-my-posh config export image --config mytheme.omp.json --data data.json
 [executiontime]: /docs/segments/system/executiontime
 [git]: /docs/segments/scm/git
 [cache]: /docs/configuration/segment#cache
+[wakatime]: /docs/segments/web/wakatime

--- a/website/docs/installation/prompt.mdx
+++ b/website/docs/installation/prompt.mdx
@@ -119,17 +119,8 @@ There's no out-of-the-box support for Windows CMD when it comes to custom prompt
 There is however a way to do it using [Clink][clink], which at the same time supercharges
 your cmd experience. Follow the installation instructions and make sure you select autostart.
 
-Integrating Oh My Posh with Clink is easy: create a new file called oh-my-posh.lua in your Clink
-scripts directory (run `clink info` inside cmd to find that file's location).
-
-```lua title="oh-my-posh.lua"
-load(io.popen('oh-my-posh init cmd'):read("*a"))()
-```
-
-Once added, restart cmd for the changes to take effect.
-
-:::info
-Clink has builtin support for Oh My Posh. It allows you to set the prompt using the `clink` command.
+Since Clink v1.7.0, Clink has builtin support for Oh My Posh. This is the recommended way to
+integrate the two, as it lets Clink manage the prompt for you:
 
 ```bash
 clink config prompt use oh-my-posh
@@ -141,6 +132,16 @@ To set the configuration file, use the following command:
 clink set ohmyposh.theme <path>
 ```
 
+:::info
+If you're on an older version of Clink without builtin support, you can integrate Oh My Posh
+manually: create a new file called oh-my-posh.lua in your Clink scripts directory (run
+`clink info` inside cmd to find that file's location).
+
+```lua title="oh-my-posh.lua"
+load(io.popen('oh-my-posh init cmd'):read("*a"))()
+```
+
+Once added, restart cmd for the changes to take effect.
 :::
 
 </TabItem>

--- a/website/docs/share-theme.md
+++ b/website/docs/share-theme.md
@@ -67,4 +67,15 @@ oh-my-posh config export image --settings ~/.image.settings.json
 
 This will export your prompt image using the custom colors and settings from the file.
 
+## Rendering From Recorded Data
+
+The `--data` flag renders the image from a recorded data file instead of the live environment, so the export
+needs no configured git repository, cloud CLI, or other tooling. See [Template data][data] for the file
+format and how to record one.
+
+```powershell
+oh-my-posh config export image --config mytheme.omp.json --data data.json
+```
+
 [colors]: /docs/configuration/colors#standard-colors
+[data]: /docs/configuration/data

--- a/website/export_themes.mjs
+++ b/website/export_themes.mjs
@@ -1,5 +1,6 @@
 import { exec } from 'node:child_process';
 import { promises } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
@@ -19,6 +20,19 @@ const CONFIG = {
   SEGMENT_DATA_FILE: join(__dirname, 'segment_data.json'),
   GITHUB_BASE_URL: 'https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/themes'
 };
+
+/**
+ * Sources used to fetch a trending track for segment previews, in fallback order
+ */
+const TRENDING_FETCH_TIMEOUT_MS = 4000;
+
+/**
+ * Small, tasteful deny-list used as a safety net behind each source's own
+ * explicit-content flag. Matched word-boundary aware so substrings inside
+ * unrelated words (e.g. "sex" in "Essex") don't trigger a false positive.
+ */
+const CONTENT_DENY_LIST = ['fuck', 'shit', 'bitch', 'nigga', 'cunt', 'motherfucker'];
+const CONTENT_DENY_REGEX = new RegExp(`\\b(${CONTENT_DENY_LIST.join('|')})\\b`, 'i');
 
 /**
  * Theme configuration overrides for specific themes
@@ -69,6 +83,138 @@ function getThemeNameFromFile(fileName) {
   const lastDotIndex = fileName.lastIndexOf('.');
   const secondLastDotIndex = fileName.lastIndexOf('.', lastDotIndex - 1);
   return fileName.slice(0, secondLastDotIndex);
+}
+
+/**
+ * Fetches JSON from a URL, aborting if it takes longer than the configured timeout
+ * @param {string} url - URL to fetch
+ * @returns {Promise<Object>} Parsed JSON response body
+ */
+async function fetchJsonWithTimeout(url) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TRENDING_FETCH_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+
+    if (!response.ok) {
+      throw new Error(`request failed with status ${response.status}`);
+    }
+
+    return await response.json();
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Checks whether a track/artist combination is safe to feature in previews.
+ * This is a plain-text safety net behind each source's own explicit flag, so it
+ * intentionally stays short rather than trying to be a comprehensive filter.
+ * @param {string} title - Track title
+ * @param {string} artist - Artist name
+ * @returns {boolean} True if the track passes the deny-list check
+ */
+function isClean(title, artist) {
+  return !CONTENT_DENY_REGEX.test(`${title} ${artist}`);
+}
+
+/**
+ * Fetches the current #1 non-explicit track from the Deezer top chart
+ * @returns {Promise<{artist: string, track: string}>} Trending track
+ */
+async function trendingFromDeezer() {
+  const body = await fetchJsonWithTimeout('https://api.deezer.com/chart/0/tracks?limit=25');
+  const tracks = body?.data;
+
+  if (!Array.isArray(tracks) || tracks.length === 0) {
+    throw new Error('no tracks returned');
+  }
+
+  const track = tracks.find((entry) => !entry.explicit_lyrics && isClean(entry.title, entry.artist?.name));
+
+  if (!track) {
+    throw new Error('no clean track found in chart');
+  }
+
+  return { artist: track.artist.name, track: track.title };
+}
+
+/**
+ * Fetches the current #1 non-explicit track from the Apple Music most-played RSS feed
+ * @returns {Promise<{artist: string, track: string}>} Trending track
+ */
+async function trendingFromAppleRSS() {
+  const body = await fetchJsonWithTimeout('https://rss.marketingtools.apple.com/api/v2/us/music/most-played/25/songs.json');
+  const tracks = body?.feed?.results;
+
+  if (!Array.isArray(tracks) || tracks.length === 0) {
+    throw new Error('no tracks returned');
+  }
+
+  // Apple only includes contentAdvisoryRating when a track is explicit, so presence of the key
+  // (not its value) is the signal to filter on. The value is the literal string "Explict" (sic),
+  // Apple's own misspelling, verified against the live feed - do not "correct" it here.
+  const track = tracks.find((entry) => !('contentAdvisoryRating' in entry) && isClean(entry.name, entry.artistName));
+
+  if (!track) {
+    throw new Error('no clean track found in feed');
+  }
+
+  return { artist: track.artistName, track: track.name };
+}
+
+/**
+ * Builds the segment data file used for theme preview rendering. Fetches a trending
+ * track (Deezer, then Apple Music RSS as a fallback) and injects it into the spotify
+ * and ytm segment payloads of a temporary copy of the committed data file. The
+ * committed file is never modified; on any failure the committed file is used as-is.
+ * @returns {Promise<string>} Path to the data file to pass to --data
+ */
+async function buildDataFileWithTrending() {
+  let trending;
+
+  try {
+    trending = await trendingFromDeezer();
+  } catch (error) {
+    console.warn(`Trending track lookup via Deezer failed: ${error.message}`);
+
+    try {
+      trending = await trendingFromAppleRSS();
+    } catch (fallbackError) {
+      console.warn(`Trending track lookup via Apple Music RSS failed: ${fallbackError.message}`);
+    }
+  }
+
+  if (!trending) {
+    return CONFIG.SEGMENT_DATA_FILE;
+  }
+
+  try {
+    const raw = await promises.readFile(CONFIG.SEGMENT_DATA_FILE, 'utf8');
+    const data = JSON.parse(raw);
+
+    for (const key of ['spotify', 'ytm']) {
+      const segment = data.segments?.[key];
+
+      if (!segment) {
+        continue;
+      }
+
+      segment.Artist = trending.artist;
+      segment.Track = trending.track;
+    }
+
+    const tempPath = join(tmpdir(), `segment_data.${process.pid}.${Date.now()}.json`);
+    await promises.writeFile(tempPath, JSON.stringify(data, null, 2));
+
+    console.log(`Using trending track "${trending.track}" by ${trending.artist} for previews`);
+
+    return tempPath;
+  } catch (error) {
+    console.warn(`Unable to build data file with trending track: ${error.message}`);
+    return CONFIG.SEGMENT_DATA_FILE;
+  }
 }
 
 /**
@@ -200,6 +346,8 @@ async function main() {
 
     await ensureDirectories();
 
+    CONFIG.SEGMENT_DATA_FILE = await buildDataFileWithTrending();
+
     const themes = await promises.readdir(CONFIG.THEMES_CONFIG_DIR);
     const validThemes = themes.filter(isValidTheme);
 
@@ -254,4 +402,9 @@ export {
   generateThemeMarkdown,
   asyncPool,
   main,
+  fetchJsonWithTimeout,
+  trendingFromDeezer,
+  trendingFromAppleRSS,
+  isClean,
+  buildDataFileWithTrending,
 };

--- a/website/export_themes.mjs
+++ b/website/export_themes.mjs
@@ -16,6 +16,7 @@ const CONFIG = {
   CONCURRENCY: 8,
   DEFAULT_BG_COLOR: '#151515',
   THEME_EXTENSIONS: ['.omp.json', '.omp.toml', '.omp.yaml'],
+  SEGMENT_DATA_FILE: join(__dirname, 'segment_data.json'),
   GITHUB_BASE_URL: 'https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/themes'
 };
 
@@ -83,6 +84,7 @@ function buildPoshCommand(configPath, outputImage, config) {
     `--config=${configPath}`,
     `--output=${outputImage}`,
     `--background-color=${config.bgColor}`,
+    `--data=${CONFIG.SEGMENT_DATA_FILE}`,
   ];
 
   if (config.author) {

--- a/website/segment_data.json
+++ b/website/segment_data.json
@@ -1,0 +1,171 @@
+{
+  "env": {
+    "UserName": "alice",
+    "HostName": "contoso-devbox",
+    "PWD": "~/dev/oh-my-posh"
+  },
+  "segments": {
+    "aws": {
+      "Profile": "anycompany-prod",
+      "Region": "us-east-1",
+      "AccountID": "111122223333",
+      "AccessKeyID": ""
+    },
+    "az": {
+      "Name": "Contoso Production",
+      "EnvironmentName": "AzureCloud",
+      "Origin": "CLI"
+    },
+    "azd": {
+      "DefaultEnvironment": "zava-prod",
+      "Version": 1
+    },
+    "azfunc": {
+      "Full": "4.0.6280",
+      "Major": "4",
+      "Minor": "0",
+      "Patch": "6280",
+      "Error": ""
+    },
+    "battery": {
+      "Percentage": 70,
+      "State": 3,
+      "Icon": ""
+    },
+    "cds": {
+      "Full": "8.5.0",
+      "Major": "8",
+      "Minor": "5",
+      "Patch": "0",
+      "Error": ""
+    },
+    "cf": {
+      "Full": "8.8.0",
+      "Major": "8",
+      "Minor": "8",
+      "Patch": "0",
+      "Error": ""
+    },
+    "cftarget": {
+      "URL": "https://api.cf.example.com",
+      "User": "demo@example.com",
+      "Org": "example-org",
+      "Space": "production"
+    },
+    "docker": {
+      "Context": "cymbal-cluster"
+    },
+    "firebase": {
+      "Project": "cymbal-superstore"
+    },
+    "gcp": {
+      "Project": "cymbal-bank-prod",
+      "Account": "demo@cymbal-bank-prod.iam.gserviceaccount.com",
+      "Region": "us-central1",
+      "ActiveConfig": "cymbal"
+    },
+    "git": {
+      "HEAD": "main",
+      "BranchStatus": "↑1",
+      "Ref": "main",
+      "ShortHash": "1a2b3c4",
+      "Hash": "1a2b3c4d5e6f7890abcdef1234567890abcdef12",
+      "Ahead": 1,
+      "Behind": 0,
+      "Upstream": "origin/main",
+      "UpstreamIcon": "",
+      "UpstreamURL": "https://github.com/JanDeDobbeleer/oh-my-posh",
+      "UpstreamGone": false,
+      "RepoName": "oh-my-posh",
+      "Detached": false,
+      "Working": {
+        "Added": 2,
+        "Modified": 1
+      },
+      "Staging": {
+        "Added": 1
+      }
+    },
+    "kubectl": {
+      "Context": "kind-cymbal",
+      "Cluster": "kind-cymbal",
+      "User": "kind-cymbal"
+    },
+    "node": {
+      "Full": "24.12.0",
+      "Major": "24",
+      "Minor": "12",
+      "Patch": "0",
+      "PackageManagerIcon": "",
+      "PackageManagerName": "",
+      "Error": ""
+    },
+    "npm": {
+      "Full": "11.6.0",
+      "Major": "11",
+      "Minor": "6",
+      "Patch": "0",
+      "Error": ""
+    },
+    "project": {
+      "Type": "node",
+      "Version": "1.4.2",
+      "Name": "oh-my-posh",
+      "Target": "",
+      "Error": ""
+    },
+    "python": {
+      "Full": "3.12.4",
+      "Major": "3",
+      "Minor": "12",
+      "Patch": "4",
+      "Venv": ".venv",
+      "Error": ""
+    },
+    "spotify": {
+      "Status": "playing",
+      "Artist": "Tycho",
+      "Track": "Easy",
+      "Icon": " "
+    },
+    "strava": {
+      "name": "Morning Ride",
+      "type": "Ride",
+      "Ago": "2h",
+      "Icon": "",
+      "Hours": 2,
+      "Error": ""
+    },
+    "sysinfo": {
+      "Precision": 2,
+      "PhysicalTotalMemory": 34359738368,
+      "PhysicalAvailableMemory": 12884901888,
+      "PhysicalFreeMemory": 12884901888,
+      "PhysicalPercentUsed": 62.5,
+      "Load1": 0.52,
+      "Load5": 0.48,
+      "Load15": 0.42
+    },
+    "talosctl": {
+      "Context": "cymbal-cluster"
+    },
+    "terraform": {
+      "WorkspaceName": "example_corp-prod",
+      "terraform_version": "1.9.0"
+    },
+    "wakatime": {
+      "start": "2026-07-09T00:00:00Z",
+      "end": "2026-07-09T23:59:59Z",
+      "cumulative_total": {
+        "text": "4 hrs 30 mins",
+        "seconds": 16200
+      }
+    },
+    "ytm": {
+      "Status": "playing",
+      "Artist": "Men I Trust",
+      "Track": "Show Me How",
+      "Icon": " "
+    }
+  }
+}

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -35,6 +35,7 @@ export default {
         "configuration/title",
         "configuration/colors",
         "configuration/templates",
+        "configuration/data",
         "configuration/secondary-prompt",
         "configuration/debug-prompt",
         "configuration/transient",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide](https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md).
- [x] The commit message follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Adds a `--data` flag to `print` and `config export image` that renders prompts from a template data file (JSON/YAML/TOML) instead of the live environment, replacing #7644 with a general mechanism.

**The feature**
- `env` section overrides global template properties; `PWD`, `Code`, `ExecutionTime` and `PipeStatus` route into the runtime so live segments see them too. Precedence: CLI flags > data file > live environment.
- `segments` section replays segment writers (keyed by alias, fallback type) exactly like the segment cache does, skipping runtime detection. Any new template property works automatically since both sides share the same reflection round-trip.
- `config export data` records the live context and every enabled segment into a replayable file: record once, replay forever.
- New docs page: `configuration/data`.

**Website pipeline**
- Theme previews render from `website/segment_data.json` — the Kind cluster, `azure/login` and the `id-token` permission are gone from CI.
- The data file shows every configured segment using the fictional names vendors publish for example use (Contoso, Cymbal, AnyCompany, example_corp), with `alice@contoso-devbox` in `~/dev/oh-my-posh`.
- At build time the pipeline injects the current most-played track (Deezer, Apple RSS fallback, explicit-content filtered) into the music segments; any failure falls back to the committed file.

**Image export**
- The canvas is now always exactly `--terminal-width` columns wide (default 120): alignment padding collapses to keep rprompts flush, genuinely long lines wrap like a real terminal, and powerline separators are single width. All 124 theme previews render at an identical 3648px width, so the website finally displays every theme at the same text size.

**Theme fixes**
- chips: removed a redundant `.Env.WAKATIME_API_KEY` template guard.
- tokyo, devious-diamonds: removed references to non-existent properties that errored when the segments render.
- pixelrobots, cloud-context: aliased duplicate `az` segments (cache/toggle key collisions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)