### PR TITLE
fix(prompt): apply shell integration marks to the transient prompt

### DIFF
--- a/src/prompt/extra.go
+++ b/src/prompt/extra.go
@@ -66,10 +66,14 @@ func (e *Engine) ExtraPrompt(promptType ExtraPromptType) string {
 		promptText = fmt.Sprintf("%s%s", e.getNewline(), promptText)
 	}
 
+	// Transient isn't rendered by the block engine, so unlike the primary
+	// prompt these marks can't go through e.write/e.string - append them to
+	// str directly instead.
+	var shellIntegrationStart, shellIntegrationEnd string
 	if promptType == Transient && e.Config.ShellIntegration {
 		exitCode, _ := e.Env.StatusCodes()
-		e.write(terminal.CommandFinished(exitCode, e.Env.Flags().NoExitCode))
-		e.write(terminal.PromptStart())
+		shellIntegrationStart = terminal.CommandFinished(exitCode, e.Env.Flags().NoExitCode) + terminal.PromptStart()
+		shellIntegrationEnd = terminal.CommandStart()
 	}
 
 	foreground := color.Ansi(prompt.ForegroundTemplates.FirstMatch(nil, string(prompt.Foreground)))
@@ -78,6 +82,7 @@ func (e *Engine) ExtraPrompt(promptType ExtraPromptType) string {
 	terminal.Write(background, foreground, promptText)
 
 	str, length := terminal.String()
+	str = shellIntegrationStart + str
 
 	if promptType == Secondary && e.Env.Shell() == shell.ZSH && e.Env.Flags().Eval {
 		evalOutput := fmt.Sprintf("_omp_secondary_prompt=%s", shell.QuotePosixStr(str))
@@ -108,15 +113,15 @@ func (e *Engine) ExtraPrompt(promptType ExtraPromptType) string {
 	switch e.Env.Shell() {
 	case shell.ZSH:
 		if !e.Env.Flags().Eval {
-			return str
+			return str + shellIntegrationEnd
 		}
 
-		return e.transientZSH(str, rightStr)
+		return e.transientZSH(str+shellIntegrationEnd, rightStr)
 	case shell.PWSH:
-		return e.transientPWSH(str, padText, rightStr, length, rightLength)
+		return e.transientPWSH(str, padText, rightStr, length, rightLength) + shellIntegrationEnd
 	}
 
-	return str
+	return str + shellIntegrationEnd
 }
 
 // transientZSH returns the transient prompt as an eval statement setting

--- a/src/prompt/extra_test.go
+++ b/src/prompt/extra_test.go
@@ -303,6 +303,56 @@ func TestExtraPromptTransientFish(t *testing.T) {
 	}
 }
 
+func TestExtraPromptTransientShellIntegration(t *testing.T) {
+	cases := []struct {
+		Case  string
+		Shell string
+		Eval  bool
+	}{
+		{Case: "pwsh", Shell: shell.PWSH},
+		{Case: "zsh, eval", Shell: shell.ZSH, Eval: true},
+		{Case: "zsh, no eval", Shell: shell.ZSH},
+		{Case: "fish", Shell: shell.FISH},
+	}
+
+	for _, tc := range cases {
+		env := setupExtraPromptTest(t, tc.Shell, &runtime.Flags{Eval: tc.Eval})
+		env.On("TerminalWidth").Return(0, nil)
+		env.On("StatusCodes").Return(3, "3")
+
+		engine := &Engine{
+			Config: &config.Config{
+				ShellIntegration: true,
+				TransientPrompt: &config.Segment{
+					Template: "L>",
+				},
+			},
+			Env: env,
+		}
+
+		got := engine.ExtraPrompt(Transient)
+
+		start := terminal.CommandFinished(3, false) + terminal.PromptStart()
+		end := terminal.CommandStart()
+
+		// zsh in eval mode wraps the marked-up string in a PS1=$'...' assignment
+		// instead of returning it as-is; unwrap that before checking the marks.
+		if tc.Shell == shell.ZSH && tc.Eval {
+			body, ok := strings.CutPrefix(got, "PS1=$'")
+			assert.True(t, ok, "%s: expected PS1=$'...' prefix, got %q", tc.Case, got)
+			got, ok = strings.CutSuffix(body, "'\nRPROMPT=''")
+			assert.True(t, ok, "%s: expected \\nRPROMPT='' suffix, got %q", tc.Case, body)
+		}
+
+		assert.True(t, strings.HasPrefix(got, start), "%s: expected prefix %q, got %q", tc.Case, start, got)
+		assert.True(t, strings.HasSuffix(got, end), "%s: expected suffix %q, got %q", tc.Case, end, got)
+
+		// the rendered template text must still be present, untouched, between the marks
+		middle := strings.TrimSuffix(strings.TrimPrefix(got, start), end)
+		assert.Contains(t, middle, "L>", tc.Case)
+	}
+}
+
 func TestTransientRPromptTemplateError(t *testing.T) {
 	env := setupExtraPromptTest(t, shell.FISH, &runtime.Flags{})
 	engine := &Engine{


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

shell_integration wrapped the primary prompt with FinalTerm OSC 133 marks (CommandFinished/PromptStart before, CommandStart after) but not the transient prompt, breaking scrollback/jump-to-prompt for anyone using both features together.

The transient path already had a stub for this (e.write of CommandFinished/PromptStart), but e.write appends to the engine's own prompt builder, which transient rendering never flushes - it returns through terminal.String() instead, so the marks were silently discarded. Thread the marks through the returned string directly, and add CommandStart after the fully rendered (and, for pwsh, right- padded) prompt.

Fixes #7750