### PR TITLE
fix(init): recover when the init script is held open on Windows

### DIFF
--- a/src/shell/filesystem.go
+++ b/src/shell/filesystem.go
@@ -82,30 +82,45 @@ func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
 	return os.Rename(tmp.Name(), path)
 }
 
+// writeFile writes data to path, atomically when possible.
+//
+// On Windows, replacing a file via rename requires that no process has the
+// target open: MoveFileEx(MOVEFILE_REPLACE_EXISTING) fails with
+// ERROR_ACCESS_DENIED as long as a single handle exists, even one opened
+// with full sharing. Shells source the init script on startup (and every
+// prompt in async mode), so brief holds are normal — retry those. When the
+// file is still held after the retries (a shell keeping it open), fall back
+// to an in-place write: sharing rules allow overwriting a file others are
+// reading, we only lose atomicity for this write.
+func writeFile(path string, data []byte, perm os.FileMode) error {
+	const attempts = 4
+	wait := 50 * time.Millisecond
+
+	var err error
+
+	for attempt := 1; ; attempt++ {
+		if err = writeFileAtomic(path, data, perm); !canRetryWrite(err) || attempt == attempts {
+			break
+		}
+
+		time.Sleep(wait)
+		wait *= 2
+	}
+
+	if err == nil || !canRetryWrite(err) {
+		return err
+	}
+
+	return os.WriteFile(path, data, perm)
+}
+
 func writeScript(env runtime.Environment, script string) (string, error) {
 	path, err := scriptPath(env)
 	if err != nil {
 		return "", err
 	}
 
-	data := []byte(script)
-
-	// another process can hold the script (or its target) open on Windows,
-	// making the rename fail with a sharing violation; retry with backoff
-	// until it lets go — all other errors are persistent, fail fast
-	const attempts = 8
-	wait := 50 * time.Millisecond
-
-	for attempt := 1; ; attempt++ {
-		if err = writeFileAtomic(path, data, 0o644); !canRetryWrite(err) || attempt == attempts {
-			break
-		}
-
-		time.Sleep(wait)
-		wait = min(wait*2, time.Second)
-	}
-
-	if err != nil {
+	if err = writeFile(path, []byte(script), 0o644); err != nil {
 		log.Error(err)
 		return "", err
 	}

--- a/src/shell/filesystem_windows.go
+++ b/src/shell/filesystem_windows.go
@@ -8,13 +8,21 @@ import (
 )
 
 // canRetryWrite reports whether the write failed because another process
-// temporarily holds the file (or its rename target) open, making a retry
-// worthwhile. All other errors are considered persistent.
+// holds the file (or its rename target) open, making a retry or an in-place
+// write worthwhile. Replacing an open file via rename fails with
+// ERROR_ACCESS_DENIED, not a sharing violation: MoveFileEx with
+// MOVEFILE_REPLACE_EXISTING requires the target to have no open handles at
+// all. All other errors are considered persistent.
 func canRetryWrite(err error) bool {
 	var errno syscall.Errno
 	if !errors.As(err, &errno) {
 		return false
 	}
 
-	return errno == windows.ERROR_SHARING_VIOLATION || errno == windows.ERROR_LOCK_VIOLATION
+	switch errno {
+	case windows.ERROR_ACCESS_DENIED, windows.ERROR_SHARING_VIOLATION, windows.ERROR_LOCK_VIOLATION:
+		return true
+	default:
+		return false
+	}
 }

--- a/src/shell/filesystem_windows_test.go
+++ b/src/shell/filesystem_windows_test.go
@@ -1,0 +1,57 @@
+package shell
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// openWithoutShareDelete opens path the way the C runtime's fopen does:
+// shared for read and write, but not for deletion. This is how Lua (clink),
+// PowerShell and most other script hosts hold the init script while sourcing
+// it, and it makes replacing the file via rename fail with
+// ERROR_ACCESS_DENIED.
+func openWithoutShareDelete(t *testing.T, path string) {
+	t.Helper()
+
+	p, err := syscall.UTF16PtrFromString(path)
+	require.NoError(t, err)
+
+	h, err := syscall.CreateFile(p,
+		syscall.GENERIC_READ,
+		syscall.FILE_SHARE_READ|syscall.FILE_SHARE_WRITE,
+		nil, syscall.OPEN_EXISTING, syscall.FILE_ATTRIBUTE_NORMAL, 0)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = syscall.CloseHandle(h)
+	})
+}
+
+func TestWriteFileTargetHeldOpen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "init.123.lua")
+	require.NoError(t, os.WriteFile(path, []byte("old"), 0o644))
+
+	openWithoutShareDelete(t, path)
+
+	err := writeFile(path, []byte("new"), 0o644)
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "new", string(got))
+}
+
+func TestWriteFileAtomicTargetHeldOpen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "init.123.lua")
+	require.NoError(t, os.WriteFile(path, []byte("old"), 0o644))
+
+	openWithoutShareDelete(t, path)
+
+	err := writeFileAtomic(path, []byte("new"), 0o644)
+	assert.True(t, canRetryWrite(err), "expected a retryable error, got %v", err)
+}

--- a/src/shell/init.go
+++ b/src/shell/init.go
@@ -261,7 +261,9 @@ func sourceCommand(env runtime.Environment, scriptPath string, async bool) strin
 	case ELVISH:
 		script += fmt.Sprintf("eval (slurp < %s)", quotePwshOrElvishStr(scriptPath))
 	case CMD:
-		script += fmt.Sprintf(`load(io.open('%s', "r"):read("*a"))()`, escapeLuaStr(scriptPath))
+		// dofile closes the file handle when done, io.open would leak it
+		// until the Lua GC kicks in, blocking script updates on Windows
+		script += fmt.Sprintf(`dofile('%s')`, escapeLuaStr(scriptPath))
 	default:
 		return fmt.Sprintf("echo \"No source command available for %s\"", env.Flags().Shell)
 	}


### PR DESCRIPTION
Resolves #7654

## Problem

29.22.1 replaced the in-place init script write with temp file + `os.Rename`. On Windows that rename is `MoveFileEx(MOVEFILE_REPLACE_EXISTING)`, which fails with `ERROR_ACCESS_DENIED` when *any* process holds a handle to the target — even a fully shared read handle. Shells hold the script open while sourcing it, so a write racing a read fails hard instead of atomically replacing the file.

The cmd loader made the failure permanent: `load(io.open(...):read("*a"))()` never closes the file, so clink holds `init.lua` open until the Lua GC collects the handle. Any open clink session blocked script updates indefinitely, and `init cmd` then printed an `echo` error that clink evaluated as Lua: `attempt to call a nil value`.

The retry added for this scenario never fired because it only matched `ERROR_SHARING_VIOLATION`/`ERROR_LOCK_VIOLATION`, while replace-while-open surfaces as `ERROR_ACCESS_DENIED`.

## Fix

- Treat `ERROR_ACCESS_DENIED` as retryable on Windows.
- After the retries (4 attempts, ~350ms), fall back to an in-place write: sharing rules allow overwriting a file others are reading, so only atomicity is lost — this is the pre-29.22.1 behavior, and it also heals sessions that still hold leaked handles from the old loader.
- Load the cmd script with `dofile` so the handle closes deterministically.

## Verification

- New Windows tests open the target without `FILE_SHARE_DELETE` (CRT `fopen` semantics, like Lua and PowerShell) and assert the atomic write fails retryably while `writeFile` recovers.
- End-to-end: forced a script rewrite while holding `init.lua` open the way clink does — 29.22.1 prints `Failed to write init script: ... Access is denied.`, this branch writes the script and emits a valid loader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)