### PR TITLE
test(prompt): remove cross-test global state dependencies

### DIFF
--- a/src/prompt/engine_test.go
+++ b/src/prompt/engine_test.go
@@ -368,6 +368,10 @@ func TestGetConsoleTitleIfGethostnameReturnsError(t *testing.T) {
 }
 
 func TestShouldFill(t *testing.T) {
+	// terminal.Plain is a package-level global. Restore it so the tests that run
+	// after this one are not silently switched into plain mode.
+	t.Cleanup(func() { terminal.Plain = false })
+
 	cases := []struct {
 		Case           string
 		Overflow       config.Overflow

--- a/src/prompt/extra_test.go
+++ b/src/prompt/extra_test.go
@@ -21,7 +21,11 @@ import (
 	testifymock "github.com/stretchr/testify/mock"
 )
 
-func setupExtraPromptTest(sh string, flags *runtime.Flags) *mock.Environment {
+func setupExtraPromptTest(t *testing.T, sh string, flags *runtime.Flags) *mock.Environment {
+	t.Helper()
+	// terminal.Plain is a package-level global; restore it for later tests.
+	t.Cleanup(func() { terminal.Plain = false })
+
 	env := new(mock.Environment)
 	env.On("Shell").Return(sh)
 	env.On("Flags").Return(flags)
@@ -36,6 +40,9 @@ func setupExtraPromptTest(sh string, flags *runtime.Flags) *mock.Environment {
 	}
 	template.Init(env, nil, nil)
 	terminal.Init(sh)
+	// These tests assert on uncolored output, so ask for it rather than
+	// inheriting whatever an earlier test left in this global.
+	terminal.Plain = true
 	terminal.Colors = color.MakeColors(nil, false, "", env)
 
 	return env
@@ -99,7 +106,7 @@ func TestExtraPromptTransientZSH(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		env := setupExtraPromptTest(shell.ZSH, &runtime.Flags{Eval: tc.Eval})
+		env := setupExtraPromptTest(t, shell.ZSH, &runtime.Flags{Eval: tc.Eval})
 		env.On("TerminalWidth").Return(tc.TerminalWidth, tc.TerminalErr)
 
 		engine := &Engine{
@@ -119,7 +126,11 @@ func TestExtraPromptTransientZSH(t *testing.T) {
 }
 
 func TestExtraPromptTransientPWSH(t *testing.T) {
-	// initialize the terminal for pwsh before resolving the expected sequences
+	// initialize the terminal for pwsh before resolving the expected sequences.
+	// Plain has to match what setupExtraPromptTest uses, otherwise the expected
+	// sequences are resolved under a different mode than the ones under test.
+	t.Cleanup(func() { terminal.Plain = false })
+	terminal.Plain = true
 	terminal.Init(shell.PWSH)
 	saveCursor := terminal.SaveCursorPosition()
 	restoreCursor := terminal.RestoreCursorPosition()
@@ -185,7 +196,7 @@ func TestExtraPromptTransientPWSH(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		env := setupExtraPromptTest(shell.PWSH, &runtime.Flags{})
+		env := setupExtraPromptTest(t, shell.PWSH, &runtime.Flags{})
 		env.On("TerminalWidth").Return(tc.TerminalWidth, tc.TerminalErr)
 
 		engine := &Engine{
@@ -205,7 +216,7 @@ func TestExtraPromptTransientPWSH(t *testing.T) {
 }
 
 func TestExtraPromptTransientPWSHNewline(t *testing.T) {
-	env := setupExtraPromptTest(shell.PWSH, &runtime.Flags{PromptCount: 2})
+	env := setupExtraPromptTest(t, shell.PWSH, &runtime.Flags{PromptCount: 2})
 	env.On("TerminalWidth").Return(20, nil)
 	env.On("CursorPosition").Return(2, 1)
 
@@ -273,7 +284,7 @@ func TestExtraPromptTransientFish(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		env := setupExtraPromptTest(shell.FISH, &runtime.Flags{})
+		env := setupExtraPromptTest(t, shell.FISH, &runtime.Flags{})
 		env.On("TerminalWidth").Return(tc.TerminalWidth, tc.TerminalErr)
 
 		engine := &Engine{
@@ -293,7 +304,7 @@ func TestExtraPromptTransientFish(t *testing.T) {
 }
 
 func TestTransientRPromptTemplateError(t *testing.T) {
-	env := setupExtraPromptTest(shell.FISH, &runtime.Flags{})
+	env := setupExtraPromptTest(t, shell.FISH, &runtime.Flags{})
 	engine := &Engine{
 		Config: &config.Config{
 			TransientPrompt: &config.Segment{RightTemplate: "{{"},
@@ -305,7 +316,7 @@ func TestTransientRPromptTemplateError(t *testing.T) {
 }
 
 func TestExtraPromptRightTemplateUnsupportedShell(t *testing.T) {
-	env := setupExtraPromptTest(shell.BASH, &runtime.Flags{})
+	env := setupExtraPromptTest(t, shell.BASH, &runtime.Flags{})
 
 	engine := &Engine{
 		Config: &config.Config{
@@ -330,7 +341,11 @@ func TestShouldFillNegativePadLength(t *testing.T) {
 	assert.Empty(t, got)
 }
 
-func setupExtraStreamingTestEnv(sh string) *mock.Environment {
+func setupExtraStreamingTestEnv(t *testing.T, sh string) *mock.Environment {
+	t.Helper()
+	// terminal.Plain is a package-level global; restore it for later tests.
+	t.Cleanup(func() { terminal.Plain = false })
+
 	env := new(mock.Environment)
 	env.On("Pwd").Return("/test")
 	env.On("Home").Return("/home")
@@ -348,13 +363,16 @@ func setupExtraStreamingTestEnv(sh string) *mock.Environment {
 	}
 	template.Init(env, nil, nil)
 	terminal.Init(sh)
+	// These tests assert on uncolored output, so ask for it rather than
+	// inheriting whatever an earlier test left in this global.
+	terminal.Plain = true
 	terminal.Colors = color.MakeColors(nil, false, "", env)
 
 	return env
 }
 
 func TestStreamPrimary_TransientRecordSkippedForZSHRightTemplate(t *testing.T) {
-	env := setupExtraStreamingTestEnv(shell.ZSH)
+	env := setupExtraStreamingTestEnv(t, shell.ZSH)
 
 	engine := &Engine{
 		Config: &config.Config{
@@ -376,7 +394,7 @@ func TestStreamPrimary_TransientRecordSkippedForZSHRightTemplate(t *testing.T) {
 }
 
 func TestStreamPrimary_TransientRecordSentForZSHWithoutRightTemplate(t *testing.T) {
-	env := setupExtraStreamingTestEnv(shell.ZSH)
+	env := setupExtraStreamingTestEnv(t, shell.ZSH)
 
 	engine := &Engine{
 		Config: &config.Config{
@@ -402,7 +420,7 @@ func TestStreamPrimary_TransientRecordSentForZSHWithoutRightTemplate(t *testing.
 }
 
 func TestStreamPrimary_TransientRecordContainsRightTemplateForPWSH(t *testing.T) {
-	env := setupExtraStreamingTestEnv(shell.PWSH)
+	env := setupExtraStreamingTestEnv(t, shell.PWSH)
 
 	engine := &Engine{
 		Config: &config.Config{

--- a/src/prompt/segments_test.go
+++ b/src/prompt/segments_test.go
@@ -4,10 +4,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jandedobbeleer/oh-my-posh/src/cache"
 	"github.com/jandedobbeleer/oh-my-posh/src/color"
 	"github.com/jandedobbeleer/oh-my-posh/src/config"
+	"github.com/jandedobbeleer/oh-my-posh/src/maps"
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+	"github.com/jandedobbeleer/oh-my-posh/src/shell"
+	"github.com/jandedobbeleer/oh-my-posh/src/template"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -222,6 +226,14 @@ func TestExecuteSegmentWithTimeout_CachedValueFallback(t *testing.T) {
 	// This test verifies that a pending segment's Text() returns "..." placeholder
 	env := new(mock.Environment)
 	env.On("Flags").Return(&runtime.Flags{})
+	env.On("Shell").Return(shell.GENERIC)
+
+	// Render writes through the template cache, so it has to exist rather than
+	// be inherited from whichever test happened to run first.
+	template.Cache = &cache.Template{
+		Segments: maps.NewConcurrent[any](),
+	}
+	template.Init(env, nil, nil)
 
 	segment := &config.Segment{
 		Type:     "text",

--- a/src/prompt/streaming_test.go
+++ b/src/prompt/streaming_test.go
@@ -648,6 +648,10 @@ func setupBasicStreamingTestEnv() *Engine {
 	env.On("Flags").Return(&runtime.Flags{Streaming: true})
 	env.On("CursorPosition").Return(1, 1)
 	env.On("StatusCodes").Return(0, "0")
+	// MakeColors resolves the accent color, which reads the registry on Windows
+	// and shells out on macOS. Without these the helper panics on those hosts.
+	env.On("RunCommand", testifymock.Anything, testifymock.Anything).Return("4", nil)
+	env.On("WindowsRegistryKeyValue", testifymock.Anything).Return(&runtime.WindowsRegistryValue{ValueType: runtime.DWORD, DWord: 0xFF0078D7}, nil)
 
 	template.Cache = &cache.Template{
 		Segments: maps.NewConcurrent[any](),
@@ -705,6 +709,10 @@ func TestStreamPrimary_RaceConditionFix(t *testing.T) {
 	env.On("Flags").Return(&runtime.Flags{Streaming: true})
 	env.On("CursorPosition").Return(1, 1)
 	env.On("StatusCodes").Return(0, "0")
+	// MakeColors resolves the accent color, which reads the registry on Windows
+	// and shells out on macOS. Without these the setup panics on those hosts.
+	env.On("RunCommand", testifymock.Anything, testifymock.Anything).Return("4", nil)
+	env.On("WindowsRegistryKeyValue", testifymock.Anything).Return(&runtime.WindowsRegistryValue{ValueType: runtime.DWORD, DWord: 0xFF0078D7}, nil)
 
 	template.Cache = &cache.Template{
 		Segments: maps.NewConcurrent[any](),


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

The `prompt` package tests only pass in declaration order. On an untouched tree:

```
go test ./prompt/ -shuffle=on     # fails
go test ./prompt/ -run TestExtraPromptTransientFish   # fails
```

Eight tests fail when run individually. They are not flaky, they are coupled through package-level globals, so the suite is only green because Go happens to run the files alphabetically.

**`terminal.Plain` leaks out of `TestShouldFill`.** It sets the global to `true` and never restores it. `engine_test.go` sorts before `extra_test.go`, so the transient prompt tests inherited plain mode and were written against it. In any other order they emit ANSI color codes and the assertions fail. Fixed by restoring the global and having the extra prompt helpers request plain mode explicitly.

**`TestExtraPromptTransientPWSH` resolves its expected escape sequences before the helper runs**, so they have to be resolved under the same `Plain` value the assertions run under.

**`TestExecuteSegmentWithTimeout_CachedValueFallback` renders a segment with no template cache.** It only survived because an earlier test left a usable `template.Cache` behind. Alone it is a nil dereference:

```
panic: runtime error: invalid memory address or nil pointer dereference
  cache.(*Template).AddSegmentData  template.go:36
  config.(*Segment).Render          segment.go:283
```

**`setupBasicStreamingTestEnv` and `TestStreamPrimary_RaceConditionFix` call `color.MakeColors` without the accent color mocks.** That path reads the registry on Windows and shells out on macOS, so both panic on those hosts when they run first.

The changes are test-only. Verified with eight consecutive `-shuffle=on` runs, each affected test run on its own, and a full `go test ./...`.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
