### PR TITLE
next

### DIFF
--- a/src/config/segment.go
+++ b/src/config/segment.go
@@ -79,11 +79,14 @@ type Segment struct {
 	restored               bool           `json:"-" toml:"-" yaml:"-"`
 	Toggled                bool           `json:"toggled,omitempty" toml:"toggled,omitempty" yaml:"toggled,omitempty"`
 	Pending                bool           `json:"-" toml:"-" yaml:"-"`
-	Interactive            bool           `json:"interactive,omitempty" toml:"interactive,omitempty" yaml:"interactive,omitempty"`
-	foregroundResolved     bool
-	backgroundResolved     bool
-	needsEvaluated         bool
-	evaluated              bool
+	// Killed is set by the engine when the segment's timeout expired and its
+	// child processes were killed; it blocks fallback_template rendering.
+	Killed             bool `json:"-" toml:"-" yaml:"-"`
+	Interactive        bool `json:"interactive,omitempty" toml:"interactive,omitempty" yaml:"interactive,omitempty"`
+	foregroundResolved bool
+	backgroundResolved bool
+	needsEvaluated     bool
+	evaluated          bool
 }
 
 // segmentAlias is used to avoid recursion during unmarshaling
@@ -223,8 +226,8 @@ func (segment *Segment) Execute(env runtime.Environment) {
 		defer runjobs.CloseGoroutineJob()
 	}
 
-	segment.evaluated = true
 	segment.Enabled = segment.writer.Enabled()
+	segment.evaluated = true
 }
 
 func (segment *Segment) Render(index int, force bool) bool {
@@ -266,13 +269,15 @@ func (segment *Segment) Render(index int, force bool) bool {
 }
 
 // renderFallback attempts to render FallbackTemplate when a segment would
-// otherwise be hidden because its writer's Enabled() returned false. It only
-// fires when the writer was actually evaluated; segments hidden for other
-// reasons (toggled off, folder include/exclude, width constraints, a killed
-// timeout, or a writer mapping error) never reach this point with evaluated
-// set, so they keep today's silent-omission behavior.
+// otherwise be hidden because its writer's Enabled() returned false. It
+// requires the writer to have completed its evaluation; segments hidden for other
+// reasons (toggled off, folder include/exclude, width constraints, or a
+// writer mapping error) never set evaluated, so they keep the silent-omission
+// behavior. Segments killed by their timeout are excluded via Killed rather
+// than evaluated, because their Execute goroutine keeps running after the
+// kill and may still complete the evaluation before rendering starts.
 func (segment *Segment) renderFallback(index int) bool {
-	if segment.FallbackTemplate == "" || !segment.evaluated {
+	if segment.FallbackTemplate == "" || !segment.evaluated || segment.Killed {
 		return false
 	}
 

--- a/src/config/segment_test.go
+++ b/src/config/segment_test.go
@@ -502,6 +502,7 @@ func TestSegment_FallbackTemplate(t *testing.T) {
 		WriterEnabled    bool
 		Evaluated        bool
 		Enabled          bool
+		Killed           bool
 		ExpectedRendered bool
 		ExpectedEnabled  bool
 	}{
@@ -528,6 +529,14 @@ func TestSegment_FallbackTemplate(t *testing.T) {
 			Case:             "whitespace-only result keeps segment hidden",
 			FallbackTemplate: "   ",
 			Evaluated:        true,
+		},
+		{
+			// A timed-out segment's goroutine may still complete the
+			// evaluation after the kill, so Killed must win over evaluated.
+			Case:             "killed by timeout keeps segment hidden",
+			FallbackTemplate: " disconnected ",
+			Evaluated:        true,
+			Killed:           true,
 		},
 		{
 			Case:             "does not write to the segment cache",
@@ -560,6 +569,7 @@ func TestSegment_FallbackTemplate(t *testing.T) {
 			FallbackTemplate: tc.FallbackTemplate,
 			Cache:            tc.Cache,
 			Enabled:          tc.Enabled,
+			Killed:           tc.Killed,
 			writer:           &fallbackWriter{enabled: tc.WriterEnabled, template: tc.Template},
 		}
 		segment.evaluated = tc.Evaluated

--- a/src/prompt/segments.go
+++ b/src/prompt/segments.go
@@ -146,6 +146,7 @@ func (e *Engine) executeSegmentWithTimeout(segment *config.Segment) {
 		}
 
 		// For non-streaming mode, kill the goroutine
+		segment.Killed = true
 		if err := runjobs.KillGoroutineChildren(gid); err != nil {
 			log.Errorf("failed to kill child processes for goroutine %d (segment: %s): %v", gid, segment.Name(), err)
 		}

--- a/src/shell/filesystem.go
+++ b/src/shell/filesystem.go
@@ -82,30 +82,45 @@ func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
 	return os.Rename(tmp.Name(), path)
 }
 
+// writeFile writes data to path, atomically when possible.
+//
+// On Windows, replacing a file via rename requires that no process has the
+// target open: MoveFileEx(MOVEFILE_REPLACE_EXISTING) fails with
+// ERROR_ACCESS_DENIED as long as a single handle exists, even one opened
+// with full sharing. Shells source the init script on startup (and every
+// prompt in async mode), so brief holds are normal — retry those. When the
+// file is still held after the retries (a shell keeping it open), fall back
+// to an in-place write: sharing rules allow overwriting a file others are
+// reading, we only lose atomicity for this write.
+func writeFile(path string, data []byte, perm os.FileMode) error {
+	const attempts = 4
+	wait := 50 * time.Millisecond
+
+	var err error
+
+	for attempt := 1; ; attempt++ {
+		if err = writeFileAtomic(path, data, perm); !canRetryWrite(err) || attempt == attempts {
+			break
+		}
+
+		time.Sleep(wait)
+		wait *= 2
+	}
+
+	if err == nil || !canRetryWrite(err) {
+		return err
+	}
+
+	return os.WriteFile(path, data, perm)
+}
+
 func writeScript(env runtime.Environment, script string) (string, error) {
 	path, err := scriptPath(env)
 	if err != nil {
 		return "", err
 	}
 
-	data := []byte(script)
-
-	// another process can hold the script (or its target) open on Windows,
-	// making the rename fail with a sharing violation; retry with backoff
-	// until it lets go — all other errors are persistent, fail fast
-	const attempts = 8
-	wait := 50 * time.Millisecond
-
-	for attempt := 1; ; attempt++ {
-		if err = writeFileAtomic(path, data, 0o644); !canRetryWrite(err) || attempt == attempts {
-			break
-		}
-
-		time.Sleep(wait)
-		wait = min(wait*2, time.Second)
-	}
-
-	if err != nil {
+	if err = writeFile(path, []byte(script), 0o644); err != nil {
 		log.Error(err)
 		return "", err
 	}

--- a/src/shell/filesystem_windows.go
+++ b/src/shell/filesystem_windows.go
@@ -8,13 +8,21 @@ import (
 )
 
 // canRetryWrite reports whether the write failed because another process
-// temporarily holds the file (or its rename target) open, making a retry
-// worthwhile. All other errors are considered persistent.
+// holds the file (or its rename target) open, making a retry or an in-place
+// write worthwhile. Replacing an open file via rename fails with
+// ERROR_ACCESS_DENIED, not a sharing violation: MoveFileEx with
+// MOVEFILE_REPLACE_EXISTING requires the target to have no open handles at
+// all. All other errors are considered persistent.
 func canRetryWrite(err error) bool {
 	var errno syscall.Errno
 	if !errors.As(err, &errno) {
 		return false
 	}
 
-	return errno == windows.ERROR_SHARING_VIOLATION || errno == windows.ERROR_LOCK_VIOLATION
+	switch errno {
+	case windows.ERROR_ACCESS_DENIED, windows.ERROR_SHARING_VIOLATION, windows.ERROR_LOCK_VIOLATION:
+		return true
+	default:
+		return false
+	}
 }

--- a/src/shell/filesystem_windows_test.go
+++ b/src/shell/filesystem_windows_test.go
@@ -1,0 +1,57 @@
+package shell
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// openWithoutShareDelete opens path the way the C runtime's fopen does:
+// shared for read and write, but not for deletion. This is how Lua (clink),
+// PowerShell and most other script hosts hold the init script while sourcing
+// it, and it makes replacing the file via rename fail with
+// ERROR_ACCESS_DENIED.
+func openWithoutShareDelete(t *testing.T, path string) {
+	t.Helper()
+
+	p, err := syscall.UTF16PtrFromString(path)
+	require.NoError(t, err)
+
+	h, err := syscall.CreateFile(p,
+		syscall.GENERIC_READ,
+		syscall.FILE_SHARE_READ|syscall.FILE_SHARE_WRITE,
+		nil, syscall.OPEN_EXISTING, syscall.FILE_ATTRIBUTE_NORMAL, 0)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = syscall.CloseHandle(h)
+	})
+}
+
+func TestWriteFileTargetHeldOpen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "init.123.lua")
+	require.NoError(t, os.WriteFile(path, []byte("old"), 0o644))
+
+	openWithoutShareDelete(t, path)
+
+	err := writeFile(path, []byte("new"), 0o644)
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "new", string(got))
+}
+
+func TestWriteFileAtomicTargetHeldOpen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "init.123.lua")
+	require.NoError(t, os.WriteFile(path, []byte("old"), 0o644))
+
+	openWithoutShareDelete(t, path)
+
+	err := writeFileAtomic(path, []byte("new"), 0o644)
+	assert.True(t, canRetryWrite(err), "expected a retryable error, got %v", err)
+}

--- a/src/shell/init.go
+++ b/src/shell/init.go
@@ -261,7 +261,9 @@ func sourceCommand(env runtime.Environment, scriptPath string, async bool) strin
 	case ELVISH:
 		script += fmt.Sprintf("eval (slurp < %s)", quotePwshOrElvishStr(scriptPath))
 	case CMD:
-		script += fmt.Sprintf(`load(io.open('%s', "r"):read("*a"))()`, escapeLuaStr(scriptPath))
+		// dofile closes the file handle when done, io.open would leak it
+		// until the Lua GC kicks in, blocking script updates on Windows
+		script += fmt.Sprintf(`dofile('%s')`, escapeLuaStr(scriptPath))
 	default:
 		return fmt.Sprintf("echo \"No source command available for %s\"", env.Flags().Shell)
 	}


### PR DESCRIPTION
- **fix(segment): skip fallback_template when a timeout kills the segment**
- **fix(init): recover when the init script is held open on Windows**

### Prerequisites

- [ ] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [ ] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

<!---

Tips:

If you're not comfortable with working with Git,
we're working on a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D)
as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
