### PR TITLE
ci(website): validate docs build in pull requests

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,11 @@
 name: Azure Static Web Apps CI/CD
 
 on:
+  pull_request:
+    paths:
+      - "website/**"
+      - "themes/**"
+      - ".github/workflows/docs.yml"
   push:
     branches:
       - main
@@ -56,6 +61,7 @@ jobs:
           cp themes/schema.json website/api/data/schema.json
           echo "✅ Copied schema.json to website/api/data/"
       - name: Build Docs And Deploy 🚀
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         id: builddeploy
         uses: Azure/static-web-apps-deploy@1a947af9992250f3bc2e68ad0754c0b0c11566c9
         with:

--- a/website/docs/configuration/general.mdx
+++ b/website/docs/configuration/general.mdx
@@ -255,7 +255,7 @@ Converters won't catch this change, so you will need to adjust manually.
 [colors]: /docs/configuration/colors
 [accent]: /docs/configuration/colors#standard-colors
 [templates]: /docs/configuration/templates#config-variables
-[vimode]: /docs/segments/vimode
+[vimode]: /docs/segments/system/vimode
 [pwsh-bleed]: https://github.com/PowerShell/PowerShell/pull/19019
 [iterm2-si]: https://iterm2.com/documentation-shell-integration.html
 [Upgrade]: /docs/installation/upgrade


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Fixes the broken Vi mode segment link that caused the website deploy build to fail on main, then adds a PR-only website validation workflow so Docusaurus broken-link errors are caught before merge. The new workflow mirrors the deploy prerequisites by building oh-my-posh, generating website artifacts, copying the schema for the API validator, and running `npm run build` for PRs that touch website or theme files.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary