### PR TITLE
feat(segment): Add Orthodox Calendar Segment

### DIFF
--- a/src/config/segment_types.go
+++ b/src/config/segment_types.go
@@ -99,6 +99,7 @@ func init() {
 	gob.Register(&segments.Npm{})
 	gob.Register(&segments.Nx{})
 	gob.Register(&segments.OCaml{})
+	gob.Register(&segments.OrthodoxCal{})
 	gob.Register(&segments.Os{})
 	gob.Register(&segments.Owm{})
 	gob.Register(&segments.Path{})
@@ -296,6 +297,8 @@ const (
 	NX SegmentType = "nx"
 	// OCAML writes the active Ocaml version
 	OCAML SegmentType = "ocaml"
+	// ORTHODOXCAL displays Orthodox fasting and feast information
+	ORTHODOXCAL SegmentType = "orthodoxcal"
 	// OS write os specific icon
 	OS SegmentType = "os"
 	// OWM writes the weather coming from openweatherdata
@@ -467,6 +470,7 @@ var Segments = map[SegmentType]func() SegmentWriter{
 	NPM:             func() SegmentWriter { return &segments.Npm{} },
 	NX:              func() SegmentWriter { return &segments.Nx{} },
 	OCAML:           func() SegmentWriter { return &segments.OCaml{} },
+	ORTHODOXCAL:     func() SegmentWriter { return &segments.OrthodoxCal{} },
 	OS:              func() SegmentWriter { return &segments.Os{} },
 	OWM:             func() SegmentWriter { return &segments.Owm{} },
 	PATH:            func() SegmentWriter { return &segments.Path{} },

--- a/src/segments/orthodoxcal.go
+++ b/src/segments/orthodoxcal.go
@@ -1,0 +1,79 @@
+package segments
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/log"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+)
+
+// OrthodoxCal displays the Orthodox fasting level and feast information
+// for the current day using the orthocal.info API.
+type OrthodoxCal struct {
+	Base
+
+	orthodoxCalResponse
+}
+
+const (
+	// OrthodoxCalType selects the calendar type: "gregorian" (default) or "julian".
+	OrthodoxCalType options.Option = "calendar"
+)
+
+type orthodoxCalResponse struct {
+	FastLevelDesc     string   `json:"fast_level_desc"`
+	FastExceptionDesc string   `json:"fast_exception_desc"`
+	SummaryTitle      string   `json:"summary_title"`
+	FeastLevelDesc    string   `json:"feast_level_description"`
+	Feasts            []string `json:"feasts"`
+	Saints            []string `json:"saints"`
+	Titles            []string `json:"titles"`
+	FastLevel         int      `json:"fast_level"`
+	FastException     int      `json:"fast_exception"`
+	FeastLevel        int      `json:"feast_level"`
+	Tone              int      `json:"tone"`
+}
+
+func (o *OrthodoxCal) Template() string {
+	return " ☦ {{ .FastLevelDesc }}{{ if .FastExceptionDesc }} ({{ .FastExceptionDesc }}){{ end }} · {{ .SummaryTitle }} "
+}
+
+func (o *OrthodoxCal) Enabled() bool {
+	if err := o.setData(); err != nil {
+		log.Error(err)
+		return false
+	}
+
+	return true
+}
+
+func (o *OrthodoxCal) setData() error {
+	cal := o.options.String(OrthodoxCalType, "gregorian")
+	url := fmt.Sprintf("https://orthocal.info/api/%s/", cal)
+
+	httpTimeout := o.options.Int(options.HTTPTimeout, options.DefaultHTTPTimeout)
+
+	body, err := o.env.HTTPRequest(url, nil, httpTimeout)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(body, &o.orthodoxCalResponse)
+}
+
+// IsFasting returns true when the day has any fasting requirement (fast_level > 0).
+func (o *OrthodoxCal) IsFasting() bool {
+	return o.FastLevel > 0
+}
+
+// FeastNames joins all feasts into a single comma-separated string.
+func (o *OrthodoxCal) FeastNames() string {
+	return strings.Join(o.Feasts, ", ")
+}
+
+// SaintNames joins all saints into a single comma-separated string.
+func (o *OrthodoxCal) SaintNames() string {
+	return strings.Join(o.Saints, ", ")
+}

--- a/src/segments/orthodoxcal_test.go
+++ b/src/segments/orthodoxcal_test.go
@@ -1,0 +1,117 @@
+package segments
+
+import (
+	"testing"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOrthodoxCalEnabled(t *testing.T) {
+	cases := []struct {
+		Case                  string
+		JSONResponse          string
+		ExpectedFastLevelDesc string
+		ExpectedSummaryTitle  string
+		ExpectedEnabled       bool
+	}{
+		{
+			Case: "no fast day",
+			JSONResponse: `{
+				"fast_level": 0,
+				"fast_level_desc": "No Fast",
+				"fast_exception": 0,
+				"fast_exception_desc": "",
+				"summary_title": "Hieromartyr Pancratius",
+				"feast_level": 0,
+				"feast_level_description": "Liturgy",
+				"feasts": null,
+				"saints": ["Hieromartyr Pancratius"],
+				"titles": ["Thursday of the 6th week after Pentecost"],
+				"tone": 4
+			}`,
+			ExpectedEnabled:       true,
+			ExpectedFastLevelDesc: "No Fast",
+			ExpectedSummaryTitle:  "Hieromartyr Pancratius",
+		},
+		{
+			Case: "strict fast day",
+			JSONResponse: `{
+				"fast_level": 1,
+				"fast_level_desc": "Strict Fast (Dry Fast)",
+				"fast_exception": 2,
+				"fast_exception_desc": "Wine and Oil are Allowed",
+				"summary_title": "Dormition Fast",
+				"feast_level": 0,
+				"feast_level_description": "Liturgy",
+				"feasts": null,
+				"saints": ["Prophet Micah"],
+				"titles": ["Monday of the 8th week after Pentecost"],
+				"tone": 6
+			}`,
+			ExpectedEnabled:       true,
+			ExpectedFastLevelDesc: "Strict Fast (Dry Fast)",
+			ExpectedSummaryTitle:  "Dormition Fast",
+		},
+		{
+			Case:            "http error",
+			JSONResponse:    "",
+			ExpectedEnabled: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Case, func(t *testing.T) {
+			env := new(mock.Environment)
+
+			opts := options.Map{
+				OrthodoxCalType: "gregorian",
+			}
+
+			if tc.JSONResponse != "" {
+				env.On("HTTPRequest", "https://orthocal.info/api/gregorian/").Return([]byte(tc.JSONResponse), nil)
+			} else {
+				env.On("HTTPRequest", "https://orthocal.info/api/gregorian/").Return([]byte{}, assert.AnError)
+			}
+
+			o := &OrthodoxCal{}
+			o.Init(opts, env)
+
+			enabled := o.Enabled()
+			assert.Equal(t, tc.ExpectedEnabled, enabled, tc.Case)
+
+			if enabled {
+				assert.Equal(t, tc.ExpectedFastLevelDesc, o.FastLevelDesc, tc.Case)
+				assert.Equal(t, tc.ExpectedSummaryTitle, o.SummaryTitle, tc.Case)
+			}
+		})
+	}
+}
+
+func TestOrthodoxCalIsFasting(t *testing.T) {
+	o := new(OrthodoxCal)
+	assert.False(t, o.IsFasting())
+
+	o.FastLevel = 3
+	assert.True(t, o.IsFasting())
+}
+
+func TestOrthodoxCalFeastNames(t *testing.T) {
+	o := new(OrthodoxCal)
+	o.Feasts = []string{"Nativity of Christ", "Synaxis of the Theotokos"}
+	assert.Equal(t, "Nativity of Christ, Synaxis of the Theotokos", o.FeastNames())
+
+	o.Feasts = nil
+	assert.Equal(t, "", o.FeastNames())
+}
+
+func TestOrthodoxCalSaintNames(t *testing.T) {
+	o := new(OrthodoxCal)
+	o.Saints = []string{"Prophet Micah", "Hieromartyr Pancratius"}
+	assert.Equal(t, "Prophet Micah, Hieromartyr Pancratius", o.SaintNames())
+
+	o.Saints = nil
+	assert.Equal(t, "", o.SaintNames())
+}

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -429,6 +429,7 @@
             "npm",
             "nx",
             "ocaml",
+            "orthodoxcal",
             "os",
             "owm",
             "path",
@@ -3459,6 +3460,39 @@
                     "title": "Zorin Icon",
                     "description": "The icon to use for Zorin OS",
                     "default": "\uf32f"
+                  }
+                },
+                "unevaluatedProperties": false
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "orthodoxcal"
+              }
+            }
+          },
+          "then": {
+            "title": "Orthodox Calendar Segment",
+            "description": "https://ohmyposh.dev/docs/segments/health/orthodoxcal",
+            "properties": {
+              "options": {
+                "properties": {
+                  "calendar": {
+                    "type": "string",
+                    "title": "Calendar Type",
+                    "description": "Calendar type: gregorian or julian",
+                    "enum": [
+                      "gregorian",
+                      "julian"
+                    ],
+                    "default": "gregorian"
+                  },
+                  "http_timeout": {
+                    "$ref": "#/definitions/http_timeout"
                   }
                 },
                 "unevaluatedProperties": false

--- a/website/docs/segments/health/orthodoxcal.mdx
+++ b/website/docs/segments/health/orthodoxcal.mdx
@@ -1,0 +1,66 @@
+---
+id: orthodoxcal
+title: Orthodox Calendar
+sidebar_label: Orthodox Calendar
+---
+
+## What
+
+Displays the Orthodox fasting level and feast information for the current day.
+Data comes from the [orthocal.info](https://orthocal.info) API, which follows OCA rubrics.
+This is the same data source used by [meatandright.com](https://www.meatandright.com).
+
+## Sample Configuration
+
+import Config from "@site/src/components/Config.js";
+
+<Config
+  data={{
+    type: "orthodoxcal",
+    style: "powerline",
+    powerline_symbol: "\uE0B0",
+    foreground: "#ffffff",
+    background: "#8B0000",
+    options: {
+      calendar: "gregorian",
+    },
+  }}
+/>
+
+## Options
+
+| Name | Type | Description | Default |
+| ---- | ---- | ----------- | ------- |
+| `calendar` | `string` | Calendar type: `gregorian` or `julian` | `gregorian` |
+| `http_timeout` | `int` | Timeout for the API request in milliseconds | `20` |
+
+## Template ([info][templates])
+
+:::note default template
+
+```template
+☦ {{ .FastLevelDesc }}{{ if .FastExceptionDesc }} ({{ .FastExceptionDesc }}){{ end }} · {{ .SummaryTitle }}
+```
+
+:::
+
+### Properties
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| `.FastLevel` | `int` | Numeric fasting level (0 = no fast, 1-5 = increasing strictness) |
+| `.FastLevelDesc` | `string` | Human-readable fasting description (e.g., "No Fast", "Strict Fast") |
+| `.FastException` | `int` | Numeric exception code |
+| `.FastExceptionDesc` | `string` | Exception detail (e.g., "Wine and Oil are Allowed") |
+| `.SummaryTitle` | `string` | Best title for the day (feast or saint commemoration) |
+| `.FeastLevel` | `int` | Numeric feast level |
+| `.FeastLevelDesc` | `string` | Feast level description (e.g., "Liturgy", "Great Feast") |
+| `.Feasts` | `[]string` | List of feast names |
+| `.Saints` | `[]string` | List of commemorated saints |
+| `.Titles` | `[]string` | Liturgical titles for the day |
+| `.Tone` | `int` | Liturgical tone (1-8) |
+| `.IsFasting` | `bool` | `true` when the day has any fasting requirement |
+| `.FeastNames` | `string` | All feasts joined with commas |
+| `.SaintNames` | `string` | All saints joined with commas |
+
+[templates]: /docs/configuration/templates

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -118,6 +118,7 @@ export default {
           collapsed: true,
           items: [
             "segments/health/nightscout",
+            "segments/health/orthodoxcal",
             "segments/health/ramadan",
             "segments/health/strava",
             "segments/health/withings",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Adds a new **`orthodoxcal`** segment that displays the Orthodox Church's daily fasting level and feast/commemoration information, sourced from the [orthocal.info](https://orthocal.info) API (OCA rubrics).

**What it does**

- Fetches the current day's data from `https://orthocal.info/api/<calendar>/` via the shared `Environment.HTTPRequest` abstraction.
- Supports both `gregorian` (default) and `julian` calendars via the `calendar` option, plus the standard `http_timeout` option.
- Exposes template properties for fast level/description, fast exception, feast level, feasts, saints, liturgical titles, tone, and summary title, along with helpers `IsFasting`, `FeastNames`, and `SaintNames`.
- Default template: `` ☦ {{ .FastLevelDesc }}{{ if .FastExceptionDesc }} ({{ .FastExceptionDesc }}){{ end }} · {{ .SummaryTitle }} ``.

**Changes**

| Area | File |
| --- | --- |
| Segment implementation | `src/segments/orthodoxcal.go` |
| Unit tests (mocked HTTP, deterministic) | `src/segments/orthodoxcal_test.go` |
| Type registration (`gob.Register` + writer map + `SegmentType`) | `src/config/segment_types.go` |
| Documentation | `website/docs/segments/health/orthodoxcal.mdx` |
| Sidebar entry | `website/sidebars.js` |
| JSON schema (`type` enum + segment options block) | `themes/schema.json` |

**Notes**

- The segment is fasting-aware: `.IsFasting` is `true` whenever `fast_level > 0`.
- Tests mock `HTTPRequest`, so they are fully deterministic and not date-dependent.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
