### PR TITLE
feat(jujutsu): expose change ID prefix and rest

### DIFF
--- a/.agents/skills/project-knowledge/references/codebase.md
+++ b/.agents/skills/project-knowledge/references/codebase.md
@@ -40,9 +40,10 @@
 - Segment writers gob-encode only exported fields. `segments.Base.env/options` are unexported and
   MUST survive a cache restore: overlay the restored data onto the writer initialized by
   `MapSegmentWithWriter`, never replace the writer.
-- `runtime/cmd.RunWithEnv` trims leading and trailing whitespace from command output (verified
-  2026-07-26). Segment machine protocols cannot encode meaningful trailing empty fields as blank
-  lines; use a non-whitespace delimiter and parse it defensively.
+- `runtime/cmd.RunWithEnv` applies `strings.TrimSpace` to the complete command output before
+  returning it (verified 2026-07-26). If a segment encodes an empty final field as a trailing blank
+  line, that field is lost. Use a record format that retains a final non-whitespace delimiter or
+  sentinel, and validate the record before assigning parsed state.
 
 ## Cache
 

--- a/.agents/skills/project-knowledge/references/codebase.md
+++ b/.agents/skills/project-knowledge/references/codebase.md
@@ -40,6 +40,9 @@
 - Segment writers gob-encode only exported fields. `segments.Base.env/options` are unexported and
   MUST survive a cache restore: overlay the restored data onto the writer initialized by
   `MapSegmentWithWriter`, never replace the writer.
+- `runtime/cmd.RunWithEnv` trims leading and trailing whitespace from command output (verified
+  2026-07-26). Segment machine protocols cannot encode meaningful trailing empty fields as blank
+  lines; use a non-whitespace delimiter and parse it defensively.
 
 ## Cache
 

--- a/src/segments/jujutsu.go
+++ b/src/segments/jujutsu.go
@@ -38,8 +38,10 @@ func (s *JujutsuStatus) add(code byte) {
 }
 
 type Jujutsu struct {
-	Working  *JujutsuStatus
-	ChangeID string
+	Working        *JujutsuStatus
+	ChangeID       string
+	ChangeIDPrefix string
+	ChangeIDRest   string
 	Scm
 }
 
@@ -159,10 +161,19 @@ func (jj *Jujutsu) setJujutsuStatus() {
 		return
 	}
 
-	lines := strings.Split(statusString, "\n")
-	jj.ChangeID = lines[0]
+	header, statusString, _ := strings.Cut(statusString, "\n")
+	prefix, rest, found := strings.Cut(header, "|")
+	// Jujutsu change IDs contain only canonical ID characters, so "|" is a safe
+	// separator that survives RunCommand's trimming when rest is empty.
+	if !found || len(prefix) == 0 || strings.Contains(rest, "|") {
+		return
+	}
 
-	for _, line := range lines[1:] {
+	jj.ChangeIDPrefix = prefix
+	jj.ChangeIDRest = rest
+	jj.ChangeID = prefix + rest
+
+	for line := range strings.SplitSeq(statusString, "\n") {
 		if len(line) > 0 {
 			jj.Working.add(line[0])
 		}
@@ -171,7 +182,12 @@ func (jj *Jujutsu) setJujutsuStatus() {
 
 func (jj *Jujutsu) logTemplate() string {
 	// https://jj-vcs.github.io/jj/latest/templates/#commit-keywords
-	return fmt.Sprintf(`change_id.shortest(%d) ++ "\n" ++ diff.summary()`, jj.options.Int(ChangeIDMinLen, 0))
+	minLength := jj.options.Int(ChangeIDMinLen, 0)
+	return fmt.Sprintf(
+		`change_id.shortest(%d).prefix() ++ "|" ++ change_id.shortest(%d).rest() ++ "\n" ++ diff.summary()`,
+		minLength,
+		minLength,
+	)
 }
 
 func (jj *Jujutsu) getJujutsuCommandOutput(command string, args ...string) (string, error) {

--- a/src/segments/jujutsu_test.go
+++ b/src/segments/jujutsu_test.go
@@ -41,19 +41,47 @@ func TestJujutsuEnabledInWorkingDirectory(t *testing.T) {
 	assert.True(t, jj.Enabled())
 	assert.Equal(t, fileInfo.Path, jj.mainSCMDir)
 	assert.Equal(t, fileInfo.Path, jj.repoRootDir)
+	assert.Empty(t, jj.ChangeID)
+	assert.Empty(t, jj.ChangeIDPrefix)
+	assert.Empty(t, jj.ChangeIDRest)
+	env.AssertNotCalled(t, "RunCommand")
+}
+
+func TestJujutsuLogTemplate(t *testing.T) {
+	jj := &Jujutsu{}
+	jj.Init(options.Map{ChangeIDMinLen: 8}, new(mock.Environment))
+
+	assert.Equal(
+		t,
+		`change_id.shortest(8).prefix() ++ "|" ++ change_id.shortest(8).rest() ++ "\n" ++ diff.summary()`,
+		jj.logTemplate(),
+	)
+}
+
+func TestJujutsuTemplate(t *testing.T) {
+	assert.Equal(t, " \uf1fa{{.ChangeID}}{{if .Working.Changed}} \uf044 {{ .Working.String }}{{ end }} ", (&Jujutsu{}).Template())
 }
 
 func TestJujutsuGetIdInfo(t *testing.T) {
 	cases := []struct {
-		ExpectedWorking  *JujutsuStatus
-		Case             string
-		LogOutput        string
-		ExpectedChangeID string
+		ExpectedWorking        *JujutsuStatus
+		CommandError           error
+		Case                   string
+		LogOutput              string
+		ExpectedChangeID       string
+		ExpectedChangeIDPrefix string
+		ExpectedChangeIDRest   string
+		ChangeIDMinLen         int
+		ValidHeader            bool
 	}{
 		{
-			Case:             "nochanges",
-			LogOutput:        "a\n\n",
-			ExpectedChangeID: "a",
+			Case:                   "clean with minimum-length rest",
+			LogOutput:              "t|ususrrr",
+			ExpectedChangeID:       "tususrrr",
+			ExpectedChangeIDPrefix: "t",
+			ExpectedChangeIDRest:   "ususrrr",
+			ChangeIDMinLen:         8,
+			ValidHeader:            true,
 			ExpectedWorking: &JujutsuStatus{ScmStatus{
 				Deleted:  0,
 				Added:    0,
@@ -62,15 +90,33 @@ func TestJujutsuGetIdInfo(t *testing.T) {
 			}},
 		},
 		{
-			Case: "changed",
-			LogOutput: `b
+			Case:                   "clean with empty rest after output trimming",
+			LogOutput:              "tususrrr|",
+			ExpectedChangeID:       "tususrrr",
+			ExpectedChangeIDPrefix: "tususrrr",
+			ExpectedChangeIDRest:   "",
+			ChangeIDMinLen:         4,
+			ValidHeader:            true,
+			ExpectedWorking: &JujutsuStatus{ScmStatus{
+				Deleted:  0,
+				Added:    0,
+				Modified: 0,
+				Moved:    0,
+			}},
+		},
+		{
+			Case: "changed with empty rest",
+			LogOutput: `tususrrr|
 D deleted_file
 A added_file
 C {copied_file => new_file}
 M modified_file
-R {renamed_file => new_file}
-`,
-			ExpectedChangeID: "b",
+R {renamed_file => new_file}`,
+			ExpectedChangeID:       "tususrrr",
+			ExpectedChangeIDPrefix: "tususrrr",
+			ExpectedChangeIDRest:   "",
+			ChangeIDMinLen:         4,
+			ValidHeader:            true,
 			ExpectedWorking: &JujutsuStatus{ScmStatus{
 				Deleted:  1,
 				Added:    2,
@@ -78,41 +124,94 @@ R {renamed_file => new_file}
 				Moved:    1,
 			}},
 		},
+		{
+			Case:           "command error",
+			LogOutput:      "ignored",
+			CommandError:   errors.New("jj failed"),
+			ChangeIDMinLen: 8,
+			ExpectedWorking: &JujutsuStatus{ScmStatus{
+				Deleted:  0,
+				Added:    0,
+				Modified: 0,
+				Moved:    0,
+			}},
+		},
+		{
+			Case:           "missing delimiter",
+			LogOutput:      "tususrrr\nD deleted_file",
+			ChangeIDMinLen: 8,
+			ExpectedWorking: &JujutsuStatus{ScmStatus{
+				Deleted:  0,
+				Added:    0,
+				Modified: 0,
+				Moved:    0,
+			}},
+		},
+		{
+			Case:           "multiple delimiters",
+			LogOutput:      "t|usus|rrr\nD deleted_file",
+			ChangeIDMinLen: 8,
+			ExpectedWorking: &JujutsuStatus{ScmStatus{
+				Deleted:  0,
+				Added:    0,
+				Modified: 0,
+				Moved:    0,
+			}},
+		},
 	}
 
 	for _, tc := range cases {
-		fileInfo := &runtime.FileInfo{
-			Path:         "/dir/hello",
-			ParentFolder: "/dir",
-			IsDir:        true,
-		}
+		t.Run(tc.Case, func(t *testing.T) {
+			fileInfo := &runtime.FileInfo{
+				Path:         "/dir/hello",
+				ParentFolder: "/dir",
+				IsDir:        true,
+			}
 
-		props := options.Map{
-			FetchStatus: true,
-		}
+			props := options.Map{
+				FetchStatus:    true,
+				ChangeIDMinLen: tc.ChangeIDMinLen,
+			}
 
-		env := new(mock.Environment)
-		env.On("InWSLSharedDrive").Return(false)
-		env.On("HasCommand", "jj").Return(true)
-		env.On("GOOS").Return("")
-		env.On("IsWsl").Return(false)
-		env.On("HasParentFilePath", ".jj", false).Return(fileInfo, nil)
-		env.On("PathSeparator").Return("/")
-		env.On("Home").Return(poshHome)
-		env.On("Getenv", poshGitEnv).Return("")
+			env := new(mock.Environment)
+			env.On("InWSLSharedDrive").Return(false)
+			env.On("HasCommand", "jj").Return(true)
+			env.On("GOOS").Return("")
+			env.On("HasParentFilePath", ".jj", false).Return(fileInfo, nil)
 
-		jj := &Jujutsu{}
-		jj.Init(props, env)
-		env.MockJjCommand(fileInfo.Path, tc.LogOutput, "log", "-r", "@", "--no-graph", "-T", jj.logTemplate())
+			jj := &Jujutsu{}
+			jj.Init(props, env)
 
-		if tc.ExpectedWorking != nil {
 			tc.ExpectedWorking.Formats = map[string]string{}
-		}
 
-		assert.True(t, jj.Enabled())
-		assert.Equal(t, fileInfo.Path, jj.mainSCMDir)
-		assert.Equal(t, fileInfo.Path, jj.repoRootDir)
-		assert.Equal(t, tc.ExpectedWorking, jj.Working, tc.Case)
-		assert.Equal(t, tc.ExpectedChangeID, jj.ChangeID, tc.Case)
+			commandArgs := []string{
+				"--repository",
+				fileInfo.Path,
+				"--no-pager",
+				"--color",
+				"never",
+				"--ignore-working-copy",
+				"log",
+				"-r",
+				"@",
+				"--no-graph",
+				"-T",
+				jj.logTemplate(),
+			}
+			env.On("RunCommand", "jj", commandArgs).Return(tc.LogOutput, tc.CommandError)
+
+			assert.True(t, jj.Enabled())
+			assert.Equal(t, fileInfo.Path, jj.mainSCMDir)
+			assert.Equal(t, fileInfo.Path, jj.repoRootDir)
+			assert.Equal(t, tc.ExpectedWorking, jj.Working)
+			assert.Equal(t, tc.ExpectedChangeID, jj.ChangeID)
+			assert.Equal(t, tc.ExpectedChangeIDPrefix, jj.ChangeIDPrefix)
+			assert.Equal(t, tc.ExpectedChangeIDRest, jj.ChangeIDRest)
+			if tc.ValidHeader {
+				assert.Equal(t, jj.ChangeIDPrefix+jj.ChangeIDRest, jj.ChangeID)
+			}
+			env.AssertNumberOfCalls(t, "RunCommand", 1)
+			env.AssertExpectations(t)
+		})
 	}
 }

--- a/website/docs/segments/scm/jujutsu.mdx
+++ b/website/docs/segments/scm/jujutsu.mdx
@@ -57,11 +57,15 @@ Set `status_formats` to `true` to enable fetching additional information (and po
 
 ### Properties
 
-| Name                | Type     | Description                                                                                  |
-| ------------------- | -------- | -------------------------------------------------------------------------------------------- |
-| `.Working`          | `Status` | changes in the working copy (see below)                                                      |
-| `.ChangeID`         | `string` | The shortest unique prefix of the working copy change that's at least change_id_min_len long |
-| `.ClosestBookmarks` | `string` | Closest bookmark(s) on ancestors                                                             |
+| Name                | Type     | Description                                                                                                                                                                      |
+| ------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `.Working`          | `Status` | changes in the working copy (see below)                                                                                                                                          |
+| `.ChangeID`         | `string` | The shortest unique prefix of the working copy change that's at least change_id_min_len long                                                                                     |
+| `.ChangeIDPrefix`   | `string` | The shortest unique prefix of the working copy change ID                                                                                                                         |
+| `.ChangeIDRest`     | `string` | The additional portion displayed after `.ChangeIDPrefix` to satisfy `change_id_min_len`; empty when the unique prefix already meets or exceeds that minimum                      |
+| `.ClosestBookmarks` | `string` | Closest bookmark(s) on ancestors                                                                                                                                                 |
+
+`.ChangeIDRest` is not the remainder of the full canonical change ID and isn't independently usable as an identifier.
 
 ### Status
 


### PR DESCRIPTION
## Summary

This is a follow-up to #6671, which added `change_id_min_len` support to the Jujutsu segment. That change exposed the combined shortened Change ID; this PR additionally preserves Jujutsu's native distinction between the minimum unique prefix and the characters appended to satisfy the configured minimum.

- add `.ChangeIDPrefix` for the shortest unique prefix
- add `.ChangeIDRest` for the additional displayed portion required by `change_id_min_len`
- preserve `.ChangeID` as `ChangeIDPrefix + ChangeIDRest`
- leave the default segment template and visual output unchanged

It's useful to achieve the hightlighting of the shortest unambiguous prefix, like how jj displays it:
[![image](https://private-user-images.githubusercontent.com/90059/475683350-19f9c4af-3464-40e9-a2b8-2175d8c50dc4.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3ODUwODQyMzAsIm5iZiI6MTc4NTA4MzkzMCwicGF0aCI6Ii85MDA1OS80NzU2ODMzNTAtMTlmOWM0YWYtMzQ2NC00MGU5LWEyYjgtMjE3NWQ4YzUwZGM0LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjA3MjYlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwNzI2VDE2Mzg1MFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTJmMjA0YmRiYTBmYmRhYWYyYWI3MjE1ODMyMTViZjkzYzFkYTExNWVjYjNiMTk0NThiZjRlM2I2Y2ExNmIyZDQmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JnJlc3BvbnNlLWNvbnRlbnQtdHlwZT1pbWFnZSUyRnBuZyJ9.q2oQJMWGg_-5W1TNgboIz2HCi-UDwQGo10pYWJVxupg)](https://github.com/JanDeDobbeleer/oh-my-posh/pull/6671#issuecomment-3164992201)

## Implementation

Both components are collected atomically by the existing single `jj log` process using `ShortestIdPrefix.prefix()` and `.rest()`. A trim-safe internal delimiter preserves an empty Rest for clean working copies, and malformed output is rejected without panicking or partially populating segment state.

No additional subprocess, version probe, ANSI parsing, configuration option, schema change, or dependency is added. No unrelated Git worktree or path behavior is included.

## Testing

Added coverage for:

- unique prefixes shorter than `change_id_min_len`
- unique prefixes already meeting the minimum
- clean and changed working copies
- unchanged combined `.ChangeID`
- command failures and malformed output
- trimmed empty-Rest output
- exact command template and a single `RunCommand` invocation
- unchanged default visual template

Validated with:

- `go test ./segments -run '^TestJujutsu' -count=1`
- `go test ./... -count=1`
- `go vet ./segments`
- Docusaurus production build
- `git diff --check`