### PR TITLE
feat(jujutsu): expose commit ID prefix and rest

### DIFF
--- a/src/segments/jujutsu.go
+++ b/src/segments/jujutsu.go
@@ -16,8 +16,12 @@ const (
 
 	IgnoreWorkingCopy options.Option = "ignore_working_copy"
 	ChangeIDMinLen    options.Option = "change_id_min_len"
+	CommitIDMinLen    options.Option = "commit_id_min_len"
 	FetchAhead        options.Option = "fetch_ahead_counter"
 	AheadIcon         options.Option = "ahead_icon"
+
+	jujutsuStatusFrameHeader = "OMPJJ1:5"
+	jujutsuStatusFieldCount  = 5
 )
 
 type JujutsuStatus struct {
@@ -42,6 +46,9 @@ type Jujutsu struct {
 	ChangeID       string
 	ChangeIDPrefix string
 	ChangeIDRest   string
+	CommitID       string
+	CommitIDPrefix string
+	CommitIDRest   string
 	Scm
 }
 
@@ -161,32 +168,49 @@ func (jj *Jujutsu) setJujutsuStatus() {
 		return
 	}
 
-	header, statusString, _ := strings.Cut(statusString, "\n")
-	prefix, rest, found := strings.Cut(header, "|")
-	// Jujutsu change IDs contain only canonical ID characters, so "|" is a safe
-	// separator that survives RunCommand's trimming when rest is empty.
-	if !found || len(prefix) == 0 || strings.Contains(rest, "|") {
+	fields := strings.Split(statusString, "\x00")
+	if len(fields) != jujutsuStatusFieldCount+2 ||
+		fields[0] != jujutsuStatusFrameHeader ||
+		fields[len(fields)-1] != "" ||
+		fields[1] == "" ||
+		fields[3] == "" {
 		return
 	}
 
-	jj.ChangeIDPrefix = prefix
-	jj.ChangeIDRest = rest
-	jj.ChangeID = prefix + rest
+	changeIDPrefix := fields[1]
+	changeIDRest := fields[2]
+	commitIDPrefix := fields[3]
+	commitIDRest := fields[4]
+	statusString = fields[5]
 
 	for line := range strings.SplitSeq(statusString, "\n") {
 		if len(line) > 0 {
 			jj.Working.add(line[0])
 		}
 	}
+
+	jj.ChangeIDPrefix = changeIDPrefix
+	jj.ChangeIDRest = changeIDRest
+	jj.ChangeID = changeIDPrefix + changeIDRest
+	jj.CommitIDPrefix = commitIDPrefix
+	jj.CommitIDRest = commitIDRest
+	jj.CommitID = commitIDPrefix + commitIDRest
 }
 
 func (jj *Jujutsu) logTemplate() string {
 	// https://jj-vcs.github.io/jj/latest/templates/#commit-keywords
-	minLength := jj.options.Int(ChangeIDMinLen, 0)
+	changeIDMinLength := jj.options.Int(ChangeIDMinLen, 0)
+	commitIDMinLength := jj.options.Int(CommitIDMinLen, 0)
+	template := `"%s\0" ++ change_id.shortest(%d).prefix() ++ "\0" ++ ` +
+		`change_id.shortest(%d).rest() ++ "\0" ++ commit_id.shortest(%d).prefix() ++ "\0" ++ ` +
+		`commit_id.shortest(%d).rest() ++ "\0" ++ diff.summary() ++ "\0"`
 	return fmt.Sprintf(
-		`change_id.shortest(%d).prefix() ++ "|" ++ change_id.shortest(%d).rest() ++ "\n" ++ diff.summary()`,
-		minLength,
-		minLength,
+		template,
+		jujutsuStatusFrameHeader,
+		changeIDMinLength,
+		changeIDMinLength,
+		commitIDMinLength,
+		commitIDMinLength,
 	)
 }
 

--- a/src/segments/jujutsu_test.go
+++ b/src/segments/jujutsu_test.go
@@ -2,6 +2,7 @@ package segments
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
@@ -10,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestJujutsuEnabledToolNotFound(t *testing.T) {
+func TestJujutsuEnabledRepositoryNotFound(t *testing.T) {
 	env := new(mock.Environment)
 	env.On("InWSLSharedDrive").Return(false)
 	env.On("HasParentFilePath", ".jj", false).Return(&runtime.FileInfo{}, errors.New("not found"))
@@ -23,7 +24,7 @@ func TestJujutsuEnabledToolNotFound(t *testing.T) {
 	assert.False(t, jj.Enabled())
 }
 
-func TestJujutsuEnabledInWorkingDirectory(t *testing.T) {
+func TestJujutsuEnabledToolNotFound(t *testing.T) {
 	fileInfo := &runtime.FileInfo{
 		Path:         "/dir/hello",
 		ParentFolder: "/dir",
@@ -31,7 +32,25 @@ func TestJujutsuEnabledInWorkingDirectory(t *testing.T) {
 	}
 	env := new(mock.Environment)
 	env.On("InWSLSharedDrive").Return(false)
-	env.On("HasCommand", "jj").Return(true)
+	env.On("HasParentFilePath", ".jj", false).Return(fileInfo, nil)
+	env.On("GOOS").Return("")
+	env.On("HasCommand", "jj").Return(false)
+
+	jj := &Jujutsu{}
+	jj.Init(options.Map{FetchStatus: true}, env)
+
+	assert.False(t, jj.Enabled())
+	env.AssertNotCalled(t, "RunCommand")
+	env.AssertExpectations(t)
+}
+
+func TestJujutsuEnabledInWorkingDirectory(t *testing.T) {
+	fileInfo := &runtime.FileInfo{
+		Path:         "/dir/hello",
+		ParentFolder: "/dir",
+		IsDir:        true,
+	}
+	env := new(mock.Environment)
 	env.On("HasParentFilePath", ".jj", false).Return(fileInfo, nil)
 	env.On("GOOS").Return("")
 
@@ -44,22 +63,56 @@ func TestJujutsuEnabledInWorkingDirectory(t *testing.T) {
 	assert.Empty(t, jj.ChangeID)
 	assert.Empty(t, jj.ChangeIDPrefix)
 	assert.Empty(t, jj.ChangeIDRest)
+	assert.Empty(t, jj.CommitID)
+	assert.Empty(t, jj.CommitIDPrefix)
+	assert.Empty(t, jj.CommitIDRest)
+	env.AssertNotCalled(t, "HasCommand")
 	env.AssertNotCalled(t, "RunCommand")
+	env.AssertExpectations(t)
 }
 
 func TestJujutsuLogTemplate(t *testing.T) {
 	jj := &Jujutsu{}
-	jj.Init(options.Map{ChangeIDMinLen: 8}, new(mock.Environment))
+	jj.Init(options.Map{
+		ChangeIDMinLen: 8,
+		CommitIDMinLen: 12,
+	}, new(mock.Environment))
 
+	expected := `"OMPJJ1:5\0" ++ change_id.shortest(8).prefix() ++ "\0" ++ ` +
+		`change_id.shortest(8).rest() ++ "\0" ++ commit_id.shortest(12).prefix() ++ "\0" ++ ` +
+		`commit_id.shortest(12).rest() ++ "\0" ++ diff.summary() ++ "\0"`
 	assert.Equal(
 		t,
-		`change_id.shortest(8).prefix() ++ "|" ++ change_id.shortest(8).rest() ++ "\n" ++ diff.summary()`,
+		expected,
+		jj.logTemplate(),
+	)
+}
+
+func TestJujutsuLogTemplateDefaults(t *testing.T) {
+	jj := &Jujutsu{}
+	jj.Init(options.Map{}, new(mock.Environment))
+
+	expected := `"OMPJJ1:5\0" ++ change_id.shortest(0).prefix() ++ "\0" ++ ` +
+		`change_id.shortest(0).rest() ++ "\0" ++ commit_id.shortest(0).prefix() ++ "\0" ++ ` +
+		`commit_id.shortest(0).rest() ++ "\0" ++ diff.summary() ++ "\0"`
+	assert.Equal(
+		t,
+		expected,
 		jj.logTemplate(),
 	)
 }
 
 func TestJujutsuTemplate(t *testing.T) {
 	assert.Equal(t, " \uf1fa{{.ChangeID}}{{if .Working.Changed}} \uf044 {{ .Working.String }}{{ end }} ", (&Jujutsu{}).Template())
+}
+
+func jujutsuStatusFrame(changeIDPrefix, changeIDRest, commitIDPrefix, commitIDRest, status string) string {
+	return jujutsuStatusFrameHeader + "\x00" +
+		changeIDPrefix + "\x00" +
+		changeIDRest + "\x00" +
+		commitIDPrefix + "\x00" +
+		commitIDRest + "\x00" +
+		status + "\x00"
 }
 
 func TestJujutsuGetIdInfo(t *testing.T) {
@@ -71,17 +124,25 @@ func TestJujutsuGetIdInfo(t *testing.T) {
 		ExpectedChangeID       string
 		ExpectedChangeIDPrefix string
 		ExpectedChangeIDRest   string
+		ExpectedCommitID       string
+		ExpectedCommitIDPrefix string
+		ExpectedCommitIDRest   string
 		ChangeIDMinLen         int
-		ValidHeader            bool
+		CommitIDMinLen         int
+		ValidFrame             bool
 	}{
 		{
-			Case:                   "clean with minimum-length rest",
-			LogOutput:              "t|ususrrr",
+			Case:                   "clean with minimum-length rests",
+			LogOutput:              jujutsuStatusFrame("t", "ususrrr", "a", "bcdefghijk", ""),
 			ExpectedChangeID:       "tususrrr",
 			ExpectedChangeIDPrefix: "t",
 			ExpectedChangeIDRest:   "ususrrr",
+			ExpectedCommitID:       "abcdefghijk",
+			ExpectedCommitIDPrefix: "a",
+			ExpectedCommitIDRest:   "bcdefghijk",
 			ChangeIDMinLen:         8,
-			ValidHeader:            true,
+			CommitIDMinLen:         11,
+			ValidFrame:             true,
 			ExpectedWorking: &JujutsuStatus{ScmStatus{
 				Deleted:  0,
 				Added:    0,
@@ -90,13 +151,17 @@ func TestJujutsuGetIdInfo(t *testing.T) {
 			}},
 		},
 		{
-			Case:                   "clean with empty rest after output trimming",
-			LogOutput:              "tususrrr|",
+			Case:                   "clean with empty rests after output trimming",
+			LogOutput:              strings.TrimSpace(jujutsuStatusFrame("tususrrr", "", "abcdef12", "", "") + "\n"),
 			ExpectedChangeID:       "tususrrr",
 			ExpectedChangeIDPrefix: "tususrrr",
 			ExpectedChangeIDRest:   "",
+			ExpectedCommitID:       "abcdef12",
+			ExpectedCommitIDPrefix: "abcdef12",
+			ExpectedCommitIDRest:   "",
 			ChangeIDMinLen:         4,
-			ValidHeader:            true,
+			CommitIDMinLen:         4,
+			ValidFrame:             true,
 			ExpectedWorking: &JujutsuStatus{ScmStatus{
 				Deleted:  0,
 				Added:    0,
@@ -105,18 +170,21 @@ func TestJujutsuGetIdInfo(t *testing.T) {
 			}},
 		},
 		{
-			Case: "changed with empty rest",
-			LogOutput: `tususrrr|
-D deleted_file
+			Case: "changed with empty rests",
+			LogOutput: jujutsuStatusFrame("tususrrr", "", "abcdef12", "", `D deleted_file
 A added_file
 C {copied_file => new_file}
 M modified_file
-R {renamed_file => new_file}`,
+R {renamed_file => new_file}`),
 			ExpectedChangeID:       "tususrrr",
 			ExpectedChangeIDPrefix: "tususrrr",
 			ExpectedChangeIDRest:   "",
+			ExpectedCommitID:       "abcdef12",
+			ExpectedCommitIDPrefix: "abcdef12",
+			ExpectedCommitIDRest:   "",
 			ChangeIDMinLen:         4,
-			ValidHeader:            true,
+			CommitIDMinLen:         4,
+			ValidFrame:             true,
 			ExpectedWorking: &JujutsuStatus{ScmStatus{
 				Deleted:  1,
 				Added:    2,
@@ -126,9 +194,10 @@ R {renamed_file => new_file}`,
 		},
 		{
 			Case:           "command error",
-			LogOutput:      "ignored",
+			LogOutput:      jujutsuStatusFrame("t", "ususrrr", "a", "bcdefghijk", ""),
 			CommandError:   errors.New("jj failed"),
 			ChangeIDMinLen: 8,
+			CommitIDMinLen: 11,
 			ExpectedWorking: &JujutsuStatus{ScmStatus{
 				Deleted:  0,
 				Added:    0,
@@ -137,9 +206,10 @@ R {renamed_file => new_file}`,
 			}},
 		},
 		{
-			Case:           "missing delimiter",
-			LogOutput:      "tususrrr\nD deleted_file",
+			Case:           "wrong magic",
+			LogOutput:      "OMPJJ2:5\x00t\x00ususrrr\x00a\x00bcdefghijk\x00D deleted_file\x00",
 			ChangeIDMinLen: 8,
+			CommitIDMinLen: 11,
 			ExpectedWorking: &JujutsuStatus{ScmStatus{
 				Deleted:  0,
 				Added:    0,
@@ -148,9 +218,70 @@ R {renamed_file => new_file}`,
 			}},
 		},
 		{
-			Case:           "multiple delimiters",
-			LogOutput:      "t|usus|rrr\nD deleted_file",
+			Case:           "wrong field count in magic",
+			LogOutput:      "OMPJJ1:4\x00t\x00ususrrr\x00a\x00bcdefghijk\x00D deleted_file\x00",
 			ChangeIDMinLen: 8,
+			CommitIDMinLen: 11,
+			ExpectedWorking: &JujutsuStatus{ScmStatus{
+				Deleted:  0,
+				Added:    0,
+				Modified: 0,
+				Moved:    0,
+			}},
+		},
+		{
+			Case:           "missing terminal sentinel",
+			LogOutput:      "OMPJJ1:5\x00t\x00ususrrr\x00a\x00bcdefghijk\x00D deleted_file",
+			ChangeIDMinLen: 8,
+			CommitIDMinLen: 11,
+			ExpectedWorking: &JujutsuStatus{ScmStatus{
+				Deleted:  0,
+				Added:    0,
+				Modified: 0,
+				Moved:    0,
+			}},
+		},
+		{
+			Case:           "missing field",
+			LogOutput:      "OMPJJ1:5\x00t\x00ususrrr\x00a\x00D deleted_file\x00",
+			ChangeIDMinLen: 8,
+			CommitIDMinLen: 11,
+			ExpectedWorking: &JujutsuStatus{ScmStatus{
+				Deleted:  0,
+				Added:    0,
+				Modified: 0,
+				Moved:    0,
+			}},
+		},
+		{
+			Case:           "extra field",
+			LogOutput:      "OMPJJ1:5\x00t\x00ususrrr\x00a\x00bcdefghijk\x00unexpected\x00D deleted_file\x00",
+			ChangeIDMinLen: 8,
+			CommitIDMinLen: 11,
+			ExpectedWorking: &JujutsuStatus{ScmStatus{
+				Deleted:  0,
+				Added:    0,
+				Modified: 0,
+				Moved:    0,
+			}},
+		},
+		{
+			Case:           "empty change ID prefix",
+			LogOutput:      jujutsuStatusFrame("", "tususrrr", "a", "bcdefghijk", "D deleted_file"),
+			ChangeIDMinLen: 8,
+			CommitIDMinLen: 11,
+			ExpectedWorking: &JujutsuStatus{ScmStatus{
+				Deleted:  0,
+				Added:    0,
+				Modified: 0,
+				Moved:    0,
+			}},
+		},
+		{
+			Case:           "empty commit ID prefix",
+			LogOutput:      jujutsuStatusFrame("t", "ususrrr", "", "abcdefghijk", "D deleted_file"),
+			ChangeIDMinLen: 8,
+			CommitIDMinLen: 11,
 			ExpectedWorking: &JujutsuStatus{ScmStatus{
 				Deleted:  0,
 				Added:    0,
@@ -171,6 +302,7 @@ R {renamed_file => new_file}`,
 			props := options.Map{
 				FetchStatus:    true,
 				ChangeIDMinLen: tc.ChangeIDMinLen,
+				CommitIDMinLen: tc.CommitIDMinLen,
 			}
 
 			env := new(mock.Environment)
@@ -207,8 +339,12 @@ R {renamed_file => new_file}`,
 			assert.Equal(t, tc.ExpectedChangeID, jj.ChangeID)
 			assert.Equal(t, tc.ExpectedChangeIDPrefix, jj.ChangeIDPrefix)
 			assert.Equal(t, tc.ExpectedChangeIDRest, jj.ChangeIDRest)
-			if tc.ValidHeader {
+			assert.Equal(t, tc.ExpectedCommitID, jj.CommitID)
+			assert.Equal(t, tc.ExpectedCommitIDPrefix, jj.CommitIDPrefix)
+			assert.Equal(t, tc.ExpectedCommitIDRest, jj.CommitIDRest)
+			if tc.ValidFrame {
 				assert.Equal(t, jj.ChangeIDPrefix+jj.ChangeIDRest, jj.ChangeID)
+				assert.Equal(t, jj.CommitIDPrefix+jj.CommitIDRest, jj.CommitID)
 			}
 			env.AssertNumberOfCalls(t, "RunCommand", 1)
 			env.AssertExpectations(t)

--- a/themes/schema.json
+++ b/themes/schema.json
@@ -2534,6 +2534,12 @@
                     "description": "Minimum length of the change ID to display",
                     "default": 0
                   },
+                  "commit_id_min_len": {
+                    "type": "integer",
+                    "title": "Commit ID Minimum Length",
+                    "description": "Minimum length of the commit ID to display",
+                    "default": 0
+                  },
                   "fetch_status": {
                     "type": "boolean",
                     "title": "Display Status",

--- a/website/docs/segments/scm/jujutsu.mdx
+++ b/website/docs/segments/scm/jujutsu.mdx
@@ -33,11 +33,12 @@ import Config from "@site/src/components/Config.js";
 ### Fetching information
 
 As doing Jujutsu (jj) calls can slow down the prompt experience, we do not fetch information by default.
-Set `status_formats` to `true` to enable fetching additional information (and populate the template).
+Set `fetch_status` to `true` to enable fetching additional information (and populate the template).
 
 | Name                  |        Type         | Default  | Description                                                                                                                                                                                                                                                      |
 | --------------------- | :-----------------: | :------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `change_id_min_len`   |        `int`        |   `0`    | `ChangeID` will be at least this many characters, even if a shorter one would be unique                                                                                                                                                                          |
+| `commit_id_min_len`   |        `int`        |   `0`    | `CommitID` will be at least this many characters, even if a shorter one would be unique                                                                                                                                                                          |
 | `fetch_status`        |      `boolean`      | `false`  | fetch the local changes                                                                                                                                                                                                                                          |
 | `ignore_working_copy` |      `boolean`      |  `true`  | don't snapshot/update the working copy                                                                                                                                                                                                                           |
 | `fetch_ahead_counter` |      `boolean`      | `false`  | fetch a counter for number of changes between working copy and closest bookmark                                                                                                                                                                                  |
@@ -63,9 +64,12 @@ Set `status_formats` to `true` to enable fetching additional information (and po
 | `.ChangeID`         | `string` | The shortest unique prefix of the working copy change that's at least change_id_min_len long                                                                                     |
 | `.ChangeIDPrefix`   | `string` | The shortest unique prefix of the working copy change ID                                                                                                                         |
 | `.ChangeIDRest`     | `string` | The additional portion displayed after `.ChangeIDPrefix` to satisfy `change_id_min_len`; empty when the unique prefix already meets or exceeds that minimum                      |
+| `.CommitID`         | `string` | The shortest unique prefix of the working copy commit that's at least commit_id_min_len long                                                                                     |
+| `.CommitIDPrefix`   | `string` | The shortest unique prefix of the working copy commit ID                                                                                                                         |
+| `.CommitIDRest`     | `string` | The additional portion displayed after `.CommitIDPrefix` to satisfy `commit_id_min_len`; empty when the unique prefix already meets or exceeds that minimum                      |
 | `.ClosestBookmarks` | `string` | Closest bookmark(s) on ancestors                                                                                                                                                 |
 
-`.ChangeIDRest` is not the remainder of the full canonical change ID and isn't independently usable as an identifier.
+`.ChangeIDRest` and `.CommitIDRest` are not remainders of the full canonical IDs and aren't independently usable as identifiers.
 
 ### Status
 


### PR DESCRIPTION
## Summary

- add `.CommitIDPrefix` and `.CommitIDRest`
- preserve `.CommitID` as their combined displayed value
- add `commit_id_min_len`
- fetch Change ID, Commit ID, and working-copy status atomically in the existing single `jj log` process
- leave the default template and existing `.ChangeID` API unchanged

## Context

This is a focused successor to #6679 and builds on the flat, backward-compatible ID presentation introduced for Change IDs in #7720.

Credit to @nemith for the original #6679 exploration and design discussion. This branch intentionally preserves that historical lineage, while replacing the old broad and now-outdated implementation with one focused contribution against current Jujutsu and Oh My Posh APIs.

## Implementation

The Jujutsu query returns a versioned, NUL-delimited frame containing:

- Change ID unique prefix
- Change ID minimum-length remainder
- Commit ID unique prefix
- Commit ID minimum-length remainder
- working-copy diff summary

The frame's magic, field count, required prefixes, and terminal sentinel are validated before any fetched state is assigned. Malformed output follows the existing command-error behavior and leaves the fields empty.

Both `Rest` properties contain only the additional characters needed to satisfy their configured minimum length. They are not suffixes of the full canonical IDs and are not independently usable identifiers.

The strict theme schema and Jujutsu documentation include `commit_id_min_len`.

## Compatibility and performance

- `.ChangeID` remains unchanged.
- `.CommitID` follows the same flat `Prefix + Rest` convention.
- The default template still renders `.ChangeID`.
- Status fetching remains gated by `fetch_status`.
- Exactly one `jj log -r @` subprocess is used.

A 30-sample clean/changed timing probe found the additional template work within normal subprocess noise:

- clean: 337.124 ms baseline, 325.490 ms with Commit ID components
- changed: 201.084 ms baseline, 202.687 ms with Commit ID components

## Tests

Added coverage for:

- empty and nonempty Commit ID remainder
- Change ID and Commit ID combined-value invariants
- clean and changed working copies
- disabled status fetching and missing-command gating
- command failure
- incorrect framing magic/count
- missing, extra, and empty required fields
- terminal-sentinel behavior across output trimming
- exact JJ template and one-command execution
- documented default minimum lengths
- unchanged default segment template

Validation completed with targeted Jujutsu tests, `go test ./... -count=1`, the Docusaurus production build, schema parsing, a real JJ 0.42.0 framing probe, and `git diff --check`.