### PR TITLE
next

### DIFF
--- a/.agents/skills/project-knowledge/references/testing.md
+++ b/.agents/skills/project-knowledge/references/testing.md
@@ -72,3 +72,13 @@ for usage. Gotchas baked into it, relevant to any future pty work:
 
 - One `bufio.Scanner` per pipe, ever - a second scanner on the same pipe loses buffered data
   (use a shared reader helper in Go tests).
+- Never decide "the records are done" from wall-clock silence (verified 2026-07-21). The serve
+  harness collected until a 500 ms gap with no record, which made every assertion a race against
+  render latency: under `go test ./...` with a cold build cache (i.e. CI), the first record of a
+  cycle regularly lands later than that, so `collect` returned empty and
+  `TestServeLoop_RenderProducesIDPrefixedRecords`, `_WaitRenderEmitsExactlyTwoRecords` and
+  `_AbortStopsRecordFlowThenNewRenderWorks` failed at exactly the 500 ms mark on an unmodified
+  tree. Reproduce with `go clean -cache && go test -count=1 ./...`; the package on its own always
+  passes, so the failure reads as a phantom. Wait on a record that proves what the test is
+  asserting instead - the cycle's transient record (always last) for a completed cycle, the cycle
+  id for a specific cycle - and keep a timeout only as a hang bound.

--- a/src/cli/serve_test.go
+++ b/src/cli/serve_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -73,8 +74,15 @@ func (h *serveHarness) render(id int, pwd string) {
 	h.send(map[string]any{"command": "render", "id": id, "shell": "pwsh", "pwd": pwd})
 }
 
-func (h *serveHarness) records(timeout time.Duration) []serveRecord {
-	return h.reader.collect(timeout)
+func (h *serveHarness) records(idle time.Duration) []serveRecord {
+	return h.reader.collect(idle)
+}
+
+// recordsFor collects until cycle id has produced a record. Use it instead of
+// records when an earlier cycle may never reach its transient record, so
+// waiting for a completed cycle would stop at the wrong one.
+func (h *serveHarness) recordsFor(id string, idle time.Duration) []serveRecord {
+	return h.reader.collectUntil(idle, carriesID(id))
 }
 
 // quitAndWait sends the quit command and fails the test when the loop does
@@ -157,12 +165,55 @@ func newRecordReader(r *os.File) *recordReader {
 	return rr
 }
 
-// collect returns records until timeout elapses with no new record arriving,
-// or the pipe closes.
-func (rr *recordReader) collect(timeout time.Duration) []serveRecord {
+// recordTimeout bounds every wait for a record the caller still needs. It is
+// generous on purpose: it only exists so a daemon that stops producing fails
+// the test instead of hanging the suite, never to decide that enough records
+// have arrived.
+const recordTimeout = 30 * time.Second
+
+// endOfCycle reports whether the records seen so far end at a cycle's
+// transient record, which is the last record a completed cycle emits.
+func endOfCycle(records []serveRecord) bool {
+	return len(records) > 0 && records[len(records)-1].transient
+}
+
+// carriesID returns a condition satisfied once a record of cycle id arrived.
+// Use it when the assertions need a specific cycle's records and an earlier
+// cycle may still be emitting, e.g. after an abort.
+func carriesID(id string) func([]serveRecord) bool {
+	return func(records []serveRecord) bool {
+		return slices.ContainsFunc(records, func(rec serveRecord) bool {
+			return rec.id == id
+		})
+	}
+}
+
+// collect returns the records of a completed cycle: it waits for records to
+// arrive and stops at the transient record that ends the cycle. See
+// collectUntil for what idle covers.
+func (rr *recordReader) collect(idle time.Duration) []serveRecord {
+	return rr.collectUntil(idle, endOfCycle)
+}
+
+// collectUntil returns records once done reports the caller has what it waited
+// for, plus whatever else arrives within idle of the previous record. Waiting
+// on done rather than on wall-clock silence is what keeps these tests stable:
+// `go test ./...` renders under the load of every other package's tests, where
+// the gap before a cycle's first record routinely exceeds any idle window a
+// test would pick, and collecting on a timer alone then returns too early -
+// empty, or holding only the previous cycle's records.
+//
+// idle still terminates the collection when done never becomes true within a
+// cycle, which is what an aborted cycle (no transient record) looks like.
+func (rr *recordReader) collectUntil(idle time.Duration, done func([]serveRecord) bool) []serveRecord {
 	var records []serveRecord
-	timer := time.NewTimer(timeout)
+
+	timer := time.NewTimer(recordTimeout)
 	defer timer.Stop()
+
+	// Until done is satisfied, a record is still owed and only recordTimeout
+	// bounds the wait for it. After that, idle decides when the flow is over.
+	satisfied := false
 
 	for {
 		select {
@@ -170,11 +221,20 @@ func (rr *recordReader) collect(timeout time.Duration) []serveRecord {
 			if !ok {
 				return records
 			}
+
 			records = append(records, rec)
+
 			if !timer.Stop() {
 				<-timer.C
 			}
-			timer.Reset(timeout)
+
+			satisfied = satisfied || done(records)
+			if satisfied {
+				timer.Reset(idle)
+				continue
+			}
+
+			timer.Reset(recordTimeout)
 		case <-timer.C:
 			return records
 		}
@@ -242,7 +302,7 @@ func TestServeLoop_AbortStopsRecordFlowThenNewRenderWorks(t *testing.T) {
 
 	h.render(2, pwd)
 
-	records := h.records(500 * time.Millisecond)
+	records := h.recordsFor("2", 500*time.Millisecond)
 	require.NotEmpty(t, records, "expected records for cycle 2 after abort+re-render")
 
 	// No record from cycle 1 should appear once cycle 2 begins - cycle 1 had

--- a/src/color/colors.go
+++ b/src/color/colors.go
@@ -160,7 +160,7 @@ func (c Ansi) ResolveTemplate() Ansi {
 		return emptyColor
 	}
 
-	text, err := template.Render(string(c), nil)
+	text, err := template.RenderTrusted(string(c), nil)
 	if err != nil {
 		return Transparent
 	}

--- a/src/color/palette.go
+++ b/src/color/palette.go
@@ -37,7 +37,7 @@ func (p Palette) resolveColor(colorName Ansi, depth int, originalColorName *Ansi
 	}
 
 	if strings.Contains(color.String(), "{{") {
-		rendered, err := template.Render(color.String(), nil)
+		rendered, err := template.RenderTrusted(color.String(), nil)
 		if err != nil {
 			return "", err
 		}

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -98,7 +98,7 @@ func (cfg *Config) getPalette() color.Palette {
 		return cfg.Palette
 	}
 
-	key, err := template.Render(cfg.Palettes.Template, nil)
+	key, err := template.RenderTrusted(cfg.Palettes.Template, nil)
 	if err != nil {
 		return cfg.Palette
 	}

--- a/src/config/segment.go
+++ b/src/config/segment.go
@@ -27,7 +27,7 @@ import (
 type SegmentStyle string
 
 func (s *SegmentStyle) resolve(context any) SegmentStyle {
-	value, err := template.Render(string(*s), context)
+	value, err := template.RenderTrusted(string(*s), context)
 
 	// default to Plain
 	if err != nil || value == "" {
@@ -301,7 +301,7 @@ func (segment *Segment) renderFallback(index int) bool {
 		return false
 	}
 
-	text, err := template.Render(segment.FallbackTemplate, segment.writer)
+	text, err := template.RenderTrusted(segment.FallbackTemplate, segment.writer)
 	if err != nil {
 		text = err.Error()
 	}
@@ -580,7 +580,7 @@ func (segment *Segment) string() string {
 		segment.Template = segment.writer.Template()
 	}
 
-	text, err := template.Render(segment.Template, segment.writer)
+	text, err := template.RenderTrusted(segment.Template, segment.writer)
 	if err != nil {
 		return err.Error()
 	}

--- a/src/prompt/engine.go
+++ b/src/prompt/engine.go
@@ -117,7 +117,7 @@ func (e *Engine) pwd() {
 	}
 
 	// Allow template logic to define when to enable the PWD (when supported)
-	pwdType, err := template.Render(e.Config.PWD, nil)
+	pwdType, err := template.RenderTrusted(e.Config.PWD, nil)
 	if err != nil || pwdType == "" {
 		return
 	}
@@ -181,7 +181,7 @@ func (e *Engine) shouldFill(filler string, padLength int) (string, bool) {
 	}()
 
 	var err error
-	if filler, err = template.Render(filler, e); err != nil {
+	if filler, err = template.RenderTrusted(filler, e); err != nil {
 		return "", false
 	}
 
@@ -202,7 +202,7 @@ func (e *Engine) shouldFill(filler string, padLength int) (string, bool) {
 }
 
 func (e *Engine) getTitleTemplateText() string {
-	if txt, err := template.Render(e.Config.ConsoleTitleTemplate, nil); err == nil {
+	if txt, err := template.RenderTrusted(e.Config.ConsoleTitleTemplate, nil); err == nil {
 		return txt
 	}
 

--- a/src/prompt/engine_test.go
+++ b/src/prompt/engine_test.go
@@ -368,6 +368,10 @@ func TestGetConsoleTitleIfGethostnameReturnsError(t *testing.T) {
 }
 
 func TestShouldFill(t *testing.T) {
+	// terminal.Plain is a package-level global. Restore it so the tests that run
+	// after this one are not silently switched into plain mode.
+	t.Cleanup(func() { terminal.Plain = false })
+
 	cases := []struct {
 		Case           string
 		Overflow       config.Overflow

--- a/src/prompt/extra.go
+++ b/src/prompt/extra.go
@@ -57,7 +57,7 @@ func (e *Engine) ExtraPrompt(promptType ExtraPromptType) string {
 		}
 	}
 
-	promptText, err := template.Render(getTemplate(prompt.Template), nil)
+	promptText, err := template.RenderTrusted(getTemplate(prompt.Template), nil)
 	if err != nil {
 		promptText = err.Error()
 	}
@@ -192,7 +192,7 @@ func (e *Engine) renderRightTemplate(prompt *config.Segment, background, foregro
 		return "", 0
 	}
 
-	text, err := template.Render(prompt.RightTemplate, nil)
+	text, err := template.RenderTrusted(prompt.RightTemplate, nil)
 	if err != nil {
 		text = err.Error()
 	}

--- a/src/prompt/extra_test.go
+++ b/src/prompt/extra_test.go
@@ -21,7 +21,11 @@ import (
 	testifymock "github.com/stretchr/testify/mock"
 )
 
-func setupExtraPromptTest(sh string, flags *runtime.Flags) *mock.Environment {
+func setupExtraPromptTest(t *testing.T, sh string, flags *runtime.Flags) *mock.Environment {
+	t.Helper()
+	// terminal.Plain is a package-level global; restore it for later tests.
+	t.Cleanup(func() { terminal.Plain = false })
+
 	env := new(mock.Environment)
 	env.On("Shell").Return(sh)
 	env.On("Flags").Return(flags)
@@ -36,6 +40,9 @@ func setupExtraPromptTest(sh string, flags *runtime.Flags) *mock.Environment {
 	}
 	template.Init(env, nil, nil)
 	terminal.Init(sh)
+	// These tests assert on uncolored output, so ask for it rather than
+	// inheriting whatever an earlier test left in this global.
+	terminal.Plain = true
 	terminal.Colors = color.MakeColors(nil, false, "", env)
 
 	return env
@@ -99,7 +106,7 @@ func TestExtraPromptTransientZSH(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		env := setupExtraPromptTest(shell.ZSH, &runtime.Flags{Eval: tc.Eval})
+		env := setupExtraPromptTest(t, shell.ZSH, &runtime.Flags{Eval: tc.Eval})
 		env.On("TerminalWidth").Return(tc.TerminalWidth, tc.TerminalErr)
 
 		engine := &Engine{
@@ -119,7 +126,11 @@ func TestExtraPromptTransientZSH(t *testing.T) {
 }
 
 func TestExtraPromptTransientPWSH(t *testing.T) {
-	// initialize the terminal for pwsh before resolving the expected sequences
+	// initialize the terminal for pwsh before resolving the expected sequences.
+	// Plain has to match what setupExtraPromptTest uses, otherwise the expected
+	// sequences are resolved under a different mode than the ones under test.
+	t.Cleanup(func() { terminal.Plain = false })
+	terminal.Plain = true
 	terminal.Init(shell.PWSH)
 	saveCursor := terminal.SaveCursorPosition()
 	restoreCursor := terminal.RestoreCursorPosition()
@@ -185,7 +196,7 @@ func TestExtraPromptTransientPWSH(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		env := setupExtraPromptTest(shell.PWSH, &runtime.Flags{})
+		env := setupExtraPromptTest(t, shell.PWSH, &runtime.Flags{})
 		env.On("TerminalWidth").Return(tc.TerminalWidth, tc.TerminalErr)
 
 		engine := &Engine{
@@ -205,7 +216,7 @@ func TestExtraPromptTransientPWSH(t *testing.T) {
 }
 
 func TestExtraPromptTransientPWSHNewline(t *testing.T) {
-	env := setupExtraPromptTest(shell.PWSH, &runtime.Flags{PromptCount: 2})
+	env := setupExtraPromptTest(t, shell.PWSH, &runtime.Flags{PromptCount: 2})
 	env.On("TerminalWidth").Return(20, nil)
 	env.On("CursorPosition").Return(2, 1)
 
@@ -273,7 +284,7 @@ func TestExtraPromptTransientFish(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		env := setupExtraPromptTest(shell.FISH, &runtime.Flags{})
+		env := setupExtraPromptTest(t, shell.FISH, &runtime.Flags{})
 		env.On("TerminalWidth").Return(tc.TerminalWidth, tc.TerminalErr)
 
 		engine := &Engine{
@@ -293,7 +304,7 @@ func TestExtraPromptTransientFish(t *testing.T) {
 }
 
 func TestTransientRPromptTemplateError(t *testing.T) {
-	env := setupExtraPromptTest(shell.FISH, &runtime.Flags{})
+	env := setupExtraPromptTest(t, shell.FISH, &runtime.Flags{})
 	engine := &Engine{
 		Config: &config.Config{
 			TransientPrompt: &config.Segment{RightTemplate: "{{"},
@@ -305,7 +316,7 @@ func TestTransientRPromptTemplateError(t *testing.T) {
 }
 
 func TestExtraPromptRightTemplateUnsupportedShell(t *testing.T) {
-	env := setupExtraPromptTest(shell.BASH, &runtime.Flags{})
+	env := setupExtraPromptTest(t, shell.BASH, &runtime.Flags{})
 
 	engine := &Engine{
 		Config: &config.Config{
@@ -330,7 +341,11 @@ func TestShouldFillNegativePadLength(t *testing.T) {
 	assert.Empty(t, got)
 }
 
-func setupExtraStreamingTestEnv(sh string) *mock.Environment {
+func setupExtraStreamingTestEnv(t *testing.T, sh string) *mock.Environment {
+	t.Helper()
+	// terminal.Plain is a package-level global; restore it for later tests.
+	t.Cleanup(func() { terminal.Plain = false })
+
 	env := new(mock.Environment)
 	env.On("Pwd").Return("/test")
 	env.On("Home").Return("/home")
@@ -348,13 +363,16 @@ func setupExtraStreamingTestEnv(sh string) *mock.Environment {
 	}
 	template.Init(env, nil, nil)
 	terminal.Init(sh)
+	// These tests assert on uncolored output, so ask for it rather than
+	// inheriting whatever an earlier test left in this global.
+	terminal.Plain = true
 	terminal.Colors = color.MakeColors(nil, false, "", env)
 
 	return env
 }
 
 func TestStreamPrimary_TransientRecordSkippedForZSHRightTemplate(t *testing.T) {
-	env := setupExtraStreamingTestEnv(shell.ZSH)
+	env := setupExtraStreamingTestEnv(t, shell.ZSH)
 
 	engine := &Engine{
 		Config: &config.Config{
@@ -376,7 +394,7 @@ func TestStreamPrimary_TransientRecordSkippedForZSHRightTemplate(t *testing.T) {
 }
 
 func TestStreamPrimary_TransientRecordSentForZSHWithoutRightTemplate(t *testing.T) {
-	env := setupExtraStreamingTestEnv(shell.ZSH)
+	env := setupExtraStreamingTestEnv(t, shell.ZSH)
 
 	engine := &Engine{
 		Config: &config.Config{
@@ -402,7 +420,7 @@ func TestStreamPrimary_TransientRecordSentForZSHWithoutRightTemplate(t *testing.
 }
 
 func TestStreamPrimary_TransientRecordContainsRightTemplateForPWSH(t *testing.T) {
-	env := setupExtraStreamingTestEnv(shell.PWSH)
+	env := setupExtraStreamingTestEnv(t, shell.PWSH)
 
 	engine := &Engine{
 		Config: &config.Config{

--- a/src/prompt/segments_test.go
+++ b/src/prompt/segments_test.go
@@ -4,10 +4,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jandedobbeleer/oh-my-posh/src/cache"
 	"github.com/jandedobbeleer/oh-my-posh/src/color"
 	"github.com/jandedobbeleer/oh-my-posh/src/config"
+	"github.com/jandedobbeleer/oh-my-posh/src/maps"
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+	"github.com/jandedobbeleer/oh-my-posh/src/shell"
+	"github.com/jandedobbeleer/oh-my-posh/src/template"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -222,6 +226,14 @@ func TestExecuteSegmentWithTimeout_CachedValueFallback(t *testing.T) {
 	// This test verifies that a pending segment's Text() returns "..." placeholder
 	env := new(mock.Environment)
 	env.On("Flags").Return(&runtime.Flags{})
+	env.On("Shell").Return(shell.GENERIC)
+
+	// Render writes through the template cache, so it has to exist rather than
+	// be inherited from whichever test happened to run first.
+	template.Cache = &cache.Template{
+		Segments: maps.NewConcurrent[any](),
+	}
+	template.Init(env, nil, nil)
 
 	segment := &config.Segment{
 		Type:     "text",

--- a/src/prompt/streaming_test.go
+++ b/src/prompt/streaming_test.go
@@ -648,6 +648,10 @@ func setupBasicStreamingTestEnv() *Engine {
 	env.On("Flags").Return(&runtime.Flags{Streaming: true})
 	env.On("CursorPosition").Return(1, 1)
 	env.On("StatusCodes").Return(0, "0")
+	// MakeColors resolves the accent color, which reads the registry on Windows
+	// and shells out on macOS. Without these the helper panics on those hosts.
+	env.On("RunCommand", testifymock.Anything, testifymock.Anything).Return("4", nil)
+	env.On("WindowsRegistryKeyValue", testifymock.Anything).Return(&runtime.WindowsRegistryValue{ValueType: runtime.DWORD, DWord: 0xFF0078D7}, nil)
 
 	template.Cache = &cache.Template{
 		Segments: maps.NewConcurrent[any](),
@@ -705,6 +709,10 @@ func TestStreamPrimary_RaceConditionFix(t *testing.T) {
 	env.On("Flags").Return(&runtime.Flags{Streaming: true})
 	env.On("CursorPosition").Return(1, 1)
 	env.On("StatusCodes").Return(0, "0")
+	// MakeColors resolves the accent color, which reads the registry on Windows
+	// and shells out on macOS. Without these the setup panics on those hosts.
+	env.On("RunCommand", testifymock.Anything, testifymock.Anything).Return("4", nil)
+	env.On("WindowsRegistryKeyValue", testifymock.Anything).Return(&runtime.WindowsRegistryValue{ValueType: runtime.DWORD, DWord: 0xFF0078D7}, nil)
 
 	template.Cache = &cache.Template{
 		Segments: maps.NewConcurrent[any](),

--- a/src/segments/http.go
+++ b/src/segments/http.go
@@ -32,7 +32,7 @@ func (h *HTTP) Enabled() bool {
 	method := h.options.String(METHOD, "GET")
 	timeout := h.options.Int(options.HTTPTimeout, 10000)
 
-	if resolved, err := template.Render(url, nil); err == nil {
+	if resolved, err := template.RenderTrusted(url, nil); err == nil {
 		url = resolved
 	}
 

--- a/src/segments/language.go
+++ b/src/segments/language.go
@@ -358,7 +358,7 @@ func (l *Language) buildVersionURL() {
 		return
 	}
 
-	url, err := template.Render(versionURLTemplate, l.Version)
+	url, err := template.RenderTrusted(versionURLTemplate, l.Version)
 	if err != nil {
 		return
 	}

--- a/src/segments/options/map.go
+++ b/src/segments/options/map.go
@@ -105,7 +105,7 @@ func (m Map) Template(option Option, defaultValue string, context any) string {
 		return value
 	}
 
-	resolved, err := template.Render(value, context)
+	resolved, err := template.RenderTrusted(value, context)
 	if err != nil {
 		debugf("%s: template error, using raw value: %s", option, err)
 		return value

--- a/src/segments/path.go
+++ b/src/segments/path.go
@@ -282,7 +282,12 @@ func (pt *Path) setStyle() {
 	}
 
 	// make sure we resolve all templates
-	if txt, err := template.Render(pt.Path, pt); err == nil {
+	//
+	// pt.Path is composed from raw filesystem folder names (untrusted) plus
+	// already-rendered config templates, so it must never get the func map
+	// entries that touch the OS (cmd/readFile/stat/glob) — use the restricted
+	// renderer, not template.Render.
+	if txt, err := template.RenderUntrusted(pt.Path, pt); err == nil {
 		pt.Path = txt
 	}
 }
@@ -293,7 +298,7 @@ func (pt *Path) getMaxWidth() int {
 		return 0
 	}
 
-	txt, err := template.Render(width, pt)
+	txt, err := template.RenderTrusted(width, pt)
 	if err != nil {
 		log.Error(err)
 		return 0
@@ -320,7 +325,7 @@ func (pt *Path) getFolderSeparator() string {
 		return separator
 	}
 
-	txt, err := template.Render(separatorTemplate, pt)
+	txt, err := template.RenderTrusted(separatorTemplate, pt)
 	if err != nil {
 		log.Error(err)
 	}
@@ -652,7 +657,7 @@ func (pt *Path) setMappedLocations() {
 			continue
 		}
 
-		location, err := template.Render(key, pt)
+		location, err := template.RenderTrusted(key, pt)
 		if err != nil {
 			log.Error(err)
 		}

--- a/src/segments/path_test.go
+++ b/src/segments/path_test.go
@@ -28,7 +28,7 @@ func renderTemplateNoTrimSpace(env *mock.Environment, segmentTemplate string, co
 	}
 	template.Init(env, nil, nil)
 
-	text, err := template.Render(segmentTemplate, context)
+	text, err := template.RenderTrusted(segmentTemplate, context)
 	if err != nil {
 		return err.Error()
 	}

--- a/src/segments/path_unix_test.go
+++ b/src/segments/path_unix_test.go
@@ -630,6 +630,13 @@ var testFullAndFolderPathCases = []testFullAndFolderPathCase{
 	{Style: Full, Pwd: homeDir + abc, Expected: "~/abc"},
 	{Style: Full, Pwd: homeDir + abc, Expected: homeDir + abc, DisableMappedLocations: true},
 	{Style: Full, Pwd: abcd, Expected: abcd},
+
+	// A folder name containing template syntax must never execute the `cmd` function
+	// once it is spliced into pt.Path and re-rendered in setStyle(): the render uses
+	// the restricted func map, so parsing fails and pt.Path keeps its raw, unexecuted
+	// text instead.
+	{Style: Full, Pwd: homeDir + "/{{ cmd `whoami` }}", Expected: "~/{{ cmd `whoami` }}"},
+	{Style: FolderType, Pwd: homeDir + "/{{ cmd `whoami` }}", Expected: "{{ cmd `whoami` }}"},
 }
 
 var testFullPathCustomMappedLocationsCases = []testFullPathCustomMappedLocationsCase{

--- a/src/segments/path_windows_test.go
+++ b/src/segments/path_windows_test.go
@@ -421,6 +421,16 @@ var testFullAndFolderPathCases = []testFullAndFolderPathCase{
 	{Style: Full, FolderSeparatorIcon: `\`, Pwd: homeDirWindows, Expected: "~", PathSeparator: `\`, GOOS: runtime.WINDOWS},
 	{Style: Full, FolderSeparatorIcon: `\`, Pwd: homeDirWindows + "\\abc", Expected: "~\\abc", PathSeparator: `\`, GOOS: runtime.WINDOWS},
 	{Style: Full, FolderSeparatorIcon: `\`, Pwd: "C:\\Users\\posh", Expected: "C:\\Users\\posh", PathSeparator: `\`, GOOS: runtime.WINDOWS},
+
+	// A folder name containing template syntax must never execute the `cmd` function
+	// once it is spliced into pt.Path and re-rendered in setStyle(): the render uses
+	// the restricted func map, so parsing fails and pt.Path keeps its raw, unexecuted
+	// text instead.
+	{
+		Style: FolderType, FolderSeparatorIcon: `\`,
+		Pwd: homeDirWindows + "\\{{ cmd `whoami` }}", Expected: "{{ cmd `whoami` }}",
+		PathSeparator: `\`, GOOS: runtime.WINDOWS,
+	},
 }
 
 var testFullPathCustomMappedLocationsCases = []testFullPathCustomMappedLocationsCase{

--- a/src/segments/scm.go
+++ b/src/segments/scm.go
@@ -163,7 +163,7 @@ func (s *Scm) formatBranch(branch string) string {
 		return branch
 	}
 
-	txt, err := template.Render(branchTemplate, struct{ Branch, Upstream string }{Branch: branch, Upstream: s.Upstream})
+	txt, err := template.RenderTrusted(branchTemplate, struct{ Branch, Upstream string }{Branch: branch, Upstream: s.Upstream})
 	if err != nil {
 		return branch
 	}

--- a/src/segments/status.go
+++ b/src/segments/status.go
@@ -48,7 +48,7 @@ func (s *Status) formatStatus(status int, pipeStatus string) string {
 	}
 
 	if pipeStatus == "" {
-		if txt, err := template.Render(statusTemplate, s); err == nil {
+		if txt, err := template.RenderTrusted(statusTemplate, s); err == nil {
 			return txt
 		}
 
@@ -87,7 +87,7 @@ func (s *Status) formatStatus(status int, pipeStatus string) string {
 
 		context.Code = code
 
-		txt, err := template.Render(statusTemplate, context)
+		txt, err := template.RenderTrusted(statusTemplate, context)
 		if err != nil {
 			write(codeStr)
 			continue

--- a/src/template/bench_test.go
+++ b/src/template/bench_test.go
@@ -19,7 +19,7 @@ func BenchmarkRenderPlain(b *testing.B) {
 	setupTemplateBench()
 	b.ReportAllocs()
 	for b.Loop() {
-		_, _ = Render("plain text without any template markers at all", nil)
+		_, _ = RenderTrusted("plain text without any template markers at all", nil)
 	}
 }
 
@@ -33,7 +33,7 @@ func BenchmarkRenderSimple(b *testing.B) {
 	data := ctx{Shell: "pwsh", UserName: "jandedobbeleer"}
 	b.ReportAllocs()
 	for b.Loop() {
-		_, _ = Render("{{ .Shell }} {{ .UserName }}", data)
+		_, _ = RenderTrusted("{{ .Shell }} {{ .UserName }}", data)
 	}
 }
 
@@ -56,7 +56,7 @@ func BenchmarkRenderRepeated(b *testing.B) {
 	tmpl := `{{ if .Root }}# {{ end }}{{ .Folder }}{{ if .Branch }} on {{ .Branch }}{{ end }} {{ if .Version }}v{{ .Version }}{{ end }}`
 	b.ReportAllocs()
 	for b.Loop() {
-		_, _ = Render(tmpl, data)
+		_, _ = RenderTrusted(tmpl, data)
 	}
 }
 

--- a/src/template/cmd_test.go
+++ b/src/template/cmd_test.go
@@ -64,7 +64,7 @@ func TestCmd(t *testing.T) {
 		Cache = new(cache.Template)
 		Init(e, nil, nil)
 
-		text, err := Render(tc.Template, nil)
+		text, err := RenderTrusted(tc.Template, nil)
 		if tc.ShouldError {
 			assert.Error(t, err, tc.Case)
 			continue

--- a/src/template/date_test.go
+++ b/src/template/date_test.go
@@ -70,7 +70,7 @@ func TestDateFromStringEpoch(t *testing.T) {
 		Cache = new(cache.Template)
 		Init(env, nil, nil)
 
-		text, err := Render(tc.Template, tc.Context)
+		text, err := RenderTrusted(tc.Template, tc.Context)
 		assert.NoError(t, err, tc.Case)
 		if tc.Expected != "" {
 			assert.Equal(t, tc.Expected, text, tc.Case)
@@ -114,7 +114,7 @@ func TestDateAndHTMLDateFunctions(t *testing.T) {
 		Cache = new(cache.Template)
 		Init(env, nil, nil)
 
-		text, err := Render(tc.Template, tc.Context)
+		text, err := RenderTrusted(tc.Template, tc.Context)
 		assert.NoError(t, err, tc.Case)
 		assert.Equal(t, tc.Expected, text, tc.Case)
 	}

--- a/src/template/files_test.go
+++ b/src/template/files_test.go
@@ -28,7 +28,7 @@ func TestGlob(t *testing.T) {
 	Init(env, nil, nil)
 
 	for _, tc := range cases {
-		text, err := Render(tc.Template, nil)
+		text, err := RenderTrusted(tc.Template, nil)
 		if tc.ShouldError {
 			assert.Error(t, err)
 			continue

--- a/src/template/func_map.go
+++ b/src/template/func_map.go
@@ -8,13 +8,25 @@ import (
 	"github.com/Masterminds/sprig/v3"
 )
 
-// sharedFuncMap is built exactly once and reused across all template constructions.
-var sharedFuncMap = sync.OnceValue(func() template.FuncMap {
+// dangerousFuncs execute host commands or touch the filesystem/environment
+// directly. They are only exposed to templates rendered via RenderTrusted
+// (see text.go) — never to RenderUntrusted, which may contain or be composed
+// from runtime data.
+var dangerousFuncs = map[string]bool{
+	"cmd":       true,
+	"readFile":  true,
+	"stat":      true,
+	"glob":      true,
+	"env":       true,
+	"expandenv": true,
+}
+
+// baseFuncMap returns the funcs available regardless of trust level.
+func baseFuncMap() map[string]any {
 	fm := map[string]any{
 		"secondsRound": secondsRound,
 		"url":          url,
 		"path":         filePath,
-		"glob":         glob,
 		"matchP":       matchP,
 		"findP":        findP,
 		"replaceP":     replaceP,
@@ -25,9 +37,6 @@ var sharedFuncMap = sync.OnceValue(func() template.FuncMap {
 		"hresult":      hresult,
 		"trunc":        trunc,
 		"truncE":       TruncE,
-		"cmd":          cmd,
-		"readFile":     readFile,
-		"stat":         stat,
 		"dir":          filepath.Dir,
 		"base":         filepath.Base,
 		// Locale-aware date/time formatting using OS regional settings.
@@ -42,15 +51,51 @@ var sharedFuncMap = sync.OnceValue(func() template.FuncMap {
 	}
 
 	for key, fun := range sprig.TxtFuncMap() {
+		if dangerousFuncs[key] {
+			continue
+		}
+
 		if _, ok := fm[key]; !ok {
 			fm[key] = fun
 		}
 	}
 
+	return fm
+}
+
+// sharedFuncMap is built exactly once and reused across all trusted template constructions.
+var sharedFuncMap = sync.OnceValue(func() template.FuncMap {
+	fm := baseFuncMap()
+
+	fm["cmd"] = cmd
+	fm["readFile"] = readFile
+	fm["stat"] = stat
+	fm["glob"] = glob
+
+	sprigFuncs := sprig.TxtFuncMap()
+	if fn, ok := sprigFuncs["env"]; ok {
+		fm["env"] = fn
+	}
+
+	if fn, ok := sprigFuncs["expandenv"]; ok {
+		fm["expandenv"] = fn
+	}
+
 	return template.FuncMap(fm)
 })
 
-// funcMap returns the shared merged FuncMap (built once, reused everywhere).
-func funcMap() template.FuncMap {
-	return sharedFuncMap()
+// restrictedFuncMap is built exactly once and reused across all restricted template
+// constructions (see RenderRestricted). It never contains dangerousFuncs.
+var restrictedFuncMap = sync.OnceValue(func() template.FuncMap {
+	return template.FuncMap(baseFuncMap())
+})
+
+// funcMap returns the merged FuncMap for the given trust level (built once per
+// level, reused everywhere).
+func funcMap(trusted bool) template.FuncMap {
+	if trusted {
+		return sharedFuncMap()
+	}
+
+	return restrictedFuncMap()
 }

--- a/src/template/link_test.go
+++ b/src/template/link_test.go
@@ -28,7 +28,7 @@ func TestUrl(t *testing.T) {
 	Init(env, nil, nil)
 
 	for _, tc := range cases {
-		text, err := Render(tc.Template, nil)
+		text, err := RenderTrusted(tc.Template, nil)
 		if tc.ShouldError {
 			assert.Error(t, err)
 			continue
@@ -57,7 +57,7 @@ func TestPath(t *testing.T) {
 	Init(env, nil, nil)
 
 	for _, tc := range cases {
-		text, _ := Render(tc.Template, nil)
+		text, _ := RenderTrusted(tc.Template, nil)
 
 		assert.Equal(t, tc.Expected, text, tc.Case)
 	}

--- a/src/template/list.go
+++ b/src/template/list.go
@@ -42,7 +42,7 @@ func (l List) Join(context any) string {
 	buffer := text.NewBuilder()
 
 	for _, tmpl := range l {
-		value, err := Render(tmpl, context)
+		value, err := RenderTrusted(tmpl, context)
 		if err != nil || len(strings.TrimSpace(value)) == 0 {
 			continue
 		}
@@ -59,7 +59,7 @@ func (l List) FirstMatch(context any, defaultValue string) string {
 	}
 
 	for _, tmpl := range l {
-		value, err := Render(tmpl, context)
+		value, err := RenderTrusted(tmpl, context)
 		if err != nil || len(strings.TrimSpace(value)) == 0 {
 			continue
 		}

--- a/src/template/locale_test.go
+++ b/src/template/locale_test.go
@@ -120,7 +120,7 @@ func TestLocaleShortDateFallback(t *testing.T) {
 
 	tmpl := `{{ localeShortDate .T }}`
 	ctx := struct{ T time.Time }{T: time.Unix(0, 0).UTC()}
-	got, err := Render(tmpl, ctx)
+	got, err := RenderTrusted(tmpl, ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, "1970-01-01", got)
 }
@@ -142,7 +142,7 @@ func TestLocaleShortTimeFallback(t *testing.T) {
 
 	tmpl := `{{ localeShortTime .T }}`
 	ctx := struct{ T time.Time }{T: time.Unix(0, 0).UTC()}
-	got, err := Render(tmpl, ctx)
+	got, err := RenderTrusted(tmpl, ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, "00:00", got)
 }
@@ -165,7 +165,7 @@ func TestLocaleShortDateWithISOLayout(t *testing.T) {
 	// knownEpoch = 2019-06-13 20:39:39 UTC (from date_test.go)
 	tmpl := `{{ localeShortDate .T }}`
 	ctx := struct{ T time.Time }{T: time.Unix(knownEpoch, 0).UTC()}
-	got, err := Render(tmpl, ctx)
+	got, err := RenderTrusted(tmpl, ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, "2019-06-13", got)
 }
@@ -186,7 +186,7 @@ func TestLocaleShortTimeWith24hLayout(t *testing.T) {
 
 	tmpl := `{{ localeShortTime .T }}`
 	ctx := struct{ T time.Time }{T: time.Unix(knownEpoch, 0).UTC()}
-	got, err := Render(tmpl, ctx)
+	got, err := RenderTrusted(tmpl, ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, "20:39", got)
 }
@@ -207,7 +207,7 @@ func TestLocaleShortDateWith12hUSLayout(t *testing.T) {
 
 	tmpl := `{{ localeShortDate .T }} {{ localeShortTime .T }}`
 	ctx := struct{ T time.Time }{T: time.Unix(knownEpoch, 0).UTC()}
-	got, err := Render(tmpl, ctx)
+	got, err := RenderTrusted(tmpl, ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, "6/13/2019 8:39 PM", got)
 }

--- a/src/template/numbers_test.go
+++ b/src/template/numbers_test.go
@@ -18,7 +18,7 @@ func TestHResult(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		text, err := Render(tc.Template, nil)
+		text, err := RenderTrusted(tc.Template, nil)
 		if tc.ShouldError {
 			assert.Error(t, err)
 			continue

--- a/src/template/pool_test.go
+++ b/src/template/pool_test.go
@@ -16,12 +16,12 @@ func TestTextPool(t *testing.T) {
 	Init(env, nil, nil)
 
 	// Test rendering
-	result, err := Render("Hello {{ .Name }}", map[string]any{"Name": "World"})
+	result, err := RenderTrusted("Hello {{ .Name }}", map[string]any{"Name": "World"})
 	assert.NoError(t, err)
 	assert.Equal(t, "Hello World", result)
 
 	// Test empty template
-	result2, err := Render("", nil)
+	result2, err := RenderTrusted("", nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "", result2)
 }

--- a/src/template/render.go
+++ b/src/template/render.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"text/template"
 	"unicode"
@@ -47,14 +48,19 @@ func (t *renderer) release() {
 }
 
 // templateCacheKey returns the key used to look up a cached *template.Template.
-// It encodes the raw (unpatched) template text and, when context is non-nil,
-// the reflect.Type of the context so that two different struct types whose
-// patchTemplate output would differ (via hasField) get separate cache entries.
-// For map[string]any contexts the key also includes the sorted exported key
-// names, since patchTemplate output depends on which keys are present.
-func templateCacheKey(rawText string, ctx any) string {
+// It encodes the raw (unpatched) template text, the trust level (parsed
+// templates are bound to a func map at Parse time, so a trusted and a
+// restricted render of identical text must never share a cache entry), and,
+// when context is non-nil, the reflect.Type of the context so that two
+// different struct types whose patchTemplate output would differ (via
+// hasField) get separate cache entries. For map[string]any contexts the key
+// also includes the sorted exported key names, since patchTemplate output
+// depends on which keys are present.
+func templateCacheKey(rawText string, trusted bool, ctx any) string {
+	key := rawText + "\x00" + strconv.FormatBool(trusted)
+
 	if ctx == nil {
-		return rawText
+		return key
 	}
 
 	t := reflect.TypeOf(ctx)
@@ -67,11 +73,11 @@ func templateCacheKey(rawText string, ctx any) string {
 				}
 			}
 			sort.Strings(keys)
-			return rawText + "\x00" + t.String() + "\x00" + strings.Join(keys, "\x01")
+			return key + "\x00" + t.String() + "\x00" + strings.Join(keys, "\x01")
 		}
 	}
 
-	return rawText + "\x00" + t.String()
+	return key + "\x00" + t.String()
 }
 
 // parsedTemplate returns a fully-parsed *template.Template for text.
@@ -79,10 +85,11 @@ func templateCacheKey(rawText string, ctx any) string {
 // return the cached value. Concurrent first-renders of the same template
 // may both parse, but LoadOrStore ensures only one result is shared.
 func parsedTemplate(text *Text) (*template.Template, error) {
-	// Key on the raw, unpatched template text plus the context type so that
-	// cache hits can skip patchTemplate entirely: patching is only needed
-	// the first time a given (raw template, context type) pair is seen.
-	key := templateCacheKey(text.template, text.context)
+	// Key on the raw, unpatched template text plus the trust level and context
+	// type so that cache hits can skip patchTemplate entirely: patching is only
+	// needed the first time a given (raw template, trust level, context type)
+	// combination is seen.
+	key := templateCacheKey(text.template, text.trusted, text.context)
 
 	if cached, ok := parsedTemplates.Load(key); ok {
 		return cached.(*template.Template), nil
@@ -91,8 +98,8 @@ func parsedTemplate(text *Text) (*template.Template, error) {
 	// Cache miss: patch the raw template into its executable form.
 	text.patchTemplate()
 
-	// Parse into a fresh template with the shared func map and settings.
-	tmpl, err := template.New("cache").Funcs(funcMap()).Parse(text.template)
+	// Parse into a fresh template with the func map matching this render's trust level.
+	tmpl, err := template.New("cache").Funcs(funcMap(text.trusted)).Parse(text.template)
 	if err != nil {
 		return nil, err
 	}

--- a/src/template/round_test.go
+++ b/src/template/round_test.go
@@ -25,7 +25,7 @@ func TestRoundSeconds(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		text, err := Render(tc.Template, nil)
+		text, err := RenderTrusted(tc.Template, nil)
 		if tc.ShouldError {
 			assert.Error(t, err)
 			continue

--- a/src/template/strings_test.go
+++ b/src/template/strings_test.go
@@ -22,7 +22,7 @@ func TestTrunc(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		text, err := Render(tc.Template, nil)
+		text, err := RenderTrusted(tc.Template, nil)
 		if tc.ShouldError {
 			assert.Error(t, err)
 			continue

--- a/src/template/text.go
+++ b/src/template/text.go
@@ -13,24 +13,46 @@ import (
 type Text struct {
 	context  Data
 	template string
+	trusted  bool
 }
 
 // New returns a Text instance from the pool with the given template and context
-func get(template string, context any) *Text {
+func get(template string, trusted bool, context any) *Text {
 	if textPool == nil {
 		// Fallback if pool is not initialized yet
-		return &Text{context: context, template: template}
+		return &Text{context: context, template: template, trusted: trusted}
 	}
 
 	text := textPool.Get()
 	text.template = template
+	text.trusted = trusted
 	text.context = context
 
 	return text
 }
 
-func Render(template string, context any) (string, error) {
-	t := get(template, context)
+// RenderTrusted executes a template the caller has verified was authored by
+// the user in their own configuration (a segment/block/palette/etc. template
+// field), as opposed to text assembled at runtime from external data
+// (filesystem names, command output, API responses, ...). The full func map
+// is available, including cmd/readFile/stat/glob.
+//
+// Only call this with a string read verbatim from a config field — passing
+// runtime-composed text here defeats the whole point of the split with
+// RenderUntrusted.
+func RenderTrusted(template string, context any) (string, error) {
+	return render(template, true, context)
+}
+
+// RenderUntrusted executes a template that may contain, or be composed from,
+// runtime data rather than user-authored config text. cmd/readFile/stat/glob
+// and env/expandenv are not available.
+func RenderUntrusted(template string, context any) (string, error) {
+	return render(template, false, context)
+}
+
+func render(template string, trusted bool, context any) (string, error) {
+	t := get(template, trusted, context)
 	defer t.release()
 
 	if !strings.Contains(t.template, "{{") || !strings.Contains(t.template, "}}") {
@@ -47,6 +69,7 @@ func Render(template string, context any) (string, error) {
 func (t *Text) release() {
 	t.context = nil
 	t.template = ""
+	t.trusted = false
 
 	if textPool != nil {
 		textPool.Put(t)

--- a/src/template/text_test.go
+++ b/src/template/text_test.go
@@ -162,7 +162,7 @@ func TestRenderTemplate(t *testing.T) {
 		Cache = new(cache.Template)
 		Init(env, nil, nil)
 
-		text, err := Render(tc.Template, tc.Context)
+		text, err := RenderTrusted(tc.Template, tc.Context)
 		if tc.ShouldError {
 			assert.Error(t, err)
 			continue
@@ -250,7 +250,7 @@ func TestRenderTemplateEnvVar(t *testing.T) {
 		}
 		Init(env, nil, nil)
 
-		text, err := Render(tc.Template, tc.Context)
+		text, err := RenderTrusted(tc.Template, tc.Context)
 		if tc.ShouldError {
 			assert.Error(t, err)
 			continue
@@ -400,7 +400,7 @@ func TestSegmentContains(t *testing.T) {
 	Init(env, nil, nil)
 
 	for _, tc := range cases {
-		text, _ := Render(tc.Template, nil)
+		text, _ := RenderTrusted(tc.Template, nil)
 		assert.Equal(t, tc.Expected, text, tc.Case)
 	}
 }

--- a/src/terminal/writer.go
+++ b/src/terminal/writer.go
@@ -674,6 +674,15 @@ func write(s rune) {
 		return
 	}
 
+	// segment content (directory names, git metadata, environment variables,
+	// command output) is potentially attacker-controlled and never passes through
+	// this function when it's Oh My Posh's own styling; drop C0/C1 control runes
+	// (ESC, BEL, CSI, OSC, ...) so they can't be interpreted as escape sequences
+	// by the terminal, including inside a hyperlink target.
+	if isControlRune(s) {
+		return
+	}
+
 	if isHyperlink {
 		builder.WriteRune(s)
 		return
@@ -692,6 +701,21 @@ func write(s rune) {
 	}
 
 	builder.WriteRune(s)
+}
+
+// isControlRune reports whether s is a C0 (0x00-0x1F), DEL (0x7F), or C1
+// (0x80-0x9F) control character. These are the bytes a terminal can interpret
+// as the start of an escape sequence (ESC, BEL, CSI, OSC, ...); no legitimate
+// rendered segment content needs them. '\n' is exempt: Oh My Posh itself
+// prepends a literal newline ahead of the transient prompt (see
+// Engine.getNewline), and unlike ESC/BEL/CSI/OSC a bare LF can't be
+// interpreted as the start of an escape sequence.
+func isControlRune(s rune) bool {
+	if s == '\n' {
+		return false
+	}
+
+	return s <= 0x1f || (s >= 0x7f && s <= 0x9f)
 }
 
 // writeVisibleRune stamps the active gradient color(s) for the current cell

--- a/src/terminal/writer_hyperlink_test.go
+++ b/src/terminal/writer_hyperlink_test.go
@@ -93,6 +93,11 @@ func TestGenerateHyperlinkWithUrl(t *testing.T) {
 			ShellName: shell.BASH,
 			Expected:  "\\[\x1b[47m\\]\\[\x1b[30m\\]\\[\x1b]8;;http://www.google.be\x1b\\\\\\]link\\[\x1b]8;;\x1b\\\\\\]\\[\x1b[0m\\]",
 		},
+		{
+			Text:      "<LINK>http://evil\x1b]0;HACKED\x07.com<TEXT>google</TEXT></LINK>",
+			ShellName: shell.FISH,
+			Expected:  "\x1b[47m\x1b[30m\x1b]8;;http://evil]0;HACKED.com\x1b\\google\x1b]8;;\x1b\\\x1b[0m",
+		},
 	}
 	for _, tc := range cases {
 		Init(tc.ShellName)

--- a/src/terminal/writer_test.go
+++ b/src/terminal/writer_test.go
@@ -219,6 +219,18 @@ func TestWriteANSIColors(t *testing.T) {
 			Expected: "\x1b[33mhello \x1b[48;2;130;170;255m\x1b[38;2;1;22;39mnew\x1b[49m\x1b[33m world\x1b[0m",
 			Colors:   &color.Set{Foreground: "yellow", Background: "transparent"},
 		},
+		{
+			Case:     "OSC injection stripped from segment content",
+			Input:    "before\x1b]0;HACKED\x07after",
+			Expected: "\x1b[47m\x1b[30mbefore]0;HACKEDafter\x1b[0m",
+			Colors:   &color.Set{Foreground: "black", Background: "white"},
+		},
+		{
+			Case:     "CSI and C1 control runes stripped from segment content",
+			Input:    "before\x1b[31mred\u009bafter",
+			Expected: "\x1b[47m\x1b[30mbefore[31mredafter\x1b[0m",
+			Colors:   &color.Set{Foreground: "black", Background: "white"},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
template.Render's func map exposed cmd/readFile/stat/glob/env/expandenv
to any string passed as the template argument, with no way to tell a
template the user authored in their config from one built at runtime
out of external data (filesystem names, command output, ...). That
distinction is exactly what let a malicious folder name reach cmd
(fixed for that one call site in a prior commit); nothing stopped the
same class of bug from reappearing at a future call site.

Split Render into two explicitly named functions instead: RenderTrusted
keeps the full func map and is for template text read verbatim from a
config field (segment/block/palette templates, mapped_locations keys,
folder_separator_template, ...) — every existing call site converts to
it. RenderUntrusted drops cmd/readFile/stat/glob/env/expandenv and is
for text that may contain or be composed from runtime data; pt.Path in
path.go's setStyle(), the one sink that re-renders a string composed
from raw filesystem folder names, uses it. Neither name is shorter or
more "default" than the other, so there's no ambient plain Render a
future call site could reach for without first deciding which one it
means. The parsed-template cache key includes the trust level so a
trusted and an untrusted render of identical text can never share a
cached *template.Template and its func map.

Entire-Checkpoint: 597e5a60d968

### Prerequisites

- [ ] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [ ] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

<!---

Tips:

If you're not comfortable with working with Git,
we're working on a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D)
as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
