### PR TITLE
fix(pwsh): stop async prompt clobbering third-party prompt wrappers

### DIFF
--- a/src/shell/init.go
+++ b/src/shell/init.go
@@ -281,7 +281,17 @@ func sourceCommand(env runtime.Environment, scriptPath string, async bool) strin
 func sourceCommandAsync(shell, scriptPath string) string {
 	switch shell {
 	case PWSH:
-		return fmt.Sprintf("function prompt() { & %s }", quotePwshOrElvishStr(scriptPath))
+		// Get-Variable, not a bare $global: dereference, for the "has this
+		// ever run before" check - on the very first run nothing has set
+		// $global:_ompOriginalPromptFunction yet, and a bare read of an
+		// unset variable throws under Set-StrictMode.
+		return fmt.Sprintf(
+			"if (-not (Get-Variable -Name _ompOriginalPromptFunction -Scope Global -ErrorAction Ignore -ValueOnly)) { $global:_ompOriginalPromptFunction = $Function:prompt }; "+
+				"$global:_ompPromptFunction = $null; "+
+				"$global:_ompInitialized = $false; "+
+				"function prompt() { if (-not $global:_ompInitialized) { $global:_ompAsyncInit = $true; & %s; return }; if ($global:_ompPromptFunction) { & $global:_ompPromptFunction } }",
+			quotePwshOrElvishStr(scriptPath),
+		)
 	case ZSH:
 		return fmt.Sprintf("precmd() { source %s }", QuotePosixStr(scriptPath))
 	case BASH:

--- a/src/shell/pwsh_test.go
+++ b/src/shell/pwsh_test.go
@@ -30,6 +30,18 @@ Enable-PoshVIMode`
 	assert.Equal(t, want, got)
 }
 
+func TestSourceCommandAsyncPwsh(t *testing.T) {
+	got := sourceCommandAsync(PWSH, "C:/cache/init.pwsh.ps1")
+
+	want := "if (-not (Get-Variable -Name _ompOriginalPromptFunction -Scope Global -ErrorAction Ignore -ValueOnly)) { $global:_ompOriginalPromptFunction = $Function:prompt }; " +
+		"$global:_ompPromptFunction = $null; " +
+		"$global:_ompInitialized = $false; " +
+		"function prompt() { if (-not $global:_ompInitialized) { $global:_ompAsyncInit = $true; & 'C:/cache/init.pwsh.ps1'; return }; " +
+		"if ($global:_ompPromptFunction) { & $global:_ompPromptFunction } }"
+
+	assert.Equal(t, want, got)
+}
+
 func TestQuotePwshOrElvishStr(t *testing.T) {
 	tests := []struct {
 		str      string

--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -37,7 +37,20 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
     # legacy per-prompt stream spawn.
     $script:ServeSupported = -not $script:ConstrainedLanguageMode -and $PSVersionTable.PSVersion.Major -ge 6
 
-    # Prompt related backup.
+    # Async mode: state is threaded through $global:_ompAsyncInit (set by the
+    # trampoline installed in the profile) and consumed once here, then
+    # cleared so a later *sync* re-source of this same file takes the sync
+    # branch below. Read via Get-Variable, not a bare $global: dereference -
+    # a plain sync source never sets this global, and a bare read of an
+    # unset variable throws under Set-StrictMode.
+    $script:AsyncInit = [bool](Get-Variable -Name _ompAsyncInit -Scope Global -ErrorAction Ignore -ValueOnly)
+    $global:_ompAsyncInit = $false
+
+    # Prompt related backup. In async mode this ends up capturing whatever
+    # wraps the trampoline at first-draw time (e.g. another tool's prompt
+    # hook), not the true pre-omp prompt - $global:_ompOriginalPromptFunction
+    # (captured by the trampoline itself, before anything can wrap it) is
+    # authoritative there instead. Kept here unconditionally for the sync path.
     $script:OriginalPromptFunction = $Function:prompt
     $originalPSReadLineOptions = Get-PSReadLineOption
     $script:OriginalContinuationPrompt = $originalPSReadLineOptions.ContinuationPrompt
@@ -986,7 +999,22 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
         $global:LASTEXITCODE = $script:OriginalLastExitCode
     }
 
-    $Function:prompt = $promptFunction
+    if ($script:AsyncInit) {
+        # Never touch the global prompt binding after the trampoline installed
+        # it - anything wrapping it (e.g. another tool's prompt hook) must
+        # keep a valid reference forever. Export-ModuleMember below becomes a
+        # silent no-op with no function named "prompt" in this module, which
+        # is intentional. $global:_ompInitialized is deliberately separate
+        # from $global:_ompPromptFunction: it only ever means "don't
+        # re-import", so OnRemove can restore a falsy original prompt without
+        # the trampoline mistaking that for "never initialized" and silently
+        # reinstalling this module on the next draw.
+        $global:_ompPromptFunction = $promptFunction
+        $global:_ompInitialized = $true
+    }
+    else {
+        $Function:prompt = $promptFunction
+    }
 
     # set secondary prompt
     Set-PSReadLineOption -ContinuationPrompt ((Invoke-Utf8Posh @("print", "secondary", "--shell=$script:ShellName")) -join "`n")
@@ -1328,7 +1356,29 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
 
             Remove-Item Function:Get-PoshStackCount -ErrorAction SilentlyContinue
 
-            $Function:prompt = $script:OriginalPromptFunction
+            if ($script:AsyncInit) {
+                # Restore from the trampoline's own capture, never from
+                # $script:OriginalPromptFunction - in async mode that backup
+                # holds the wrapper chain (e.g. another tool's prompt hook),
+                # and restoring it here would recurse infinitely. Keep
+                # $global:_ompInitialized true even when the captured
+                # original is falsy, so the trampoline treats this as
+                # "restored", not "never initialized" - otherwise the next
+                # draw would silently reinstall the module Remove-Module just
+                # removed.
+                $global:_ompPromptFunction = $global:_ompOriginalPromptFunction
+                $global:_ompInitialized = $true
+            }
+            else {
+                # Only restore if this module's own prompt function is still
+                # the live global binding. If something replaced it since
+                # (e.g. a fresh async trampoline installed while switching
+                # this session from sync to async), leave it alone instead of
+                # clobbering whatever now owns the prompt.
+                if ($Function:prompt -eq $promptFunction) {
+                    $Function:prompt = $script:OriginalPromptFunction
+                }
+            }
 
             (Get-PSReadLineOption).ContinuationPrompt = $script:OriginalContinuationPrompt
             (Get-PSReadLineOption).PromptText = $script:OriginalPromptText


### PR DESCRIPTION
async: true deferred the entire init script, including the line that
installs the global `prompt` function, to the first prompt draw.
Anything wrapping `prompt` before that draw (e.g. zoxide's directory
hook) got silently overwritten once the deferred script ran, since
PowerShell's global prompt binding is written to unconditionally.

Route the deferred install through a global function pointer variable
instead: the trampoline installed at init time now owns the `prompt`
binding permanently and never gets replaced, so anything wrapping it
keeps a valid reference across the lazy load, re-init, and module
removal.

Fixes #7714

Entire-Checkpoint: 18db4675baa8

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!---

Tips:

If you're not comfortable with working with Git,
we're working on a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D)
as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
