### PR TITLE
fix: handle non-ASCII characters in PowerShell paths

### DIFF
--- a/src/shell/elvish.go
+++ b/src/shell/elvish.go
@@ -2,10 +2,20 @@ package shell
 
 import (
 	_ "embed"
+	"fmt"
+	"strings"
 )
 
 //go:embed scripts/omp.elv
 var elvishInit string
+
+func quoteElvishStr(str string) string {
+	if str == "" {
+		return "''"
+	}
+
+	return fmt.Sprintf("'%s'", strings.ReplaceAll(str, "'", "''"))
+}
 
 func (f Features) Elvish() Code {
 	switch f {

--- a/src/shell/elvish_test.go
+++ b/src/shell/elvish_test.go
@@ -1,6 +1,7 @@
 package shell
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,4 +15,18 @@ $_omp_executable upgrade --auto
 $_omp_executable notice`
 
 	assert.Equal(t, want, got)
+}
+
+func TestQuoteElvishStr(t *testing.T) {
+	tests := []struct {
+		str      string
+		expected string
+	}{
+		{str: "", expected: "''"},
+		{str: `/tmp/"omp's dir"/oh-my-posh`, expected: `'/tmp/"omp''s dir"/oh-my-posh'`},
+		{str: `C:/tmp\omp's dir/oh-my-posh.exe`, expected: `'C:/tmp\omp''s dir/oh-my-posh.exe'`},
+	}
+	for _, tc := range tests {
+		assert.Equal(t, tc.expected, quoteElvishStr(tc.str), fmt.Sprintf("quoteElvishStr: %s", tc.str))
+	}
 }

--- a/src/shell/init.go
+++ b/src/shell/init.go
@@ -98,16 +98,19 @@ func recurseInitCommand(env runtime.Environment) string {
 		additionalParams += " --eval"
 	}
 
-	config := quotePwshOrElvishStr(env.Flags().ConfigPath)
-	executable = quotePwshOrElvishStr(executable)
+	config := env.Flags().ConfigPath
 
 	var command string
 
 	switch env.Flags().Shell {
 	case PWSH:
 		command = "(@(& %s init %s --config=%s --print%s) -join \"`n\") | Invoke-Expression"
+		config = quotePwshStr(config)
+		executable = quotePwshStr(executable)
 	case ELVISH:
 		command = "eval ((external %s) init %s --config=%s --print%s | slurp)"
+		config = quoteElvishStr(config)
+		executable = quoteElvishStr(executable)
 	}
 
 	return fmt.Sprintf(command, executable, env.Flags().Shell, config, additionalParams)
@@ -163,7 +166,7 @@ func generateScript(env runtime.Environment, feats Features) string {
 
 	switch env.Flags().Shell {
 	case PWSH:
-		executable = quotePwshOrElvishStr(executable)
+		executable = quotePwshStr(executable)
 		script = pwshInit
 	case ZSH:
 		executable = QuotePosixStr(executable)
@@ -182,7 +185,7 @@ func generateScript(env runtime.Environment, feats Features) string {
 		config = quoteNuStr(env.Flags().ConfigPath)
 		script = nuInit
 	case ELVISH:
-		executable = quotePwshOrElvishStr(executable)
+		executable = quoteElvishStr(executable)
 		script = elvishInit
 	case XONSH:
 		executable = quotePythonStr(executable)
@@ -241,7 +244,7 @@ func sourceCommand(env runtime.Environment, scriptPath string, async bool) strin
 
 	switch env.Flags().Shell {
 	case PWSH:
-		script += fmt.Sprintf("& %s", quotePwshOrElvishStr(scriptPath))
+		script += fmt.Sprintf("& %s", quotePwshStr(scriptPath))
 	case ZSH, BASH:
 		script += fmt.Sprintf("source %s", QuotePosixStr(scriptPath))
 	case XONSH:
@@ -252,7 +255,7 @@ func sourceCommand(env runtime.Environment, scriptPath string, async bool) strin
 		// yash has no source builtin, use the dot command instead
 		script += fmt.Sprintf(". %s", quoteYashStr(scriptPath))
 	case ELVISH:
-		script += fmt.Sprintf("eval (slurp < %s)", quotePwshOrElvishStr(scriptPath))
+		script += fmt.Sprintf("eval (slurp < %s)", quoteElvishStr(scriptPath))
 	case CMD:
 		// dofile closes the file handle when done, io.open would leak it
 		// until the Lua GC kicks in, blocking script updates on Windows
@@ -276,7 +279,7 @@ func sourceCommandAsync(shell, scriptPath string) string {
 				"$global:_ompPromptFunction = $null; "+
 				"$global:_ompInitialized = $false; "+
 				"function prompt() { if (-not $global:_ompInitialized) { $global:_ompAsyncInit = $true; & %s; return }; if ($global:_ompPromptFunction) { & $global:_ompPromptFunction } }",
-			quotePwshOrElvishStr(scriptPath),
+			quotePwshStr(scriptPath),
 		)
 	case ZSH:
 		return fmt.Sprintf("precmd() { source %s }", QuotePosixStr(scriptPath))
@@ -312,7 +315,7 @@ func sessionScript(env runtime.Environment) string {
 
 	switch env.Flags().Shell {
 	case PWSH:
-		return fmt.Sprintf("$env:POSH_SESSION_ID = \"%s\"; $env:POSH_CONFIG = %s;", sessionID, quotePwshOrElvishStr(config))
+		return fmt.Sprintf("$env:POSH_SESSION_ID = \"%s\"; $env:POSH_CONFIG = %s;", sessionID, quotePwshStr(config))
 	case ZSH, BASH:
 		return fmt.Sprintf("export POSH_SESSION_ID=\"%s\"; export POSH_CONFIG=%s;", sessionID, QuotePosixStr(config))
 	case YASH:
@@ -322,7 +325,7 @@ func sessionScript(env runtime.Environment) string {
 	case FISH:
 		return fmt.Sprintf("set --export --global POSH_SESSION_ID \"%s\"; set --export --global POSH_CONFIG %s;", sessionID, quoteFishStr(config))
 	case ELVISH:
-		return fmt.Sprintf("set-env POSH_SESSION_ID \"%s\"; set-env POSH_CONFIG %s;", sessionID, quotePwshOrElvishStr(config))
+		return fmt.Sprintf("set-env POSH_SESSION_ID \"%s\"; set-env POSH_CONFIG %s;", sessionID, quoteElvishStr(config))
 	case CMD:
 		return fmt.Sprintf(`os.setenv('POSH_SESSION_ID', '%s'); os.setenv('POSH_CONFIG', '%s');`, sessionID, escapeLuaStr(config))
 	}

--- a/src/shell/pwsh.go
+++ b/src/shell/pwsh.go
@@ -4,6 +4,7 @@ import (
 	_ "embed"
 	"fmt"
 	"strings"
+	"unicode/utf8"
 )
 
 //go:embed scripts/omp.ps1
@@ -42,10 +43,59 @@ func (f Features) Pwsh() Code {
 	}
 }
 
-func quotePwshOrElvishStr(str string) string {
+func quotePwshStr(str string) string {
 	if str == "" {
 		return "''"
 	}
 
-	return fmt.Sprintf("'%s'", strings.ReplaceAll(str, "'", "''"))
+	ascii := strings.IndexFunc(str, func(r rune) bool { return r >= utf8.RuneSelf }) == -1
+	if ascii {
+		return fmt.Sprintf("'%s'", strings.ReplaceAll(str, "'", "''"))
+	}
+
+	// PowerShell decodes native command output using [Console]::OutputEncoding,
+	// which defaults to the legacy OEM code page on Windows. Multi-byte UTF-8
+	// sequences in stdout are mangled before the init script gets a chance to
+	// run, so non-ASCII runes must be spelled out as [char] expressions to keep
+	// the emitted code pure ASCII, which survives every code page.
+	// The expandable string form "$( )" stays a single token in argument mode,
+	// so the result can be used anywhere a quoted string can.
+	var parts []string
+
+	var segment strings.Builder
+
+	flush := func() {
+		if segment.Len() == 0 {
+			return
+		}
+
+		parts = append(parts, fmt.Sprintf("'%s'", strings.ReplaceAll(segment.String(), "'", "''")))
+		segment.Reset()
+	}
+
+	for _, r := range str {
+		if r < utf8.RuneSelf {
+			segment.WriteRune(r)
+			continue
+		}
+
+		flush()
+
+		if r > 0xFFFF {
+			parts = append(parts, fmt.Sprintf("[char]::ConvertFromUtf32(0x%X)", r))
+			continue
+		}
+
+		parts = append(parts, fmt.Sprintf("[char]0x%X", r))
+	}
+
+	flush()
+
+	// a leading [char] would make + do character arithmetic instead of
+	// string concatenation, an empty string first forces string semantics
+	if !strings.HasPrefix(parts[0], "'") {
+		parts = append([]string{"''"}, parts...)
+	}
+
+	return fmt.Sprintf(`"$(%s)"`, strings.Join(parts, " + "))
 }

--- a/src/shell/pwsh_test.go
+++ b/src/shell/pwsh_test.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -42,7 +45,7 @@ func TestSourceCommandAsyncPwsh(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
-func TestQuotePwshOrElvishStr(t *testing.T) {
+func TestQuotePwshStr(t *testing.T) {
 	tests := []struct {
 		str      string
 		expected string
@@ -50,8 +53,31 @@ func TestQuotePwshOrElvishStr(t *testing.T) {
 		{str: "", expected: "''"},
 		{str: `/tmp/"omp's dir"/oh-my-posh`, expected: `'/tmp/"omp''s dir"/oh-my-posh'`},
 		{str: `C:/tmp\omp's dir/oh-my-posh.exe`, expected: `'C:/tmp\omp''s dir/oh-my-posh.exe'`},
+		// non-ASCII runes are emitted as [char] expressions so the output
+		// survives PowerShell's OEM code page decoding of native stdout
+		{str: `C:/Users/MyNameE²/init.ps1`, expected: `"$('C:/Users/MyNameE' + [char]0xB2 + '/init.ps1')"`},
+		{str: `C:/Users/Ø²/omp's.ps1`, expected: `"$('C:/Users/' + [char]0xD8 + [char]0xB2 + '/omp''s.ps1')"`},
+		{str: `²init.ps1`, expected: `"$('' + [char]0xB2 + 'init.ps1')"`},
+		{str: `C:/Users/📁/init.ps1`, expected: `"$('C:/Users/' + [char]::ConvertFromUtf32(0x1F4C1) + '/init.ps1')"`},
 	}
 	for _, tc := range tests {
-		assert.Equal(t, tc.expected, quotePwshOrElvishStr(tc.str), fmt.Sprintf("quotePwshOrElvishStr: %s", tc.str))
+		assert.Equal(t, tc.expected, quotePwshStr(tc.str), fmt.Sprintf("quotePwshStr: %s", tc.str))
+	}
+}
+
+// PowerShell decodes native command output using [Console]::OutputEncoding,
+// which defaults to the legacy OEM code page on Windows. Everything written
+// to stdout for pwsh must therefore be pure ASCII, no matter which characters
+// the injected paths contain.
+func TestSessionScriptPwshIsPureASCII(t *testing.T) {
+	env := new(mock.Environment)
+	env.On("Flags").Return(&runtime.Flags{Shell: PWSH, ConfigPath: "C:/Users/MyNameE²/omp.json"})
+
+	got := sessionScript(env)
+
+	assert.Contains(t, got, `$env:POSH_CONFIG = "$('C:/Users/MyNameE' + [char]0xB2 + '/omp.json')";`)
+
+	for i, b := range []byte(got) {
+		assert.Less(t, b, uint8(0x80), fmt.Sprintf("non-ASCII byte at index %d in: %s", i, got))
 	}
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

PowerShell on Windows decodes native command output using `[Console]::OutputEncoding`, which defaults to the legacy OEM code page. This causes multi-byte UTF-8 sequences in stdout to be mangled before the init script can process them, breaking paths containing non-ASCII characters.

This fix addresses the issue by:

1. **Splitting `quotePwshOrElvishStr` into separate functions**: Created `quotePwshStr()` for PowerShell and `quoteElvishStr()` for Elvish, since they have different quoting requirements.

2. **Encoding non-ASCII characters as `[char]` expressions**: The new `quotePwshStr()` function detects non-ASCII runes and emits them as PowerShell character expressions (e.g., `[char]0xB2` for `²`, `[char]::ConvertFromUtf32(0x1F4C1)` for `📁`). This keeps the emitted code pure ASCII, which survives any code page decoding.

3. **Using expandable strings for concatenation**: Non-ASCII characters are wrapped in `"$(...)"` syntax to ensure proper string concatenation semantics in PowerShell.

4. **Updated all call sites**: Replaced `quotePwshOrElvishStr()` calls with the appropriate shell-specific function in `init.go`.

### Test Plan

- Added comprehensive unit tests for `quotePwshStr()` covering ASCII paths, paths with single quotes, and paths with various non-ASCII characters (U+00B2, U+00D8, U+1F4C1)
- Added new test `TestSessionScriptPwshIsPureASCII()` that verifies the entire session script output contains only ASCII bytes, even when config paths contain non-ASCII characters
- Existing tests for Elvish quoting continue to pass with the new `quoteElvishStr()` function

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary

https://claude.ai/code/session_01BCNz9G4sSmwRixkjVodcWo