### PR TITLE
feat(fish): surface full vi mode details

### DIFF
--- a/src/segments/vimode.go
+++ b/src/segments/vimode.go
@@ -33,9 +33,9 @@ func mapVIModeKeymap(keymap string) string {
 		return "normal"
 	case "visual":
 		return "visual"
-	case "viopp":
+	case "viopp", "f", "F", "t", "T":
 		return "viopp"
-	case "replace":
+	case "replace", "replace_one":
 		return "replace"
 	default:
 		return keymap

--- a/src/segments/vimode_test.go
+++ b/src/segments/vimode_test.go
@@ -23,7 +23,12 @@ func TestVIMode(t *testing.T) {
 		{Case: "vicmd keymap maps to normal", Env: "vicmd", ExpectedMode: "normal", ExpectedKeymap: "vicmd", ExpectedEnabled: true},
 		{Case: "visual keymap is preserved", Env: "visual", ExpectedMode: "visual", ExpectedKeymap: "visual", ExpectedEnabled: true},
 		{Case: "viopp keymap is preserved", Env: "viopp", ExpectedMode: "viopp", ExpectedKeymap: "viopp", ExpectedEnabled: true},
+		{Case: "f keymap maps to viopp", Env: "f", ExpectedMode: "viopp", ExpectedKeymap: "f", ExpectedEnabled: true},
+		{Case: "F keymap maps to viopp", Env: "F", ExpectedMode: "viopp", ExpectedKeymap: "F", ExpectedEnabled: true},
+		{Case: "t keymap maps to viopp", Env: "t", ExpectedMode: "viopp", ExpectedKeymap: "t", ExpectedEnabled: true},
+		{Case: "T keymap maps to viopp", Env: "T", ExpectedMode: "viopp", ExpectedKeymap: "T", ExpectedEnabled: true},
 		{Case: "replace keymap is preserved", Env: "replace", ExpectedMode: "replace", ExpectedKeymap: "replace", ExpectedEnabled: true},
+		{Case: "replace_one keymap maps to replace", Env: "replace_one", ExpectedMode: "replace", ExpectedKeymap: "replace_one", ExpectedEnabled: true},
 		{Case: "unknown keymap falls through", Env: "custom", ExpectedMode: "custom", ExpectedKeymap: "custom", ExpectedEnabled: true},
 		{Case: "empty env disables segment", Env: "", ExpectedEnabled: false},
 	}

--- a/src/shell/scripts/omp.fish
+++ b/src/shell/scripts/omp.fish
@@ -751,33 +751,37 @@ end
 # vi mode tracking — mirror the active fish bind mode into POSH_VI_MODE and
 # re-render the prompt whenever it changes. Enabled through the vimode segment.
 function _omp_enable_vimode
-    # only track when vi (or hybrid) key bindings are active
-    contains -- "$fish_key_bindings" fish_vi_key_bindings fish_hybrid_key_bindings
-    or return
-
-    # translate fish's bind mode into the keymap names the vimode segment expects
     function _omp_set_vimode
-        switch $fish_bind_mode
-            case default
-                set --global --export POSH_VI_MODE vicmd
-            case replace replace_one
-                set --global --export POSH_VI_MODE replace
-            case insert
-                set --global --export POSH_VI_MODE viins
-            case '*'
-                set --global --export POSH_VI_MODE $fish_bind_mode
+        # fish uses "default" for emacs mode as well as normal/command mode in
+        # vi mode; to avoid confusion, explicitly map to the "emacs" value known
+        # by the vimode segment
+        if not contains -- "$fish_key_bindings" fish_vi_key_bindings fish_hybrid_key_bindings
+            set --export --global POSH_VI_MODE "emacs"
+        else
+            # translate fish's bind mode into the keymap names the vimode
+            # segment expects
+            switch $fish_bind_mode
+                case default
+                    set --global --export POSH_VI_MODE vicmd
+                case insert
+                    set --global --export POSH_VI_MODE viins
+                case operator
+                    set --global --export POSH_VI_MODE viopp
+                case '*'
+                    set --global --export POSH_VI_MODE $fish_bind_mode
+            end
         end
-    end
-
-    # re-render the prompt on every mode change
-    function _omp_render_vimode --on-variable fish_bind_mode
-        _omp_set_vimode
-        omp_repaint_prompt
     end
 
     # oh-my-posh renders the mode through the vimode segment, so silence fish's
     # built-in mode indicator to avoid a duplicate
+    # fish calls `fish_mode_prompt` when the bind mode is changed, and this is
+    # more reliable than `function --on-variable`.
     function fish_mode_prompt
+        _omp_set_vimode
+        # if `fish_mode_prompt` produces no output, fish will then call
+        # `fish_prompt` so there's no need for full repaint
+        set --global _omp_new_prompt 1
     end
 
     _omp_set_vimode

--- a/website/docs/segments/system/vimode.mdx
+++ b/website/docs/segments/system/vimode.mdx
@@ -27,10 +27,10 @@ segment in the prompt instead.
 
 :::caution fish mode prompt
 
-fish support overrides `fish_mode_prompt` with an empty function so fish's
-built-in `[N]` / `[I]` mode indicator does not show up next to the mode
-rendered by this segment. Make sure vi key bindings are enabled (e.g.
-`fish_vi_key_bindings`) for the segment to display.
+fish support overrides `fish_mode_prompt` to hook into bind mode changes and so
+that fish's built-in `[N]` / `[I]` mode indicator does not show up next to the
+mode rendered by this segment. Make sure nothing else in your config overrides
+`fish_mode_prompt`.
 
 :::
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Surface full information from fish's `fish_bind_mode` to the vimode segment's `Keymap` property, while mapping properly to `Mode` for cross-shell compatibility.

Compared to the existing implementation, this PR's approach has four advantages:
1. Full details from the shell's mode (specifically, the `replace_one`, `f`, `F`, `t`, and `T` modes) are available to the user, but only if desired (through the `Keymap` property).
2. The `f`, `F`, `t`, and `T` modes map correctly to the `viopp` `Mode`.
3. The setup is done even when not in one of the vi modes at OMP init time, so that changes in the mode can be processed without having to set them permanently in the user's config and start a new shell session. (I believe this is how it works for ZSH.)
4. Using `fish_mode_prompt` to hook into bind mode changes is guaranteed, since fish explicitly [says][fish-mode-prompt] "`fish_mode_prompt` will be executed when the vi mode changes." By contrast, the existing implementation uses a separate function with `--on-variable`, and fish says [this][fish-on-variable] about `--on-variable`:
> Note that **fish** makes no guarantees on any particular timing or even that the function will be run for every single `set`. Rather it will be run when the variable has been set at least once, possibly skipping some values or being run when the variable has been set to the same value.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[fish-mode-prompt]: https://fishshell.com/docs/current/cmds/fish_mode_prompt.html
[fish-on-variable]: https://fishshell.com/docs/current/cmds/function.html