### PR TITLE
fix(zsh): keep the prompt on multi-line loop headers

### DIFF
--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -591,7 +591,20 @@ function _omp_is_buffer_complete() {
     return 1
   fi
 
-  # 3. An odd number of trailing backslashes escapes the newline that follows the
+  # 3. The SHORT_LOOPS option (on by default) makes `zsh -n` accept a bare loop
+  # header as a complete empty loop - `for i in 1 2`, `while true`, or the
+  # `for i in 1 2 do;` form - even though the line editor keeps waiting for the
+  # body. Re-parse with an explicit `do : done` appended and SHORT_LOOPS off:
+  # an open `for`/`while`/`until`/`select`/`repeat` header absorbs it into a
+  # valid loop, while every genuinely complete command - including the
+  # `for x (...) cmd` and `repeat n cmd` short forms - orphans the `do` into a
+  # syntax error. The keyword test keeps the extra parse off the common path.
+  if [[ $buf == *(for|while|until|select|repeat)* ]] && \
+     print -r -- "$buf"$'\ndo\n:\ndone' | zsh +o shortloops -n 2>/dev/null; then
+    return 1
+  fi
+
+  # 4. An odd number of trailing backslashes escapes the newline that follows the
   # buffer, which parses as a line continuation rather than an incomplete command.
   local trailing=${buf##*[^\\]}
   (( ${#trailing} % 2 )) && return 1

--- a/src/shell/zsh_test.go
+++ b/src/shell/zsh_test.go
@@ -61,6 +61,29 @@ func TestZshIsBufferComplete(t *testing.T) {
 		{Case: "Trailing pipe", Buffer: "echo hi |", Expected: false},
 		{Case: "Open for loop", Buffer: "for i in 1 2; do", Expected: false},
 		{Case: "Closed for loop", Buffer: "for i in 1 2; do\necho $i\ndone", Expected: true},
+		// A bare loop header parses as a complete empty loop under SHORT_LOOPS,
+		// but the line editor still waits for the body - it must stay open.
+		{Case: "Bare for header", Buffer: "for i in 1 2", Expected: false},
+		{Case: "Bare while header", Buffer: "while true", Expected: false},
+		{Case: "Bare until header", Buffer: "until false", Expected: false},
+		{Case: "Bare select header", Buffer: "select x in a b", Expected: false},
+		// The `<keyword> ... do;` form (a `do` immediately closed by `;`) is the
+		// same SHORT_LOOPS leniency; it must stay open for every loop keyword.
+		{Case: "for header with do;", Buffer: "for i in 1 2 do;", Expected: false},
+		{Case: "while header with do;", Buffer: "while true do;", Expected: false},
+		{Case: "until header with do;", Buffer: "until false do;", Expected: false},
+		{Case: "select header with do;", Buffer: "select x in a b do;", Expected: false},
+		// The keyword gate matches substrings ("before" contains "for"), so a
+		// plain command that merely embeds a loop keyword must stay complete.
+		{Case: "Keyword substring in a plain command", Buffer: "echo before", Expected: true},
+		// Genuine zsh short-loop forms are complete and must not be held open.
+		{Case: "for short-loop form", Buffer: "for i (1 2) echo $i", Expected: true},
+		{Case: "C-style for short-loop form", Buffer: "for ((i = 0; i < 2; i++)) echo $i", Expected: true},
+		{Case: "repeat short-loop form", Buffer: "repeat 2 echo hi", Expected: true},
+		// foreach uses `end`, not `do`/`done`, so it needs no special handling -
+		// but the keyword gate matches it (via "for"), so pin both ends.
+		{Case: "Open foreach header", Buffer: "foreach i (1 2)", Expected: false},
+		{Case: "Closed foreach loop", Buffer: "foreach i (1 2)\necho $i\nend", Expected: true},
 		{Case: "Open case", Buffer: "case x in a) echo 1", Expected: false},
 		{Case: "Closed case", Buffer: "case x in a) echo 1;; esac", Expected: true},
 		{Case: "Odd trailing backslash", Buffer: `echo a \`, Expected: false},


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

This fixes a `zsh -n` vs. `zsh interactive` inconsistent behavior for multiline_keepprompt.

The multiline_keepprompt feature uses `zsh -n` to decide whether the buffer is a complete command. With SHORT_LOOPS (on by default) `zsh -n` accepts a bare loop header - `for i in 1 2`, `while true`, or the `for i in 1 2 do;` form - as a complete empty loop, even though the line editor keeps waiting for the body. The keep-prompt loop then exits early and the transient prompt takes over mid-command.

Even if these do the same output:
- this breaks the keepprompt:
```shell
❯ for i in 1 2 do;
do;
echo $i;
done
1
2
do
```
- while this works
```
❯ for i in 1 2 do; do
echo $i;
done
1
2
do
```

| you type | zsh -n | interactive | result |
|----------|-------|------------|-------|
| for i in 1 2; do (works) | incomplete | incomplete | agree → keep-prompt engages, primary stays ✓ |
| for i in 1 2 do; (breaks) | complete | incomplete | disagree → collapses to transient early ✗ |

Detect the disguised open header by re-parsing with an explicit `do : done` appended and SHORT_LOOPS off: an open for/while/until/select/ repeat header absorbs it into a valid loop, while every genuinely complete command - including the `for x (...) cmd` and `repeat n cmd` short forms - orphans the `do` into a syntax error and is left untouched. foreach is unaffected: it uses `end`, not do/done.

| typed + Enter | before | after |
|--------------|--------|------|
| for i in 1 2 (Allman) | transient took over | ❯ for i in 1 2 primary survives ✓ |
| for i in 1 2 do; (your case) | transient took over | ❯ for i in 1 2 do primary survives ✓ |
| while true | transient took over | ❯ while true primary survives ✓ |
| for i (1 2) echo hi-$i (short form) | ran | still ran, no hang ✓ |
