### PR TITLE
next

### DIFF
--- a/src/color/keywords.go
+++ b/src/color/keywords.go
@@ -26,7 +26,10 @@ func (color Ansi) isKeyword() bool {
 
 func (color Ansi) Resolve(current *Set, parents []*Set) Ansi {
 	resolveParentColor := func(keyword Ansi) Ansi {
-		for _, parentColor := range parents {
+		// parents is a stack pushed tail-first (see terminal.SetParentColors):
+		// the nearest ancestor is the last element, so walk back-to-front.
+		for i := len(parents) - 1; i >= 0; i-- {
+			parentColor := parents[i]
 			if parentColor == nil {
 				return Transparent
 			}

--- a/src/color/keywords.go
+++ b/src/color/keywords.go
@@ -31,7 +31,6 @@ func (color Ansi) Resolve(current *Set, parents []*Set) Ansi {
 		// parents is a stack pushed tail-first (see terminal.SetParentColors):
 		// the nearest ancestor is the last element, so walk back-to-front.
 		for _, parentColor := range slices.Backward(parents) {
-
 			if parentColor == nil {
 				return Transparent
 			}

--- a/src/color/keywords.go
+++ b/src/color/keywords.go
@@ -1,5 +1,7 @@
 package color
 
+import "slices"
+
 const (
 	// Transparent implies a transparent color
 	Transparent Ansi = "transparent"
@@ -28,8 +30,8 @@ func (color Ansi) Resolve(current *Set, parents []*Set) Ansi {
 	resolveParentColor := func(keyword Ansi) Ansi {
 		// parents is a stack pushed tail-first (see terminal.SetParentColors):
 		// the nearest ancestor is the last element, so walk back-to-front.
-		for i := len(parents) - 1; i >= 0; i-- {
-			parentColor := parents[i]
+		for _, parentColor := range slices.Backward(parents) {
+
 			if parentColor == nil {
 				return Transparent
 			}
@@ -84,7 +86,7 @@ func (color Ansi) Resolve(current *Set, parents []*Set) Ansi {
 			return current.Background
 		case keyword == Foreground && current != nil:
 			return current.Foreground
-		case (keyword == ParentBackground || keyword == ParentForeground) && parents != nil:
+		case (keyword == ParentBackground || keyword == ParentForeground) && len(parents) != 0:
 			return resolveParentColor(keyword)
 		default:
 			return Transparent

--- a/src/prompt/engine.go
+++ b/src/prompt/engine.go
@@ -1,6 +1,7 @@
 package prompt
 
 import (
+	"slices"
 	"strings"
 	"sync"
 
@@ -25,13 +26,17 @@ type Engine struct {
 	Config                *config.Config
 	activeSegment         *config.Segment
 	previousActiveSegment *config.Segment
-	// blockTailColors is the last rendered segment's colors, captured just
+	// blockTailColors is a snapshot of terminal.ParentColors captured just
 	// before previousActiveSegment resets to nil at the end of a block. A
 	// block's own Filler (see shouldFill) renders after terminal.String()
 	// has already cleared the parent stack for the next block, so a filler
 	// template using <parentBackground>/<parentForeground> needs this to
 	// resolve against the block it is padding rather than an empty stack.
-	blockTailColors   *color.Set
+	// A full copy, not just the tail entry: the tail segment's own stored
+	// color can itself be an unresolved parentBackground/parentForeground
+	// keyword, and resolving that requires walking the rest of the chain
+	// the same way the block's own last segment did.
+	blockTailColors   []*color.Set
 	pendingSegments   sync.Map
 	rprompt           string
 	Overflow          config.Overflow
@@ -196,10 +201,10 @@ func (e *Engine) shouldFill(filler string, padLength int) (string, bool) {
 	terminal.SetColors("default", "default")
 
 	// the block's own segments already reset the parent stack when their
-	// terminal.String() call produced blockText - reseed the one entry a
+	// terminal.String() call produced blockText - reseed the chain a
 	// <parentBackground>/<parentForeground> anchor in the filler needs.
-	if e.blockTailColors != nil {
-		terminal.ParentColors = append(terminal.ParentColors, e.blockTailColors)
+	if len(e.blockTailColors) != 0 {
+		terminal.ParentColors = append(terminal.ParentColors, e.blockTailColors...)
 	}
 
 	terminal.Write("", "", filler)
@@ -518,21 +523,21 @@ func (e *Engine) renderActiveSegment() {
 	terminal.SetParentColors(e.previousActiveSegment.ResolveBackground(), e.previousActiveSegment.ResolveForeground())
 }
 
-// captureBlockTailColors snapshots the last rendered segment's colors into
-// blockTailColors just before previousActiveSegment resets to nil, so a
-// later shouldFill call for this same block's Filler can still resolve
+// captureBlockTailColors snapshots terminal.ParentColors into blockTailColors
+// just before previousActiveSegment resets to nil, so a later shouldFill call
+// for this same block's Filler can still resolve
 // <parentBackground>/<parentForeground> after terminal.String() has already
-// cleared the parent stack for the next block.
+// cleared the parent stack for the next block. A full copy of the chain, not
+// just the tail entry: the tail segment's own stored color can itself be an
+// unresolved parentBackground/parentForeground keyword, which needs the rest
+// of the chain to resolve the same way it did for the block's own segments.
 func (e *Engine) captureBlockTailColors() {
 	if e.previousActiveSegment == nil {
 		e.blockTailColors = nil
 		return
 	}
 
-	e.blockTailColors = &color.Set{
-		Background: e.previousActiveSegment.ResolveBackground(),
-		Foreground: e.previousActiveSegment.ResolveForeground(),
-	}
+	e.blockTailColors = slices.Clone(terminal.ParentColors)
 }
 
 func (e *Engine) writeSeparator(final bool) {

--- a/src/prompt/engine.go
+++ b/src/prompt/engine.go
@@ -25,16 +25,23 @@ type Engine struct {
 	Config                *config.Config
 	activeSegment         *config.Segment
 	previousActiveSegment *config.Segment
-	pendingSegments       sync.Map
-	rprompt               string
-	Overflow              config.Overflow
-	prompt                strings.Builder
-	allBlocks             []*config.Block
-	currentLineLength     int
-	Padding               int
-	rpromptLength         int
-	Plain                 bool
-	forceRender           bool
+	// blockTailColors is the last rendered segment's colors, captured just
+	// before previousActiveSegment resets to nil at the end of a block. A
+	// block's own Filler (see shouldFill) renders after terminal.String()
+	// has already cleared the parent stack for the next block, so a filler
+	// template using <parentBackground>/<parentForeground> needs this to
+	// resolve against the block it is padding rather than an empty stack.
+	blockTailColors   *color.Set
+	pendingSegments   sync.Map
+	rprompt           string
+	Overflow          config.Overflow
+	prompt            strings.Builder
+	allBlocks         []*config.Block
+	currentLineLength int
+	Padding           int
+	rpromptLength     int
+	Plain             bool
+	forceRender       bool
 }
 
 const (
@@ -187,6 +194,14 @@ func (e *Engine) shouldFill(filler string, padLength int) (string, bool) {
 
 	// allow for easy color overrides and templates
 	terminal.SetColors("default", "default")
+
+	// the block's own segments already reset the parent stack when their
+	// terminal.String() call produced blockText - reseed the one entry a
+	// <parentBackground>/<parentForeground> anchor in the filler needs.
+	if e.blockTailColors != nil {
+		terminal.ParentColors = append(terminal.ParentColors, e.blockTailColors)
+	}
+
 	terminal.Write("", "", filler)
 	filler, lenFiller := terminal.String()
 	if lenFiller == 0 {
@@ -337,6 +352,7 @@ func (e *Engine) renderBlockFromCache(block *config.Block, cancelNewline bool) b
 
 	e.writeSeparator(true)
 	e.activeSegment = nil
+	e.captureBlockTailColors()
 	e.previousActiveSegment = nil
 
 	blockText, length := terminal.String()
@@ -500,6 +516,23 @@ func (e *Engine) renderActiveSegment() {
 	e.previousActiveSegment = e.activeSegment
 
 	terminal.SetParentColors(e.previousActiveSegment.ResolveBackground(), e.previousActiveSegment.ResolveForeground())
+}
+
+// captureBlockTailColors snapshots the last rendered segment's colors into
+// blockTailColors just before previousActiveSegment resets to nil, so a
+// later shouldFill call for this same block's Filler can still resolve
+// <parentBackground>/<parentForeground> after terminal.String() has already
+// cleared the parent stack for the next block.
+func (e *Engine) captureBlockTailColors() {
+	if e.previousActiveSegment == nil {
+		e.blockTailColors = nil
+		return
+	}
+
+	e.blockTailColors = &color.Set{
+		Background: e.previousActiveSegment.ResolveBackground(),
+		Foreground: e.previousActiveSegment.ResolveForeground(),
+	}
 }
 
 func (e *Engine) writeSeparator(final bool) {

--- a/src/prompt/segments.go
+++ b/src/prompt/segments.go
@@ -80,6 +80,7 @@ func (e *Engine) renderBlockSegments(results []*config.Segment, block *config.Bl
 	e.writeSeparator(true)
 
 	e.activeSegment = nil
+	e.captureBlockTailColors()
 	e.previousActiveSegment = nil
 
 	return terminal.String()

--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -445,30 +445,76 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
         Stop-StreamingProcess
     }
 
-    # Byte-level reader for NUL-delimited prompt records, shared by the serve
+    # Chunked reader for NUL-delimited prompt records, shared by the serve
     # daemon (which passes a wake signal) and the legacy per-prompt stream
     # (which passes $null). Runs in its own runspace for the lifetime of the
     # stream it reads.
+    #
+    # Reads in 4KB chunks and splits on NUL via [Array]::IndexOf instead of
+    # one $stream.ReadByte() call per byte: a gradient-heavy prompt record
+    # can run 1-2KB, and a PowerShell method call per byte to drain it was
+    # measured adding tens of ms per cycle - enough to push a spammed Enter
+    # past the ~33ms key-repeat interval and turn "stops instantly on
+    # release" into "keeps draining for seconds".
     $script:StreamingReaderScript = {
         param($stream, $signal)
-        while ($true) {
-            $bytes = [System.Collections.Generic.List[byte]]::new()
-            while (($b = $stream.ReadByte()) -notin -1, 0) {
-                $bytes.Add($b)
-            }
 
-            if ($bytes.Count -gt 0) {
-                Write-Output ([Text.Encoding]::UTF8.GetString($bytes.ToArray()))
-            }
+        $bufferSize = 4096
+        $buffer = [byte[]]::new($bufferSize)
+        $pending = [System.Collections.Generic.List[byte]]::new()
 
-            # Wake the waiter - also on EOF, so a dying daemon triggers the
-            # fallback path immediately instead of after the timeout.
-            if ($signal) {
-                $signal.Set()
-            }
+        $appendSegment = {
+            param($segStart, $segEnd)
 
-            if ($b -eq -1) {
+            $segLen = $segEnd - $segStart
+            if ($segLen -le 0) {
                 return
+            }
+
+            $segment = [byte[]]::new($segLen)
+            [Array]::Copy($buffer, $segStart, $segment, 0, $segLen)
+            $pending.AddRange($segment)
+        }
+
+        while ($true) {
+            $read = $stream.Read($buffer, 0, $bufferSize)
+
+            if ($read -le 0) {
+                if ($pending.Count -gt 0) {
+                    Write-Output ([Text.Encoding]::UTF8.GetString($pending.ToArray()))
+                }
+
+                # Wake the waiter - also on EOF, so a dying daemon triggers
+                # the fallback path immediately instead of after the timeout.
+                if ($signal) {
+                    $signal.Set()
+                }
+
+                return
+            }
+
+            $offset = 0
+            while ($offset -lt $read) {
+                $nul = [Array]::IndexOf($buffer, [byte]0, $offset, $read - $offset)
+
+                if ($nul -lt 0) {
+                    & $appendSegment $offset $read
+                    $offset = $read
+                    continue
+                }
+
+                & $appendSegment $offset $nul
+
+                if ($pending.Count -gt 0) {
+                    Write-Output ([Text.Encoding]::UTF8.GetString($pending.ToArray()))
+                    $pending.Clear()
+                }
+
+                if ($signal) {
+                    $signal.Set()
+                }
+
+                $offset = $nul + 1
             }
         }
     }

--- a/src/terminal/writer.go
+++ b/src/terminal/writer.go
@@ -218,15 +218,15 @@ func SetColors(background, foreground color.Ansi) {
 	}
 }
 
+// SetParentColors pushes the completed segment's colors onto the parent
+// stack; the most recent entry (nearest ancestor) sits at the tail. Cleared
+// per block by String() - see resolveParentColor in color/keywords.go for
+// the matching tail-to-head walk.
 func SetParentColors(background, foreground color.Ansi) {
-	if ParentColors == nil {
-		ParentColors = make([]*color.Set, 0)
-	}
-
-	ParentColors = append([]*color.Set{{
+	ParentColors = append(ParentColors, &color.Set{
 		Background: background,
 		Foreground: foreground,
-	}}, ParentColors...)
+	})
 }
 
 func ChangeLine(numberOfLines int) string {
@@ -602,6 +602,11 @@ func String() (string, int) {
 
 		bgGradientCells, fgGradientCells = nil, nil
 		cellIndex = 0
+
+		// the parent stack is scoped to one block; each new block starts a
+		// fresh ancestor chain. Slicing to zero keeps the backing array so
+		// same-size blocks (the common case) push without reallocating.
+		ParentColors = ParentColors[:0]
 	}()
 
 	return builder.String(), length


### PR DESCRIPTION
- **fix(terminal): stop parent color stack growing unbounded**
- **perf(shell): read pwsh streaming records in chunks, not bytes**
- **fix(prompt): resolve parentBackground in a block's own filler**
- **fix(color): degrade empty parent stack to transparent, chain fillers**

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!---

Tips:

If you're not comfortable with working with Git,
we're working on a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D)
as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
