### PR TITLE
fix(blog): fix link formatting for Configurator app

### DIFF
--- a/website/blog/2026-08-03-studio-native-git-and-a-leaner-binary.md
+++ b/website/blog/2026-08-03-studio-native-git-and-a-leaner-binary.md
@@ -37,8 +37,8 @@ type. Config editing changes from "look up the docs, guess the property name, re
 into something closer to writing code with a linter looking over your shoulder.
 
 If you're looking for a more drag and drop experience, **Open in Configurator** hands your config
-straight off to the full Configurator app. Shout out to [James Montemagno] for maintaining that
-awesome tool!
+straight off to the full [Configurator app](https://configurator.ohmyposh.dev/).
+Shout out to [James Montemagno] for maintaining that awesome tool!
 
 Studio and the Configurator aren't a linear path where one replaces the other. They're two
 different ways of working, and now you can move between them freely. If you want a fast,


### PR DESCRIPTION
Updated link formatting for Configurator app reference.

### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

<!---

Tips:

If you're not comfortable with working with Git,
we're working on a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D)
as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
