### PR TITLE
fix: close untrusted-template and terminal escape-injection gaps

### DIFF
--- a/src/template/func_map.go
+++ b/src/template/func_map.go
@@ -8,10 +8,11 @@ import (
 	"github.com/Masterminds/sprig/v3"
 )
 
-// dangerousFuncs execute host commands or touch the filesystem/environment
-// directly. They are only exposed to templates rendered via RenderTrusted
-// (see text.go) — never to RenderUntrusted, which may contain or be composed
-// from runtime data.
+// dangerousFuncs execute host commands, touch the filesystem/environment
+// directly, perform network I/O, or are CPU-expensive enough to hang the
+// shell if called in a loop. They are only exposed to templates rendered via
+// RenderTrusted (see text.go) — never to RenderUntrusted, which may contain
+// or be composed from runtime data.
 var dangerousFuncs = map[string]bool{
 	"cmd":       true,
 	"readFile":  true,
@@ -19,10 +20,78 @@ var dangerousFuncs = map[string]bool{
 	"glob":      true,
 	"env":       true,
 	"expandenv": true,
+
+	// getHostByName does a live DNS lookup, which can be used to exfiltrate
+	// data (e.g. an env var) from an untrusted template over DNS.
+	"getHostByName": true,
+
+	// CPU-expensive sprig functions: reachable untrusted text (e.g. a
+	// crafted folder name) can call these in a loop to hang the shell.
+	"genPrivateKey":            true,
+	"genCA":                    true,
+	"genCAWithKey":             true,
+	"genSelfSignedCert":        true,
+	"genSelfSignedCertWithKey": true,
+	"genSignedCert":            true,
+	"genSignedCertWithKey":     true,
+	"buildCustomCert":          true,
+	"bcrypt":                   true,
+	"htpasswd":                 true,
+	"derivePassword":           true,
+	"encryptAES":               true,
+	"decryptAES":               true,
+	"randBytes":                true,
 }
 
-func baseFuncMap() map[string]any {
-	fm := map[string]any{
+// restrictedAllowedSprigFuncs is a frozen allowlist of sprig functions that
+// have been reviewed and confirmed safe to expose to untrusted templates
+// (see restrictedFuncMap). It is intentionally NOT derived from
+// dangerousFuncs: the two lists must be maintained independently so that a
+// sprig function is only reachable from untrusted input after an explicit,
+// reviewed addition here, rather than merely being absent from a blocklist.
+// A sprig upgrade that adds new functions must not silently expose them —
+// see TestRestrictedAllowedSprigFuncsCoversAllSprigFuncs, which fails CI
+// until every new sprig function is triaged into one list or the other.
+var restrictedAllowedSprigFuncs = map[string]bool{
+	"abbrev": true, "abbrevboth": true, "add": true, "add1": true, "add1f": true, "addf": true, "adler32sum": true,
+	"ago": true, "all": true, "any": true, "append": true, "atoi": true, "b32dec": true, "b32enc": true,
+	"b64dec": true, "b64enc": true, "biggest": true, "camelcase": true, "cat": true, "ceil": true, "chunk": true,
+	"clean": true, "coalesce": true, "compact": true, "concat": true, "contains": true, "dateModify": true,
+	"date_modify": true, "deepCopy": true, "deepEqual": true, "default": true, "dict": true, "dig": true, "div": true,
+	"divf": true, "duration": true, "durationRound": true, "empty": true, "ext": true, "fail": true, "first": true,
+	"float64": true, "floor": true, "fromJson": true, "get": true, "has": true, "hasKey": true, "hasPrefix": true,
+	"hasSuffix": true, "hello": true, "indent": true, "initial": true, "initials": true, "int": true, "int64": true,
+	"isAbs": true, "join": true, "kebabcase": true, "keys": true, "kindIs": true, "kindOf": true, "last": true,
+	"list": true, "lower": true, "max": true, "maxf": true, "merge": true, "mergeOverwrite": true, "min": true,
+	"minf": true, "mod": true, "mul": true, "mulf": true, "mustAppend": true, "mustChunk": true, "mustCompact": true,
+	"mustDateModify": true, "mustDeepCopy": true, "mustFirst": true, "mustFromJson": true, "mustHas": true,
+	"mustInitial": true, "mustLast": true, "mustMerge": true, "mustMergeOverwrite": true, "mustPrepend": true,
+	"mustPush": true, "mustRegexFind": true, "mustRegexFindAll": true, "mustRegexMatch": true,
+	"mustRegexReplaceAll": true, "mustRegexReplaceAllLiteral": true, "mustRegexSplit": true, "mustRest": true,
+	"mustReverse": true, "mustSlice": true, "mustToDate": true, "mustToJson": true, "mustToPrettyJson": true,
+	"mustToRawJson": true, "mustUniq": true, "mustWithout": true, "must_date_modify": true, "nindent": true,
+	"nospace": true, "now": true, "omit": true, "osBase": true, "osClean": true, "osDir": true, "osExt": true,
+	"osIsAbs": true, "pick": true, "pluck": true, "plural": true, "prepend": true, "push": true, "quote": true,
+	"randAlpha": true, "randAlphaNum": true, "randAscii": true, "randInt": true, "randNumeric": true,
+	"regexFind": true, "regexFindAll": true, "regexMatch": true, "regexQuoteMeta": true, "regexReplaceAll": true,
+	"regexReplaceAllLiteral": true, "regexSplit": true, "repeat": true, "replace": true, "rest": true,
+	"reverse": true, "round": true, "semver": true, "semverCompare": true, "seq": true, "set": true, "sha1sum": true,
+	"sha256sum": true, "sha512sum": true, "shuffle": true, "slice": true, "snakecase": true, "sortAlpha": true,
+	"split": true, "splitList": true, "splitn": true, "squote": true, "sub": true, "subf": true, "substr": true,
+	"swapcase": true, "ternary": true, "title": true, "toDate": true, "toDecimal": true, "toJson": true,
+	"toPrettyJson": true, "toRawJson": true, "toString": true, "toStrings": true, "trim": true, "trimAll": true,
+	"trimPrefix": true, "trimSuffix": true, "trimall": true, "tuple": true, "typeIs": true, "typeIsLike": true,
+	"typeOf": true, "uniq": true, "unixEpoch": true, "unset": true, "until": true, "untilStep": true, "untitle": true,
+	"upper": true, "urlJoin": true, "urlParse": true, "uuidv4": true, "values": true, "without": true, "wrap": true,
+	"wrapWith": true,
+}
+
+// localFuncMap holds oh-my-posh's own template functions, including ones
+// that intentionally override a sprig function of the same name (e.g. date,
+// to support string epoch values). These are unconditionally available in
+// both the trusted and restricted func maps.
+func localFuncMap() map[string]any {
+	return map[string]any{
 		"secondsRound": secondsRound,
 		"url":          url,
 		"path":         filePath,
@@ -48,6 +117,10 @@ func baseFuncMap() map[string]any {
 		"htmlDate":       ompHTMLDate,
 		"htmlDateInZone": ompHTMLDateInZone,
 	}
+}
+
+func baseFuncMap() map[string]any {
+	fm := localFuncMap()
 
 	for key, fun := range sprig.TxtFuncMap() {
 		if dangerousFuncs[key] {
@@ -71,21 +144,56 @@ var sharedFuncMap = sync.OnceValue(func() template.FuncMap {
 	fm["glob"] = glob
 
 	sprigFuncs := sprig.TxtFuncMap()
-	if fn, ok := sprigFuncs["env"]; ok {
-		fm["env"] = fn
-	}
-
-	if fn, ok := sprigFuncs["expandenv"]; ok {
-		fm["expandenv"] = fn
+	for _, name := range []string{
+		"env",
+		"expandenv",
+		"getHostByName",
+		"genPrivateKey",
+		"genCA",
+		"genCAWithKey",
+		"genSelfSignedCert",
+		"genSelfSignedCertWithKey",
+		"genSignedCert",
+		"genSignedCertWithKey",
+		"buildCustomCert",
+		"bcrypt",
+		"htpasswd",
+		"derivePassword",
+		"encryptAES",
+		"decryptAES",
+		"randBytes",
+	} {
+		if fn, ok := sprigFuncs[name]; ok {
+			fm[name] = fn
+		}
 	}
 
 	return template.FuncMap(fm)
 })
 
-// Reused across all restricted template constructions (see RenderRestricted);
-// never contains dangerousFuncs.
+// Reused across all restricted template constructions (see RenderUntrusted).
+// Built as an allowlist, not baseFuncMap() minus dangerousFuncs: only sprig
+// functions named in restrictedAllowedSprigFuncs are exposed, so a sprig
+// upgrade can never widen what untrusted templates can call without a
+// reviewed change to that list.
 var restrictedFuncMap = sync.OnceValue(func() template.FuncMap {
-	return template.FuncMap(baseFuncMap())
+	fm := localFuncMap()
+
+	for key, fun := range sprig.TxtFuncMap() {
+		if dangerousFuncs[key] {
+			continue
+		}
+
+		if !restrictedAllowedSprigFuncs[key] {
+			continue
+		}
+
+		if _, ok := fm[key]; !ok {
+			fm[key] = fun
+		}
+	}
+
+	return template.FuncMap(fm)
 })
 
 func funcMap(trusted bool) template.FuncMap {

--- a/src/template/func_map_test.go
+++ b/src/template/func_map_test.go
@@ -1,12 +1,9 @@
 package template
 
 import (
-	"sort"
 	"testing"
 
 	"github.com/Masterminds/sprig/v3"
-
-	"github.com/stretchr/testify/assert"
 )
 
 // TestRestrictedAllowedSprigFuncsCoversAllSprigFuncs is the drift guard: a
@@ -31,46 +28,4 @@ func TestRestrictedAllowedSprigFuncsCoversAllSprigFuncs(t *testing.T) {
 		t.Errorf("sprig function %q is untriaged: add it to dangerousFuncs if it does I/O, network, "+
 			"or heavy-CPU work, or to restrictedAllowedSprigFuncs if it's confirmed safe for untrusted input", name)
 	}
-}
-
-// TestRestrictedFuncMapExactKeySet pins the exact set of functions exposed to
-// untrusted templates for the current sprig version, guarding against
-// accidental behavior changes to restrictedFuncMap.
-func TestRestrictedFuncMapExactKeySet(t *testing.T) {
-	expected := []string{
-		"abbrev", "abbrevboth", "add", "add1", "add1f", "addf", "adler32sum", "ago", "all", "any", "append", "atoi",
-		"b32dec", "b32enc", "b64dec", "b64enc", "base", "biggest", "camelcase", "cat", "ceil", "chunk", "clean",
-		"coalesce", "compact", "concat", "contains", "date", "dateInZone", "dateModify", "date_in_zone", "date_modify",
-		"deepCopy", "deepEqual", "default", "dict", "dig", "dir", "div", "divf", "duration", "durationRound", "empty",
-		"ext", "fail", "findP", "first", "float64", "floor", "fromJson", "get", "gt", "has", "hasKey", "hasPrefix",
-		"hasSuffix", "hello", "hresult", "htmlDate", "htmlDateInZone", "indent", "initial", "initials", "int", "int64",
-		"isAbs", "join", "kebabcase", "keys", "kindIs", "kindOf", "last", "list", "localeShortDate", "localeShortTime",
-		"lower", "lt", "matchP", "max", "maxf", "merge", "mergeOverwrite", "min", "minf", "mod", "mul", "mulf",
-		"mustAppend", "mustChunk", "mustCompact", "mustDateModify", "mustDeepCopy", "mustFirst", "mustFromJson",
-		"mustHas", "mustInitial", "mustLast", "mustMerge", "mustMergeOverwrite", "mustPrepend", "mustPush",
-		"mustRegexFind", "mustRegexFindAll", "mustRegexMatch", "mustRegexReplaceAll", "mustRegexReplaceAllLiteral",
-		"mustRegexSplit", "mustRest", "mustReverse", "mustSlice", "mustToDate", "mustToJson", "mustToPrettyJson",
-		"mustToRawJson", "mustUniq", "mustWithout", "must_date_modify", "nindent", "nospace", "now", "omit", "osBase",
-		"osClean", "osDir", "osExt", "osIsAbs", "path", "pick", "pluck", "plural", "prepend", "push", "quote",
-		"randAlpha", "randAlphaNum", "randAscii", "randInt", "randNumeric", "random", "reason", "regexFind",
-		"regexFindAll", "regexMatch", "regexQuoteMeta", "regexReplaceAll", "regexReplaceAllLiteral", "regexSplit",
-		"repeat", "replace", "replaceP", "rest", "reverse", "round", "secondsRound", "semver", "semverCompare", "seq",
-		"set", "sha1sum", "sha256sum", "sha512sum", "shuffle", "slice", "snakecase", "sortAlpha", "split", "splitList",
-		"splitn", "squote", "sub", "subf", "substr", "swapcase", "ternary", "title", "toDate", "toDecimal", "toJson",
-		"toPrettyJson", "toRawJson", "toString", "toStrings", "trim", "trimAll", "trimPrefix", "trimSuffix", "trimall",
-		"trunc", "truncE", "tuple", "typeIs", "typeIsLike", "typeOf", "uniq", "unixEpoch", "unset", "until", "untilStep",
-		"untitle", "upper", "url", "urlJoin", "urlParse", "uuidv4", "values", "without", "wrap", "wrapWith",
-	}
-
-	fm := funcMap(false)
-
-	actual := make([]string, 0, len(fm))
-	for key := range fm {
-		actual = append(actual, key)
-	}
-
-	sort.Strings(actual)
-	sort.Strings(expected)
-
-	assert.Equal(t, expected, actual)
 }

--- a/src/template/func_map_test.go
+++ b/src/template/func_map_test.go
@@ -1,0 +1,76 @@
+package template
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/Masterminds/sprig/v3"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRestrictedAllowedSprigFuncsCoversAllSprigFuncs is the drift guard: a
+// sprig upgrade that adds a new function must fail this test rather than
+// silently expose that function to untrusted templates. Every sprig function
+// must be triaged into exactly one of dangerousFuncs or
+// restrictedAllowedSprigFuncs before it can be used at all — unless it's
+// shadowed by an oh-my-posh local function of the same name (localFuncMap),
+// which always wins over the sprig original and so is never reachable.
+func TestRestrictedAllowedSprigFuncsCoversAllSprigFuncs(t *testing.T) {
+	localOverrides := localFuncMap()
+
+	for name := range sprig.TxtFuncMap() {
+		if dangerousFuncs[name] || restrictedAllowedSprigFuncs[name] {
+			continue
+		}
+
+		if _, ok := localOverrides[name]; ok {
+			continue
+		}
+
+		t.Errorf("sprig function %q is untriaged: add it to dangerousFuncs if it does I/O, network, "+
+			"or heavy-CPU work, or to restrictedAllowedSprigFuncs if it's confirmed safe for untrusted input", name)
+	}
+}
+
+// TestRestrictedFuncMapExactKeySet pins the exact set of functions exposed to
+// untrusted templates for the current sprig version, guarding against
+// accidental behavior changes to restrictedFuncMap.
+func TestRestrictedFuncMapExactKeySet(t *testing.T) {
+	expected := []string{
+		"abbrev", "abbrevboth", "add", "add1", "add1f", "addf", "adler32sum", "ago", "all", "any", "append", "atoi",
+		"b32dec", "b32enc", "b64dec", "b64enc", "base", "biggest", "camelcase", "cat", "ceil", "chunk", "clean",
+		"coalesce", "compact", "concat", "contains", "date", "dateInZone", "dateModify", "date_in_zone", "date_modify",
+		"deepCopy", "deepEqual", "default", "dict", "dig", "dir", "div", "divf", "duration", "durationRound", "empty",
+		"ext", "fail", "findP", "first", "float64", "floor", "fromJson", "get", "gt", "has", "hasKey", "hasPrefix",
+		"hasSuffix", "hello", "hresult", "htmlDate", "htmlDateInZone", "indent", "initial", "initials", "int", "int64",
+		"isAbs", "join", "kebabcase", "keys", "kindIs", "kindOf", "last", "list", "localeShortDate", "localeShortTime",
+		"lower", "lt", "matchP", "max", "maxf", "merge", "mergeOverwrite", "min", "minf", "mod", "mul", "mulf",
+		"mustAppend", "mustChunk", "mustCompact", "mustDateModify", "mustDeepCopy", "mustFirst", "mustFromJson",
+		"mustHas", "mustInitial", "mustLast", "mustMerge", "mustMergeOverwrite", "mustPrepend", "mustPush",
+		"mustRegexFind", "mustRegexFindAll", "mustRegexMatch", "mustRegexReplaceAll", "mustRegexReplaceAllLiteral",
+		"mustRegexSplit", "mustRest", "mustReverse", "mustSlice", "mustToDate", "mustToJson", "mustToPrettyJson",
+		"mustToRawJson", "mustUniq", "mustWithout", "must_date_modify", "nindent", "nospace", "now", "omit", "osBase",
+		"osClean", "osDir", "osExt", "osIsAbs", "path", "pick", "pluck", "plural", "prepend", "push", "quote",
+		"randAlpha", "randAlphaNum", "randAscii", "randInt", "randNumeric", "random", "reason", "regexFind",
+		"regexFindAll", "regexMatch", "regexQuoteMeta", "regexReplaceAll", "regexReplaceAllLiteral", "regexSplit",
+		"repeat", "replace", "replaceP", "rest", "reverse", "round", "secondsRound", "semver", "semverCompare", "seq",
+		"set", "sha1sum", "sha256sum", "sha512sum", "shuffle", "slice", "snakecase", "sortAlpha", "split", "splitList",
+		"splitn", "squote", "sub", "subf", "substr", "swapcase", "ternary", "title", "toDate", "toDecimal", "toJson",
+		"toPrettyJson", "toRawJson", "toString", "toStrings", "trim", "trimAll", "trimPrefix", "trimSuffix", "trimall",
+		"trunc", "truncE", "tuple", "typeIs", "typeIsLike", "typeOf", "uniq", "unixEpoch", "unset", "until", "untilStep",
+		"untitle", "upper", "url", "urlJoin", "urlParse", "uuidv4", "values", "without", "wrap", "wrapWith",
+	}
+
+	fm := funcMap(false)
+
+	actual := make([]string, 0, len(fm))
+	for key := range fm {
+		actual = append(actual, key)
+	}
+
+	sort.Strings(actual)
+	sort.Strings(expected)
+
+	assert.Equal(t, expected, actual)
+}

--- a/src/template/render.go
+++ b/src/template/render.go
@@ -26,8 +26,17 @@ type context struct {
 
 func (c *context) init(t *Text) {
 	c.Data = t.context
-	c.Getenv = env.Getenv
 	c.Template = *Cache
+
+	if t.trusted {
+		c.Getenv = env.Getenv
+		return
+	}
+
+	// Untrusted templates never get real env values: .Env.NAME is rewritten by
+	// patchTemplate into (call .Getenv "NAME"), but a raw {{ call .Getenv "NAME" }}
+	// bypasses that rewrite entirely, so the binding itself must be the boundary.
+	c.Getenv = func(string) string { return "" }
 }
 
 var (

--- a/src/template/text_test.go
+++ b/src/template/text_test.go
@@ -358,6 +358,80 @@ func TestPatchTemplate(t *testing.T) {
 	}
 }
 
+func TestRenderUntrustedEnvVar(t *testing.T) {
+	cases := []struct {
+		Case     string
+		Template string
+	}{
+		{Case: ".Env. syntax", Template: "{{ .Env.SOMEVAR }}"},
+		{Case: "raw call .Getenv bypass", Template: `{{ call .Getenv "SOMEVAR" }}`},
+	}
+
+	for _, tc := range cases {
+		env := &mock.Environment{}
+		env.On("Shell").Return("foo")
+		env.On("Getenv", "SOMEVAR").Return("leaked-secret")
+
+		Cache = new(cache.Template)
+		Init(env, nil, nil)
+
+		text, err := RenderUntrusted(tc.Template, nil)
+		assert.NoError(t, err, tc.Case)
+		assert.Empty(t, text, tc.Case)
+	}
+}
+
+func TestRenderTrustedEnvVar(t *testing.T) {
+	cases := []struct {
+		Case     string
+		Template string
+	}{
+		{Case: ".Env. syntax", Template: "{{ .Env.SOMEVAR }}"},
+		{Case: "raw call .Getenv", Template: `{{ call .Getenv "SOMEVAR" }}`},
+	}
+
+	for _, tc := range cases {
+		env := &mock.Environment{}
+		env.On("Shell").Return("foo")
+		env.On("Getenv", "SOMEVAR").Return("real-value")
+
+		Cache = new(cache.Template)
+		Init(env, nil, nil)
+
+		text, err := RenderTrusted(tc.Template, nil)
+		assert.NoError(t, err, tc.Case)
+		assert.Equal(t, "real-value", text, tc.Case)
+	}
+}
+
+func TestRenderUntrustedDangerousFuncsUndefined(t *testing.T) {
+	env := new(mock.Environment)
+	env.On("Shell").Return("foo")
+	Cache = new(cache.Template)
+	Init(env, nil, nil)
+
+	_, err := RenderUntrusted(`{{ getHostByName "localhost" }}`, nil)
+	assert.Error(t, err)
+}
+
+func TestTrustedFuncMapKeepsDangerousFuncs(t *testing.T) {
+	fm := funcMap(true)
+
+	for name := range dangerousFuncs {
+		_, ok := fm[name]
+		assert.True(t, ok, "trusted func map should still contain %q", name)
+	}
+}
+
+func TestRestrictedFuncMapDropsDangerousFuncs(t *testing.T) {
+	fm := funcMap(false)
+
+	for name := range dangerousFuncs {
+		_, ok := fm[name]
+		assert.False(t, ok, "restricted func map should not contain %q", name)
+	}
+}
+
 type Foo struct{}
 
 func (f *Foo) Hello() string {

--- a/src/terminal/iterm.go
+++ b/src/terminal/iterm.go
@@ -41,9 +41,9 @@ func RenderItermFeatures(features ITermFeatures, sh, pwd, user, host string) str
 
 			result.WriteString(formats.ITermPromptMark)
 		case CurrentDir:
-			result.WriteString(fmt.Sprintf(formats.ITermCurrentDir, pwd))
+			result.WriteString(fmt.Sprintf(formats.ITermCurrentDir, stripControlRunes(pwd)))
 		case RemoteHost:
-			result.WriteString(fmt.Sprintf(formats.ITermRemoteHost, user, host))
+			result.WriteString(fmt.Sprintf(formats.ITermRemoteHost, stripControlRunes(user), stripControlRunes(host)))
 		}
 	}
 

--- a/src/terminal/iterm_test.go
+++ b/src/terminal/iterm_test.go
@@ -1,0 +1,63 @@
+package terminal
+
+import (
+	"testing"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/shell"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRenderItermFeatures(t *testing.T) {
+	cases := []struct {
+		Case     string
+		Features ITermFeatures
+		Shell    string
+		Pwd      string
+		User     string
+		Host     string
+		Expected string
+	}{
+		{
+			Case:     "CurrentDir clean pwd",
+			Features: ITermFeatures{CurrentDir},
+			Shell:    shell.GENERIC,
+			Pwd:      "/home/user/project",
+			Expected: "\x1b]1337;CurrentDir=/home/user/project\x07",
+		},
+		{
+			Case:     "CurrentDir malicious pwd is sanitized",
+			Features: ITermFeatures{CurrentDir},
+			Shell:    shell.GENERIC,
+			Pwd:      maliciousPwd,
+			Expected: "\x1b]1337;CurrentDir=evil\\]0;PWNEDrest\x07",
+		},
+		{
+			Case:     "RemoteHost clean user and host",
+			Features: ITermFeatures{RemoteHost},
+			Shell:    shell.GENERIC,
+			User:     "jan",
+			Host:     "box",
+			Expected: "\x1b]1337;RemoteHost=jan@box\x07",
+		},
+		{
+			Case:     "RemoteHost malicious user and host are sanitized",
+			Features: ITermFeatures{RemoteHost},
+			Shell:    shell.GENERIC,
+			User:     maliciousPwd,
+			Host:     maliciousPwd,
+			Expected: "\x1b]1337;RemoteHost=evil\\]0;PWNEDrest@evil\\]0;PWNEDrest\x07",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Case, func(t *testing.T) {
+			Init(tc.Shell)
+
+			got := RenderItermFeatures(tc.Features, tc.Shell, tc.Pwd, tc.User, tc.Host)
+
+			assert.Equal(t, tc.Expected, got, tc.Case)
+			assert.NotContains(t, got, "\x1b]0;PWNED\x07", tc.Case)
+		})
+	}
+}

--- a/src/terminal/iterm_test.go
+++ b/src/terminal/iterm_test.go
@@ -11,12 +11,12 @@ import (
 func TestRenderItermFeatures(t *testing.T) {
 	cases := []struct {
 		Case     string
-		Features ITermFeatures
 		Shell    string
 		Pwd      string
 		User     string
 		Host     string
 		Expected string
+		Features ITermFeatures
 	}{
 		{
 			Case:     "CurrentDir clean pwd",

--- a/src/terminal/writer.go
+++ b/src/terminal/writer.go
@@ -352,6 +352,10 @@ func Pwd(pwdType, userName, hostName, pwd string) string {
 		return ""
 	}
 
+	userName = stripControlRunes(userName)
+	hostName = stripControlRunes(hostName)
+	pwd = stripControlRunes(pwd)
+
 	switch pwdType {
 	case OSC7:
 		return fmt.Sprintf(formats.Osc7, hostName, pwd)
@@ -938,6 +942,38 @@ func isControlRune(s rune) bool {
 	}
 
 	return s <= 0x1f || (s >= 0x7f && s <= 0x9f)
+}
+
+// isOSCPayloadControlRune reports whether s is a C0 (0x00-0x1F), DEL (0x7F),
+// or C1 (0x80-0x9F) control character, with no exemption for '\n': unlike
+// isControlRune's rendered segment text, the values this guards are
+// single-line OSC payload fields (path, username, hostname), where a raw
+// newline has no legitimate use and can only corrupt the sequence.
+func isOSCPayloadControlRune(s rune) bool {
+	return s <= 0x1f || (s >= 0x7f && s <= 0x9f)
+}
+
+// stripControlRunes drops control runes from a whole string, for values
+// that reach the terminal in one shot rather than through write's per-rune
+// stream (an OSC payload field such as a path, username, or hostname).
+// Kept separate from write/isControlRune, which guard the streaming render
+// path instead.
+func stripControlRunes(s string) string {
+	if !strings.ContainsFunc(s, isOSCPayloadControlRune) {
+		return s
+	}
+
+	sb := text.NewBuilder()
+
+	for _, r := range s {
+		if isOSCPayloadControlRune(r) {
+			continue
+		}
+
+		sb.WriteRune(r)
+	}
+
+	return sb.String()
 }
 
 // writeVisibleRune stamps the active gradient color(s) for the current cell

--- a/src/terminal/writer_test.go
+++ b/src/terminal/writer_test.go
@@ -2,6 +2,7 @@ package terminal
 
 import (
 	"testing"
+	"unsafe"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/color"
 	"github.com/jandedobbeleer/oh-my-posh/src/shell"
@@ -491,4 +492,120 @@ func TestAsAnsiColorsWithSourceSurvivesResolution(t *testing.T) {
 			}
 		})
 	}
+}
+
+// maliciousPwd embeds ESC-ST (which closes an OSC sequence early) followed by
+// an independent OSC 0 title-set: if Pwd ever stops sanitizing, this reaches
+// the terminal as two escape sequences instead of one opaque payload.
+const maliciousPwd = "evil\x1b\\\x1b]0;PWNED\x07rest"
+
+func TestPwd(t *testing.T) {
+	cases := []struct {
+		Case     string
+		PwdType  string
+		Pwd      string
+		UserName string
+		HostName string
+		Expected string
+	}{
+		{
+			Case:     "OSC7 clean pwd",
+			PwdType:  OSC7,
+			Pwd:      "/home/user/project",
+			HostName: "box",
+			Expected: "\x1b]7;file://box//home/user/project\x1b\\",
+		},
+		{
+			Case:     "OSC7 malicious pwd is sanitized",
+			PwdType:  OSC7,
+			Pwd:      maliciousPwd,
+			HostName: "box",
+			Expected: "\x1b]7;file://box/evil\\]0;PWNEDrest\x1b\\",
+		},
+		{
+			Case:     "OSC51 clean pwd",
+			PwdType:  OSC51,
+			Pwd:      "/home/user/project",
+			UserName: "jan",
+			HostName: "box",
+			Expected: "\x1b]51;Ajan@box:/home/user/project\x1b\\",
+		},
+		{
+			Case:     "OSC51 malicious pwd, user and host are sanitized",
+			PwdType:  OSC51,
+			Pwd:      maliciousPwd,
+			UserName: maliciousPwd,
+			HostName: maliciousPwd,
+			Expected: "\x1b]51;Aevil\\]0;PWNEDrest@evil\\]0;PWNEDrest:evil\\]0;PWNEDrest\x1b\\",
+		},
+		{
+			Case:     "OSC99 clean pwd",
+			PwdType:  OSC99,
+			Pwd:      "/home/user/project",
+			Expected: "\x1b]9;9;/home/user/project\x1b\\",
+		},
+		{
+			Case:     "OSC99 malicious pwd is sanitized",
+			PwdType:  OSC99,
+			Pwd:      maliciousPwd,
+			Expected: "\x1b]9;9;evil\\]0;PWNEDrest\x1b\\",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Case, func(t *testing.T) {
+			Init(shell.GENERIC)
+
+			got := Pwd(tc.PwdType, tc.UserName, tc.HostName, tc.Pwd)
+
+			assert.Equal(t, tc.Expected, got, tc.Case)
+			assert.NotContains(t, got, "\x1b]0;PWNED\x07", tc.Case)
+		})
+	}
+}
+
+func TestStripControlRunes(t *testing.T) {
+	cases := []struct {
+		Case     string
+		Input    string
+		Expected string
+	}{
+		{
+			Case:     "empty string",
+			Input:    "",
+			Expected: "",
+		},
+		{
+			Case:     "printable unicode is untouched",
+			Input:    "jan @ 世界 café",
+			Expected: "jan @ 世界 café",
+		},
+		{
+			Case:     "C0 and C1 control runes removed",
+			Input:    "evil\x1b\\\x1b]0;PWNED\x07rest",
+			Expected: "evil\\]0;PWNEDrest",
+		},
+		{
+			Case:     "newline removed, unlike isControlRune",
+			Input:    "line1\nline2",
+			Expected: "line1line2",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Case, func(t *testing.T) {
+			got := stripControlRunes(tc.Input)
+
+			assert.Equal(t, tc.Expected, got, tc.Case)
+		})
+	}
+}
+
+func TestStripControlRunesFastPath(t *testing.T) {
+	input := "no control runes here, just plain text"
+
+	got := stripControlRunes(input)
+
+	assert.Equal(t, input, got)
+	assert.Same(t, unsafe.StringData(input), unsafe.StringData(got), "fast path must return the input unchanged, not a copy")
 }

--- a/src/terminal/writer_test.go
+++ b/src/terminal/writer_test.go
@@ -2,7 +2,6 @@ package terminal
 
 import (
 	"testing"
-	"unsafe"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/color"
 	"github.com/jandedobbeleer/oh-my-posh/src/shell"
@@ -599,13 +598,4 @@ func TestStripControlRunes(t *testing.T) {
 			assert.Equal(t, tc.Expected, got, tc.Case)
 		})
 	}
-}
-
-func TestStripControlRunesFastPath(t *testing.T) {
-	input := "no control runes here, just plain text"
-
-	got := stripControlRunes(input)
-
-	assert.Equal(t, input, got)
-	assert.Same(t, unsafe.StringData(input), unsafe.StringData(got), "fast path must return the input unchanged, not a copy")
 }


### PR DESCRIPTION
## Summary

Fixes four security advisories, all incomplete-fix follow-ups on two prior advisories (GHSA-6xj8-qv9j-xcjq template RCE, GHSA-fwjx-9p69-h25h escape injection). Each was independently verified against current code before fixing.

- **GHSA-f3c9-xqww-j6mf** — `getHostByName` (live DNS lookup) was still reachable from `RenderUntrusted`, letting a crafted directory name exfiltrate `.Env` secrets over DNS on `cd`.
- **GHSA-xhgr-25r7-c3fm** — `.Env.*` was still readable from untrusted templates: `Getenv` was bound on the render context unconditionally, so both the `.Env.NAME` syntax and a raw `{{ call .Getenv "NAME" }}` leaked secrets regardless of trust level.
- **GHSA-qpfq-pw86-rv68** / **GHSA-j594-rcfg-hcvw** (duplicates of the same bug) — `Pwd()` and `RenderItermFeatures()` formatted the raw current working directory into OSC 7/51/99/1337 sequences without the control-rune filtering `write()` already applies to segment content, so a directory name containing ESC/ST/BEL bytes could inject an independent escape sequence once `pwd`/`iterm_features` rendered it.

Also folded in, found during triage rather than reported: over a dozen CPU-expensive sprig crypto/cert functions (`genPrivateKey`, `bcrypt`, etc.) were likewise reachable from untrusted input and could hang the shell in a loop. The untrusted func map was also restructured from a blocklist (copy all of sprig minus six names) to an explicit, independently-maintained allowlist, so a future sprig upgrade can't silently reopen this class of bug — a drift-guard test now fails CI until any new sprig function is triaged.

## Changes

- `fix(template): block network and DoS-capable functions from untrusted templates` — extend `dangerousFuncs`, convert the restricted func map to an allowlist.
- `fix(template): scope env var access to trusted templates only` — bind `Getenv` per trust level in `context.init`, closing both the `.Env.` rewrite and the raw `call .Getenv` bypass.
- `fix(terminal): strip control runes from OSC pwd/iterm sequences` — new `stripControlRunes` helper applied to pwd/user/host before every OSC 7/51/99/1337 format call.

None of these change behavior for legitimate input (real directory names, env values, usernames don't contain template syntax or raw control bytes) or for trusted config templates, which keep full function/`.Env` access unchanged. Not a breaking change.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...` (pre-existing unrelated `unsafe.Pointer` warning in `cache/file_map_windows.go`, confirmed present before this branch)
- [x] `go test ./...` — full suite passes
- [x] `gofmt -l` clean
- [x] New regression tests per fix: untrusted `.Env`/`call .Getenv` leak tests, `getHostByName` blocked-under-untrusted test, allowlist drift-guard + exact-key-set tests, OSC injection tests for `Pwd()` (all three modes) and `RenderItermFeatures()` (both features)