### PR TITLE
feat: add darken() and lighten() color shade functions

### DIFF
--- a/src/color/colors.go
+++ b/src/color/colors.go
@@ -282,6 +282,17 @@ func (d *Defaults) ToAnsi(ansiColor Ansi, isBackground bool) Ansi {
 		return ansiColor
 	}
 
+	if dir, inner, percent, ok := ansiColor.ShadeArgs(); ok {
+		hex, ok := shadeHex(inner, dir, percent)
+		if !ok {
+			log.Errorf("%s: darken()/lighten() only support hex colors and palette references resolving to one; "+
+				"named ANSI/terminal colors have no fixed RGB oh-my-posh can shift, define the color in your palette with a hex value instead", ansiColor)
+			return emptyColor
+		}
+
+		ansiColor = Ansi(hex)
+	}
+
 	if ansiColor == Accent {
 		if d.accent == nil {
 			return emptyColor
@@ -362,6 +373,13 @@ func (p *PaletteColors) ToAnsi(colorString Ansi, isBackground bool) Ansi {
 		return colorString
 	}
 
+	// a shade call's color argument may itself be a palette reference; resolve it here
+	// so Defaults.ToAnsi only ever sees a concrete color inside darken()/lighten().
+	colorString, err := p.palette.resolveShade(colorString)
+	if err != nil {
+		return emptyColor
+	}
+
 	paletteColor, err := p.palette.ResolveColor(colorString)
 	if err != nil {
 		return emptyColor
@@ -373,6 +391,11 @@ func (p *PaletteColors) ToAnsi(colorString Ansi, isBackground bool) Ansi {
 }
 
 func (p *PaletteColors) Resolve(colorString Ansi) (Ansi, error) {
+	colorString, err := p.palette.resolveShade(colorString)
+	if err != nil {
+		return "", err
+	}
+
 	return p.palette.ResolveColor(colorString)
 }
 

--- a/src/color/colors.go
+++ b/src/color/colors.go
@@ -373,8 +373,6 @@ func (p *PaletteColors) ToAnsi(colorString Ansi, isBackground bool) Ansi {
 		return colorString
 	}
 
-	// a shade call's color argument may itself be a palette reference; resolve it here
-	// so Defaults.ToAnsi only ever sees a concrete color inside darken()/lighten().
 	colorString, err := p.palette.resolveShade(colorString)
 	if err != nil {
 		return emptyColor

--- a/src/color/palette.go
+++ b/src/color/palette.go
@@ -101,6 +101,24 @@ func (p *PaletteRecursiveKeyError) Error() string {
 	return errorStr
 }
 
+// resolveShade resolves a darken(...)/lighten(...) call's color argument through the
+// palette - so darken(p:accent, 20) reaches Defaults.ToAnsi as darken(#3465A4, 20) -
+// rebuilding the call with that resolved value in place of the original argument.
+// Returns colorString unchanged when it isn't a shade call.
+func (p Palette) resolveShade(colorString Ansi) (Ansi, error) {
+	dir, inner, percent, ok := colorString.ShadeArgs()
+	if !ok {
+		return colorString, nil
+	}
+
+	resolved, err := p.ResolveColor(inner)
+	if err != nil {
+		return "", err
+	}
+
+	return withShadeCall(dir, resolved, percent), nil
+}
+
 // MaybeResolveColor wraps resolveColor and silences possible errors, returning
 // Transparent color by default, as a Block does not know how to handle color errors.
 func (p Palette) MaybeResolveColor(colorName Ansi) Ansi {

--- a/src/color/palette.go
+++ b/src/color/palette.go
@@ -102,9 +102,8 @@ func (p *PaletteRecursiveKeyError) Error() string {
 }
 
 // resolveShade resolves a darken(...)/lighten(...) call's color argument through the
-// palette - so darken(p:accent, 20) reaches Defaults.ToAnsi as darken(#3465A4, 20) -
-// rebuilding the call with that resolved value in place of the original argument.
-// Returns colorString unchanged when it isn't a shade call.
+// palette, so a reference like darken(p:accent, 20) reaches Defaults.ToAnsi with a
+// concrete color. Returns colorString unchanged when it isn't a shade call.
 func (p Palette) resolveShade(colorString Ansi) (Ansi, error) {
 	dir, inner, percent, ok := colorString.ShadeArgs()
 	if !ok {

--- a/src/color/shade.go
+++ b/src/color/shade.go
@@ -1,0 +1,131 @@
+package color
+
+import (
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/lucasb-eyer/go-colorful"
+)
+
+const (
+	darkenPrefix  = "darken("
+	lightenPrefix = "lighten("
+)
+
+// IsShade reports whether c is a darken(...)/lighten(...) single-color shade call.
+func (c Ansi) IsShade() bool {
+	_, ok := c.shadeCallDirection()
+	return ok
+}
+
+func (c Ansi) shadeCallDirection() (shadeDirection, bool) {
+	s := c.String()
+
+	switch {
+	case strings.HasPrefix(s, darkenPrefix):
+		return shadeDark, true
+	case strings.HasPrefix(s, lightenPrefix):
+		return shadeLight, true
+	default:
+		return shadeNone, false
+	}
+}
+
+// ShadeArgs parses darken(<color>, <percent>)/lighten(<color>, <percent>) into its color
+// argument and a percent in [0, 100]. ok is false when c isn't a shade call, its closing
+// paren is missing, the body isn't exactly two comma-separated arguments, or the percent
+// argument doesn't parse as a number in [0, 100].
+func (c Ansi) ShadeArgs() (dir shadeDirection, inner Ansi, percent float64, ok bool) {
+	dir, isShade := c.shadeCallDirection()
+	if !isShade {
+		return shadeNone, "", 0, false
+	}
+
+	s := c.String()
+	if !strings.HasSuffix(s, gradientSuffix) {
+		return shadeNone, "", 0, false
+	}
+
+	prefix := darkenPrefix
+	if dir == shadeLight {
+		prefix = lightenPrefix
+	}
+
+	body := s[len(prefix) : len(s)-len(gradientSuffix)]
+	if strings.ContainsAny(body, "()") {
+		return shadeNone, "", 0, false
+	}
+
+	parts := strings.Split(body, ",")
+	if len(parts) != 2 {
+		return shadeNone, "", 0, false
+	}
+
+	innerPart := strings.TrimSpace(parts[0])
+	percentPart := strings.TrimSpace(parts[1])
+
+	if innerPart == "" || percentPart == "" {
+		return shadeNone, "", 0, false
+	}
+
+	pct, err := strconv.ParseFloat(percentPart, 64)
+	if err != nil || pct < 0 || pct > 100 {
+		return shadeNone, "", 0, false
+	}
+
+	return dir, Ansi(innerPart), pct, true
+}
+
+// withShadeCall rebuilds a darken/lighten call from its parts, so a palette reference in
+// the color argument can be resolved to a concrete color before Defaults.ToAnsi sees it.
+func withShadeCall(dir shadeDirection, inner Ansi, percent float64) Ansi {
+	prefix := darkenPrefix
+	if dir == shadeLight {
+		prefix = lightenPrefix
+	}
+
+	return Ansi(prefix + inner.String() + ", " + strconv.FormatFloat(percent, 'g', -1, 64) + gradientSuffix)
+}
+
+// shadeHex resolves inner as a hex color and shifts its HCL lightness toward black
+// (shadeDark) or white (shadeLight) by percent of its remaining headroom to that end,
+// walking chroma down only as far as the sRGB gamut demands - the same technique as
+// autoShade, for a caller-chosen percentage instead of the auto-tuned curve.
+//
+// ok is false when inner isn't a hex color: darken()/lighten() only operate on colors
+// oh-my-posh knows the actual RGB of, which rules out named ANSI/terminal colors, 256
+// palette indices, and keywords - their real color is decided by the terminal's own
+// scheme (or, for keywords, by segment context this single-color call has no access
+// to), not by oh-my-posh. Define the color in a palette entry with a literal hex value
+// and reference it with darken(p:name, n)/lighten(p:name, n) instead.
+func shadeHex(inner Ansi, dir shadeDirection, percent float64) (string, bool) {
+	innerStr := inner.String()
+	if !strings.HasPrefix(innerStr, "#") {
+		return "", false
+	}
+
+	base, err := colorful.Hex(innerStr)
+	if err != nil {
+		return "", false
+	}
+
+	h, c, l := base.Hcl()
+	pct := percent / 100
+
+	if dir == shadeLight {
+		l += (1 - l) * pct
+	} else {
+		l -= l * pct
+	}
+
+	l = math.Max(0, math.Min(1, l))
+
+	shade := colorful.Hcl(h, c, l)
+	for !shade.IsValid() && c > 0 {
+		c -= autoShadeChromaStep
+		shade = colorful.Hcl(h, c, l)
+	}
+
+	return shade.Clamped().Hex(), true
+}

--- a/src/color/shade.go
+++ b/src/color/shade.go
@@ -88,10 +88,9 @@ func withShadeCall(dir shadeDirection, inner Ansi, percent float64) Ansi {
 	return Ansi(prefix + inner.String() + ", " + strconv.FormatFloat(percent, 'g', -1, 64) + gradientSuffix)
 }
 
-// shadeHex resolves inner as a hex color and shifts its HCL lightness toward black
-// (shadeDark) or white (shadeLight) by percent of its remaining headroom to that end,
-// walking chroma down only as far as the sRGB gamut demands - the same technique as
-// autoShade, for a caller-chosen percentage instead of the auto-tuned curve.
+// shadeHex shifts inner's HCL lightness toward black (shadeDark) or white (shadeLight)
+// by percent - the same technique as autoShade, but driven by a caller-chosen
+// percentage instead of the auto-tuned curve.
 //
 // ok is false when inner isn't a hex color: darken()/lighten() only operate on colors
 // oh-my-posh knows the actual RGB of, which rules out named ANSI/terminal colors, 256

--- a/src/color/shade_test.go
+++ b/src/color/shade_test.go
@@ -1,0 +1,155 @@
+package color
+
+import (
+	"testing"
+
+	"github.com/alecthomas/assert"
+	"github.com/lucasb-eyer/go-colorful"
+)
+
+func TestShadeArgs(t *testing.T) {
+	cases := []struct {
+		Case            string
+		Color           Ansi
+		ExpectedOK      bool
+		ExpectedDir     shadeDirection
+		ExpectedInner   Ansi
+		ExpectedPercent float64
+	}{
+		{Case: "darken", Color: "darken(#3465A4, 20)", ExpectedOK: true, ExpectedDir: shadeDark, ExpectedInner: "#3465A4", ExpectedPercent: 20},
+		{Case: "lighten", Color: "lighten(#3465A4, 20)", ExpectedOK: true, ExpectedDir: shadeLight, ExpectedInner: "#3465A4", ExpectedPercent: 20},
+		{Case: "palette reference", Color: "darken(p:accent, 20)", ExpectedOK: true, ExpectedDir: shadeDark, ExpectedInner: "p:accent", ExpectedPercent: 20},
+		{Case: "whitespace variants", Color: "darken( #3465A4  ,  20 )", ExpectedOK: true, ExpectedDir: shadeDark, ExpectedInner: "#3465A4", ExpectedPercent: 20},
+		{Case: "decimal percent", Color: "darken(#3465A4, 12.5)", ExpectedOK: true, ExpectedDir: shadeDark, ExpectedInner: "#3465A4", ExpectedPercent: 12.5},
+		{Case: "percent 0", Color: "darken(#3465A4, 0)", ExpectedOK: true, ExpectedDir: shadeDark, ExpectedInner: "#3465A4", ExpectedPercent: 0},
+		{Case: "percent 100", Color: "darken(#3465A4, 100)", ExpectedOK: true, ExpectedDir: shadeDark, ExpectedInner: "#3465A4", ExpectedPercent: 100},
+		{Case: "not a shade call", Color: "#3465A4"},
+		{Case: "gradient", Color: "linear-gradient(#FF0000, #0000FF)"},
+		{Case: "missing closing paren", Color: "darken(#3465A4, 20"},
+		{Case: "nested parens", Color: "darken(darken(#3465A4, 10), 20)"},
+		{Case: "missing percent", Color: "darken(#3465A4)"},
+		{Case: "too many args", Color: "darken(#3465A4, 20, 30)"},
+		{Case: "non-numeric percent", Color: "darken(#3465A4, abc)"},
+		{Case: "percent below 0", Color: "darken(#3465A4, -1)"},
+		{Case: "percent above 100", Color: "darken(#3465A4, 101)"},
+		{Case: "empty color arg", Color: "darken(, 20)"},
+	}
+
+	for _, tc := range cases {
+		dir, inner, percent, ok := tc.Color.ShadeArgs()
+
+		assert.Equal(t, tc.ExpectedOK, ok, tc.Case)
+
+		if !tc.ExpectedOK {
+			continue
+		}
+
+		assert.Equal(t, tc.ExpectedDir, dir, tc.Case)
+		assert.Equal(t, tc.ExpectedInner, inner, tc.Case)
+		assert.Equal(t, tc.ExpectedPercent, percent, tc.Case)
+	}
+}
+
+func TestIsShade(t *testing.T) {
+	cases := []struct {
+		Case     string
+		Color    Ansi
+		Expected bool
+	}{
+		{Case: "darken", Color: "darken(#3465A4, 20)", Expected: true},
+		{Case: "lighten", Color: "lighten(#3465A4, 20)", Expected: true},
+		{Case: "gradient", Color: "linear-gradient(#FF0000, #0000FF)", Expected: false},
+		{Case: "dark-gradient", Color: "dark-gradient(#3465A4)", Expected: false},
+		{Case: "hex", Color: "#3465A4", Expected: false},
+		{Case: "empty", Color: "", Expected: false},
+	}
+
+	for _, tc := range cases {
+		assert.Equal(t, tc.Expected, tc.Color.IsShade(), tc.Case)
+	}
+}
+
+func TestShadeHex(t *testing.T) {
+	base := "#3465A4"
+
+	darker, ok := shadeHex(Ansi(base), shadeDark, 20)
+	assert.True(t, ok, "darken should resolve a hex color")
+
+	lighter, ok := shadeHex(Ansi(base), shadeLight, 20)
+	assert.True(t, ok, "lighten should resolve a hex color")
+
+	baseColor, _ := colorful.Hex(base)
+	darkerColor, _ := colorful.Hex(darker)
+	lighterColor, _ := colorful.Hex(lighter)
+
+	_, _, baseLightness := baseColor.Hcl()
+	_, _, darkerLightness := darkerColor.Hcl()
+	_, _, lighterLightness := lighterColor.Hcl()
+
+	assert.True(t, darkerLightness < baseLightness, "darken should reduce lightness")
+	assert.True(t, lighterLightness > baseLightness, "lighten should increase lightness")
+
+	unchanged, ok := shadeHex(Ansi(base), shadeDark, 0)
+	assert.True(t, ok, "0%% shade should still resolve")
+	assert.Equal(t, "#3465a4", unchanged, "0%% darken should leave the color unchanged")
+
+	black, ok := shadeHex(Ansi(base), shadeDark, 100)
+	assert.True(t, ok, "100%% darken should resolve")
+	assert.Equal(t, "#000000", black, "100%% darken should reach black")
+
+	white, ok := shadeHex(Ansi(base), shadeLight, 100)
+	assert.True(t, ok, "100%% lighten should resolve")
+
+	whiteColor, err := colorful.Hex(white)
+	assert.Nil(t, err, "100%% lighten should still be a valid hex color")
+	r, g, b := whiteColor.RGB255()
+	// the gamut-walk loop only guarantees IsValid, not zero chroma, so 100% lighten
+	// lands very close to white rather than exactly #ffffff
+	assert.True(t, r >= 250 && g >= 250 && b >= 250, "100%% lighten should reach near-white, got "+white)
+
+	_, ok = shadeHex("green", shadeDark, 20)
+	assert.False(t, ok, "named ANSI colors have no known RGB and cannot be shaded")
+
+	_, ok = shadeHex("146", shadeDark, 20)
+	assert.False(t, ok, "256 color indices have no known RGB and cannot be shaded")
+
+	_, ok = shadeHex("not-a-color", shadeDark, 20)
+	assert.False(t, ok, "an unparseable hex string should not resolve")
+}
+
+func TestDefaultsToAnsiShade(t *testing.T) {
+	expectedHex, _ := shadeHex("#3465A4", shadeDark, 20)
+
+	cases := []struct {
+		Case       string
+		Color      Ansi
+		Background bool
+		Expected   Ansi
+	}{
+		{Case: "darken hex foreground", Color: "darken(#3465A4, 20)", Background: false, Expected: (&Defaults{}).ToAnsi(Ansi(expectedHex), false)},
+		{Case: "darken hex background", Color: "darken(#3465A4, 20)", Background: true, Expected: (&Defaults{}).ToAnsi(Ansi(expectedHex), true)},
+		{Case: "named ANSI color is rejected", Color: "darken(green, 20)", Background: false, Expected: emptyColor},
+		{Case: "256 color index is rejected", Color: "darken(146, 20)", Background: false, Expected: emptyColor},
+		{Case: "keyword is rejected", Color: "darken(foreground, 20)", Background: false, Expected: emptyColor},
+	}
+
+	for _, tc := range cases {
+		ansiColors := &Defaults{}
+		assert.Equal(t, tc.Expected, ansiColors.ToAnsi(tc.Color, tc.Background), tc.Case)
+	}
+}
+
+func TestPaletteColorsResolveShade(t *testing.T) {
+	colors := &PaletteColors{ansiColors: &Defaults{}, palette: testPalette}
+
+	expectedHex, _ := shadeHex("#FF0000", shadeDark, 30)
+	expected := (&Defaults{}).ToAnsi(Ansi(expectedHex), false)
+
+	assert.Equal(t, expected, colors.ToAnsi("darken(p:red, 30)", false), "darken should resolve a palette reference before shading")
+
+	resolved, err := colors.Resolve("darken(p:red, 30)")
+	assert.Nil(t, err)
+	assert.Equal(t, withShadeCall(shadeDark, "#FF0000", 30), resolved, "Resolve should rebuild the call with the palette reference resolved")
+
+	assert.Equal(t, emptyColor, colors.ToAnsi("darken(p:missing, 30)", false), "an unresolvable palette reference should fail closed")
+}

--- a/src/color/shade_test.go
+++ b/src/color/shade_test.go
@@ -11,10 +11,10 @@ func TestShadeArgs(t *testing.T) {
 	cases := []struct {
 		Case            string
 		Color           Ansi
-		ExpectedOK      bool
-		ExpectedDir     shadeDirection
 		ExpectedInner   Ansi
+		ExpectedDir     shadeDirection
 		ExpectedPercent float64
+		ExpectedOK      bool
 	}{
 		{Case: "darken", Color: "darken(#3465A4, 20)", ExpectedOK: true, ExpectedDir: shadeDark, ExpectedInner: "#3465A4", ExpectedPercent: 20},
 		{Case: "lighten", Color: "lighten(#3465A4, 20)", ExpectedOK: true, ExpectedDir: shadeLight, ExpectedInner: "#3465A4", ExpectedPercent: 20},
@@ -123,8 +123,8 @@ func TestDefaultsToAnsiShade(t *testing.T) {
 	cases := []struct {
 		Case       string
 		Color      Ansi
-		Background bool
 		Expected   Ansi
+		Background bool
 	}{
 		{Case: "darken hex foreground", Color: "darken(#3465A4, 20)", Background: false, Expected: (&Defaults{}).ToAnsi(Ansi(expectedHex), false)},
 		{Case: "darken hex background", Color: "darken(#3465A4, 20)", Background: true, Expected: (&Defaults{}).ToAnsi(Ansi(expectedHex), true)},

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -15,6 +15,9 @@
         },
         {
           "$ref": "#/definitions/gradient"
+        },
+        {
+          "$ref": "#/definitions/shade"
         }
       ]
     },
@@ -36,6 +39,12 @@
       "pattern": "^(linear|dark|light)-gradient\\(\\s*[^,()]+(\\s*,\\s*[^,()]+)*\\s*\\)$",
       "title": "Gradient color",
       "description": "https://ohmyposh.dev/docs/configuration/colors#gradients"
+    },
+    "shade": {
+      "type": "string",
+      "pattern": "^(darken|lighten)\\(\\s*[^,()]+\\s*,\\s*[^,()]+\\s*\\)$",
+      "title": "Shade color",
+      "description": "https://ohmyposh.dev/docs/configuration/colors#shades"
     },
     "palette_color": {
       "anyOf": [

--- a/website/docs/configuration/colors.mdx
+++ b/website/docs/configuration/colors.mdx
@@ -129,6 +129,52 @@ character.
 
 :::
 
+## Shades
+
+Anywhere a **Standard color** is expected, you can instead use `darken(color, percent)` or
+`lighten(color, percent)` to shift a single color's lightness toward black or white:
+
+<Config
+  data={{
+    type: "text",
+    style: "plain",
+    foreground: "#3465A4",
+    background: "darken(#3465A4, 20)",
+  }}
+/>
+
+`percent` is a number from `0` to `100`. It shifts the color's lightness toward black
+(`darken`) or white (`lighten`) by that share of the remaining distance to it, in the same HCL
+color space `dark-gradient`/`light-gradient` use, so hue stays exact and the result doesn't read
+as muddy. `0` leaves the color unchanged, `100` reaches (near-)black or (near-)white.
+
+The color argument must resolve to a hex color: a literal hex value (`darken(#3465A4, 20)`) or a
+[Palette reference][palette] to one (`darken(p:accent, 20)`). **ANSI color names** (`green`,
+`lightBlue`), **256 color palette numbers**, and keywords (`foreground`, `accent`, ...) are not
+supported and render no color, with the reason logged in `oh-my-posh debug` output.
+
+This is a deliberate limitation, not a missing feature: a named ANSI/terminal color's actual RGB
+value is decided by the terminal's own color scheme, and oh-my-posh has no reliable, fast way to
+ask the terminal what that value is on every prompt render. If you want a color that's a shade of
+one of your terminal's named colors, define its real hex value once as a
+[Palette][palette] entry and shade that:
+
+<Config
+  data={{
+    palette: {
+      accent: "#3465A4",
+    },
+    type: "text",
+    style: "plain",
+    foreground: "p:accent",
+    background: "darken(p:accent, 20)",
+  }}
+/>
+
+`darken`/`lighten` calls cannot be nested inside each other or inside a `linear-gradient`/
+`dark-gradient`/`light-gradient`, and do not themselves support gradient stops or segment-context
+keywords like `parentBackground`.
+
 ## Color templates
 
 Array of string [templates][templates] to define the color based on the current context.


### PR DESCRIPTION
### Prerequisites

- [ ] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [ ] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

This PR adds support for `darken(color, percent)` and `lighten(color, percent)` functions to shift a single color's lightness in the HCL color space, complementing the existing gradient functionality.

#### Key Changes

**New functionality:**
- Added `darken()` and `lighten()` shade functions that accept a hex color or palette reference and a percentage (0-100)
- Shifts color lightness toward black or white by the specified percentage of remaining distance, using the same HCL color space as `dark-gradient`/`light-gradient`
- Automatically reduces chroma as needed to stay within the sRGB gamut

**Implementation details:**
- `shade.go`: Core parsing and shading logic
  - `IsShade()`: Detects if a color string is a shade call
  - `ShadeArgs()`: Parses shade calls into direction, inner color, and percentage
  - `shadeHex()`: Performs the actual HCL lightness shift with gamut walking
  - `withShadeCall()`: Rebuilds shade calls with resolved palette references
- `colors.go`: Integration with color resolution pipeline
  - `Defaults.ToAnsi()`: Resolves shade calls to hex colors
  - `PaletteColors.ToAnsi()` and `Resolve()`: Resolves palette references within shade calls before processing
- `palette.go`: Added `resolveShade()` to handle palette references in shade call arguments
- `schema.json`: Added JSON schema validation for shade syntax

**Limitations (by design):**
- Only supports hex colors and palette references resolving to hex colors
- Named ANSI colors, 256-color indices, and keywords are not supported (their RGB values are terminal-dependent)
- Shade calls cannot be nested or used inside gradients

#### Testing

Comprehensive unit tests added in `shade_test.go` covering:
- Valid shade call parsing with various formats (hex, palette refs, whitespace variants, decimals)
- Invalid inputs (missing parens, nested calls, invalid percentages, etc.)
- `IsShade()` detection
- Lightness shifting behavior (darker/lighter than base, 0% unchanged, 100% reaches black/white)
- Rejection of non-hex color types
- Palette reference resolution through shade calls

#### Documentation

Updated `website/docs/configuration/colors.mdx` with:
- Shade function syntax and examples
- Explanation of percentage behavior
- Clarification on supported color types
- Guidance on using palette entries for named colors
- Limitations and nesting restrictions

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary

https://claude.ai/code/session_0124kTCCpvKd5bWWzCkt8yeq