### PR TITLE
feat(transient): support right-aligned template

### DIFF
--- a/src/config/segment.go
+++ b/src/config/segment.go
@@ -49,6 +49,7 @@ type Segment struct {
 	LeadingDiamond         string         `json:"leading_diamond,omitempty" toml:"leading_diamond,omitempty" yaml:"leading_diamond,omitempty"`
 	TrailingDiamond        string         `json:"trailing_diamond,omitempty" toml:"trailing_diamond,omitempty" yaml:"trailing_diamond,omitempty"`
 	Template               string         `json:"template,omitempty" toml:"template,omitempty" yaml:"template,omitempty"`
+	RightTemplate          string         `json:"right_template,omitempty" toml:"right_template,omitempty" yaml:"right_template,omitempty"`
 	Foreground             color.Ansi     `json:"foreground,omitempty" toml:"foreground,omitempty" yaml:"foreground,omitempty"`
 	TemplatesLogic         template.Logic `json:"templates_logic,omitempty" toml:"templates_logic,omitempty" yaml:"templates_logic,omitempty"`
 	PowerlineSymbol        string         `json:"powerline_symbol,omitempty" toml:"powerline_symbol,omitempty" yaml:"powerline_symbol,omitempty"`

--- a/src/prompt/engine.go
+++ b/src/prompt/engine.go
@@ -168,6 +168,11 @@ func (e *Engine) shouldFill(filler string, padLength int) (string, bool) {
 		return "", false
 	}
 
+	if padLength < 0 {
+		log.Debug("padding length is negative")
+		return "", false
+	}
+
 	e.Padding = padLength
 
 	defer func() {

--- a/src/prompt/extra.go
+++ b/src/prompt/extra.go
@@ -2,6 +2,7 @@ package prompt
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/color"
 	"github.com/jandedobbeleer/oh-my-posh/src/config"
@@ -78,34 +79,101 @@ func (e *Engine) ExtraPrompt(promptType ExtraPromptType) string {
 
 	str, length := terminal.String()
 
-	if promptType == Transient && len(prompt.Filler) != 0 {
+	if promptType != Transient {
+		return str
+	}
+
+	rightStr, rightLength := e.renderRightTemplate(prompt, background, foreground)
+
+	var padText string
+	if len(prompt.Filler) != 0 {
 		consoleWidth, err := e.Env.TerminalWidth()
 		if err == nil || consoleWidth != 0 {
-			if padText, OK := e.shouldFill(prompt.Filler, consoleWidth-length); OK {
-				str += padText
-			}
+			padText, _ = e.shouldFill(prompt.Filler, consoleWidth-length-rightLength)
 		}
+	}
+
+	// for pwsh, the padding moves inside the cursor save/restore sequence
+	// when a right-aligned template is rendered, see transientPWSH
+	if e.Env.Shell() != shell.PWSH || rightLength == 0 {
+		str += padText
 	}
 
 	switch e.Env.Shell() {
 	case shell.ZSH:
-		if promptType == Transient {
-			if !e.Env.Flags().Eval {
-				break
-			}
+		if !e.Env.Flags().Eval {
+			return str
+		}
 
-			prompt := fmt.Sprintf("PS1=%s", shell.QuotePosixStr(str))
-			// empty RPROMPT
-			prompt += "\nRPROMPT=''"
-			return prompt
-		}
+		return e.transientZSH(str, rightStr)
 	case shell.PWSH:
-		if promptType == Transient {
-			// clear the line afterwards to prevent text from being written on the same line
-			// see https://github.com/JanDeDobbeleer/oh-my-posh/issues/3628
-			return str + terminal.ClearAfter()
-		}
+		return e.transientPWSH(str, padText, rightStr, length, rightLength)
 	}
 
 	return str
+}
+
+// transientZSH returns the transient prompt as an eval statement setting
+// both PS1 and RPROMPT, letting zsh align the right-aligned template natively.
+func (e *Engine) transientZSH(str, rightStr string) string {
+	// Warp doesn't support RPROMPT
+	if e.isWarp() {
+		rightStr = ""
+	}
+
+	prompt := fmt.Sprintf("PS1=%s", shell.QuotePosixStr(str))
+	prompt += fmt.Sprintf("\nRPROMPT=%s", shell.QuotePosixStr(rightStr))
+	return prompt
+}
+
+// transientPWSH appends the right-aligned template to the transient prompt by
+// writing the gap and the right-aligned text, then restoring the cursor to
+// right after the left part so the accepted command is drawn there,
+// mirroring writePrimaryRightPrompt.
+func (e *Engine) transientPWSH(str, padText, rightStr string, length, rightLength int) string {
+	// clear the line afterwards to prevent text from being written on the same line
+	// see https://github.com/JanDeDobbeleer/oh-my-posh/issues/3628
+	str += terminal.ClearAfter()
+
+	if rightLength == 0 {
+		return str
+	}
+
+	consoleWidth, err := e.Env.TerminalWidth()
+	if err != nil || consoleWidth == 0 {
+		return str
+	}
+
+	gap := consoleWidth - length - rightLength
+	if gap < 0 {
+		return str
+	}
+
+	if len(padText) == 0 {
+		padText = strings.Repeat(" ", gap)
+	}
+
+	return str + terminal.SaveCursorPosition() + padText + rightStr + terminal.RestoreCursorPosition()
+}
+
+// renderRightTemplate renders the transient prompt's right-aligned template.
+// Only zsh (via RPROMPT) and pwsh (via cursor save/restore) can display it.
+func (e *Engine) renderRightTemplate(prompt *config.Segment, background, foreground color.Ansi) (string, int) {
+	if len(prompt.RightTemplate) == 0 {
+		return "", 0
+	}
+
+	switch e.Env.Shell() {
+	case shell.ZSH, shell.PWSH:
+	default:
+		return "", 0
+	}
+
+	text, err := template.Render(prompt.RightTemplate, nil)
+	if err != nil {
+		text = err.Error()
+	}
+
+	terminal.Write(background, foreground, text)
+	return terminal.String()
 }

--- a/src/prompt/extra_test.go
+++ b/src/prompt/extra_test.go
@@ -1,0 +1,353 @@
+package prompt
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/cache"
+	"github.com/jandedobbeleer/oh-my-posh/src/color"
+	"github.com/jandedobbeleer/oh-my-posh/src/config"
+	"github.com/jandedobbeleer/oh-my-posh/src/maps"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+	"github.com/jandedobbeleer/oh-my-posh/src/shell"
+	"github.com/jandedobbeleer/oh-my-posh/src/template"
+	"github.com/jandedobbeleer/oh-my-posh/src/terminal"
+
+	"github.com/stretchr/testify/assert"
+	testifymock "github.com/stretchr/testify/mock"
+)
+
+func setupExtraPromptTest(sh string, flags *runtime.Flags) *mock.Environment {
+	env := new(mock.Environment)
+	env.On("Shell").Return(sh)
+	env.On("Flags").Return(flags)
+	// Mock accent color retrieval for both Windows and macOS. The mock
+	// forwards RunCommand as Called(command, args), so the expectation
+	// takes two arguments: the command and the args slice.
+	env.On("RunCommand", testifymock.Anything, testifymock.Anything).Return("4", nil)
+	env.On("WindowsRegistryKeyValue", testifymock.Anything).Return(&runtime.WindowsRegistryValue{ValueType: runtime.DWORD, DWord: 0xFF0078D7}, nil)
+
+	template.Cache = &cache.Template{
+		Segments: maps.NewConcurrent[any](),
+	}
+	template.Init(env, nil, nil)
+	terminal.Init(sh)
+	terminal.Colors = color.MakeColors(nil, false, "", env)
+
+	return env
+}
+
+func TestExtraPromptTransientZSH(t *testing.T) {
+	cases := []struct {
+		TerminalErr   error
+		Case          string
+		Template      string
+		RightTemplate string
+		Filler        string
+		Expected      string
+		TerminalWidth int
+		Eval          bool
+	}{
+		{
+			Case:     "no right template, eval - byte identical to previous behavior",
+			Template: "L>",
+			Eval:     true,
+			Expected: fmt.Sprintf("PS1=%s\nRPROMPT=''", shell.QuotePosixStr("L>")),
+		},
+		{
+			Case:          "right template, eval",
+			Template:      "L>",
+			RightTemplate: "R>",
+			Eval:          true,
+			Expected:      fmt.Sprintf("PS1=%s\nRPROMPT=%s", shell.QuotePosixStr("L>"), shell.QuotePosixStr("R>")),
+		},
+		{
+			Case:          "right template with quote and backslash, eval",
+			Template:      "L>",
+			RightTemplate: `it's a \`,
+			Eval:          true,
+			Expected:      fmt.Sprintf("PS1=%s\nRPROMPT=%s", shell.QuotePosixStr("L>"), shell.QuotePosixStr(`it's a \`)),
+		},
+		{
+			Case:          "right template and filler, eval",
+			Template:      "L>",
+			RightTemplate: "R>",
+			Filler:        "-",
+			TerminalWidth: 20,
+			Eval:          true,
+			Expected:      fmt.Sprintf("PS1=%s\nRPROMPT=%s", shell.QuotePosixStr("L>"+strings.Repeat("-", 16)), shell.QuotePosixStr("R>")),
+		},
+		{
+			Case:          "right template and filler, unknown terminal width, eval",
+			Template:      "L>",
+			RightTemplate: "R>",
+			Filler:        "-",
+			TerminalErr:   errors.New("burp"),
+			Eval:          true,
+			Expected:      fmt.Sprintf("PS1=%s\nRPROMPT=%s", shell.QuotePosixStr("L>"), shell.QuotePosixStr("R>")),
+		},
+		{
+			Case:          "right template, no eval - raw string without RPROMPT",
+			Template:      "L>",
+			RightTemplate: "R>",
+			Expected:      "L>",
+		},
+	}
+
+	for _, tc := range cases {
+		env := setupExtraPromptTest(shell.ZSH, &runtime.Flags{Eval: tc.Eval})
+		env.On("TerminalWidth").Return(tc.TerminalWidth, tc.TerminalErr)
+
+		engine := &Engine{
+			Config: &config.Config{
+				TransientPrompt: &config.Segment{
+					Template:      tc.Template,
+					RightTemplate: tc.RightTemplate,
+					Filler:        tc.Filler,
+				},
+			},
+			Env: env,
+		}
+
+		got := engine.ExtraPrompt(Transient)
+		assert.Equal(t, tc.Expected, got, tc.Case)
+	}
+}
+
+func TestExtraPromptTransientPWSH(t *testing.T) {
+	// initialize the terminal for pwsh before resolving the expected sequences
+	terminal.Init(shell.PWSH)
+	saveCursor := terminal.SaveCursorPosition()
+	restoreCursor := terminal.RestoreCursorPosition()
+	clearAfter := terminal.ClearAfter()
+
+	cases := []struct {
+		TerminalErr   error
+		Case          string
+		Template      string
+		RightTemplate string
+		Filler        string
+		Expected      string
+		TerminalWidth int
+	}{
+		{
+			Case:     "no right template - byte identical to previous behavior",
+			Template: "L>",
+			Expected: "L>" + clearAfter,
+		},
+		{
+			Case:          "no right template with filler - byte identical to previous behavior",
+			Template:      "L>",
+			Filler:        "-",
+			TerminalWidth: 20,
+			Expected:      "L>" + strings.Repeat("-", 18) + clearAfter,
+		},
+		{
+			Case:          "right template",
+			Template:      "L>",
+			RightTemplate: "R>",
+			TerminalWidth: 20,
+			Expected:      "L>" + clearAfter + saveCursor + strings.Repeat(" ", 16) + "R>" + restoreCursor,
+		},
+		{
+			Case:          "right template with filler - padding inside cursor save/restore",
+			Template:      "L>",
+			RightTemplate: "R>",
+			Filler:        "-",
+			TerminalWidth: 20,
+			Expected:      "L>" + clearAfter + saveCursor + strings.Repeat("-", 16) + "R>" + restoreCursor,
+		},
+		{
+			Case:          "right template, exact fit",
+			Template:      "L>",
+			RightTemplate: "R>",
+			TerminalWidth: 4,
+			Expected:      "L>" + clearAfter + saveCursor + "R>" + restoreCursor,
+		},
+		{
+			Case:          "right template, insufficient width - right side omitted",
+			Template:      "L>",
+			RightTemplate: "R>",
+			TerminalWidth: 3,
+			Expected:      "L>" + clearAfter,
+		},
+		{
+			Case:          "right template, unknown terminal width - right side omitted",
+			Template:      "L>",
+			RightTemplate: "R>",
+			TerminalErr:   errors.New("burp"),
+			Expected:      "L>" + clearAfter,
+		},
+	}
+
+	for _, tc := range cases {
+		env := setupExtraPromptTest(shell.PWSH, &runtime.Flags{})
+		env.On("TerminalWidth").Return(tc.TerminalWidth, tc.TerminalErr)
+
+		engine := &Engine{
+			Config: &config.Config{
+				TransientPrompt: &config.Segment{
+					Template:      tc.Template,
+					RightTemplate: tc.RightTemplate,
+					Filler:        tc.Filler,
+				},
+			},
+			Env: env,
+		}
+
+		got := engine.ExtraPrompt(Transient)
+		assert.Equal(t, tc.Expected, got, tc.Case)
+	}
+}
+
+func TestExtraPromptTransientPWSHNewline(t *testing.T) {
+	env := setupExtraPromptTest(shell.PWSH, &runtime.Flags{PromptCount: 2})
+	env.On("TerminalWidth").Return(20, nil)
+	env.On("CursorPosition").Return(2, 1)
+
+	engine := &Engine{
+		Config: &config.Config{
+			TransientPrompt: &config.Segment{
+				Template:      "L>",
+				RightTemplate: "R>",
+				Newline:       true,
+			},
+		},
+		Env: env,
+	}
+
+	got := engine.ExtraPrompt(Transient)
+	// the leading newline has no width and must not shift the right side
+	expected := "\nL>" + terminal.ClearAfter() + terminal.SaveCursorPosition() + strings.Repeat(" ", 16) + "R>" + terminal.RestoreCursorPosition()
+	assert.Equal(t, expected, got)
+}
+
+func TestExtraPromptRightTemplateUnsupportedShell(t *testing.T) {
+	env := setupExtraPromptTest(shell.FISH, &runtime.Flags{})
+
+	engine := &Engine{
+		Config: &config.Config{
+			TransientPrompt: &config.Segment{
+				Template:      "L>",
+				RightTemplate: "R>",
+			},
+		},
+		Env: env,
+	}
+
+	got := engine.ExtraPrompt(Transient)
+	assert.Equal(t, "L>", got)
+}
+
+func TestShouldFillNegativePadLength(t *testing.T) {
+	engine := &Engine{}
+
+	// must not panic on a negative padding length
+	got, OK := engine.shouldFill("-", -5)
+	assert.False(t, OK)
+	assert.Empty(t, got)
+}
+
+func setupExtraStreamingTestEnv(sh string) *mock.Environment {
+	env := new(mock.Environment)
+	env.On("Pwd").Return("/test")
+	env.On("Home").Return("/home")
+	env.On("Shell").Return(sh)
+	env.On("Flags").Return(&runtime.Flags{Streaming: true})
+	env.On("CursorPosition").Return(1, 1)
+	env.On("StatusCodes").Return(0, "0")
+	env.On("TerminalWidth").Return(120, nil)
+	env.On("DirMatchesOneOf", testifymock.Anything, testifymock.Anything).Return(false)
+	env.On("RunCommand", testifymock.Anything, testifymock.Anything).Return("4", nil)
+	env.On("WindowsRegistryKeyValue", testifymock.Anything).Return(&runtime.WindowsRegistryValue{ValueType: runtime.DWORD, DWord: 0xFF0078D7}, nil)
+
+	template.Cache = &cache.Template{
+		Segments: maps.NewConcurrent[any](),
+	}
+	template.Init(env, nil, nil)
+	terminal.Init(sh)
+	terminal.Colors = color.MakeColors(nil, false, "", env)
+
+	return env
+}
+
+func TestStreamPrimary_TransientRecordSkippedForZSHRightTemplate(t *testing.T) {
+	env := setupExtraStreamingTestEnv(shell.ZSH)
+
+	engine := &Engine{
+		Config: &config.Config{
+			Blocks: []*config.Block{},
+			TransientPrompt: &config.Segment{
+				Template:      "L>",
+				RightTemplate: "R>",
+			},
+		},
+		Env: env,
+	}
+
+	out := engine.StreamPrimary()
+	prompts := collectChannelOutput(out, 100*time.Millisecond)
+
+	for _, prompt := range prompts {
+		assert.False(t, strings.HasPrefix(prompt, TransientMarker), "no transient record should be streamed for zsh with a right template")
+	}
+}
+
+func TestStreamPrimary_TransientRecordSentForZSHWithoutRightTemplate(t *testing.T) {
+	env := setupExtraStreamingTestEnv(shell.ZSH)
+
+	engine := &Engine{
+		Config: &config.Config{
+			Blocks: []*config.Block{},
+			TransientPrompt: &config.Segment{
+				Template: "L>",
+			},
+		},
+		Env: env,
+	}
+
+	out := engine.StreamPrimary()
+	prompts := collectChannelOutput(out, 100*time.Millisecond)
+
+	transientRecords := 0
+	for _, prompt := range prompts {
+		if strings.HasPrefix(prompt, TransientMarker) {
+			transientRecords++
+		}
+	}
+
+	assert.Equal(t, 1, transientRecords, "the transient record should still be streamed for zsh without a right template")
+}
+
+func TestStreamPrimary_TransientRecordContainsRightTemplateForPWSH(t *testing.T) {
+	env := setupExtraStreamingTestEnv(shell.PWSH)
+
+	engine := &Engine{
+		Config: &config.Config{
+			Blocks: []*config.Block{},
+			TransientPrompt: &config.Segment{
+				Template:      "L>",
+				RightTemplate: "R>",
+			},
+		},
+		Env: env,
+	}
+
+	out := engine.StreamPrimary()
+	prompts := collectChannelOutput(out, 100*time.Millisecond)
+
+	var transient string
+	for _, prompt := range prompts {
+		if after, OK := strings.CutPrefix(prompt, TransientMarker); OK {
+			transient = after
+		}
+	}
+
+	assert.NotEmpty(t, transient, "the transient record should be streamed for pwsh")
+	assert.Contains(t, transient, terminal.SaveCursorPosition(), "the streamed transient record should carry the right-aligned template")
+	assert.Contains(t, transient, "R>", "the streamed transient record should carry the right-aligned template")
+}

--- a/src/prompt/streaming.go
+++ b/src/prompt/streaming.go
@@ -62,6 +62,14 @@ func (e *Engine) StreamPrimary() <-chan string {
 			return
 		}
 
+		// The zsh script caches a streamed transient record as PS1 only and
+		// resets RPROMPT (see _omp_zle-line-init in omp.zsh), so the record
+		// cannot carry a right-aligned template. Skip it to make the script
+		// fall back to the eval path which sets both PS1 and RPROMPT.
+		if e.Env.Shell() == shell.ZSH && e.Config.TransientPrompt != nil && len(e.Config.TransientPrompt.RightTemplate) != 0 {
+			return
+		}
+
 		// The zsh script renders the transient prompt one column narrower to avoid
 		// a redundant blank line when a filler is configured and the input is empty
 		// (see _omp_zle-line-init in omp.zsh), mirror that for the streamed record.

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -5429,6 +5429,11 @@
               "title": "Newline",
               "description": "Add a newline before the prompt",
               "default": false
+            },
+            "right_template": {
+              "type": "string",
+              "title": "Right Template",
+              "description": "The right-aligned template to render next to the transient prompt, supported in zsh and PowerShell only"
             }
           }
         }

--- a/website/docs/configuration/transient.mdx
+++ b/website/docs/configuration/transient.mdx
@@ -48,6 +48,7 @@ You need to extend or create a custom theme with your transient prompt. For exam
 | `background`           | `string`  | [color][colors]                                                                                                                                |
 | `background_templates` | `array`   | [color templates][color-templates]                                                                                                             |
 | `template`             | `string`  | a go [text/template][go-text-template] template extended with [sprig][sprig] utilizing the properties below - defaults to `{{ .Shell }}> `     |
+| `right_template`       | `string`  | a go [text/template][go-text-template] template extended with [sprig][sprig], right-aligned at the end of the line. Supported in `zsh` and `powershell` only, designed for single line transient prompts |
 | `filler`               | `string`  | when you want to create a line with a repeated set of characters spanning the width of the terminal. Will be added _after_ the `template` text |
 | `newline`              | `boolean` | add a newline before the prompt. The newline will not be printed under the same conditions as for primary prompt [newlines][block-newline].    |
 


### PR DESCRIPTION
## What

Adds a `right_template` option to the transient prompt, rendered right-aligned at the end of the line:

```json
"transient_prompt": {
  "template": "❯ ",
  "right_template": "{{ now | date \"15:04:05\" }}",
  "filler": "."
}
```

resolves #4822

## Demo

Three accepted commands collapsed to a single transient line each, followed by the multi-line primary prompt. Same theme in both shots — the only difference is `right_template`.

**Before** — the transient prompt has no right side; a `filler` just runs to the edge of the terminal:

![transient prompt without a right-aligned template](https://raw.githubusercontent.com/JamBalaya56562/oh-my-posh/assets-transient-right-template/transient-right-template-before.png)

**After** — `right_template` renders the exit status and time at the right edge, and the `filler` now bridges the gap:

![transient prompt with a right-aligned template](https://raw.githubusercontent.com/JamBalaya56562/oh-my-posh/assets-transient-right-template/transient-right-template.png)

<sub>Generated with the built-in image exporter (<code>image.Renderer</code>) from real <code>print transient</code> output, the same way the theme previews on ohmyposh.dev are produced.</sub>

<details><summary>demo theme</summary>

```json
"transient_prompt": {
  "foreground": "#A6E3A1",
  "template": "❯ ",
  "right_template": "{{ if gt .Code 0 }}<#F38BA8> {{ .Code }}</>{{ else }}<#A6E3A1></>{{ end }} <#7F849C>{{ now | date \"15:04:05\" }}</>",
  "filler": "<#45475A>·</>"
}
```

</details>

## How

Kept deliberately minimal — a single new property, no changes to any shell script:

- **zsh**: the eval output now sets `RPROMPT=<rendered right template>` instead of the hardcoded `RPROMPT=''`, letting zsh align it natively (same pattern the primary prompt already uses). Without a `right_template` the output is byte-identical to before.
- **pwsh**: the right side is embedded in the returned prompt string via cursor save/restore after `ClearAfter()`, mirroring `writePrimaryRightPrompt()`. The cursor is restored to right after the left part, so the accepted command is drawn over the gap — same graceful degradation as the primary right prompt.
- **filler**: when configured together with `right_template`, the filler now fills the gap between both parts.
- **streaming (zsh)**: a streamed transient record can only carry PS1 (the script resets `RPROMPT=''`, see `_omp_zle-line-init`), so the record is skipped when a `right_template` is configured — the script then falls back to the eval path and gets both values. pwsh needs no special handling since everything is embedded in the returned string. `serve`'s Clink wait protocol is untouched (cmd is out of scope).
- **`shouldFill`**: guarded against a negative padding length, which would panic in `strings.Repeat` (the right side subtraction makes this reachable; a too-wide left prompt could already trigger it).

### Scope

`zsh` and `powershell` only, as both work through the existing CLI surface. `fish`/`cmd`/`nu` would each need a new way to fetch the right side separately (and for cmd a serve protocol change), so they are intentionally left out — happy to follow up if there's demand. This covers the use case from #4822 (pwsh + zsh). The docs note the supported shells.

## Verification

- New unit tests in `src/prompt/extra_test.go` covering zsh (±eval, ±filler, quoting, unknown width), pwsh (±filler, exact fit, insufficient width, newline), the streaming skip/regression cases, and the `shouldFill` guard — plus byte-identical regression assertions for configs without `right_template`.
- `go test ./...`, `golangci-lint run`, `fieldalignment` and `modernize` all clean.
- Verified end-to-end on Windows: `print transient --shell pwsh` emits `left + ClearAfter + DECSC + gap + right + DECRC`, `--shell zsh --eval` emits `PS1=...` + `RPROMPT=...`, and configs without `right_template` produce unchanged output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
