### PR TITLE
docs(battery): correct not_charging_icon description

### DIFF
--- a/website/docs/segments/system/battery.mdx
+++ b/website/docs/segments/system/battery.mdx
@@ -46,7 +46,7 @@ import Config from "@site/src/components/Config.js";
 | `charging_icon`     | `string`  |         | icon to display when charging                                           |
 | `discharging_icon`  | `string`  |         | icon to display when discharging                                        |
 | `charged_icon`      | `string`  |         | icon to display when fully charged                                      |
-| `not_charging_icon` | `string`  |         | icon to display when fully charged                                      |
+| `not_charging_icon` | `string`  |         | icon to display when on AC power                                        |
 
 ## Template ([info][templates])
 


### PR DESCRIPTION
### Prerequisites

- [x ] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x ] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [x ] Docs have been added/updated (for bug fixes / features).

### Description
Correct the description of the `not_charging_icon` option in the battery segment documentation.

The current description incorrectly states that the icon is displayed when the battery is fully charged. It should describe the icon as being displayed when the battery is on AC power.

This change updates the documentation only and does not modify the segment behavior.
<!---

Tips:

If you're not comfortable with working with Git,
we're working on a guide (https://ohmyposh.dev/docs/contributing/git) to help you out.
Oh My Posh advises GitKraken (https://www.gitkraken.com/invite/nQmDPR9D)
as your preferred cross platform Git GUI power tool.

-->

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
