### PR TITLE
fix(pwsh): keep tooltip restore redraw in UTF-8

### DIFF
--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -1116,13 +1116,13 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
                 $previousOutputEncoding = [Console]::OutputEncoding
                 try {
                     [Console]::OutputEncoding = [Text.Encoding]::UTF8
+                    [Microsoft.PowerShell.PSConsoleReadLine]::InvokePrompt()
                 }
                 catch [System.ArgumentOutOfRangeException] {
                 }
                 finally {
                     [Console]::OutputEncoding = $previousOutputEncoding
                 }
-                [Microsoft.PowerShell.PSConsoleReadLine]::InvokePrompt()
                 return
             }
 


### PR DESCRIPTION
### Prerequisites

- [ ] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

The PowerShell tooltip Backspace handler temporarily switched the console output encoding to UTF-8, but restored the previous encoding before asking PSReadLine to redraw the prompt. On non-UTF-8 Windows console codepages, that redraw could replace prompt glyphs with `?`.

This keeps `InvokePrompt()` inside the UTF-8 guard, matching the other PowerShell prompt repaint paths, so tooltip restore redraws preserve Nerd Font and powerline glyphs.

Fixes #7776

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary