### PR TITLE
feat(spotify): detect ads on macOS and Linux

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -211,7 +211,7 @@ func (cfg *Config) Features(env runtime.Environment) shell.Features {
 				}
 			}
 
-			if segment.Type == VIMODE && slices.Contains([]string{shell.ZSH, shell.PWSH}, env.Shell()) {
+			if segment.Type == VIMODE && slices.Contains([]string{shell.ZSH, shell.PWSH, shell.FISH}, env.Shell()) {
 				log.Debug("vi mode tracking enabled")
 				feats |= shell.VIMode
 			}

--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -213,6 +213,11 @@ func TestFeaturesVIMode(t *testing.T) {
 			ExpectedFeats: shell.VIMode,
 		},
 		{
+			Case:          "fish enables vi mode tracking",
+			Shell:         shell.FISH,
+			ExpectedFeats: shell.VIMode,
+		},
+		{
 			Case:          "bash does not enable vi mode tracking",
 			Shell:         shell.BASH,
 			ExpectedFeats: 0,

--- a/src/segments/spotify_darwin.go
+++ b/src/segments/spotify_darwin.go
@@ -2,7 +2,12 @@
 
 package segments
 
-import "strings"
+import (
+	"strconv"
+	"strings"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
+)
 
 func (s *Spotify) Enabled() bool {
 	// Batching commands to reduce latency. Each individual call to `osascript` creates additional delays.
@@ -14,42 +19,50 @@ func (s *Spotify) Enabled() bool {
 			set playerState to player state as string
 			set artistName to ""
 			set trackName to ""
+			set albumName to ""
+			set trackNumber to 0
 			if playerState is not "stopped" then
-				set artistName to artist of current track as string
-				set trackName to name of current track as string
+				try
+					set artistName to artist of current track as string
+				end try
+				try
+					set trackName to name of current track as string
+				end try
+				try
+					set albumName to album of current track as string
+				end try
+				try
+					set trackNumber to track number of current track as integer
+				end try
 			end if
-			return "true|" & playerState & "|" & artistName & "|" & trackName
+			return "true|" & playerState & "|" & artistName & "|" & trackName & "|" & albumName & "|" & trackNumber
 		end tell
 	else
-		return "false|||"
+		return "false|||||0"
 	end if
 	`
 
 	batchedOutput := s.runAppleScriptCommand(batchedCommand)
 
-	outputStrings := strings.SplitN(batchedOutput, "|", 4)
-	if outputStrings[0] == "false" || outputStrings[0] == "" || len(outputStrings) != 4 {
+	outputStrings := strings.SplitN(batchedOutput, "|", 6)
+	if len(outputStrings) != 6 || outputStrings[0] == "false" || outputStrings[0] == "" {
 		s.Status = stopped
 		return false
 	}
 
-	s.Status = outputStrings[1]
-
-	// Check if running
-	if s.Status == "" {
+	if outputStrings[1] == "" {
 		s.Status = stopped
 		return false
 	}
 
-	if s.Status == stopped {
-		return false
-	}
-
-	s.Artist = outputStrings[2]
-	s.Track = outputStrings[3]
-	s.resolveIcon()
-
-	return true
+	trackNumber, _ := strconv.Atoi(outputStrings[5])
+	return s.applyMediaInfo(&runtime.MediaInfo{
+		Status:      outputStrings[1],
+		Artist:      outputStrings[2],
+		Title:       outputStrings[3],
+		Album:       outputStrings[4],
+		TrackNumber: trackNumber,
+	})
 }
 
 func (s *Spotify) runAppleScriptCommand(command string) string {

--- a/src/segments/spotify_darwin_test.go
+++ b/src/segments/spotify_darwin_test.go
@@ -19,10 +19,12 @@ func TestSpotifyDarwinEnabledAndSpotifyPlaying(t *testing.T) {
 		Expected    string
 		Enabled     bool
 	}{
-		{BatchedCase: "false|||", Expected: "", Enabled: false},
+		{BatchedCase: "false|||||0", Expected: "", Enabled: false},
 		{BatchedCase: "false||", Expected: "", Error: errors.New("oops"), Enabled: false},
-		{BatchedCase: "true|playing|Candlemass|Spellbreaker", Expected: "\ue602 Candlemass - Spellbreaker", Enabled: true},
-		{BatchedCase: "true|paused|Candlemass|Spellbreaker", Expected: "\uf04c Candlemass - Spellbreaker", Enabled: true},
+		{BatchedCase: "true|playing|Candlemass|Spellbreaker|Nightfall|3", Expected: "\ue602 Candlemass - Spellbreaker", Enabled: true},
+		{BatchedCase: "true|paused|Candlemass|Spellbreaker|Nightfall|3", Expected: "\uf04c Candlemass - Spellbreaker", Enabled: true},
+		{BatchedCase: "true|playing||アコム【公式】||0", Expected: "\ueebb  - アコム【公式】", Enabled: true},
+		{BatchedCase: "true|stopped||||0", Expected: "", Enabled: false},
 	}
 	batchedCommand := `
 	if application "Spotify" is running then
@@ -30,14 +32,26 @@ func TestSpotifyDarwinEnabledAndSpotifyPlaying(t *testing.T) {
 			set playerState to player state as string
 			set artistName to ""
 			set trackName to ""
+			set albumName to ""
+			set trackNumber to 0
 			if playerState is not "stopped" then
-				set artistName to artist of current track as string
-				set trackName to name of current track as string
+				try
+					set artistName to artist of current track as string
+				end try
+				try
+					set trackName to name of current track as string
+				end try
+				try
+					set albumName to album of current track as string
+				end try
+				try
+					set trackNumber to track number of current track as integer
+				end try
 			end if
-			return "true|" & playerState & "|" & artistName & "|" & trackName
+			return "true|" & playerState & "|" & artistName & "|" & trackName & "|" & albumName & "|" & trackNumber
 		end tell
 	else
-		return "false|||"
+		return "false|||||0"
 	end if
 	`
 	for _, tc := range cases {

--- a/src/segments/spotify_linux.go
+++ b/src/segments/spotify_linux.go
@@ -3,9 +3,22 @@
 package segments
 
 import (
+	"strconv"
 	"strings"
 
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
 	"github.com/jandedobbeleer/oh-my-posh/src/shell"
+)
+
+const (
+	spotifyDBusCommand = "dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify " +
+		"/org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:org.mpris.MediaPlayer2.Player"
+	spotifyPlaybackStatusCommand = " string:PlaybackStatus | awk -F '\"' '/string/ {print tolower($2)}'"
+	spotifyArtistCommand         = " string:Metadata | awk -F '\"' 'BEGIN {RS=\"entry\"}; /'xesam:artist'/ {a=$4} END {print a}'"
+	spotifyTrackCommand          = " string:Metadata | awk -F '\"' 'BEGIN {RS=\"entry\"}; /'xesam:title'/ {t=$4} END {print t}'"
+	spotifyAlbumCommand          = " string:Metadata | awk -F '\"' 'BEGIN {RS=\"entry\"}; /'xesam:album'/ {a=$4} END {print a}'"
+	spotifyTrackNumberCommand    = " string:Metadata | awk 'BEGIN {RS=\"entry\"}; /'xesam:trackNumber'/ " +
+		"{for (i=1; i<=NF; i++) if ($i ~ /^[0-9]+$/) n=$i} END {print n}'"
 )
 
 func (s *Spotify) Enabled() bool {
@@ -15,7 +28,7 @@ func (s *Spotify) Enabled() bool {
 	}
 
 	// Standard Linux implementation
-	running := s.runLinuxScriptCommand(" string:PlaybackStatus | awk -F '\"' '/string/ {print tolower($2)}'")
+	running := s.runLinuxScriptCommand(spotifyPlaybackStatusCommand)
 
 	if strings.HasPrefix(running, "Error") || running == "" {
 		return false
@@ -25,23 +38,27 @@ func (s *Spotify) Enabled() bool {
 		s.Status = stopped
 		return false
 	}
-
-	if running == stopped {
-		s.Status = stopped
-		return false
+	if running != playing && running != paused {
+		return s.applyMediaInfo(&runtime.MediaInfo{Status: running})
 	}
 
-	s.Status = running
-	s.Artist = s.runLinuxScriptCommand(" string:Metadata | awk -F '\"' 'BEGIN {RS=\"entry\"}; /'xesam:artist'/ {a=$4} END {print a}'")
-	s.Track = s.runLinuxScriptCommand(" string:Metadata | awk -F '\"' 'BEGIN {RS=\"entry\"}; /'xesam:title'/ {t=$4} END {print t}'")
-	s.resolveIcon()
+	artist := s.runLinuxScriptCommand(spotifyArtistCommand)
+	track := s.runLinuxScriptCommand(spotifyTrackCommand)
+	album := s.runLinuxScriptCommand(spotifyAlbumCommand)
+	trackNumberOutput := s.runLinuxScriptCommand(spotifyTrackNumberCommand)
+	trackNumber, _ := strconv.Atoi(trackNumberOutput)
 
-	return true
+	return s.applyMediaInfo(&runtime.MediaInfo{
+		Status:      running,
+		Artist:      artist,
+		Title:       track,
+		Album:       album,
+		TrackNumber: trackNumber,
+	})
 }
 
 func (s *Spotify) runLinuxScriptCommand(command string) string {
-	dbusCMD := "dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:org.mpris.MediaPlayer2.Player"
-	val := s.env.RunShellCommand(shell.BASH, dbusCMD+command)
+	val := s.env.RunShellCommand(shell.BASH, spotifyDBusCommand+command)
 	return val
 }
 

--- a/src/segments/spotify_linux_test.go
+++ b/src/segments/spotify_linux_test.go
@@ -19,22 +19,32 @@ func TestSpotifyLinux(t *testing.T) {
 		Status          string
 		Artist          string
 		Track           string
+		Album           string
+		TrackNumber     string
 		Expected        string
 		ExpectedEnabled bool
 	}{
 		{Case: "no data", ExpectedEnabled: false},
 		{Case: "error", ExpectedEnabled: false, Status: "Error.ServiceUnknown"},
-		{Case: "paused", ExpectedEnabled: true, Expected: "\uf04c Candlemass - Spellbreaker", Status: "paused", Artist: "Candlemass", Track: "Spellbreaker"},
-		{Case: "playing", ExpectedEnabled: true, Expected: "\ue602 Candlemass - Spellbreaker", Status: "playing", Artist: "Candlemass", Track: "Spellbreaker"},
+		{
+			Case: "paused", ExpectedEnabled: true, Expected: "\uf04c Candlemass - Spellbreaker",
+			Status: "paused", Artist: "Candlemass", Track: "Spellbreaker", Album: "Nightfall", TrackNumber: "3",
+		},
+		{
+			Case: "playing", ExpectedEnabled: true, Expected: "\ue602 Candlemass - Spellbreaker",
+			Status: "playing", Artist: "Candlemass", Track: "Spellbreaker", Album: "Nightfall", TrackNumber: "3",
+		},
+		{Case: "ad", ExpectedEnabled: true, Expected: "\ueebb Spotify - Try Premium for free", Status: "playing", Artist: "Spotify", Track: "Try Premium for free"},
 	}
 	for _, tc := range cases {
 		env := new(mock.Environment)
 		env.On("IsWsl").Return(false)
 
-		dbusCMD := "dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 org.freedesktop.DBus.Properties.Get string:org.mpris.MediaPlayer2.Player"
-		env.On("RunShellCommand", shell.BASH, dbusCMD+" string:PlaybackStatus | awk -F '\"' '/string/ {print tolower($2)}'").Return(tc.Status)
-		env.On("RunShellCommand", shell.BASH, dbusCMD+" string:Metadata | awk -F '\"' 'BEGIN {RS=\"entry\"}; /'xesam:artist'/ {a=$4} END {print a}'").Return(tc.Artist)
-		env.On("RunShellCommand", shell.BASH, dbusCMD+" string:Metadata | awk -F '\"' 'BEGIN {RS=\"entry\"}; /'xesam:title'/ {t=$4} END {print t}'").Return(tc.Track)
+		env.On("RunShellCommand", shell.BASH, spotifyDBusCommand+spotifyPlaybackStatusCommand).Return(tc.Status)
+		env.On("RunShellCommand", shell.BASH, spotifyDBusCommand+spotifyArtistCommand).Return(tc.Artist)
+		env.On("RunShellCommand", shell.BASH, spotifyDBusCommand+spotifyTrackCommand).Return(tc.Track)
+		env.On("RunShellCommand", shell.BASH, spotifyDBusCommand+spotifyAlbumCommand).Return(tc.Album)
+		env.On("RunShellCommand", shell.BASH, spotifyDBusCommand+spotifyTrackNumberCommand).Return(tc.TrackNumber)
 
 		s := &Spotify{}
 		s.Init(options.Map{}, env)

--- a/src/segments/spotify_smtc_parser.go
+++ b/src/segments/spotify_smtc_parser.go
@@ -1,11 +1,8 @@
-//go:build windows || (linux && !darwin)
-
 package segments
 
 import "github.com/jandedobbeleer/oh-my-posh/src/runtime"
 
-// applyMediaInfo maps a media session read from SMTC (native WinRT on Windows
-// via runtime.QueryMediaPlayer, or the WSL PowerShell script in spotify_smtc.go)
+// applyMediaInfo maps media information read from the platform player API
 // onto s and returns whether the segment should be displayed.
 func (s *Spotify) applyMediaInfo(info *runtime.MediaInfo) bool {
 	if info == nil {

--- a/src/shell/fish.go
+++ b/src/shell/fish.go
@@ -29,7 +29,9 @@ func (f Features) Fish() Code {
 		return unixUpgrade
 	case Notice:
 		return unixNotice
-	case RPrompt, PoshGit, Azure, LineError, Jobs, Async, KeyHandlers, VIMode:
+	case VIMode:
+		return "_omp_enable_vimode"
+	case RPrompt, PoshGit, Azure, LineError, Jobs, Async, KeyHandlers:
 		fallthrough
 	default:
 		return ""

--- a/src/shell/fish_test.go
+++ b/src/shell/fish_test.go
@@ -19,6 +19,7 @@ set --global _omp_ftcs_marks 1
 set --global _omp_prompt_mark 1
 set --global _omp_cursor_positioning 1
 set --global _omp_enable_streaming 1
+_omp_enable_vimode
 set --global _omp_transient_rprompt 1`
 
 	assert.Equal(t, want, got)

--- a/src/shell/scripts/omp.fish
+++ b/src/shell/scripts/omp.fish
@@ -747,3 +747,38 @@ function omp_repaint_prompt
     set --global _omp_new_prompt 1
     commandline --function repaint
 end
+
+# vi mode tracking — mirror the active fish bind mode into POSH_VI_MODE and
+# re-render the prompt whenever it changes. Enabled through the vimode segment.
+function _omp_enable_vimode
+    # only track when vi (or hybrid) key bindings are active
+    contains -- "$fish_key_bindings" fish_vi_key_bindings fish_hybrid_key_bindings
+    or return
+
+    # translate fish's bind mode into the keymap names the vimode segment expects
+    function _omp_set_vimode
+        switch $fish_bind_mode
+            case default
+                set --global --export POSH_VI_MODE vicmd
+            case replace replace_one
+                set --global --export POSH_VI_MODE replace
+            case insert
+                set --global --export POSH_VI_MODE viins
+            case '*'
+                set --global --export POSH_VI_MODE $fish_bind_mode
+        end
+    end
+
+    # re-render the prompt on every mode change
+    function _omp_render_vimode --on-variable fish_bind_mode
+        _omp_set_vimode
+        omp_repaint_prompt
+    end
+
+    # oh-my-posh renders the mode through the vimode segment, so silence fish's
+    # built-in mode indicator to avoid a duplicate
+    function fish_mode_prompt
+    end
+
+    _omp_set_vimode
+end

--- a/website/docs/segments/music/spotify.mdx
+++ b/website/docs/segments/music/spotify.mdx
@@ -11,8 +11,7 @@ Show the currently playing song in the [Spotify][spotify] client.
 :::caution
 Be aware this can make the prompt a tad bit slower as it needs to get a response from the Spotify player.
 
-All playback states are supported on every platform (playing/paused/stopped, and an optional `ad` state on
-Windows and WSL). On _Windows_ the data is read from the [System Media Transport Controls][smtc], which
+All playback states are supported on every platform (playing/paused/stopped and `ad`). On _Windows_ the data is read from the [System Media Transport Controls][smtc], which
 covers both the native Spotify client and the Microsoft Store version, with a fall-back to scraping the
 Edge PWA window title. On _WSL_ the same SMTC session is queried via the Windows interop `powershell.exe`,
 so the Linux side sees the same information the Windows host does.
@@ -45,7 +44,7 @@ import Config from "@site/src/components/Config.js";
 | `playing_icon` | `string` | `\ue602 ` | text/icon to show when playing                                   |
 | `paused_icon`  | `string` | `\uf04c ` | text/icon to show when paused                                    |
 | `stopped_icon` | `string` | `\uf04d ` | text/icon to show when stopped                                   |
-| `ad_icon`      | `string` | `\ueebb ` | text/icon to show when an advertisement is playing (Windows/WSL) |
+| `ad_icon`      | `string` | `\ueebb ` | text/icon to show when an advertisement is playing             |
 
 ## Template ([info][templates])
 

--- a/website/docs/segments/system/vimode.mdx
+++ b/website/docs/segments/system/vimode.mdx
@@ -7,18 +7,30 @@ sidebar_label: Vi mode
 ## What
 
 Display the current Vi mode (insert / normal / visual …) in the prompt. Useful
-when using ZSH [keymaps][zsh-vi-mode] via `bindkey -v` or PowerShell PSReadLine
-`-EditMode Vi` so you can tell at a glance which mode you are in.
+when using ZSH [keymaps][zsh-vi-mode] via `bindkey -v`, PowerShell PSReadLine
+`-EditMode Vi`, or fish [vi key bindings][fish-vi-mode] so you can tell at a
+glance which mode you are in.
 
 In ZSH, adding this segment automatically registers a `zle-keymap-select` hook.
 In PowerShell, it registers a PSReadLine [Vi mode change handler][pwsh-vi-mode].
-Both re-render the prompt every time the active mode changes.
+In fish, it registers an [`--on-variable fish_bind_mode`][fish-bind-mode] handler
+(only when vi or hybrid key bindings are active). All of them re-render the
+prompt every time the active mode changes.
 
 :::caution PowerShell cursor indicator
 
 PowerShell support sets PSReadLine's `ViModeIndicator` to `Script`, replacing
 cursor-shape mode indicators such as `Cursor`. The mode is then shown by this
 segment in the prompt instead.
+
+:::
+
+:::caution fish mode prompt
+
+fish support overrides `fish_mode_prompt` with an empty function so fish's
+built-in `[N]` / `[I]` mode indicator does not show up next to the mode
+rendered by this segment. Make sure vi key bindings are enabled (e.g.
+`fish_vi_key_bindings`) for the segment to display.
 
 :::
 
@@ -51,9 +63,11 @@ import Config from "@site/src/components/Config.js";
 | Name      |   Type   | Description                                                                                                                                    |
 | --------- | :------: | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | `.Mode`   | `string` | the normalized mode: `insert`, `normal`, `visual`, `viopp`, `replace`, or the raw keymap when unmapped                                         |
-| `.Keymap` | `string` | the raw mode value ([`$KEYMAP`][zsh-keymap] in ZSH, e.g. `main`, `viins`, `vicmd`, `visual`, `viopp`; `viins` or `vicmd` in PowerShell PSReadLine) |
+| `.Keymap` | `string` | the raw mode value ([`$KEYMAP`][zsh-keymap] in ZSH, e.g. `main`, `viins`, `vicmd`, `visual`, `viopp`; `viins` or `vicmd` in PowerShell PSReadLine; `viins`, `vicmd`, `visual` or `replace` in fish) |
 
 [templates]: /docs/configuration/templates
 [zsh-vi-mode]: https://zsh.sourceforge.io/Doc/Release/Zsh-Line-Editor.html#Keymaps
 [zsh-keymap]: https://zsh.sourceforge.io/Doc/Release/Zsh-Line-Editor.html#index-KEYMAP
 [pwsh-vi-mode]: https://learn.microsoft.com/en-us/powershell/module/psreadline/set-psreadlineoption#-vimodechangehandler
+[fish-vi-mode]: https://fishshell.com/docs/current/interactive.html#vi-mode-commands
+[fish-bind-mode]: https://fishshell.com/docs/current/language.html#the-fish-bind-mode-variable


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Extend the Spotify advertisement state introduced for Windows and WSL to macOS and native Linux.

On macOS, the existing batched AppleScript query now also reads the current track's album and track number. Each metadata property is read on a best-effort basis so an unavailable advertisement property does not make the entire query fail. On Linux, the MPRIS query now reads `xesam:album` and `xesam:trackNumber`. Both implementations pass a shared `MediaInfo` value through the existing advertisement heuristic: a playing item with an empty album and track number zero is treated as an advertisement.

The shared media-info mapper is now available on every supported Spotify platform, and the documentation describes the `ad` state and `ad_icon` as cross-platform behavior.

#### Manual verification

Verified against Spotify 1.2.94.583 on macOS 26.5.2 (Apple Silicon):

- Regular tracks returned a non-empty album and a positive track number.
- Pausing preserved the metadata and returned the `paused` state.
- A live advertisement returned `playing||アコム【公式】||0`, confirming that album is empty and track number is zero. The artist may be empty while the advertisement name is exposed as the track name.
- Four regular tracks were monitored without an advertisement false positive.

#### Tests

- `go test ./...`
- `GOOS=linux GOARCH=amd64 go test -c ./segments`
- `npm run build` in `website/`
- `vale .agents/skills/project-knowledge/references/codebase.md` (0 errors)

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
