### PR TITLE
fix(status): reset .Executed per prompt in cmd, bash and nushell

### DIFF
--- a/src/shell/scripts/omp.bash
+++ b/src/shell/scripts/omp.bash
@@ -162,6 +162,7 @@ function _omp_hook() {
     _omp_job_count=${#_omp_jobs[@]}
 
     _omp_execution_time=-1
+    _omp_no_status=true
     if [[ $_omp_start_time ]]; then
         local omp_now=$(_omp_milliseconds)
         _omp_execution_time=$((omp_now - _omp_start_time))

--- a/src/shell/scripts/omp.lua
+++ b/src/shell/scripts/omp.lua
@@ -376,9 +376,7 @@ local function url_encode(str)
 end
 
 local function command_executed_mark(input)
-    if string.gsub(input, '^%s*(.-)%s*$', '%1') ~= '' then
-        no_exit_code = false
-    end
+    no_exit_code = string.gsub(input, '^%s*(.-)%s*$', '%1') == ''
 
     if not ftcs_marks_enabled then
         return

--- a/src/shell/scripts/omp.nu
+++ b/src/shell/scripts/omp.nu
@@ -35,13 +35,22 @@ def --wrapped _omp_get_prompt [
         $ms => { $ms | into int }
     }
 
+    # `$env.POSH_EXECUTED` is set once per prompt cycle in `$env.PROMPT_COMMAND`, based on
+    # whether history actually grew. Falls back to the execution-time sentinel when history
+    # is disabled, which only detects a freshly started shell.
+    let no_status = if $nu.history-enabled {
+        not ($env.POSH_EXECUTED? | default false)
+    } else {
+        $execution_time < 0
+    }
+
     (
         ^$_omp_executable print $type
             --save-cache
             --shell=nu
             $"--shell-version=($env.POSH_SHELL_VERSION)"
             $"--status=($env.LAST_EXIT_CODE)"
-            $"--no-status=($execution_time < 0)"
+            $"--no-status=($no_status)"
             $"--execution-time=($execution_time)"
             $"--terminal-width=((term size).columns)"
             $"--job-count=(job list | length)"
@@ -56,15 +65,23 @@ $env.PROMPT_MULTILINE_INDICATOR = (
 )
 
 $env.PROMPT_COMMAND = {||
+    let hist = if $nu.history-enabled { history } else { [] }
+    let hist_len = ($hist | length)
+
     # hack: sets cursor line to 1 on clear; not bulletproof, just a start
     let clear = $nu.history-enabled and (
-        (history | is-empty)
-        or (history | last | get command?) == "clear"
+        ($hist | is-empty)
+        or ($hist | last | get command?) == "clear"
     )
 
     if ($env.SET_POSHCONTEXT? | is-not-empty) {
         do --env $env.SET_POSHCONTEXT
     }
+
+    # a command was executed this prompt cycle only if history actually grew;
+    # an empty Enter (or history disabled) leaves the length unchanged
+    $env.POSH_EXECUTED = ($nu.history-enabled and ($hist_len > ($env.POSH_LAST_HISTORY_LEN? | default 0)))
+    $env.POSH_LAST_HISTORY_LEN = $hist_len
 
     _omp_get_prompt primary $"--cleared=($clear)"
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

Fixes #7757.

The docs promise that the global `.Executed` template property (used to hide segments like `status` on a fresh prompt) goes `false` both "when the shell just started" **and** "when enter was pressed without a command". Only pwsh, zsh and fish implement the second half — clink (cmd), bash (Git Bash) and nushell only ever latch it `true` on the first real command and never reset it, so `.Executed` stays stuck "true" for the rest of the session in those shells.

The Go-side plumbing (`--no-status` → `template.Executed`) is unaffected and identical for every shell; this is purely a per-shell init-script fix, each brought in line with how `pwsh`/`zsh`/`fish` already re-evaluate the flag every prompt cycle:

- **clink** (`src/shell/scripts/omp.lua`): `command_executed_mark` now derives `no_exit_code` from whether the current input line is empty, instead of only ever clearing it once.
- **bash** (`src/shell/scripts/omp.bash`): `_omp_hook` resets `_omp_no_status=true` before checking whether `PS0` recorded a command start, mirroring the existing zsh `precmd` hook.
- **nushell** (`src/shell/scripts/omp.nu`): `--no-status` is now derived from whether `history` actually grew during the current prompt cycle (stored in `$env.POSH_EXECUTED`/`$env.POSH_LAST_HISTORY_LEN`), instead of the one-shot `CMD_DURATION_MS` startup sentinel which can only ever detect "shell just started" and never resets after the first command. Falls back to the old sentinel-only behavior when history is disabled.

No Go code was touched. `go build ./...` and `go test ./shell/...` pass; `bash -n` validates the updated bash script syntax.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary

---
_Generated by [Claude Code](https://claude.ai/code/session_018AhjcGCfxm2mFCfZhehLhv)_