### PR TITLE
fix(studio): use configurator nonce fragment

### DIFF
--- a/website/src/components/Studio/configuratorHandoff.mjs
+++ b/website/src/components/Studio/configuratorHandoff.mjs
@@ -5,6 +5,7 @@ const MESSAGE_VERSION = 1;
 const READY_MESSAGE_TYPE = 'omp-configurator-ready';
 const CONFIG_MESSAGE_TYPE = 'omp-studio-config';
 const NONCE_BYTES = 32;
+const NONCE_FRAGMENT_KEY = 'omp-configurator-nonce';
 
 export function generateNonce(crypto = globalThis.crypto) {
   if (!crypto || typeof crypto.getRandomValues !== 'function') {
@@ -20,7 +21,7 @@ export function generateNonce(crypto = globalThis.crypto) {
 export function createConfiguratorHandoff(format, text, crypto) {
   const nonce = generateNonce(crypto);
   const url = new URL(CONFIGURATOR_URL);
-  url.hash = `nonce=${encodeURIComponent(nonce)}`;
+  url.hash = `${NONCE_FRAGMENT_KEY}=${encodeURIComponent(nonce)}`;
 
   return { nonce, format, text, url: url.toString() };
 }

--- a/website/src/components/Studio/configuratorHandoff.test.mjs
+++ b/website/src/components/Studio/configuratorHandoff.test.mjs
@@ -8,7 +8,7 @@ import {
 } from './configuratorHandoff.mjs';
 
 describe('Configurator handoff', () => {
-  it('creates a config-free URL with a cryptographically random fragment nonce', () => {
+  it('uses the Configurator nonce fragment with no config data in the URL', () => {
     const handoff = createConfiguratorHandoff('yaml', 'version: 4', {
       getRandomValues(bytes) {
         bytes.fill(0xab);
@@ -17,7 +17,10 @@ describe('Configurator handoff', () => {
     });
 
     assert.equal(handoff.nonce, 'ab'.repeat(32));
-    assert.equal(handoff.url, `https://configurator.ohmyposh.dev/#nonce=${'ab'.repeat(32)}`);
+    assert.equal(
+      handoff.url,
+      `https://configurator.ohmyposh.dev/#omp-configurator-nonce=${'ab'.repeat(32)}`,
+    );
     assert.equal(handoff.url.includes('version'), false);
   });
 


### PR DESCRIPTION
## Why
Studio is a producer in the Studio-to-Configurator handoff protocol. Configurator’s canonical fragment key is `omp-configurator-nonce`; emitting the older generic `nonce` key made Studio rely on a compatibility parser alias rather than the contract. This change keeps the producer aligned with the canonical key without changing any Configurator receiver aliases.

## How the handoff works
Studio generates a cryptographically random nonce and opens Configurator at `#omp-configurator-nonce=<nonce>`. Configurator reads that fragment, then signals readiness with the same nonce. Studio accepts the signal only when the origin, popup window, message version, and nonce all match, and then delivers the configuration using `postMessage` targeted exclusively to the Configurator origin. The configuration itself remains out of the URL.

## Validation
- `cd website && npm test`
- `cd website && npm run build`