### PR TITLE
ci(size): comment size report from a workflow_run job

### DIFF
--- a/.github/workflows/binary_size.yml
+++ b/.github/workflows/binary_size.yml
@@ -11,7 +11,6 @@ name: Binary Size Check
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   build:
@@ -80,85 +79,15 @@ jobs:
           retention-days: 1
           path: /tmp/report-${{ matrix.goos }}.json
 
-  report:
-    needs: build
-    if: always()
+  pr-context:
     runs-on: ubuntu-latest
     steps:
-      - name: Download size reports 📥
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+      - name: Save PR number
+        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
+
+      - name: Upload PR number 📤
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          pattern: size-report-*
-          path: reports
-          merge-multiple: true
-
-      - name: Report size deltas 💬
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
-        with:
-          script: |
-            const fs = require('fs');
-            const path = require('path');
-
-            const marker = '<!-- binary-size-report -->';
-
-            // Flag growth above ~256 KiB or 2%, whichever is more forgiving for small binaries.
-            const thresholdBytes = 256 * 1024;
-            const thresholdPercent = 2;
-
-            const fmtMB = (bytes) => (bytes / 1024 / 1024).toFixed(2) + ' MB';
-            const fmtDeltaKB = (bytes) => (bytes >= 0 ? '+' : '') + (bytes / 1024).toFixed(1) + ' KB';
-            const fmtPercent = (p) => (p >= 0 ? '+' : '') + p + '%';
-
-            const reportsDir = 'reports';
-            const files = fs.existsSync(reportsDir)
-              ? fs.readdirSync(reportsDir).filter((f) => f.endsWith('.json')).sort()
-              : [];
-
-            if (files.length === 0) {
-              core.setFailed('No size reports were produced by the build job.');
-              return;
-            }
-
-            const reports = files.map((f) => JSON.parse(fs.readFileSync(path.join(reportsDir, f), 'utf8')));
-
-            let anyFlagged = false;
-            let anyShrank = false;
-            const rows = reports.map((r) => {
-              const flagged = r.delta > 0 && (r.delta > thresholdBytes || r.percent > thresholdPercent);
-              if (flagged) anyFlagged = true;
-              if (r.delta < 0) anyShrank = true;
-              const mark = flagged ? ' ⚠️' : '';
-              return `| ${r.goos} | ${fmtMB(r.baseline_size)} | ${fmtMB(r.pr_size)} | ${fmtDeltaKB(r.delta)} (${fmtPercent(r.percent)})${mark} |`;
-            });
-
-            let callout = '✅ No significant size change on any platform.';
-            if (anyFlagged) {
-              callout = `⚠️ **Binary size grew by more than the ${thresholdPercent}% / 256 KiB threshold on at least one platform.** If this PR doesn't add a feature that justifies it, double-check for a new or heavier dependency.`;
-            } else if (anyShrank) {
-              callout = '🎉 Binary size shrank on at least one platform.';
-            }
-
-            const body = [
-              marker,
-              '### 📦 Release binary size report',
-              '',
-              'Compares this PR\'s release-equivalent build against the latest published release, per OS (amd64).',
-              '',
-              '| OS | Baseline | This PR | Delta |',
-              '|---|---|---|---|',
-              ...rows,
-              '',
-              callout,
-            ].join('\n');
-
-            const { repo: { owner, repo } } = context;
-            const issue_number = context.payload.pull_request.number;
-
-            const comments = await github.rest.issues.listComments({ owner, repo, issue_number });
-            const existing = comments.data.find((c) => c.body && c.body.includes(marker));
-
-            if (existing) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-            } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number, body });
-            }
+          name: pr-number
+          retention-days: 1
+          path: pr-number.txt

--- a/.github/workflows/binary_size_report.yml
+++ b/.github/workflows/binary_size_report.yml
@@ -1,0 +1,123 @@
+on:
+  workflow_run:
+    workflows: ["Binary Size Check"]
+    types: [completed]
+
+name: Binary Size Report
+
+permissions:
+  actions: read
+  pull-requests: write
+
+jobs:
+  report:
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download reports 📥
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          pattern: '*'
+          path: reports
+          merge-multiple: true
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Report size deltas 💬
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const marker = '<!-- binary-size-report -->';
+
+            // Flag growth above ~256 KiB or 2%, whichever is more forgiving for small binaries.
+            const thresholdBytes = 256 * 1024;
+            const thresholdPercent = 2;
+
+            const fmtMB = (bytes) => (bytes / 1024 / 1024).toFixed(2) + ' MB';
+            const fmtDeltaKB = (bytes) => (bytes >= 0 ? '+' : '') + (bytes / 1024).toFixed(1) + ' KB';
+            const fmtPercent = (p) => (p >= 0 ? '+' : '') + p + '%';
+
+            const issue_number = parseInt(fs.readFileSync('reports/pr-number.txt', 'utf8').trim(), 10);
+            if (!Number.isInteger(issue_number) || issue_number <= 0) {
+              core.setFailed('Invalid PR number in artifact.');
+              return;
+            }
+
+            const { repo: { owner, repo } } = context;
+
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: issue_number });
+            if (pr.head.sha !== context.payload.workflow_run.head_sha) {
+              core.setFailed('PR head SHA does not match triggering workflow run.');
+              return;
+            }
+
+            const reportsDir = 'reports';
+            const files = fs.existsSync(reportsDir)
+              ? fs.readdirSync(reportsDir).filter((f) => f.endsWith('.json')).sort()
+              : [];
+
+            if (files.length === 0) {
+              core.setFailed('No size reports were produced by the build job.');
+              return;
+            }
+
+            const allowedGoos = ['darwin', 'linux', 'windows'];
+
+            const reports = files
+              .map((f) => JSON.parse(fs.readFileSync(path.join(reportsDir, f), 'utf8')))
+              .filter((r) => allowedGoos.includes(r.goos))
+              .map((r) => ({
+                goos: r.goos,
+                pr_size: Number(r.pr_size),
+                baseline_size: Number(r.baseline_size),
+                delta: Number(r.delta),
+                percent: Number(r.percent),
+              }))
+              .filter((r) => [r.pr_size, r.baseline_size, r.delta, r.percent].every(Number.isFinite));
+
+            if (reports.length === 0) {
+              core.setFailed('No valid size reports were produced by the build job.');
+              return;
+            }
+
+            let anyFlagged = false;
+            let anyShrank = false;
+            const rows = reports.map((r) => {
+              const flagged = r.delta > 0 && (r.delta > thresholdBytes || r.percent > thresholdPercent);
+              if (flagged) anyFlagged = true;
+              if (r.delta < 0) anyShrank = true;
+              const mark = flagged ? ' ⚠️' : '';
+              return `| ${r.goos} | ${fmtMB(r.baseline_size)} | ${fmtMB(r.pr_size)} | ${fmtDeltaKB(r.delta)} (${fmtPercent(r.percent)})${mark} |`;
+            });
+
+            let callout = '✅ No significant size change on any platform.';
+            if (anyFlagged) {
+              callout = `⚠️ **Binary size grew by more than the ${thresholdPercent}% / 256 KiB threshold on at least one platform.** If this PR doesn't add a feature that justifies it, double-check for a new or heavier dependency.`;
+            } else if (anyShrank) {
+              callout = '🎉 Binary size shrank on at least one platform.';
+            }
+
+            const body = [
+              marker,
+              '### 📦 Release binary size report',
+              '',
+              'Compares this PR\'s release-equivalent build against the latest published release, per OS (amd64).',
+              '',
+              '| OS | Baseline | This PR | Delta |',
+              '|---|---|---|---|',
+              ...rows,
+              '',
+              callout,
+            ].join('\n');
+
+            const comments = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const existing = comments.data.find((c) => c.body && c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }


### PR DESCRIPTION
The binary size check fails on every fork PR ([example](https://github.com/JanDeDobbeleer/oh-my-posh/actions/runs/30618502868/job/91117349506?pr=7737)): the `pull_request` event gives fork runs a read-only `GITHUB_TOKEN`, so posting the size comment dies with `403 Resource not accessible by integration`.

This splits the workflow using the standard `workflow_run` pattern:

- **Binary Size Check** (`pull_request`) now only builds and uploads the size-report artifacts, plus the PR number. Its token drops to `contents: read`.
- **Binary Size Report** (new, `workflow_run`) runs in base-repo context with `pull-requests: write`, downloads the artifacts from the triggering run, and posts or updates the comment.

Since the PR-number artifact is produced in fork context it is untrusted: the report validates it is a positive integer, fetches the PR, and requires its head SHA to match the triggering run's `head_sha` before commenting. Numeric report fields are coerced and filtered, and `goos` is restricted to the known set, so no fork-controlled string reaches the comment body. Thresholds and comment wording are unchanged.

Note: `workflow_run` workflows execute from the default branch, so the comment flow only activates after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)