### PR TITLE
fix(battery): support illumos/solaris cross-compilation

### DIFF
--- a/src/runtime/battery/battery_illumos.go
+++ b/src/runtime/battery/battery_illumos.go
@@ -1,0 +1,11 @@
+//go:build illumos || solaris
+
+package battery
+
+// Get returns information about all batteries in the system.
+//
+// Battery reporting is not implemented on illumos/solaris; this always
+// returns a NoBatteryError so the battery segment disables itself cleanly.
+func Get() (*Info, error) {
+	return nil, &NoBatteryError{}
+}

--- a/src/runtime/battery/battery_illumos_test.go
+++ b/src/runtime/battery/battery_illumos_test.go
@@ -1,0 +1,16 @@
+//go:build illumos || solaris
+
+package battery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetNoBattery(t *testing.T) {
+	info, err := Get()
+
+	assert.Nil(t, info)
+	assert.IsType(t, &NoBatteryError{}, err)
+}

--- a/src/runtime/battery/battery_windows_nix.go
+++ b/src/runtime/battery/battery_windows_nix.go
@@ -1,4 +1,4 @@
-//go:build !darwin && !netbsd && !openbsd && !freebsd && !js
+//go:build !darwin && !netbsd && !openbsd && !freebsd && !js && !illumos && !solaris
 
 package battery
 

--- a/src/runtime/battery/battery_windows_nix_test.go
+++ b/src/runtime/battery/battery_windows_nix_test.go
@@ -1,4 +1,4 @@
-//go:build !darwin && !netbsd && !openbsd
+//go:build !darwin && !netbsd && !openbsd && !illumos && !solaris
 
 // battery
 // Copyright (C) 2016-2017 Karol 'Kenji Takahashi' Woźniak


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

Fixes #7730.

`go build` fails on illumos/solaris with `undefined: systemGetAll`. The cause: `battery_windows_nix.go` uses the negative build constraint `!darwin && !netbsd && !openbsd && !freebsd`, which matches illumos/solaris (and anything else not explicitly excluded), but its `Get()` depends on a `systemGetAll()` function that is only implemented in `battery_linux.go` and `battery_windows.go`.

This adds a dedicated `battery_illumos.go` (build tag `illumos || solaris`) providing a no-op `Get()` that returns `&NoBatteryError{}` — matching the existing "no battery" pattern already handled by `segments/battery.go`, so the battery segment simply disables itself on these platforms rather than showing bogus data. `battery_windows_nix.go` and its test file are updated to exclude `illumos`/`solaris` so the two implementations of `Get()` don't collide.

Verified with cross-compilation (`go build`/`go vet`) for `illumos`, `solaris`, `linux`, `windows`, `darwin`, `freebsd`, `openbsd`, and `netbsd`, plus the existing native test suite.

A real battery reading (e.g. via `kstat`) can be added later; this unblocks the build in the meantime.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kux8kuvykbMrtxukThmB7K)_