### PR TITLE
fix(segment): render detected empty batteries

### DIFF
--- a/src/segments/battery.go
+++ b/src/segments/battery.go
@@ -37,11 +37,6 @@ func (b *Battery) Enabled() bool {
 
 	b.Info = *info
 
-	// case on computer without batteries(no error, empty array)
-	if err == nil && b.Percentage == 0 {
-		return false
-	}
-
 	switch b.State {
 	case battery.Discharging:
 		b.Icon = b.options.String(DischargingIcon, "")

--- a/src/segments/battery_test.go
+++ b/src/segments/battery_test.go
@@ -1,0 +1,25 @@
+package segments
+
+import (
+	"testing"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/battery"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBatteryEnabledAtZeroPercent(t *testing.T) {
+	env := new(mock.Environment)
+	env.On("IsWsl").Return(false)
+	env.On("BatteryState").Return(&battery.Info{
+		Percentage: 0,
+		State:      battery.NotCharging,
+	}, nil)
+
+	segment := &Battery{}
+	segment.Init(options.Map{}, env)
+
+	assert.True(t, segment.Enabled())
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

A valid battery at 0% is currently disabled before the battery segment can render.

Remove the percentage-based no-battery check so a successfully retrieved empty battery renders as `0%`. `NoBatteryError` continues to handle computers without a battery.

Adds a regression test for a `NotCharging` battery at 0%.

Fixes #7782

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary