### PR TITLE
next

### DIFF
--- a/src/cache/command.go
+++ b/src/cache/command.go
@@ -3,7 +3,6 @@ package cache
 import (
 	"hash/fnv"
 	"os"
-	"sync"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/maps"
 )
@@ -14,15 +13,19 @@ const commandPathKeyPrefix = "command_path_"
 
 // pathEnvHash returns an FNV-1a hash of the environment that determines how
 // exec.LookPath resolves a command: PATH, plus PATHEXT on Windows (unset and
-// therefore a no-op elsewhere). It's computed once per process -- the
-// environment can't change under us in a short-lived prompt render.
-var pathEnvHash = sync.OnceValue(func() uint64 {
+// therefore a no-op elsewhere). Computed on every call, NOT memoized: the
+// serve daemon lives across prompts and applies each request's env overlay
+// (PATH included) in-process, so a per-process hash would keep matching
+// entries persisted under an earlier PATH and pin e.g. `python` to a
+// previous virtual environment's interpreter for the daemon's lifetime -
+// the old binary still exists, so the os.Stat revalidation never catches it.
+func pathEnvHash() uint64 {
 	h := fnv.New64a()
 	_, _ = h.Write([]byte(os.Getenv("PATH")))
 	_, _ = h.Write([]byte{0})
 	_, _ = h.Write([]byte(os.Getenv("PATHEXT")))
 	return h.Sum64()
-})
+}
 
 // Command lookup TTLs for the session-persisted layer (L2). The in-memory
 // layer (L1, Commands below) is unbounded for the lifetime of the process,

--- a/src/cache/command_test.go
+++ b/src/cache/command_test.go
@@ -48,6 +48,27 @@ func TestGetPersistedCommandPathStalePathHashIsAMiss(t *testing.T) {
 	assert.False(t, ok, "entry persisted under a different PATH must be treated as a miss")
 }
 
+func TestGetPersistedCommandPathInProcessPathChangeIsAMiss(t *testing.T) {
+	session = Session.new()
+
+	// The serve daemon applies each render request's env overlay (PATH
+	// included) in-process, so the hash must track the CURRENT environment:
+	// an entry persisted before a venv activation changed PATH must not be
+	// served afterwards, even within the same process.
+	t.Setenv("PATH", "/project-a/.venv/bin")
+	PersistCommandPath("python", "/project-a/.venv/bin/python", true)
+
+	path, found, ok := GetPersistedCommandPath("python")
+	assert.True(t, ok)
+	assert.True(t, found)
+	assert.Equal(t, "/project-a/.venv/bin/python", path)
+
+	t.Setenv("PATH", "/project-b/.venv/bin")
+
+	_, _, ok = GetPersistedCommandPath("python")
+	assert.False(t, ok, "entry persisted under a previous PATH must be a miss after PATH changes in-process")
+}
+
 func TestCommandPathKeyIsPrefixed(t *testing.T) {
 	assert.Equal(t, "command_path_git", commandPathKey("git"))
 }

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -172,8 +172,12 @@ function _omp_serve_start() {
   _omp_serve_pid=$!
 
   # Duplicate both directions to session fds: the duplicates survive a later
-  # `coproc` (ours or the user's) replacing the coproc slot.
-  exec {_omp_serve_fd_out}<&p {_omp_serve_fd_in}>&p 2>/dev/null
+  # `coproc` (ours or the user's) replacing the coproc slot. The stderr
+  # redirect (suppressing "no coprocess" when the daemon failed to start) must
+  # be scoped to a block: on a redirection-only `exec`, zsh applies every
+  # listed redirection to the shell permanently, which would silence the
+  # session's stderr for good.
+  { exec {_omp_serve_fd_out}<&p {_omp_serve_fd_in}>&p } 2>/dev/null
   if [[ $_omp_serve_fd_in -lt 0 || $_omp_serve_fd_out -lt 0 ]]; then
     _omp_serve_stop
     return 1


### PR DESCRIPTION
- **fix(zsh): scope serve fd dup stderr redirect to a block**
- **fix(cache): rehash PATH per command lookup for the serve daemon)**

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!---

Tips:

If you're not comfortable with working with Git,
we're working on a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D)
as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
