### PR TITLE
Fix cache Get to handle gob pointer-registered types

### DIFF
--- a/src/cache/store.go
+++ b/src/cache/store.go
@@ -212,6 +212,16 @@ func Get[T any](s Store, key string) (T, bool) {
 		return typed, true
 	}
 
+	// gob.Register keys its decode-side type map on the exact type it was given,
+	// while encoding an interface value uses the base type. Registering a type
+	// as a pointer (see segment_registry.go) therefore makes every gob round-trip
+	// of a value stored under that type come back as *T instead of T. Accept that
+	// shape here rather than dropping it as a cache miss.
+	if ptr, ok := entry.Value.(*T); ok && ptr != nil {
+		log.Debugf("(%s) found entry: %s - %v", string(s), key, *ptr)
+		return *ptr, true
+	}
+
 	log.Error(fmt.Errorf("(%s) type mismatch for key: %s. Got %T, expected %T", string(s), key, entry.Value, zero))
 	return zero, false
 }

--- a/src/cache/store_test.go
+++ b/src/cache/store_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"encoding/gob"
 	"os"
 	"path/filepath"
 	"strings"
@@ -119,4 +120,47 @@ func TestStoreCloseTouchesSessionFileMTime(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, info.ModTime().Before(before), "mtime should be bumped to the close time, not left stale")
 	assert.WithinDuration(t, time.Now(), info.ModTime(), time.Minute)
+}
+
+type storeGobPointerType struct {
+	Name string
+}
+
+// Guards against #7766: gob.Register keys its decode-side type map on the
+// exact type registered, while encoding an interface value uses the base
+// type. Registering a type as a pointer (as segment_registry.go does for
+// segments.Version, ClaudeData and CopilotCLIData) means a value stored
+// under that type comes back as *T, not T, on the next process's gob decode
+// of the on-disk device cache. Get[T] must still return a hit in that case,
+// otherwise cache_duration silently never survives a process restart.
+func TestGetSurvivesGobPointerRegistration(t *testing.T) {
+	gob.Register(&storeGobPointerType{})
+
+	origDevice := device
+	origCachePath := cachePath
+	t.Cleanup(func() {
+		device = origDevice
+		cachePath = origCachePath
+	})
+
+	cachePath = t.TempDir()
+	const fileName = "device.cache"
+
+	// First process: set the value and persist it to disk.
+	writer := Device.new()
+	writer.filePath = filepath.Join(cachePath, fileName)
+	writer.persist = true
+	device = writer
+
+	Set(Device, "test_key", storeGobPointerType{Name: "value"}, Duration("1h"))
+	Device.close()
+
+	// Second process: fresh store, loaded from disk. This is the gob decode
+	// that flips the interface-typed value from T to *T.
+	device = nil
+	Device.init(fileName, true)
+
+	got, ok := Get[storeGobPointerType](Device, "test_key")
+	require.True(t, ok, "expected a cache hit after a gob round-trip of a pointer-registered type")
+	assert.Equal(t, "value", got.Name)
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the contributing guide.
- [x] The commit message follows the conventional commits guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).

### Description

Fixes an issue where cached values would be lost after a process restart when the type was registered with `gob.Register()` as a pointer (e.g., `gob.Register(&MyType{})`).

**Root Cause:**
When a type is registered with gob as a pointer, the gob decoder uses the pointer type as the key in its type map. However, when encoding an interface value, gob uses the base type. This mismatch causes values to be decoded as `*T` instead of `T` on subsequent process loads, resulting in silent cache misses.

**Solution:**
Modified the `Get[T]()` function in `store.go` to handle this edge case by checking if the cached value is a pointer to the expected type. If it is, dereference it and return the value. This allows cache hits to survive gob round-trips even when types are pointer-registered.

**Changes:**
- Updated `Get[T]()` in `src/cache/store.go` to accept pointer-typed values when the expected type is registered as a pointer
- Added `TestGetSurvivesGobPointerRegistration()` in `src/cache/store_test.go` to verify the fix works correctly across process boundaries

This ensures that cache entries like `cache_duration` survive process restarts regardless of how their types are registered with gob.

https://claude.ai/code/session_01VkRSU4Rrpa5TCYNFAk1jva