### PR TITLE
fix(battery): render a detected battery at 0% instead of disabling the segment

### DIFF
--- a/src/segments/battery.go
+++ b/src/segments/battery.go
@@ -35,11 +35,8 @@ func (b *Battery) Enabled() bool {
 		return false
 	}
 
-	b.Info = *info
-
-	// case on computer without batteries(no error, empty array)
-	if err == nil && b.Percentage == 0 {
-		return false
+	if info != nil {
+		b.Info = *info
 	}
 
 	switch b.State {

--- a/src/segments/battery_test.go
+++ b/src/segments/battery_test.go
@@ -13,12 +13,12 @@ import (
 
 func TestBatteryEnabled(t *testing.T) {
 	cases := []struct {
-		Case            string
 		Info            *battery.Info
 		Error           error
+		Case            string
+		Expected        string
 		DisplayError    bool
 		ExpectedEnabled bool
-		Expected        string
 	}{
 		{
 			Case:            "detected battery at 0%",

--- a/src/segments/battery_test.go
+++ b/src/segments/battery_test.go
@@ -1,0 +1,83 @@
+package segments
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/battery"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBatteryEnabled(t *testing.T) {
+	cases := []struct {
+		Case            string
+		Info            *battery.Info
+		Error           error
+		DisplayError    bool
+		ExpectedEnabled bool
+		Expected        string
+	}{
+		{
+			Case:            "detected battery at 0%",
+			Info:            &battery.Info{Percentage: 0, State: battery.NotCharging},
+			ExpectedEnabled: true,
+			Expected:        "0",
+		},
+		{
+			Case:            "discharging",
+			Info:            &battery.Info{Percentage: 42, State: battery.Discharging},
+			ExpectedEnabled: true,
+			Expected:        "42",
+		},
+		{
+			Case:            "full",
+			Info:            &battery.Info{Percentage: 100, State: battery.Full},
+			ExpectedEnabled: true,
+			Expected:        "100",
+		},
+		{
+			Case:            "no battery present",
+			Info:            nil,
+			Error:           &battery.NoBatteryError{},
+			ExpectedEnabled: false,
+		},
+		{
+			Case:            "retrieval error, display_error disabled",
+			Info:            nil,
+			Error:           errors.New("boom"),
+			ExpectedEnabled: false,
+		},
+		{
+			Case:            "retrieval error, display_error enabled",
+			Info:            nil,
+			Error:           errors.New("boom"),
+			DisplayError:    true,
+			ExpectedEnabled: true,
+			Expected:        "boom",
+		},
+	}
+
+	for _, tc := range cases {
+		env := new(mock.Environment)
+		env.On("IsWsl").Return(false)
+		env.On("BatteryState").Return(tc.Info, tc.Error)
+
+		props := options.Map{}
+		if tc.DisplayError {
+			props[options.DisplayError] = true
+		}
+
+		b := &Battery{}
+		b.Init(props, env)
+
+		got := b.Enabled()
+
+		assert.Equal(t, tc.ExpectedEnabled, got, tc.Case)
+		if tc.ExpectedEnabled {
+			assert.Equal(t, tc.Expected, renderTemplate(env, b.Template(), b), tc.Case)
+		}
+	}
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features). — not applicable, this restores existing documented behavior; no options/docs changed.

### Description

Fixes #7782.

`Battery.Enabled()` disabled the segment whenever `err == nil && b.Percentage == 0`, treating a computed 0% reading as a "no battery" sentinel. That's wrong: every platform backend (`battery_linux.go`, `battery_windows.go`, `battery_darwin.go`) already signals "no battery" through a dedicated error (`NoBatteryError` / `ErrNotFound`) *before* this check is reached. By the time `err == nil`, a real battery was found, and `Percentage == 0` is legitimate data — e.g. a battery reporting `capacity: 0`, `status: Not charging` — that should render as `0%`, not be hidden.

While adding regression tests I also found and fixed a related nil-pointer panic in the same function: on the `display_error: true` path, `BatteryState()` returns `(nil, err)` for any error other than `NoBatteryError`, but `Enabled()` unconditionally did `b.Info = *info`, dereferencing that nil pointer. Guarded it with an `info != nil` check.

Added `TestBatteryEnabled` covering: a detected 0% battery renders, discharging/full render normally, no battery present disables the segment, a retrieval error is hidden by default, and a retrieval error renders (without crashing) when `display_error` is enabled.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary

---
_Generated by [Claude Code](https://claude.ai/code/session_01ESQgPhy7NYZKy1W7gehiKh)_