### PR TITLE
fix(runtime): honor COLUMNS fallback without a TTY

### DIFF
--- a/.agents/skills/project-knowledge/references/terminal.md
+++ b/.agents/skills/project-knowledge/references/terminal.md
@@ -28,3 +28,10 @@
 - On Windows there is no SIGPIPE; child lifecycle management must rely on fd closure / stdin EOF.
 - On native Linux, process spawns cost 11-16ms - daemon architectures that pay off on Windows can
   be a wash there (see the bash serve revert in [bash](bash.md)).
+
+## Statusline width detection
+
+- On Unix, `terminal-dimensions` runs `stty size` against the renderer's stdin. Claude Code sends
+  statusline JSON over that stdin, so it is not a TTY. A valid `COLUMNS` fallback must replace the
+  resulting `stty` error; returning a non-zero width with the stale error makes
+  `prompt.Engine.canWriteRightBlock` reject ordinary right-aligned blocks (verified 2026-08-03).

--- a/src/runtime/terminal_unix.go
+++ b/src/runtime/terminal_unix.go
@@ -3,6 +3,7 @@
 package runtime
 
 import (
+	"errors"
 	"strconv"
 	"strings"
 	"time"
@@ -62,24 +63,34 @@ func (term *Terminal) TerminalWidth() (int, error) {
 	}
 
 	width, err := terminal.Width()
-	if err != nil {
-		log.Error(err)
+	if width == 0 {
+		width, err = resolveTerminalWidth(width, err, term.Getenv("COLUMNS"))
 	}
 
-	// fetch width from the environment variable
-	// in case the terminal width is not available
-	if width == 0 {
-		i, err := strconv.Atoi(term.Getenv("COLUMNS"))
-		if err != nil {
-			log.Error(err)
-		}
-		width = uint(i)
+	if err != nil {
+		log.Error(err)
 	}
 
 	term.CmdFlags.TerminalWidth = int(width)
 	log.Debugf("terminal width: %d", term.CmdFlags.TerminalWidth)
 
 	return term.CmdFlags.TerminalWidth, err
+}
+
+func resolveTerminalWidth(width uint, terminalErr error, columns string) (uint, error) {
+	if width != 0 {
+		return width, terminalErr
+	}
+
+	columnWidth, err := strconv.Atoi(columns)
+	if err != nil {
+		return 0, errors.Join(terminalErr, err)
+	}
+	if columnWidth <= 0 {
+		return 0, errors.Join(terminalErr, errors.New("terminal width must be greater than zero"))
+	}
+
+	return uint(columnWidth), nil
 }
 
 func (term *Terminal) Platform() string {

--- a/src/runtime/terminal_unix_test.go
+++ b/src/runtime/terminal_unix_test.go
@@ -3,6 +3,7 @@
 package runtime
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -61,6 +62,63 @@ func TestMemoryPercentageCalculation(t *testing.T) {
 			}
 
 			assert.InDelta(t, tc.ExpectedPercent, percentUsed, 0.01, tc.Name)
+		})
+	}
+}
+
+func TestResolveTerminalWidth(t *testing.T) {
+	terminalErr := errors.New("not a tty")
+	cases := []struct {
+		TerminalError   error
+		Name            string
+		Columns         string
+		TerminalWidth   uint
+		ExpectedWidth   uint
+		ExpectedToError bool
+	}{
+		{
+			Name:          "terminal width is available",
+			Columns:       "120",
+			TerminalWidth: 80,
+			ExpectedWidth: 80,
+		},
+		{
+			Name:          "COLUMNS replaces terminal error",
+			Columns:       "120",
+			TerminalError: terminalErr,
+			ExpectedWidth: 120,
+		},
+		{
+			Name:            "terminal and COLUMNS both fail",
+			Columns:         "invalid",
+			TerminalError:   terminalErr,
+			ExpectedToError: true,
+		},
+		{
+			Name:            "zero COLUMNS is invalid",
+			Columns:         "0",
+			TerminalError:   terminalErr,
+			ExpectedToError: true,
+		},
+		{
+			Name:            "negative COLUMNS is invalid",
+			Columns:         "-1",
+			TerminalError:   terminalErr,
+			ExpectedToError: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			width, err := resolveTerminalWidth(tc.TerminalWidth, tc.TerminalError, tc.Columns)
+
+			assert.Equal(t, tc.ExpectedWidth, width)
+			if tc.ExpectedToError {
+				assert.Error(t, err)
+				assert.ErrorIs(t, err, terminalErr)
+				return
+			}
+			assert.NoError(t, err)
 		})
 	}
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Fixes #7759.

Unix statusline renderers can receive their payload over stdin, so `stty size` cannot always read terminal dimensions. A valid `COLUMNS` fallback already supplies the width, but the previous code returned that width together with the stale terminal-probe error. Right-block rendering treats any terminal-width error as fatal and omitted `alignment: right` blocks.

This change makes successful positive `COLUMNS` parsing replace the failed probe, preserves both errors when neither width source succeeds, and adds table-driven regression coverage for valid, non-numeric, zero, and negative values.

Validation:

- `go test ./runtime -run '^TestResolveTerminalWidth$' -count=1`
- `go test ./runtime ./prompt ./cli -count=1`
- `go test ./...`
- `GOOS=windows GOARCH=amd64 go build ./...`
- `modernize --fix "./..."`
- `fieldalignment --fix "./..."`
- `go mod tidy`
- `gofmt -w .`
- `golangci-lint run`
- `git diff --check`

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
