### PR TITLE
feat(transient): support right template in fish

### DIFF
--- a/src/cli/print.go
+++ b/src/cli/print.go
@@ -43,7 +43,7 @@ func init() {
 
 func createPrintCmd() *cobra.Command {
 	printCmd := &cobra.Command{
-		Use:   "print [debug|primary|secondary|transient|right|tooltip|valid|error|preview]",
+		Use:   "print [debug|primary|secondary|transient|transient-right|right|tooltip|valid|error|preview]",
 		Short: "Print the prompt/context",
 		Long:  "Print one of the prompts based on the location/use-case.",
 		ValidArgs: []string{
@@ -51,6 +51,7 @@ func createPrintCmd() *cobra.Command {
 			prompt.PRIMARY,
 			prompt.SECONDARY,
 			prompt.TRANSIENT,
+			prompt.TRANSIENT_RIGHT,
 			prompt.RIGHT,
 			prompt.TOOLTIP,
 			prompt.VALID,
@@ -121,6 +122,8 @@ func createPrintCmd() *cobra.Command {
 				fmt.Print(eng.ExtraPrompt(prompt.Secondary))
 			case prompt.TRANSIENT:
 				fmt.Print(eng.ExtraPrompt(prompt.Transient))
+			case prompt.TRANSIENT_RIGHT:
+				fmt.Print(eng.TransientRPrompt())
 			case prompt.RIGHT:
 				fmt.Print(eng.RPrompt())
 			case prompt.TOOLTIP:

--- a/src/cli/print_test.go
+++ b/src/cli/print_test.go
@@ -1,0 +1,15 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/prompt"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrintCommandTransientRight(t *testing.T) {
+	cmd := createPrintCmd()
+
+	assert.Contains(t, cmd.ValidArgs, prompt.TRANSIENT_RIGHT)
+}

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -131,6 +131,11 @@ func (cfg *Config) Features(env runtime.Environment) shell.Features {
 	if cfg.TransientPrompt != nil {
 		log.Debug("transient prompt enabled")
 		feats |= shell.Transient
+
+		if env.Shell() == shell.FISH && len(cfg.TransientPrompt.RightTemplate) != 0 {
+			log.Debug("transient right prompt enabled")
+			feats |= shell.TransientRPrompt
+		}
 	}
 
 	if cfg.Streaming > 0 {

--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -165,6 +165,37 @@ func TestFeaturesShellIntegration(t *testing.T) {
 	}
 }
 
+func TestFeaturesTransientRightPrompt(t *testing.T) {
+	cases := []struct {
+		Case          string
+		RightTemplate string
+		ExpectedFeats shell.Features
+	}{
+		{
+			Case:          "transient prompt without right template",
+			ExpectedFeats: shell.Transient | shell.KeyHandlers,
+		},
+		{
+			Case:          "transient prompt with right template",
+			RightTemplate: "R>",
+			ExpectedFeats: shell.Transient | shell.TransientRPrompt | shell.KeyHandlers,
+		},
+	}
+
+	for _, tc := range cases {
+		env := &mock.Environment{}
+		env.On("Shell").Return(shell.FISH)
+
+		cfg := &Config{
+			TransientPrompt: &Segment{RightTemplate: tc.RightTemplate},
+			Upgrade:         &upgrade.Config{},
+		}
+
+		got := cfg.Features(env)
+		assert.Equal(t, tc.ExpectedFeats, got, tc.Case)
+	}
+}
+
 func TestFeaturesVIMode(t *testing.T) {
 	cases := []struct {
 		Case          string

--- a/src/prompt/engine.go
+++ b/src/prompt/engine.go
@@ -38,15 +38,16 @@ type Engine struct {
 }
 
 const (
-	PRIMARY   = "primary"
-	TRANSIENT = "transient"
-	DEBUG     = "debug"
-	SECONDARY = "secondary"
-	RIGHT     = "right"
-	TOOLTIP   = "tooltip"
-	VALID     = "valid"
-	ERROR     = "error"
-	PREVIEW   = "preview"
+	PRIMARY         = "primary"
+	TRANSIENT       = "transient"
+	TRANSIENT_RIGHT = "transient-right"
+	DEBUG           = "debug"
+	SECONDARY       = "secondary"
+	RIGHT           = "right"
+	TOOLTIP         = "tooltip"
+	VALID           = "valid"
+	ERROR           = "error"
+	PREVIEW         = "preview"
 )
 
 func (e *Engine) write(txt string) {

--- a/src/prompt/extra.go
+++ b/src/prompt/extra.go
@@ -156,15 +156,32 @@ func (e *Engine) transientPWSH(str, padText, rightStr string, length, rightLengt
 	return str + terminal.SaveCursorPosition() + padText + rightStr + terminal.RestoreCursorPosition()
 }
 
+// TransientRPrompt renders only the transient prompt's right-aligned template.
+// Shells with a native right prompt function use this independently from the
+// transient prompt's left side.
+func (e *Engine) TransientRPrompt() string {
+	prompt := e.Config.TransientPrompt
+	if prompt == nil {
+		return ""
+	}
+
+	foreground := color.Ansi(prompt.ForegroundTemplates.FirstMatch(nil, string(prompt.Foreground)))
+	background := color.Ansi(prompt.BackgroundTemplates.FirstMatch(nil, string(prompt.Background)))
+	terminal.SetColors(background, foreground)
+
+	str, _ := e.renderRightTemplate(prompt, background, foreground)
+	return str
+}
+
 // renderRightTemplate renders the transient prompt's right-aligned template.
-// Only zsh (via RPROMPT) and pwsh (via cursor save/restore) can display it.
+// Only shells with a supported native or emulated right prompt can display it.
 func (e *Engine) renderRightTemplate(prompt *config.Segment, background, foreground color.Ansi) (string, int) {
 	if len(prompt.RightTemplate) == 0 {
 		return "", 0
 	}
 
 	switch e.Env.Shell() {
-	case shell.ZSH, shell.PWSH:
+	case shell.ZSH, shell.PWSH, shell.FISH:
 	default:
 		return "", 0
 	}

--- a/src/prompt/extra_test.go
+++ b/src/prompt/extra_test.go
@@ -226,8 +226,86 @@ func TestExtraPromptTransientPWSHNewline(t *testing.T) {
 	assert.Equal(t, expected, got)
 }
 
-func TestExtraPromptRightTemplateUnsupportedShell(t *testing.T) {
+func TestExtraPromptTransientFish(t *testing.T) {
+	cases := []struct {
+		TerminalErr   error
+		Case          string
+		RightTemplate string
+		Filler        string
+		ExpectedLeft  string
+		ExpectedRight string
+		TerminalWidth int
+	}{
+		{
+			Case:         "no right template - byte identical to previous behavior",
+			ExpectedLeft: "L>",
+		},
+		{
+			Case:          "right template is returned separately",
+			RightTemplate: "R>",
+			ExpectedLeft:  "L>",
+			ExpectedRight: "R>",
+		},
+		{
+			Case:          "right template and filler",
+			RightTemplate: "R>",
+			Filler:        "-",
+			TerminalWidth: 20,
+			ExpectedLeft:  "L>" + strings.Repeat("-", 16),
+			ExpectedRight: "R>",
+		},
+		{
+			Case:          "right template and filler with unknown terminal width",
+			RightTemplate: "R>",
+			Filler:        "-",
+			TerminalErr:   errors.New("burp"),
+			ExpectedLeft:  "L>",
+			ExpectedRight: "R>",
+		},
+		{
+			Case:          "right template and filler with insufficient width",
+			RightTemplate: "R>",
+			Filler:        "-",
+			TerminalWidth: 3,
+			ExpectedLeft:  "L>",
+			ExpectedRight: "R>",
+		},
+	}
+
+	for _, tc := range cases {
+		env := setupExtraPromptTest(shell.FISH, &runtime.Flags{})
+		env.On("TerminalWidth").Return(tc.TerminalWidth, tc.TerminalErr)
+
+		engine := &Engine{
+			Config: &config.Config{
+				TransientPrompt: &config.Segment{
+					Template:      "L>",
+					RightTemplate: tc.RightTemplate,
+					Filler:        tc.Filler,
+				},
+			},
+			Env: env,
+		}
+
+		assert.Equal(t, tc.ExpectedLeft, engine.ExtraPrompt(Transient), tc.Case)
+		assert.Equal(t, tc.ExpectedRight, engine.TransientRPrompt(), tc.Case)
+	}
+}
+
+func TestTransientRPromptTemplateError(t *testing.T) {
 	env := setupExtraPromptTest(shell.FISH, &runtime.Flags{})
+	engine := &Engine{
+		Config: &config.Config{
+			TransientPrompt: &config.Segment{RightTemplate: "{{"},
+		},
+		Env: env,
+	}
+
+	assert.NotEmpty(t, engine.TransientRPrompt())
+}
+
+func TestExtraPromptRightTemplateUnsupportedShell(t *testing.T) {
+	env := setupExtraPromptTest(shell.BASH, &runtime.Flags{})
 
 	engine := &Engine{
 		Config: &config.Config{

--- a/src/shell/features.go
+++ b/src/shell/features.go
@@ -21,6 +21,7 @@ const (
 	Streaming
 	KeyHandlers
 	VIMode
+	TransientRPrompt
 )
 
 // getAllFeatures returns all defined feature flags by iterating through bit positions
@@ -32,7 +33,7 @@ func getAllFeatures() []Features {
 		feature := Features(1 << i)
 
 		// Stop when we reach a power of 2 greater than our highest defined feature
-		if feature > VIMode*2 {
+		if feature > TransientRPrompt {
 			break
 		}
 

--- a/src/shell/fish.go
+++ b/src/shell/fish.go
@@ -13,6 +13,8 @@ func (f Features) Fish() Code {
 	switch f {
 	case Transient:
 		return "set --global _omp_transient_prompt 1"
+	case TransientRPrompt:
+		return "set --global _omp_transient_rprompt 1"
 	case CursorPositioning:
 		return "set --global _omp_cursor_positioning 1"
 	case FTCSMarks:

--- a/src/shell/fish_test.go
+++ b/src/shell/fish_test.go
@@ -18,7 +18,8 @@ set --global _omp_ftcs_marks 1
 "$_omp_executable" notice
 set --global _omp_prompt_mark 1
 set --global _omp_cursor_positioning 1
-set --global _omp_enable_streaming 1`
+set --global _omp_enable_streaming 1
+set --global _omp_transient_rprompt 1`
 
 	assert.Equal(t, want, got)
 }

--- a/src/shell/pwsh_test.go
+++ b/src/shell/pwsh_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 var allFeatures = Tooltips | LineError | Transient | Jobs | Azure | PoshGit | FTCSMarks |
-	Upgrade | Notice | PromptMark | RPrompt | CursorPositioning | KeyHandlers | Streaming | VIMode
+	Upgrade | Notice | PromptMark | RPrompt | CursorPositioning | KeyHandlers | Streaming | VIMode | TransientRPrompt
 
 func TestPwshFeatures(t *testing.T) {
 	got := allFeatures.Lines(PWSH).String("")

--- a/src/shell/scripts/omp.fish
+++ b/src/shell/scripts/omp.fish
@@ -10,6 +10,7 @@ set --global _omp_executable ::OMP::
 set --global _omp_cursor_positioning 0
 set --global _omp_ftcs_marks 0
 set --global _omp_transient_prompt 0
+set --global _omp_transient_rprompt 0
 set --global _omp_prompt_mark 0
 
 # streaming support variables
@@ -550,6 +551,11 @@ end
 function fish_right_prompt
     if test "$_omp_transient" = 1
         set --global _omp_transient 0
+
+        if test $_omp_transient_rprompt = 1
+            _omp_get_prompt transient-right
+        end
+
         return
     end
 

--- a/website/docs/configuration/transient.mdx
+++ b/website/docs/configuration/transient.mdx
@@ -48,7 +48,7 @@ You need to extend or create a custom theme with your transient prompt. For exam
 | `background`           | `string`  | [color][colors]                                                                                                                                |
 | `background_templates` | `array`   | [color templates][color-templates]                                                                                                             |
 | `template`             | `string`  | a go [text/template][go-text-template] template extended with [sprig][sprig] utilizing the properties below - defaults to `{{ .Shell }}> `     |
-| `right_template`       | `string`  | a go [text/template][go-text-template] template extended with [sprig][sprig], right-aligned at the end of the line. Supported in `zsh` and `powershell` only, designed for single line transient prompts |
+| `right_template`       | `string`  | a go [text/template][go-text-template] template extended with [sprig][sprig], right-aligned at the end of the line. Supported in `zsh`, `powershell`, and `fish`, designed for single line transient prompts |
 | `filler`               | `string`  | when you want to create a line with a repeated set of characters spanning the width of the terminal. Will be added _after_ the `template` text |
 | `newline`              | `boolean` | add a newline before the prompt. The newline will not be printed under the same conditions as for primary prompt [newlines][block-newline].    |
 


### PR DESCRIPTION
## Summary

- add `oh-my-posh print transient-right` to render the transient prompt's right template independently
- use fish's native `fish_right_prompt` for transient right prompts while preserving the primary right prompt
- enable the fish integration only when `transient_prompt.right_template` is configured, so existing configurations do not incur an extra CLI call
- account for the right template width when rendering a transient filler and document fish support

This is the fish follow-up to #7665. It does not change the streaming/serve protocol.

## Preview

![fish transient right template preview](https://raw.githubusercontent.com/JamBalaya56562/oh-my-posh/assets/pr-7672/.github/assets/pr-7672/fish-transient-right-template.png)

## Compatibility

- configurations without `right_template` keep the existing fish behavior
- the normal primary right prompt is unchanged
- zsh and PowerShell behavior is unchanged

## Validation

- `go test ./...` (Go 1.26.0)
- `golangci-lint run` (0 issues)
- `fieldalignment ./...`
- `modernize ./...`
- `fish -n src/shell/scripts/omp.fish`
- CLI smoke test confirmed separate `transient` and `transient-right` output and config-gated fish initialization
- `npm run build` in `website`

