### PR TITLE
fix(git): handle worktree gitdir files without trailing newline

### DIFF
--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -499,7 +499,7 @@ func (g *Git) hasWorktree(gitdir *runtime.FileInfo) bool {
 		if worktreeIndex > -1 && g.env.HasFilesInDir(g.scmDir, "gitdir") {
 			gitDir := filepath.Join(g.scmDir, "gitdir")
 			realGitFolder := g.env.FileContent(gitDir)
-			g.repoRootDir = strings.TrimSuffix(realGitFolder, ".git\n")
+			g.repoRootDir = strings.TrimSuffix(strings.TrimRight(realGitFolder, "\n\r "), ".git")
 			// resolve relative paths (worktree.useRelativePaths = true)
 			g.repoRootDir = resolveGitPath(g.scmDir, g.repoRootDir)
 			g.scmDir = g.scmDir[:worktreeIndex]
@@ -522,7 +522,7 @@ func (g *Git) hasWorktree(gitdir *runtime.FileInfo) bool {
 		gitDir := filepath.Join(g.mainSCMDir, "gitdir")
 		g.scmDir = g.mainSCMDir[:worktreeIndex]
 		gitDirContent := g.env.FileContent(gitDir)
-		g.repoRootDir = strings.TrimSuffix(gitDirContent, ".git\n")
+		g.repoRootDir = strings.TrimSuffix(strings.TrimRight(gitDirContent, "\n\r "), ".git")
 		// resolve relative paths (worktree.useRelativePaths = true)
 		g.repoRootDir = resolveGitPath(g.mainSCMDir, g.repoRootDir)
 		g.IsWorkTree = true

--- a/src/segments/git_test.go
+++ b/src/segments/git_test.go
@@ -136,6 +136,16 @@ func TestEnabledInWorktree(t *testing.T) {
 			ExpectedRealFolder:    TestRootPath + "dev/worktree",
 			ExpectedRootFolder:    TestRootPath + dotGit,
 		},
+		{
+			Case:                  "worktree with relative gitdir path, no trailing newline",
+			ExpectedEnabled:       true,
+			WorkingFolder:         TestRootPath + "dev/.git/worktrees/folder_worktree",
+			WorkingFolderAddon:    "gitdir",
+			WorkingFolderContent:  "../../../worktree/.git",
+			ExpectedWorkingFolder: TestRootPath + "dev/.git/worktrees/folder_worktree",
+			ExpectedRealFolder:    TestRootPath + "dev/worktree",
+			ExpectedRootFolder:    TestRootPath + dotGit,
+		},
 	}
 	fileInfo := &runtime.FileInfo{
 		Path:         TestRootPath + dotGit,


### PR DESCRIPTION
## Description

The `hasWorktree()` function parses the reverse `gitdir` admin file (`worktrees/<id>/gitdir`) using `strings.TrimSuffix(content, ".git\n")`, which assumes the file always ends with a trailing newline. When the file is missing its trailing newline (e.g., written by a third-party tool or after `git worktree repair --relative-paths` in some configurations), the `.git` suffix is not stripped and remains in the resolved `repoRootDir` path.

This causes every git command run by the Git segment to fail with:
```
fatal: cannot change to '.../.git': Not a directory
```

## Fix

Use `strings.TrimRight` to strip trailing whitespace (newlines, carriage returns, spaces) before applying `strings.TrimSuffix` to remove the `.git` suffix. This matches Git's own approach — `read_gitfile_gently()` in `setup.c` strips trailing newlines with a `while (buf[len-1] == '\n' || buf[len-1] == '\r') len--` loop before parsing.

## Related

- Closes #7267
- Identified during a health check on a worktree bundle where the `worktrees/<id>/gitdir` files were missing their trailing newlines (likely from a tool or manual creation of the `.git` files)