### PR TITLE
test(serve): wait on records instead of wall-clock silence

### DIFF
--- a/.agents/skills/project-knowledge/references/testing.md
+++ b/.agents/skills/project-knowledge/references/testing.md
@@ -72,3 +72,13 @@ for usage. Gotchas baked into it, relevant to any future pty work:
 
 - One `bufio.Scanner` per pipe, ever - a second scanner on the same pipe loses buffered data
   (use a shared reader helper in Go tests).
+- Never decide "the records are done" from wall-clock silence (verified 2026-07-21). The serve
+  harness collected until a 500 ms gap with no record, which made every assertion a race against
+  render latency: under `go test ./...` with a cold build cache (i.e. CI), the first record of a
+  cycle regularly lands later than that, so `collect` returned empty and
+  `TestServeLoop_RenderProducesIDPrefixedRecords`, `_WaitRenderEmitsExactlyTwoRecords` and
+  `_AbortStopsRecordFlowThenNewRenderWorks` failed at exactly the 500 ms mark on an unmodified
+  tree. Reproduce with `go clean -cache && go test -count=1 ./...`; the package on its own always
+  passes, so the failure reads as a phantom. Wait on a record that proves what the test is
+  asserting instead - the cycle's transient record (always last) for a completed cycle, the cycle
+  id for a specific cycle - and keep a timeout only as a hang bound.

--- a/src/cli/serve_test.go
+++ b/src/cli/serve_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -73,8 +74,15 @@ func (h *serveHarness) render(id int, pwd string) {
 	h.send(map[string]any{"command": "render", "id": id, "shell": "pwsh", "pwd": pwd})
 }
 
-func (h *serveHarness) records(timeout time.Duration) []serveRecord {
-	return h.reader.collect(timeout)
+func (h *serveHarness) records(idle time.Duration) []serveRecord {
+	return h.reader.collect(idle)
+}
+
+// recordsFor collects until cycle id has produced a record. Use it instead of
+// records when an earlier cycle may never reach its transient record, so
+// waiting for a completed cycle would stop at the wrong one.
+func (h *serveHarness) recordsFor(id string, idle time.Duration) []serveRecord {
+	return h.reader.collectUntil(idle, carriesID(id))
 }
 
 // quitAndWait sends the quit command and fails the test when the loop does
@@ -157,12 +165,55 @@ func newRecordReader(r *os.File) *recordReader {
 	return rr
 }
 
-// collect returns records until timeout elapses with no new record arriving,
-// or the pipe closes.
-func (rr *recordReader) collect(timeout time.Duration) []serveRecord {
+// recordTimeout bounds every wait for a record the caller still needs. It is
+// generous on purpose: it only exists so a daemon that stops producing fails
+// the test instead of hanging the suite, never to decide that enough records
+// have arrived.
+const recordTimeout = 30 * time.Second
+
+// endOfCycle reports whether the records seen so far end at a cycle's
+// transient record, which is the last record a completed cycle emits.
+func endOfCycle(records []serveRecord) bool {
+	return len(records) > 0 && records[len(records)-1].transient
+}
+
+// carriesID returns a condition satisfied once a record of cycle id arrived.
+// Use it when the assertions need a specific cycle's records and an earlier
+// cycle may still be emitting, e.g. after an abort.
+func carriesID(id string) func([]serveRecord) bool {
+	return func(records []serveRecord) bool {
+		return slices.ContainsFunc(records, func(rec serveRecord) bool {
+			return rec.id == id
+		})
+	}
+}
+
+// collect returns the records of a completed cycle: it waits for records to
+// arrive and stops at the transient record that ends the cycle. See
+// collectUntil for what idle covers.
+func (rr *recordReader) collect(idle time.Duration) []serveRecord {
+	return rr.collectUntil(idle, endOfCycle)
+}
+
+// collectUntil returns records once done reports the caller has what it waited
+// for, plus whatever else arrives within idle of the previous record. Waiting
+// on done rather than on wall-clock silence is what keeps these tests stable:
+// `go test ./...` renders under the load of every other package's tests, where
+// the gap before a cycle's first record routinely exceeds any idle window a
+// test would pick, and collecting on a timer alone then returns too early -
+// empty, or holding only the previous cycle's records.
+//
+// idle still terminates the collection when done never becomes true within a
+// cycle, which is what an aborted cycle (no transient record) looks like.
+func (rr *recordReader) collectUntil(idle time.Duration, done func([]serveRecord) bool) []serveRecord {
 	var records []serveRecord
-	timer := time.NewTimer(timeout)
+
+	timer := time.NewTimer(recordTimeout)
 	defer timer.Stop()
+
+	// Until done is satisfied, a record is still owed and only recordTimeout
+	// bounds the wait for it. After that, idle decides when the flow is over.
+	satisfied := false
 
 	for {
 		select {
@@ -170,11 +221,20 @@ func (rr *recordReader) collect(timeout time.Duration) []serveRecord {
 			if !ok {
 				return records
 			}
+
 			records = append(records, rec)
+
 			if !timer.Stop() {
 				<-timer.C
 			}
-			timer.Reset(timeout)
+
+			satisfied = satisfied || done(records)
+			if satisfied {
+				timer.Reset(idle)
+				continue
+			}
+
+			timer.Reset(recordTimeout)
 		case <-timer.C:
 			return records
 		}
@@ -242,7 +302,7 @@ func TestServeLoop_AbortStopsRecordFlowThenNewRenderWorks(t *testing.T) {
 
 	h.render(2, pwd)
 
-	records := h.records(500 * time.Millisecond)
+	records := h.recordsFor("2", 500*time.Millisecond)
 	require.NotEmpty(t, records, "expected records for cycle 2 after abort+re-render")
 
 	// No record from cycle 1 should appear once cycle 2 begins - cycle 1 had


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

The serve harness collected records until 500 ms passed without a new one, so every
assertion raced render latency instead of checking behaviour. Under `go test ./...` with
a cold build cache, which is what CI runs, a cycle's first record regularly arrives later
than that: `collect` returns empty and the test fails at exactly the idle mark.

Reproduced on an untouched `main` (Windows, Go 1.26.4):

```console
$ go clean -cache && go test -count=1 ./...
--- FAIL: TestServeLoop_RenderProducesIDPrefixedRecords (0.51s)
--- FAIL: TestServeLoop_AbortStopsRecordFlowThenNewRenderWorks (0.51s)
--- FAIL: TestServeLoop_WaitRenderEmitsExactlyTwoRecords (1.01s)
FAIL	github.com/jandedobbeleer/oh-my-posh/src/cli	7.817s
```

`go test ./cli/...` on its own always passes, so this only shows up in a full-suite run,
which is why it reads as a phantom when it hits a PR.

The fix collects until the records prove what the test asserts:

- a completed cycle ends at its transient record, which is the record `collect` now stops
  on rather than on a timer;
- `TestServeLoop_AbortStopsRecordFlowThenNewRenderWorks` waits for a record carrying cycle
  2's id, because an aborted cycle 1 may never reach a transient;
- the idle window still ends a collection whose condition never becomes true, and a 30 s
  bound keeps a stalled daemon a test failure rather than a hang.

No production code changes, `src/cli/serve.go` is untouched.

Verified with `go clean -cache && go test -count=1 ./...` (the failing scenario above) plus
`golangci-lint run`, `go vet ./...`, markdownlint and `vale .agents/skills`.

The gotcha is recorded in `.agents/skills/project-knowledge/references/testing.md`, per the
project-knowledge contract in `AGENTS.md`.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
