### PR TITLE
fix(path): support gitdir_format in linked worktrees

### DIFF
--- a/src/segments/path.go
+++ b/src/segments/path.go
@@ -993,7 +993,8 @@ func (pt *Path) makeFolderFormatMap() map[string]string {
 
 	if gitDirFormat := pt.options.String(GitDirFormat, ""); len(gitDirFormat) != 0 {
 		dir, err := pt.env.HasParentFilePath(".git", false)
-		if err == nil && dir.IsDir {
+		if err == nil {
+			// Linked worktrees use a .git file instead of a directory.
 			// Make it consistent with the modified parent.
 			parent := pt.join(pt.replaceMappedLocations(dir.ParentFolder))
 			folderFormatMap[parent] = gitDirFormat

--- a/src/segments/path_unix_test.go
+++ b/src/segments/path_unix_test.go
@@ -698,6 +698,18 @@ var testSplitPathCases = []testSplitPathCase{
 			{Name: "d", Path: "~/c/d"},
 		},
 	},
+	{
+		Case:         "Home directory - linked git worktree",
+		Root:         "~",
+		Relative:     "c/d",
+		GOOS:         runtime.DARWIN,
+		GitDir:       &runtime.FileInfo{ParentFolder: "/a/b/c"},
+		GitDirFormat: "<b>%s</b>",
+		Expected: Folders{
+			{Name: "<b>c</b>", Path: "~/c", Display: true},
+			{Name: "d", Path: "~/c/d"},
+		},
+	},
 }
 
 var testNormalizePathCases = []testNormalizePathCase{

--- a/src/segments/path_windows_test.go
+++ b/src/segments/path_windows_test.go
@@ -498,6 +498,20 @@ var testSplitPathCases = []testSplitPathCase{
 			{Name: "d", Path: "C:/a/b/c/d"},
 		},
 	},
+	{
+		Case:         "Home directory - linked git worktree on Windows",
+		Root:         "C:",
+		Relative:     "a/b/c/d",
+		GOOS:         runtime.WINDOWS,
+		GitDir:       &runtime.FileInfo{ParentFolder: "C:/a/b/c"},
+		GitDirFormat: "<b>%s</b>",
+		Expected: Folders{
+			{Name: "a", Path: "C:/a"},
+			{Name: "b", Path: "C:/a/b"},
+			{Name: "<b>c</b>", Path: "C:/a/b/c", Display: true},
+			{Name: "d", Path: "C:/a/b/c/d"},
+		},
+	},
 }
 
 var testNormalizePathCases = []testNormalizePathCase{

--- a/website/docs/segments/system/path.mdx
+++ b/website/docs/segments/system/path.mdx
@@ -48,7 +48,7 @@ import Config from "@site/src/components/Config.js";
 | `edge_format`               |  `string`  |    `%s`    | format to use on the first and last folder of the path                                                           |
 | `left_format`               |  `string`  |    `%s`    | format to use on the first folder of the path - defaults to `edge_format`                                        |
 | `right_format`              |  `string`  |    `%s`    | format to use on the last folder of the path - defaults to `edge_format`                                         |
-| `gitdir_format`             |  `string`  |            | format to use for a git root directory                                                                           |
+| `gitdir_format`             |  `string`  |            | format to use for a Git root directory, including linked worktrees                                                |
 | `display_cygpath`           | `boolean`  |  `false`   | display the Cygwin style path using `cygpath -u $PWD`                                                            |
 | `display_root`              | `boolean`  |  `false`   | display the root `/` on Unix systems                                                                             |
 | `dir_length`                |  `number`  |    `1`     | the length of the directory name to display when using `fish`                                                    |


### PR DESCRIPTION
## Summary

- apply `gitdir_format` when the repository root is discovered through either a `.git` directory or the `.git` indirection file used by linked worktrees
- preserve the existing path formatting behavior for standard Git worktrees
- clarify the linked-worktree behavior in the path segment documentation

## Implementation

The existing parent lookup already returns the working-tree root for both `.git` directories and files. This removes the directory-only guard and continues using that returned `ParentFolder`, without adding a Git subprocess or parsing the indirection file.

## Tests

- `go test ./segments -run '^TestSplitPath$' -count=1`
- Linux cross-compile of the segments test package
- `go test ./... -count=1`
- `go vet ./segments`
- `npm run build`
- `git diff --check`

Regression cases cover linked worktrees on both Unix-style and Windows paths. This is a focused follow-up to the original `gitdir_format` feature context in #4727; it does not add main-worktree discovery or repository-aware path shortening.