### PR TITLE
fix(init): isolate strict init scripts

### DIFF
--- a/src/cli/init.go
+++ b/src/cli/init.go
@@ -62,7 +62,7 @@ See the documentation to initialize your shell: https://ohmyposh.dev/docs/instal
 	}
 
 	initCmd.Flags().BoolVarP(&printOutput, "print", "p", false, "print the init script")
-	initCmd.Flags().BoolVarP(&strict, "strict", "s", false, "run in strict mode")
+	initCmd.Flags().BoolVarP(&strict, "strict", "s", false, "resolve the executable through PATH")
 	initCmd.Flags().BoolVar(&debug, "debug", false, "enable/disable debug mode")
 	initCmd.Flags().BoolVar(&eval, "eval", false, "output the full init script for eval")
 

--- a/src/shell/filesystem.go
+++ b/src/shell/filesystem.go
@@ -36,7 +36,7 @@ func hasScript(env runtime.Environment) (string, bool) {
 	}
 
 	// check if we have the same context
-	if val, _ := cache.Get[string](cache.Device, cacheKey(env.Flags().Shell)); val != cacheValue(env) {
+	if val, _ := cache.Get[string](cache.Device, cacheKey(env.Flags())); val != cacheValue(env) {
 		log.Debug("script context has changed")
 		return "", false
 	}
@@ -126,13 +126,18 @@ func writeScript(env runtime.Environment, script string) (string, error) {
 	}
 
 	log.Debug("init script written successfully")
-	cache.Set(cache.Device, cacheKey(env.Flags().Shell), cacheValue(env), cache.INFINITE)
+	cache.Set(cache.Device, cacheKey(env.Flags()), cacheValue(env), cache.INFINITE)
 
 	return path, nil
 }
 
-func cacheKey(sh string) string {
-	return fmt.Sprintf("INITVERSION%s", strings.ToUpper(sh))
+func cacheKey(flags *runtime.Flags) string {
+	key := fmt.Sprintf("INITVERSION%s", strings.ToUpper(flags.Shell))
+	if flags.Strict {
+		key += "STRICT"
+	}
+
+	return key
 }
 
 func cacheValue(env runtime.Environment) string {
@@ -161,6 +166,9 @@ func InitScriptName(flags *runtime.Flags) string {
 	h := fnv.New64a()
 	h.Write([]byte(flags.ConfigPath))
 	hash := h.Sum64()
+	if flags.Strict {
+		return fmt.Sprintf("init.%d.strict.%s", hash, sh)
+	}
 
 	return fmt.Sprintf("init.%d.%s", hash, sh)
 }

--- a/src/shell/filesystem_test.go
+++ b/src/shell/filesystem_test.go
@@ -1,0 +1,17 @@
+package shell
+
+import (
+	"testing"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStrictUsesSeparateInitScript(t *testing.T) {
+	defaultFlags := &runtime.Flags{Shell: BASH, ConfigPath: "default.omp.json"}
+	strictFlags := &runtime.Flags{Shell: BASH, ConfigPath: "default.omp.json", Strict: true}
+
+	assert.NotEqual(t, cacheKey(defaultFlags), cacheKey(strictFlags))
+	assert.NotEqual(t, InitScriptName(defaultFlags), InitScriptName(strictFlags))
+	assert.Contains(t, InitScriptName(strictFlags), ".strict.sh")
+}

--- a/website/docs/installation/prompt.mdx
+++ b/website/docs/installation/prompt.mdx
@@ -297,6 +297,21 @@ exec zsh
 </TabItem>
 </Tabs>
 
+## Version managers
+
+By default, the generated init script for most Oh My Posh installations uses the executable's
+absolute path. A version manager that removes the previous version during an upgrade can leave an
+existing shell pointing to a path that no longer exists.
+
+Add `--strict` to resolve `oh-my-posh` through `PATH` instead:
+
+```bash
+eval "$(oh-my-posh init bash --strict)"
+```
+
+Use the equivalent init command for your shell. This keeps the prompt working when the version
+manager updates `PATH` to a new Oh My Posh installation.
+
 [Copilot CLI segment documentation]: /docs/segments/cli/copilot-cli
 [clink]: https://chrisant996.github.io/clink/
 [iterm2]: https://iterm2.com/


### PR DESCRIPTION
## Problem

Version managers can remove an old Oh My Posh installation as part of an upgrade. For example, `mise upgrade` replaces `~/.local/share/mise/installs/oh-my-posh/<version>` and removes the previous version, while an existing shell still has `_omp_executable` set to that old absolute path. The next prompt then fails with `No such file or directory` until the shell is restarted.

The existing `init --strict` option is intended to avoid this by resolving `oh-my-posh` through `PATH`, but strict and default initialization currently share the same cached script and cache key. Switching modes can therefore reuse the wrong script, and concurrent shells can overwrite each other's executable choice. The current installation and upgrade docs also do not describe the PATH-based behavior. The only existing documentation I found is a one-line mention in a 2022 release post, while the CLI help says only "run in strict mode".

## Change

This change gives strict and default initialization separate cache keys and script files, ensuring each mode consistently uses its intended executable path. It also clarifies the purpose of `--strict` in the CLI help and installation documentation.

## Validation

Validation included `go test ./...`, `go test -race ./shell`, `go vet ./shell ./cli`, and `npm run build`. I also generated default and strict Bash init scripts from the same configuration and verified that they remain separate and contain the expected executable paths.