### PR TITLE
fix(segment): resolve a relative gitdir: pointer against its .git file's folder

### DIFF
--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -347,12 +347,12 @@ func (g *Git) shouldDisplay() bool {
 		return false
 	}
 
-	if g.options.Bool(FetchBareInfo, false) {
-		g.IsBare = g.isBareRepo(gitdir)
-	}
-
 	if !g.hasCommand(GITCOMMAND) {
 		return false
+	}
+
+	if g.options.Bool(FetchBareInfo, false) {
+		g.IsBare = g.isBareRepo(gitdir)
 	}
 
 	return g.isRepo(gitdir)
@@ -402,7 +402,7 @@ func (g *Git) isBareRepo(gitDir *runtime.FileInfo) bool {
 	} else {
 		content := g.fileContent(gitDir.ParentFolder, ".git")
 		dir := strings.TrimPrefix(content, "gitdir: ")
-		g.mainSCMDir = filepath.Join(gitDir.ParentFolder, dir)
+		g.mainSCMDir = resolveGitPath(gitDir.ParentFolder, g.convertToLinuxPath(dir))
 	}
 
 	cfg, err := g.getGitConfig()

--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -1196,6 +1196,23 @@ func (g *Git) commonGitDir() string {
 	return filepath.ToSlash(g.scmDir)
 }
 
+func worktreeAdminIndex(path string) int {
+	const segment = "/worktrees/"
+
+	normalised := filepath.ToSlash(filepath.Clean(path))
+	index := strings.LastIndex(normalised, segment)
+	if index < 0 {
+		return -1
+	}
+
+	name := normalised[index+len(segment):]
+	if name == "" || strings.Contains(name, "/") {
+		return -1
+	}
+
+	return index
+}
+
 func parseMainWorktree(output string) (string, bool) {
 	// Git guarantees the main worktree is the first record.
 	record, _, found := strings.Cut(output, "\x00\x00")

--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -462,10 +462,10 @@ func (g *Git) hasWorktree(gitdir *runtime.FileInfo) bool {
 	// to the mounted path
 	g.mainSCMDir = g.convertToLinuxPath(matches["dir"])
 
-	// in worktrees, the path looks like this: gitdir: path/.git/worktrees/branch
-	// scmDir needs to become path/.git
-	// repoRootDir needs to become path
-	worktreeIndex := strings.LastIndex(g.mainSCMDir, "/worktrees/")
+	// Worktree admin dirs are <common>/worktrees/<name>. Classify on the normalised form
+	// and slice that same form, so a "." or a doubled separator cannot shift the index.
+	adminDir := filepath.ToSlash(filepath.Clean(g.mainSCMDir))
+	worktreeIndex := worktreeAdminIndex(adminDir)
 
 	// in submodules, the path looks like this: gitdir: ../.git/modules/test-submodule
 	// we need the parent folder to detect where the real .git folder is
@@ -474,7 +474,8 @@ func (g *Git) hasWorktree(gitdir *runtime.FileInfo) bool {
 		// this might be both a worktree and a submodule, where the path would look like
 		// this: path/.git/modules/module/path/worktrees/location. We cannot distinguish
 		// between worktree and a module path containing the word 'worktree,' however.
-		worktreeIndex = strings.LastIndex(g.scmDir, "/worktrees/")
+		moduleDir := filepath.ToSlash(filepath.Clean(g.scmDir))
+		worktreeIndex = worktreeAdminIndex(moduleDir)
 		if worktreeIndex > -1 && g.env.HasFilesInDir(g.scmDir, "gitdir") {
 			gitDir := filepath.Join(g.scmDir, "gitdir")
 			realGitFolder := g.env.FileContent(gitDir)
@@ -482,7 +483,7 @@ func (g *Git) hasWorktree(gitdir *runtime.FileInfo) bool {
 			g.repoRootDir = g.convertToLinuxPath(g.repoRootDir)
 			// resolve relative paths (worktree.useRelativePaths = true)
 			g.repoRootDir = resolveGitPath(g.scmDir, g.repoRootDir)
-			g.scmDir = g.scmDir[:worktreeIndex]
+			g.scmDir = moduleDir[:worktreeIndex]
 			g.mainSCMDir = g.scmDir
 			g.IsWorkTree = true
 			return true
@@ -496,19 +497,25 @@ func (g *Git) hasWorktree(gitdir *runtime.FileInfo) bool {
 	// convert to absolute path for worktrees only
 	if strings.HasPrefix(g.mainSCMDir, "..") {
 		g.mainSCMDir = resolveGitPath(gitdir.ParentFolder, g.mainSCMDir)
-		worktreeIndex = strings.LastIndex(g.mainSCMDir, "/worktrees/")
+		adminDir = filepath.ToSlash(filepath.Clean(g.mainSCMDir))
+		worktreeIndex = worktreeAdminIndex(adminDir)
 	}
 
 	if worktreeIndex > -1 {
-		gitDir := filepath.Join(g.mainSCMDir, "gitdir")
-		g.scmDir = g.mainSCMDir[:worktreeIndex]
-		gitDirContent := g.env.FileContent(gitDir)
-		g.repoRootDir = strings.TrimSuffix(strings.TrimRight(gitDirContent, "\n\r "), ".git")
-		g.repoRootDir = g.convertToLinuxPath(g.repoRootDir)
+		gitDirContent := g.env.FileContent(filepath.Join(g.mainSCMDir, "gitdir"))
+		gitDirPath := strings.TrimRight(gitDirContent, "\n\r ")
+		root := strings.TrimSuffix(gitDirPath, ".git")
+		root = g.convertToLinuxPath(root)
 		// resolve relative paths (worktree.useRelativePaths = true)
-		g.repoRootDir = resolveGitPath(g.mainSCMDir, g.repoRootDir)
-		g.IsWorkTree = true
-		return true
+		root = resolveGitPath(g.mainSCMDir, root)
+
+		// A genuine worktree's metadata points back at the .git file we just read.
+		if gitDirPath != "" && filepath.Clean(root) == filepath.Clean(gitdir.ParentFolder) {
+			g.scmDir = adminDir[:worktreeIndex]
+			g.repoRootDir = root
+			g.IsWorkTree = true
+			return true
+		}
 	}
 
 	// check for separate git folder(--separate-git-dir)

--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -1239,10 +1239,10 @@ func (g *Git) isModuleAdminDir(target, parent string) bool {
 	return filepath.Clean(root) == filepath.Clean(parent)
 }
 
-func worktreeAdminIndex(path string) int {
+func worktreeAdminIndex(dir string) int {
 	const segment = "/worktrees/"
 
-	normalised := filepath.ToSlash(filepath.Clean(path))
+	normalised := filepath.ToSlash(filepath.Clean(dir))
 	index := strings.LastIndex(normalised, segment)
 	if index < 0 {
 		return -1

--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -467,8 +467,10 @@ func (g *Git) hasWorktree(gitdir *runtime.FileInfo) bool {
 	worktreeIndex := worktreeAdminIndex(adminDir)
 
 	// in submodules, the path looks like this: gitdir: ../.git/modules/test-submodule
-	// we need the parent folder to detect where the real .git folder is
-	if strings.Contains(raw, "/modules/") {
+	// we need the parent folder to detect where the real .git folder is. Test raw rather
+	// than the resolved path: a checkout below a folder named modules would otherwise
+	// drag every genuine worktree in it into this branch.
+	if strings.Contains(raw, "/modules/") && g.isModuleAdminDir(g.mainSCMDir, gitdir.ParentFolder) {
 		g.scmDir = g.mainSCMDir
 		// this might be both a worktree and a submodule, where the path would look like
 		// this: path/.git/modules/module/path/worktrees/location. We cannot distinguish
@@ -1193,6 +1195,48 @@ func (g *Git) commonGitDir() string {
 	}
 
 	return filepath.ToSlash(g.scmDir)
+}
+
+// isModuleAdminDir reports whether target is a submodule administrative directory
+// belonging to the checkout at parent, or a linked worktree inside one.
+//
+// A pointer whose spelling merely contains a modules component is not enough: a
+// --separate-git-dir target such as /srv/modules/project.git spells the same substring
+// without being a submodule. Nor does the shape help the way it does for worktrees. A
+// submodule's name is its path, so it may hold separators (.git/modules/vendor/libfoo),
+// it may nest (.../modules/vendor/libfoo/modules/inner), and the folder in front of
+// modules is only called .git when the superproject has no --separate-git-dir of its own
+// (../../sepgit/modules/sub is a real pointer).
+//
+// What does hold is that git records core.worktree in a submodule's git dir, pointing
+// back at the checkout, and never records it in a --separate-git-dir target. That
+// back-reference is the same kind of proof the worktree branch takes from its gitdir
+// metadata.
+func (g *Git) isModuleAdminDir(target, parent string) bool {
+	// A linked worktree inside a module dir keeps no config of its own, so it cannot
+	// carry core.worktree. Its gitdir metadata identifies it instead, which is what the
+	// worktree case in the caller goes on to validate.
+	if worktreeAdminIndex(target) > -1 && g.env.HasFilesInDir(target, "gitdir") {
+		return true
+	}
+
+	cfg, err := ini.Load(g.fileContent(target, "config"))
+	if err != nil {
+		log.Error(err)
+		return false
+	}
+
+	worktree := cfg.Section("core").Key("worktree").String()
+	if worktree == "" {
+		log.Debug("no core.worktree in", target, "- not a submodule git dir")
+		return false
+	}
+
+	// core.worktree is relative to the git dir holding it, and may need the same WSL
+	// conversion as the pointer itself.
+	root := resolveGitPath(target, g.convertToLinuxPath(worktree))
+
+	return filepath.Clean(root) == filepath.Clean(parent)
 }
 
 func worktreeAdminIndex(path string) int {

--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -458,19 +458,18 @@ func (g *Git) hasWorktree(gitdir *runtime.FileInfo) bool {
 		return false
 	}
 
-	// if we open a worktree file in a WSL shared folder, we have to convert it back
-	// to the mounted path
-	g.mainSCMDir = g.convertToLinuxPath(matches["dir"])
+	// Convert before resolving because filepath.IsAbs("C:/repo/.git") is false on Linux.
+	raw := g.convertToLinuxPath(matches["dir"])
+	g.mainSCMDir = resolveGitPath(gitdir.ParentFolder, raw)
 
-	// Worktree admin dirs are <common>/worktrees/<name>. Classify on the normalised form
-	// and slice that same form, so a "." or a doubled separator cannot shift the index.
+	// The returned index only applies to the normalized path.
 	adminDir := filepath.ToSlash(filepath.Clean(g.mainSCMDir))
 	worktreeIndex := worktreeAdminIndex(adminDir)
 
 	// in submodules, the path looks like this: gitdir: ../.git/modules/test-submodule
 	// we need the parent folder to detect where the real .git folder is
-	if strings.Contains(g.mainSCMDir, "/modules/") {
-		g.scmDir = resolveGitPath(gitdir.ParentFolder, g.mainSCMDir)
+	if strings.Contains(raw, "/modules/") {
+		g.scmDir = g.mainSCMDir
 		// this might be both a worktree and a submodule, where the path would look like
 		// this: path/.git/modules/module/path/worktrees/location. We cannot distinguish
 		// between worktree and a module path containing the word 'worktree,' however.
@@ -492,13 +491,6 @@ func (g *Git) hasWorktree(gitdir *runtime.FileInfo) bool {
 		g.repoRootDir = g.scmDir
 		g.mainSCMDir = g.scmDir
 		return true
-	}
-
-	// convert to absolute path for worktrees only
-	if strings.HasPrefix(g.mainSCMDir, "..") {
-		g.mainSCMDir = resolveGitPath(gitdir.ParentFolder, g.mainSCMDir)
-		adminDir = filepath.ToSlash(filepath.Clean(g.mainSCMDir))
-		worktreeIndex = worktreeAdminIndex(adminDir)
 	}
 
 	if worktreeIndex > -1 {

--- a/src/segments/git_test.go
+++ b/src/segments/git_test.go
@@ -451,6 +451,99 @@ func TestEnabledInBareLayout(t *testing.T) {
 	}
 }
 
+func TestIsBareRepoResolvesPointer(t *testing.T) {
+	cases := []struct {
+		Case              string
+		Pointer           string
+		ExpectedConfig    string
+		ExpectedProbedDir string
+		ExpectedIsBare    bool
+		OldConfig         string
+	}{
+		{
+			Case:              "relative pointer",
+			Pointer:           "./.bare",
+			ExpectedConfig:    "/repo/.bare/config",
+			ExpectedProbedDir: "/repo/.bare",
+			ExpectedIsBare:    true,
+		},
+		{
+			Case:              "absolute pointer",
+			Pointer:           "/repo/.bare",
+			ExpectedConfig:    "/repo/.bare/config",
+			ExpectedProbedDir: "/repo/.bare",
+			ExpectedIsBare:    true,
+			OldConfig:         "/repo/repo/.bare/config",
+		},
+		{
+			Case:              "absolute pointer to a non-bare git dir",
+			Pointer:           "/elsewhere/gitdir",
+			ExpectedConfig:    "/elsewhere/gitdir/config",
+			ExpectedProbedDir: "/elsewhere/gitdir",
+			ExpectedIsBare:    false,
+			OldConfig:         "/repo/elsewhere/gitdir/config",
+		},
+	}
+
+	for _, tc := range cases {
+		fileInfo := &runtime.FileInfo{
+			Path:         "/repo/.git",
+			ParentFolder: "/repo",
+		}
+
+		env := new(mock.Environment)
+		env.On("InWSLSharedDrive").Return(false)
+		env.On("HasCommand", "git").Return(true)
+		env.On("GOOS").Return("")
+		env.On("HasParentFilePath", ".git", true).Return(fileInfo, nil)
+		env.On("FileContent", "/repo/.git").Return(fmt.Sprintf("gitdir: %s", tc.Pointer))
+		env.On("FileContent", tc.ExpectedConfig).Return(fmt.Sprintf("[core]\n\tbare = %t", tc.ExpectedIsBare))
+		env.On("HasFilesInDir", tc.ExpectedProbedDir, "HEAD").Return(true)
+
+		if tc.OldConfig != "" {
+			env.On("FileContent", tc.OldConfig).Return("")
+		}
+
+		g := &Git{}
+		g.Init(options.Map{FetchBareInfo: true}, env)
+
+		assert.True(t, g.shouldDisplay(), tc.Case)
+		assert.Equal(t, tc.ExpectedIsBare, g.IsBare, tc.Case)
+		env.AssertCalled(t, "FileContent", tc.ExpectedConfig)
+
+		if tc.OldConfig != "" {
+			env.AssertNotCalled(t, "FileContent", tc.OldConfig)
+		}
+	}
+}
+
+func TestShouldDisplayInitializesWSLBeforeBareRepoDetection(t *testing.T) {
+	fileInfo := &runtime.FileInfo{
+		Path:         "/repo/.git",
+		ParentFolder: "/repo",
+	}
+
+	env := new(mock.Environment)
+	env.On("InWSLSharedDrive").Return(true)
+	env.On("HasCommand", "git.exe").Return(true)
+	env.On("GOOS").Return("")
+	env.On("HasParentFilePath", ".git", true).Return(fileInfo, nil)
+	env.On("ConvertToLinuxPath").Return("/mnt/c/repo/.bare")
+	env.On("FileContent", "/repo/.git").Return("gitdir: C:/repo/.bare")
+	env.On("FileContent", "/repo/C:/repo/.bare/config").Return("")
+	env.On("FileContent", "/mnt/c/repo/.bare/config").Return("[core]\n\tbare = true")
+	env.On("HasFilesInDir", "/mnt/c/repo/.bare", "HEAD").Return(true)
+	env.On("ConvertToWindowsPath", "/repo/").Return("C:/repo")
+
+	g := &Git{}
+	g.Init(options.Map{FetchBareInfo: true}, env)
+
+	assert.True(t, g.shouldDisplay())
+	assert.True(t, g.IsBare)
+	env.AssertNumberOfCalls(t, "ConvertToLinuxPath", 2)
+	env.AssertCalled(t, "FileContent", "/mnt/c/repo/.bare/config")
+}
+
 func TestEnabledInBareRepo(t *testing.T) {
 	cases := []struct {
 		Case   string

--- a/src/segments/git_test.go
+++ b/src/segments/git_test.go
@@ -109,12 +109,15 @@ func TestResolveEmptyGitPath(t *testing.T) {
 }
 
 func TestEnabledInWorktree(t *testing.T) {
+	// Field order below is what fieldalignment wants, so the groups a reader would expect
+	// together are not adjacent. The comments travel with the fields instead.
 	cases := []struct {
-		Pointer    string
-		RawGitFile string
-		// For a worktree topology, the discovered parent is the worktree root and
-		// must match the metadata back-reference.
-		DiscoveredGitFile string
+		// nil reserves directory-role assertions for a later decision.
+		ExpectedWorkingFolder *string
+		ExpectedRootFolder    *string
+		ExpectedRealFolder    *string
+		// For a worktree topology, the discovered parent is the worktree root and must
+		// match the metadata back-reference. See DiscoveredGitFile below.
 		DiscoveredParent  string
 		MetadataAddon     string
 		MetadataContent   string
@@ -124,12 +127,16 @@ func TestEnabledInWorktree(t *testing.T) {
 		// from a --separate-git-dir target, which has no core.worktree at all.
 		TargetConfig string
 		Case         string
-		// nil reserves directory-role assertions for a later decision.
-		ExpectedWorkingFolder *string
-		ExpectedRealFolder    *string
-		ExpectedRootFolder    *string
-		ExpectedIsWorkTree    bool
-		ExpectedEnabled       bool
+		Pointer      string
+		// DiscoveredGitFile is the .git file HasParentFilePath found, whose parent is
+		// DiscoveredParent above.
+		DiscoveredGitFile string
+		// RawGitFile overrides the whole .git file body. Use it when the test is about
+		// the file's syntax rather than the pointer it carries; leave it empty and the
+		// loop writes "gitdir: <Pointer>".
+		RawGitFile         string
+		ExpectedIsWorkTree bool
+		ExpectedEnabled    bool
 	}{
 		{
 			Case:                  "worktree",
@@ -489,9 +496,14 @@ func TestEnabledInBareLayout(t *testing.T) {
 	}
 
 	for _, tc := range cases {
+		// Fixtures are built from TestRootPath so the paths are absolute on the platform
+		// the test binary runs on. filepath.IsAbs below is the real one, not the mocked
+		// GOOS, so a literal "/repo" would not be absolute on Windows.
+		root := TestRootPath + "repo"
+
 		fileInfo := &runtime.FileInfo{
-			Path:         "/repo/.git",
-			ParentFolder: "/repo",
+			Path:         root + "/.git",
+			ParentFolder: root,
 		}
 
 		env := new(mock.Environment)
@@ -504,13 +516,13 @@ func TestEnabledInBareLayout(t *testing.T) {
 		env.On("Home").Return(poshHome)
 		env.On("Getenv", poshGitEnv).Return("")
 		env.On("DirMatchesOneOf", testify_.Anything, testify_.Anything).Return(false)
-		env.On("FileContent", "/repo/.git").Return("gitdir: ./.bare")
-		env.On("HasFilesInDir", "/repo/.bare", "HEAD").Return(true)
-		env.On("FileContent", "/repo/.bare/config").Return("[core]\n\tbare = true")
-		env.On("FileContent", "/repo//HEAD").Return("")
-		env.MockGitCommand("/repo/", "1234567890abcdef1234567890abcdef12345678", "rev-parse", "HEAD")
-		env.MockGitCommand("/repo/", "", "describe", "--tags", "--exact-match")
-		env.MockGitCommand("/repo/", "", "remote")
+		env.On("FileContent", root+"/.git").Return("gitdir: ./.bare")
+		env.On("HasFilesInDir", root+"/.bare", "HEAD").Return(true)
+		env.On("FileContent", root+"/.bare/config").Return("[core]\n\tbare = true")
+		env.On("FileContent", root+"//HEAD").Return("")
+		env.MockGitCommand(root+"/", "1234567890abcdef1234567890abcdef12345678", "rev-parse", "HEAD")
+		env.MockGitCommand(root+"/", "", "describe", "--tags", "--exact-match")
+		env.MockGitCommand(root+"/", "", "remote")
 
 		props := options.Map{}
 		if tc.FetchBareInfo {
@@ -528,56 +540,61 @@ func TestEnabledInBareLayout(t *testing.T) {
 }
 
 func TestIsBareRepoResolvesPointer(t *testing.T) {
+	// Fixtures are built from TestRootPath so that "absolute pointer" really is absolute
+	// on the platform the test binary runs on. A literal "/repo/.bare" is only
+	// disk-relative on Windows, which would exercise a different resolveGitPath branch
+	// than the one these cases are about.
+	root := TestRootPath + "repo"
+
 	cases := []struct {
 		Case              string
 		Pointer           string
-		ExpectedConfig    string
 		ExpectedProbedDir string
 		ExpectedIsBare    bool
-		OldConfig         string
 	}{
 		{
 			Case:              "relative pointer",
 			Pointer:           "./.bare",
-			ExpectedConfig:    "/repo/.bare/config",
-			ExpectedProbedDir: "/repo/.bare",
+			ExpectedProbedDir: root + "/.bare",
 			ExpectedIsBare:    true,
 		},
 		{
 			Case:              "absolute pointer",
-			Pointer:           "/repo/.bare",
-			ExpectedConfig:    "/repo/.bare/config",
-			ExpectedProbedDir: "/repo/.bare",
+			Pointer:           root + "/.bare",
+			ExpectedProbedDir: root + "/.bare",
 			ExpectedIsBare:    true,
-			OldConfig:         "/repo/repo/.bare/config",
 		},
 		{
 			Case:              "absolute pointer to a non-bare git dir",
-			Pointer:           "/elsewhere/gitdir",
-			ExpectedConfig:    "/elsewhere/gitdir/config",
-			ExpectedProbedDir: "/elsewhere/gitdir",
+			Pointer:           TestRootPath + "elsewhere/gitdir",
+			ExpectedProbedDir: TestRootPath + "elsewhere/gitdir",
 			ExpectedIsBare:    false,
-			OldConfig:         "/repo/elsewhere/gitdir/config",
 		},
 	}
 
 	for _, tc := range cases {
 		fileInfo := &runtime.FileInfo{
-			Path:         "/repo/.git",
-			ParentFolder: "/repo",
+			Path:         root + "/.git",
+			ParentFolder: root,
 		}
+
+		expectedConfig := tc.ExpectedProbedDir + "/config"
+		// What the old filepath.Join produced: the same path for a relative pointer, and
+		// the pointer concatenated onto the parent for an absolute one. Derived rather
+		// than written out so it stays correct under Windows path semantics too.
+		oldConfig := filepath.Join(fileInfo.ParentFolder, tc.Pointer) + "/config"
 
 		env := new(mock.Environment)
 		env.On("InWSLSharedDrive").Return(false)
 		env.On("HasCommand", "git").Return(true)
 		env.On("GOOS").Return("")
 		env.On("HasParentFilePath", ".git", true).Return(fileInfo, nil)
-		env.On("FileContent", "/repo/.git").Return(fmt.Sprintf("gitdir: %s", tc.Pointer))
-		env.On("FileContent", tc.ExpectedConfig).Return(fmt.Sprintf("[core]\n\tbare = %t", tc.ExpectedIsBare))
+		env.On("FileContent", root+"/.git").Return(fmt.Sprintf("gitdir: %s", tc.Pointer))
+		env.On("FileContent", expectedConfig).Return(fmt.Sprintf("[core]\n\tbare = %t", tc.ExpectedIsBare))
 		env.On("HasFilesInDir", tc.ExpectedProbedDir, "HEAD").Return(true)
 
-		if tc.OldConfig != "" {
-			env.On("FileContent", tc.OldConfig).Return("")
+		if oldConfig != expectedConfig {
+			env.On("FileContent", oldConfig).Return("")
 		}
 
 		g := &Git{}
@@ -585,10 +602,10 @@ func TestIsBareRepoResolvesPointer(t *testing.T) {
 
 		assert.True(t, g.shouldDisplay(), tc.Case)
 		assert.Equal(t, tc.ExpectedIsBare, g.IsBare, tc.Case)
-		env.AssertCalled(t, "FileContent", tc.ExpectedConfig)
+		env.AssertCalled(t, "FileContent", expectedConfig)
 
-		if tc.OldConfig != "" {
-			env.AssertNotCalled(t, "FileContent", tc.OldConfig)
+		if oldConfig != expectedConfig {
+			env.AssertNotCalled(t, "FileContent", oldConfig)
 		}
 	}
 }

--- a/src/segments/git_test.go
+++ b/src/segments/git_test.go
@@ -30,6 +30,39 @@ const (
 	dotGitSubmodule = "dev/.git/modules/submodule"
 )
 
+func TestWorktreeAdminIndex(t *testing.T) {
+	cases := []struct {
+		Case string
+		Path string
+		// Expected is the common git directory a caller slices out, or "" when Path is
+		// not a worktree administrative directory.
+		Expected string
+	}{
+		{Case: "admin dir", Path: "/repo/.git/worktrees/feat", Expected: "/repo/.git"},
+		{Case: "trailing separator", Path: "/repo/.git/worktrees/feat/", Expected: "/repo/.git"},
+		{Case: "dot component", Path: "/repo/.git/worktrees/feat/.", Expected: "/repo/.git"},
+		{Case: "doubled separator", Path: "/repo/.git/worktrees//feat", Expected: "/repo/.git"},
+		{Case: "nested worktrees keeps the last", Path: "/a/.git/worktrees/x/.git/worktrees/y", Expected: "/a/.git/worktrees/x/.git"},
+		{Case: "two components after worktrees", Path: "/repo/.git/worktrees/a/b", Expected: ""},
+		{Case: "repo under a worktrees component", Path: "/home/me/worktrees/proj/.bare", Expected: ""},
+		{Case: "no name after worktrees", Path: "/repo/.git/worktrees/", Expected: ""},
+		{Case: "no worktrees segment", Path: "/repo/.git", Expected: ""},
+		{Case: "empty", Path: "", Expected: ""},
+		// Shape alone cannot reject this one: the remainder is a single component. Task 2's
+		// metadata back-reference check is what keeps it out of the worktree branch.
+		{Case: "bare layout in a dir named worktrees", Path: "/home/me/worktrees/.bare", Expected: "/home/me"},
+	}
+
+	for _, tc := range cases {
+		var got string
+		if index := worktreeAdminIndex(tc.Path); index > -1 {
+			got = filepath.ToSlash(filepath.Clean(tc.Path))[:index]
+		}
+
+		assert.Equal(t, tc.Expected, got, tc.Case)
+	}
+}
+
 func TestEnabledGitNotFound(t *testing.T) {
 	env := new(mock.Environment)
 	env.On("InWSLSharedDrive").Return(false)

--- a/src/segments/git_test.go
+++ b/src/segments/git_test.go
@@ -114,7 +114,8 @@ func strPtr(s string) *string {
 
 func TestEnabledInWorktree(t *testing.T) {
 	cases := []struct {
-		Pointer string
+		Pointer    string
+		RawGitFile string
 		// For a worktree topology, the discovered parent is the worktree root and
 		// must match the metadata back-reference.
 		DiscoveredGitFile string
@@ -289,12 +290,89 @@ func TestEnabledInWorktree(t *testing.T) {
 			MetadataContent:    TestRootPath + "me/checkouts/feat/.git\n",
 			ExpectedProbedDir:  TestRootPath + "me/worktrees/proj/.git/worktrees/feat",
 		},
+		{
+			Case:              "bare layout, dot-slash relative pointer",
+			ExpectedEnabled:   true,
+			Pointer:           "./.bare",
+			DiscoveredGitFile: TestRootPath + "repo/.git",
+			DiscoveredParent:  TestRootPath + "repo",
+			ExpectedProbedDir: TestRootPath + "repo/.bare",
+		},
+		{
+			Case:              "bare layout, bare relative pointer",
+			ExpectedEnabled:   true,
+			Pointer:           ".bare",
+			DiscoveredGitFile: TestRootPath + "repo/.git",
+			DiscoveredParent:  TestRootPath + "repo",
+			ExpectedProbedDir: TestRootPath + "repo/.bare",
+		},
+		{
+			Case:              "relative pointer into a subdirectory",
+			ExpectedEnabled:   true,
+			Pointer:           "sub/git",
+			DiscoveredGitFile: TestRootPath + "repo/.git",
+			DiscoveredParent:  TestRootPath + "repo",
+			ExpectedProbedDir: TestRootPath + "repo/sub/git",
+		},
+		{
+			// Absolute pointers retain their trailing separator; filepath.Join cleans relative ones.
+			Case:               "absolute pointer ending in a separator",
+			ExpectedEnabled:    true,
+			ExpectedIsWorkTree: true,
+			Pointer:            TestRootPath + "repo/.git/worktrees/feat/",
+			DiscoveredGitFile:  TestRootPath + "repo/feat/.git",
+			DiscoveredParent:   TestRootPath + "repo/feat",
+			MetadataAddon:      "gitdir",
+			MetadataContent:    TestRootPath + "repo/feat/.git\n",
+			ExpectedProbedDir:  TestRootPath + "repo/.git/worktrees/feat/",
+		},
+		{
+			// This pins the existing trim; Git treats a trailing space as part of the path.
+			Case:              "pointer with trailing whitespace is trimmed",
+			ExpectedEnabled:   true,
+			RawGitFile:        "gitdir: ./.bare \n",
+			DiscoveredGitFile: TestRootPath + "repo/.git",
+			DiscoveredParent:  TestRootPath + "repo",
+			ExpectedProbedDir: TestRootPath + "repo/.bare",
+		},
+		{
+			Case:              "malformed .git file with no gitdir line",
+			ExpectedEnabled:   false,
+			RawGitFile:        "not a gitdir line",
+			DiscoveredGitFile: TestRootPath + "repo/.git",
+			DiscoveredParent:  TestRootPath + "repo",
+			ExpectedProbedDir: TestRootPath + "repo",
+		},
+		{
+			Case:              "gitdir line with an empty pointer",
+			ExpectedEnabled:   false,
+			RawGitFile:        "gitdir: ",
+			DiscoveredGitFile: TestRootPath + "repo/.git",
+			DiscoveredParent:  TestRootPath + "repo",
+			ExpectedProbedDir: TestRootPath + "repo",
+		},
+		{
+			// Keep this check on the raw pointer: resolving it first changes the branch.
+			Case:               "worktree with a relative pointer under a modules component",
+			ExpectedEnabled:    true,
+			ExpectedIsWorkTree: true,
+			Pointer:            "../.git/worktrees/feat",
+			DiscoveredGitFile:  TestRootPath + "modules/repo/feat/.git",
+			DiscoveredParent:   TestRootPath + "modules/repo/feat",
+			MetadataAddon:      "gitdir",
+			MetadataContent:    TestRootPath + "modules/repo/feat/.git\n",
+			ExpectedProbedDir:  TestRootPath + "modules/repo/.git/worktrees/feat",
+		},
 	}
 
 	for _, tc := range cases {
 		fileInfo := &runtime.FileInfo{Path: tc.DiscoveredGitFile, ParentFolder: tc.DiscoveredParent}
 		env := new(mock.Environment)
-		env.On("FileContent", tc.DiscoveredGitFile).Return(fmt.Sprintf("gitdir: %s", tc.Pointer))
+		gitFileContent := fmt.Sprintf("gitdir: %s", tc.Pointer)
+		if tc.RawGitFile != "" {
+			gitFileContent = tc.RawGitFile
+		}
+		env.On("FileContent", tc.DiscoveredGitFile).Return(gitFileContent)
 		env.On("FileContent", filepath.Join(tc.ExpectedProbedDir, tc.MetadataAddon)).Return(tc.MetadataContent)
 		env.On("HasFilesInDir", tc.ExpectedProbedDir, tc.MetadataAddon).Return(tc.MetadataAddon != "")
 		env.On("HasFilesInDir", tc.ExpectedProbedDir, "HEAD").Return(true)
@@ -322,6 +400,54 @@ func TestEnabledInWorktree(t *testing.T) {
 			assert.True(t, filepath.IsAbs(g.mainSCMDir), tc.Case+": mainSCMDir must be absolute")
 			assert.True(t, filepath.IsAbs(g.scmDir), tc.Case+": scmDir must be absolute")
 		}
+	}
+}
+
+func TestEnabledInBareLayout(t *testing.T) {
+	cases := []struct {
+		Case          string
+		FetchBareInfo bool
+	}{
+		{Case: "bare layout without fetch_bare_info", FetchBareInfo: false},
+		{Case: "bare layout with fetch_bare_info", FetchBareInfo: true},
+	}
+
+	for _, tc := range cases {
+		fileInfo := &runtime.FileInfo{
+			Path:         "/repo/.git",
+			ParentFolder: "/repo",
+		}
+
+		env := new(mock.Environment)
+		env.On("InWSLSharedDrive").Return(false)
+		env.On("HasCommand", "git").Return(true)
+		env.On("GOOS").Return("")
+		env.On("IsWsl").Return(false)
+		env.On("HasParentFilePath", ".git", true).Return(fileInfo, nil)
+		env.On("PathSeparator").Return("/")
+		env.On("Home").Return(poshHome)
+		env.On("Getenv", poshGitEnv).Return("")
+		env.On("DirMatchesOneOf", testify_.Anything, testify_.Anything).Return(false)
+		env.On("FileContent", "/repo/.git").Return("gitdir: ./.bare")
+		env.On("HasFilesInDir", "/repo/.bare", "HEAD").Return(true)
+		env.On("FileContent", "/repo/.bare/config").Return("[core]\n\tbare = true")
+		env.On("FileContent", "/repo//HEAD").Return("")
+		env.MockGitCommand("/repo/", "1234567890abcdef1234567890abcdef12345678", "rev-parse", "HEAD")
+		env.MockGitCommand("/repo/", "", "describe", "--tags", "--exact-match")
+		env.MockGitCommand("/repo/", "", "remote")
+
+		props := options.Map{}
+		if tc.FetchBareInfo {
+			props = options.Map{FetchBareInfo: true}
+		}
+
+		g := &Git{}
+		g.Init(props, env)
+
+		assert.True(t, g.Enabled(), tc.Case)
+		assert.Equal(t, tc.FetchBareInfo, g.IsBare, tc.Case)
+		assert.True(t, filepath.IsAbs(g.mainSCMDir), tc.Case+": mainSCMDir must be absolute")
+		assert.True(t, filepath.IsAbs(g.scmDir), tc.Case+": scmDir must be absolute")
 	}
 }
 

--- a/src/segments/git_test.go
+++ b/src/segments/git_test.go
@@ -108,101 +108,146 @@ func TestResolveEmptyGitPath(t *testing.T) {
 	assert.Equal(t, base, resolveGitPath(base, ""))
 }
 
+func strPtr(s string) *string {
+	return &s
+}
+
 func TestEnabledInWorktree(t *testing.T) {
 	cases := []struct {
-		Case                  string
-		WorkingFolder         string
-		WorkingFolderAddon    string
-		WorkingFolderContent  string
-		ExpectedRealFolder    string
-		ExpectedWorkingFolder string
-		ExpectedRootFolder    string
+		Pointer string
+		// For a worktree topology, the discovered parent is the worktree root and
+		// must match the metadata back-reference.
+		DiscoveredGitFile string
+		DiscoveredParent  string
+		MetadataAddon     string
+		MetadataContent   string
+		ExpectedProbedDir string
+		Case              string
+		// nil reserves directory-role assertions for a later decision.
+		ExpectedWorkingFolder *string
+		ExpectedRealFolder    *string
+		ExpectedRootFolder    *string
+		ExpectedIsWorkTree    bool
 		ExpectedEnabled       bool
 	}{
 		{
 			Case:                  "worktree",
 			ExpectedEnabled:       true,
-			WorkingFolder:         TestRootPath + "dev/.git/worktrees/folder_worktree",
-			WorkingFolderAddon:    "gitdir",
-			WorkingFolderContent:  TestRootPath + "dev/worktree.git\n",
-			ExpectedWorkingFolder: TestRootPath + "dev/.git/worktrees/folder_worktree",
-			ExpectedRealFolder:    TestRootPath + "dev/worktree",
-			ExpectedRootFolder:    TestRootPath + dotGit,
+			ExpectedIsWorkTree:    true,
+			Pointer:               TestRootPath + "dev/.git/worktrees/folder_worktree",
+			DiscoveredGitFile:     TestRootPath + "dev/worktree/.git",
+			DiscoveredParent:      TestRootPath + "dev/worktree",
+			MetadataAddon:         "gitdir",
+			MetadataContent:       TestRootPath + "dev/worktree.git\n",
+			ExpectedProbedDir:     TestRootPath + "dev/.git/worktrees/folder_worktree",
+			ExpectedWorkingFolder: strPtr(TestRootPath + "dev/.git/worktrees/folder_worktree"),
+			ExpectedRealFolder:    strPtr(TestRootPath + "dev/worktree"),
+			ExpectedRootFolder:    strPtr(TestRootPath + dotGit),
 		},
 		{
 			Case:                  "submodule",
 			ExpectedEnabled:       true,
-			WorkingFolder:         "./.git/modules/submodule",
-			ExpectedWorkingFolder: TestRootPath + dotGitSubmodule,
-			ExpectedRealFolder:    TestRootPath + dotGitSubmodule,
-			ExpectedRootFolder:    TestRootPath + dotGitSubmodule,
+			Pointer:               "./.git/modules/submodule",
+			DiscoveredGitFile:     TestRootPath + dotGit,
+			DiscoveredParent:      TestRootPath + "dev",
+			ExpectedProbedDir:     TestRootPath + dotGitSubmodule,
+			ExpectedWorkingFolder: strPtr(TestRootPath + dotGitSubmodule),
+			ExpectedRealFolder:    strPtr(TestRootPath + dotGitSubmodule),
+			ExpectedRootFolder:    strPtr(TestRootPath + dotGitSubmodule),
 		},
 		{
 			Case:                  "submodule with root working folder",
 			ExpectedEnabled:       true,
-			WorkingFolder:         TestRootPath + dotGitSubmodule,
-			ExpectedWorkingFolder: TestRootPath + dotGitSubmodule,
-			ExpectedRealFolder:    TestRootPath + dotGitSubmodule,
-			ExpectedRootFolder:    TestRootPath + dotGitSubmodule,
+			Pointer:               TestRootPath + dotGitSubmodule,
+			DiscoveredGitFile:     TestRootPath + dotGit,
+			DiscoveredParent:      TestRootPath + "dev",
+			ExpectedProbedDir:     TestRootPath + dotGitSubmodule,
+			ExpectedWorkingFolder: strPtr(TestRootPath + dotGitSubmodule),
+			ExpectedRealFolder:    strPtr(TestRootPath + dotGitSubmodule),
+			ExpectedRootFolder:    strPtr(TestRootPath + dotGitSubmodule),
 		},
 		{
-			Case:                  "submodule with worktrees",
-			ExpectedEnabled:       true,
-			WorkingFolder:         TestRootPath + "dev/.git/modules/module/path/worktrees/location",
-			WorkingFolderAddon:    "gitdir",
-			WorkingFolderContent:  TestRootPath + "dev/worktree.git\n",
-			ExpectedWorkingFolder: TestRootPath + "dev/.git/modules/module/path",
-			ExpectedRealFolder:    TestRootPath + "dev/worktree",
-			ExpectedRootFolder:    TestRootPath + "dev/.git/modules/module/path",
+			// Directory-role assertions are reserved for a later decision.
+			Case:               "submodule with worktrees",
+			ExpectedEnabled:    true,
+			ExpectedIsWorkTree: true,
+			Pointer:            TestRootPath + "dev/.git/modules/module/path/worktrees/location",
+			DiscoveredGitFile:  TestRootPath + dotGit,
+			DiscoveredParent:   TestRootPath + "dev",
+			MetadataAddon:      "gitdir",
+			MetadataContent:    TestRootPath + "dev/worktree.git\n",
+			ExpectedProbedDir:  TestRootPath + "dev/.git/modules/module/path/worktrees/location",
 		},
 		{
-			Case:                  "separate git dir",
-			ExpectedEnabled:       true,
-			WorkingFolder:         TestRootPath + "dev/separate/.git/posh",
-			ExpectedWorkingFolder: TestRootPath + "dev/",
-			ExpectedRealFolder:    TestRootPath + "dev/",
-			ExpectedRootFolder:    TestRootPath + "dev/separate/.git/posh",
+			// Directory-role assertions are reserved for a later decision.
+			Case:              "separate git dir",
+			ExpectedEnabled:   true,
+			Pointer:           TestRootPath + "dev/separate/.git/posh",
+			DiscoveredGitFile: TestRootPath + dotGit,
+			DiscoveredParent:  TestRootPath + "dev",
+			ExpectedProbedDir: TestRootPath + "dev/separate/.git/posh",
 		},
 		{
 			Case:                  "worktree with relative gitdir path",
 			ExpectedEnabled:       true,
-			WorkingFolder:         TestRootPath + "dev/.git/worktrees/folder_worktree",
-			WorkingFolderAddon:    "gitdir",
-			WorkingFolderContent:  "../../../worktree/.git\n",
-			ExpectedWorkingFolder: TestRootPath + "dev/.git/worktrees/folder_worktree",
-			ExpectedRealFolder:    TestRootPath + "dev/worktree",
-			ExpectedRootFolder:    TestRootPath + dotGit,
+			ExpectedIsWorkTree:    true,
+			Pointer:               TestRootPath + "dev/.git/worktrees/folder_worktree",
+			DiscoveredGitFile:     TestRootPath + "dev/worktree/.git",
+			DiscoveredParent:      TestRootPath + "dev/worktree",
+			MetadataAddon:         "gitdir",
+			MetadataContent:       "../../../worktree/.git\n",
+			ExpectedProbedDir:     TestRootPath + "dev/.git/worktrees/folder_worktree",
+			ExpectedWorkingFolder: strPtr(TestRootPath + "dev/.git/worktrees/folder_worktree"),
+			ExpectedRealFolder:    strPtr(TestRootPath + "dev/worktree"),
+			ExpectedRootFolder:    strPtr(TestRootPath + dotGit),
 		},
 		{
 			Case:                  "worktree with relative gitdir path, no trailing newline",
 			ExpectedEnabled:       true,
-			WorkingFolder:         TestRootPath + "dev/.git/worktrees/folder_worktree",
-			WorkingFolderAddon:    "gitdir",
-			WorkingFolderContent:  "../../../worktree/.git",
-			ExpectedWorkingFolder: TestRootPath + "dev/.git/worktrees/folder_worktree",
-			ExpectedRealFolder:    TestRootPath + "dev/worktree",
-			ExpectedRootFolder:    TestRootPath + dotGit,
+			ExpectedIsWorkTree:    true,
+			Pointer:               TestRootPath + "dev/.git/worktrees/folder_worktree",
+			DiscoveredGitFile:     TestRootPath + "dev/worktree/.git",
+			DiscoveredParent:      TestRootPath + "dev/worktree",
+			MetadataAddon:         "gitdir",
+			MetadataContent:       "../../../worktree/.git",
+			ExpectedProbedDir:     TestRootPath + "dev/.git/worktrees/folder_worktree",
+			ExpectedWorkingFolder: strPtr(TestRootPath + "dev/.git/worktrees/folder_worktree"),
+			ExpectedRealFolder:    strPtr(TestRootPath + "dev/worktree"),
+			ExpectedRootFolder:    strPtr(TestRootPath + dotGit),
 		},
 	}
-	fileInfo := &runtime.FileInfo{
-		Path:         TestRootPath + dotGit,
-		ParentFolder: TestRootPath + "dev",
-	}
+
 	for _, tc := range cases {
+		fileInfo := &runtime.FileInfo{Path: tc.DiscoveredGitFile, ParentFolder: tc.DiscoveredParent}
 		env := new(mock.Environment)
-		env.On("FileContent", TestRootPath+dotGit).Return(fmt.Sprintf("gitdir: %s", tc.WorkingFolder))
-		env.On("FileContent", filepath.Join(tc.WorkingFolder, tc.WorkingFolderAddon)).Return(tc.WorkingFolderContent)
-		env.On("HasFilesInDir", tc.WorkingFolder, tc.WorkingFolderAddon).Return(true)
-		env.On("HasFilesInDir", tc.WorkingFolder, "HEAD").Return(true)
+		env.On("FileContent", tc.DiscoveredGitFile).Return(fmt.Sprintf("gitdir: %s", tc.Pointer))
+		env.On("FileContent", filepath.Join(tc.ExpectedProbedDir, tc.MetadataAddon)).Return(tc.MetadataContent)
+		env.On("HasFilesInDir", tc.ExpectedProbedDir, tc.MetadataAddon).Return(tc.MetadataAddon != "")
+		env.On("HasFilesInDir", tc.ExpectedProbedDir, "HEAD").Return(true)
 		env.On("PathSeparator").Return(string(os.PathSeparator))
 
 		g := &Git{}
 		g.Init(options.Map{}, env)
 
 		assert.Equal(t, tc.ExpectedEnabled, g.hasWorktree(fileInfo), tc.Case)
-		assert.Equal(t, tc.ExpectedWorkingFolder, g.mainSCMDir, tc.Case)
-		assert.Equal(t, tc.ExpectedRealFolder, g.repoRootDir, tc.Case)
-		assert.Equal(t, tc.ExpectedRootFolder, g.scmDir, tc.Case)
+		assert.Equal(t, tc.ExpectedIsWorkTree, g.IsWorkTree, tc.Case)
+
+		if tc.ExpectedWorkingFolder != nil {
+			assert.Equal(t, *tc.ExpectedWorkingFolder, g.mainSCMDir, tc.Case)
+		}
+
+		if tc.ExpectedRealFolder != nil {
+			assert.Equal(t, *tc.ExpectedRealFolder, g.repoRootDir, tc.Case)
+		}
+
+		if tc.ExpectedRootFolder != nil {
+			assert.Equal(t, *tc.ExpectedRootFolder, g.scmDir, tc.Case)
+		}
+
+		if tc.ExpectedEnabled {
+			assert.True(t, filepath.IsAbs(g.mainSCMDir), tc.Case+": mainSCMDir must be absolute")
+			assert.True(t, filepath.IsAbs(g.scmDir), tc.Case+": scmDir must be absolute")
+		}
 	}
 }
 

--- a/src/segments/git_test.go
+++ b/src/segments/git_test.go
@@ -123,7 +123,11 @@ func TestEnabledInWorktree(t *testing.T) {
 		MetadataAddon     string
 		MetadataContent   string
 		ExpectedProbedDir string
-		Case              string
+		// TargetConfig is the config file found in the directory the pointer names. The
+		// modules classifier reads core.worktree out of it to tell a submodule git dir
+		// from a --separate-git-dir target, which has no core.worktree at all.
+		TargetConfig string
+		Case         string
 		// nil reserves directory-role assertions for a later decision.
 		ExpectedWorkingFolder *string
 		ExpectedRealFolder    *string
@@ -146,12 +150,15 @@ func TestEnabledInWorktree(t *testing.T) {
 			ExpectedRootFolder:    strPtr(TestRootPath + dotGit),
 		},
 		{
+			// The discovered .git file sits in the submodule's own checkout, and the git
+			// dir points back at it through core.worktree. Both are what git writes.
 			Case:                  "submodule",
 			ExpectedEnabled:       true,
-			Pointer:               "./.git/modules/submodule",
-			DiscoveredGitFile:     TestRootPath + dotGit,
-			DiscoveredParent:      TestRootPath + "dev",
+			Pointer:               "../.git/modules/submodule",
+			DiscoveredGitFile:     TestRootPath + "dev/sub/.git",
+			DiscoveredParent:      TestRootPath + "dev/sub",
 			ExpectedProbedDir:     TestRootPath + dotGitSubmodule,
+			TargetConfig:          "[core]\n\tworktree = ../../../sub",
 			ExpectedWorkingFolder: strPtr(TestRootPath + dotGitSubmodule),
 			ExpectedRealFolder:    strPtr(TestRootPath + dotGitSubmodule),
 			ExpectedRootFolder:    strPtr(TestRootPath + dotGitSubmodule),
@@ -160,9 +167,10 @@ func TestEnabledInWorktree(t *testing.T) {
 			Case:                  "submodule with root working folder",
 			ExpectedEnabled:       true,
 			Pointer:               TestRootPath + dotGitSubmodule,
-			DiscoveredGitFile:     TestRootPath + dotGit,
-			DiscoveredParent:      TestRootPath + "dev",
+			DiscoveredGitFile:     TestRootPath + "dev/sub/.git",
+			DiscoveredParent:      TestRootPath + "dev/sub",
 			ExpectedProbedDir:     TestRootPath + dotGitSubmodule,
+			TargetConfig:          "[core]\n\tworktree = ../../../sub",
 			ExpectedWorkingFolder: strPtr(TestRootPath + dotGitSubmodule),
 			ExpectedRealFolder:    strPtr(TestRootPath + dotGitSubmodule),
 			ExpectedRootFolder:    strPtr(TestRootPath + dotGitSubmodule),
@@ -187,6 +195,77 @@ func TestEnabledInWorktree(t *testing.T) {
 			DiscoveredGitFile: TestRootPath + dotGit,
 			DiscoveredParent:  TestRootPath + "dev",
 			ExpectedProbedDir: TestRootPath + "dev/separate/.git/posh",
+		},
+		{
+			// The pointer's spelling contains a "modules" component, but the directory
+			// before it is an ordinary folder, not a superproject git dir. This is a
+			// separate git dir, so repoRootDir must be the working tree root and not the
+			// git dir the pointer names.
+			Case:              "separate git dir under a modules path component",
+			ExpectedEnabled:   true,
+			Pointer:           TestRootPath + "srv/modules/project.git",
+			DiscoveredGitFile: TestRootPath + "work/project/.git",
+			DiscoveredParent:  TestRootPath + "work/project",
+			ExpectedProbedDir: TestRootPath + "srv/modules/project.git",
+			// A --separate-git-dir target records no core.worktree.
+			TargetConfig:       "[core]\n\trepositoryformatversion = 0",
+			ExpectedRealFolder: strPtr(TestRootPath + "work/project/"),
+		},
+		{
+			// A submodule's name is its path, so it can hold separators. Rejecting this
+			// is what a "one component after modules" rule would do.
+			Case:                  "submodule at a nested path",
+			ExpectedEnabled:       true,
+			Pointer:               "../../.git/modules/vendor/libfoo",
+			DiscoveredGitFile:     TestRootPath + "dev/vendor/libfoo/.git",
+			DiscoveredParent:      TestRootPath + "dev/vendor/libfoo",
+			ExpectedProbedDir:     TestRootPath + "dev/.git/modules/vendor/libfoo",
+			TargetConfig:          "[core]\n\tworktree = ../../../../vendor/libfoo",
+			ExpectedWorkingFolder: strPtr(TestRootPath + "dev/.git/modules/vendor/libfoo"),
+			ExpectedRealFolder:    strPtr(TestRootPath + "dev/.git/modules/vendor/libfoo"),
+			ExpectedRootFolder:    strPtr(TestRootPath + "dev/.git/modules/vendor/libfoo"),
+		},
+		{
+			// When the superproject itself uses --separate-git-dir, the folder in front of
+			// modules is not called .git. Rejecting this is what a ".git/modules" rule
+			// would do.
+			Case:                  "submodule of a separate-git-dir superproject",
+			ExpectedEnabled:       true,
+			Pointer:               "../../sepgit/modules/sub",
+			DiscoveredGitFile:     TestRootPath + "dev/sep/sub/.git",
+			DiscoveredParent:      TestRootPath + "dev/sep/sub",
+			ExpectedProbedDir:     TestRootPath + "dev/sepgit/modules/sub",
+			TargetConfig:          "[core]\n\tworktree = ../../../sep/sub",
+			ExpectedWorkingFolder: strPtr(TestRootPath + "dev/sepgit/modules/sub"),
+			ExpectedRealFolder:    strPtr(TestRootPath + "dev/sepgit/modules/sub"),
+			ExpectedRootFolder:    strPtr(TestRootPath + "dev/sepgit/modules/sub"),
+		},
+		{
+			// A submodule checked out at modules/foo doubles the segment. Rejecting this
+			// is what keying on the last modules occurrence would do, because the prefix
+			// then lands on .git/modules, which is a container and not a git dir.
+			Case:                  "submodule checked out below a modules folder",
+			ExpectedEnabled:       true,
+			Pointer:               "../../.git/modules/modules/foo",
+			DiscoveredGitFile:     TestRootPath + "dev/modules/foo/.git",
+			DiscoveredParent:      TestRootPath + "dev/modules/foo",
+			ExpectedProbedDir:     TestRootPath + "dev/.git/modules/modules/foo",
+			TargetConfig:          "[core]\n\tworktree = ../../../../modules/foo",
+			ExpectedWorkingFolder: strPtr(TestRootPath + "dev/.git/modules/modules/foo"),
+			ExpectedRealFolder:    strPtr(TestRootPath + "dev/.git/modules/modules/foo"),
+			ExpectedRootFolder:    strPtr(TestRootPath + "dev/.git/modules/modules/foo"),
+		},
+		{
+			// core.worktree present but pointing at another checkout: the git dir is not
+			// this checkout's, so it must not be treated as its submodule.
+			Case:               "module dir whose core.worktree points elsewhere",
+			ExpectedEnabled:    true,
+			Pointer:            TestRootPath + "dev/.git/modules/stale",
+			DiscoveredGitFile:  TestRootPath + "dev/sub/.git",
+			DiscoveredParent:   TestRootPath + "dev/sub",
+			ExpectedProbedDir:  TestRootPath + "dev/.git/modules/stale",
+			TargetConfig:       "[core]\n\tworktree = ../../../elsewhere",
+			ExpectedRealFolder: strPtr(TestRootPath + "dev/sub/"),
 		},
 		{
 			Case:                  "worktree with relative gitdir path",
@@ -376,6 +455,7 @@ func TestEnabledInWorktree(t *testing.T) {
 		env.On("FileContent", filepath.Join(tc.ExpectedProbedDir, tc.MetadataAddon)).Return(tc.MetadataContent)
 		env.On("HasFilesInDir", tc.ExpectedProbedDir, tc.MetadataAddon).Return(tc.MetadataAddon != "")
 		env.On("HasFilesInDir", tc.ExpectedProbedDir, "HEAD").Return(true)
+		env.On("FileContent", tc.ExpectedProbedDir+"/config").Return(tc.TargetConfig)
 		env.On("PathSeparator").Return(string(os.PathSeparator))
 
 		g := &Git{}

--- a/src/segments/git_test.go
+++ b/src/segments/git_test.go
@@ -108,10 +108,6 @@ func TestResolveEmptyGitPath(t *testing.T) {
 	assert.Equal(t, base, resolveGitPath(base, ""))
 }
 
-func strPtr(s string) *string {
-	return &s
-}
-
 func TestEnabledInWorktree(t *testing.T) {
 	cases := []struct {
 		Pointer    string
@@ -145,9 +141,9 @@ func TestEnabledInWorktree(t *testing.T) {
 			MetadataAddon:         "gitdir",
 			MetadataContent:       TestRootPath + "dev/worktree.git\n",
 			ExpectedProbedDir:     TestRootPath + "dev/.git/worktrees/folder_worktree",
-			ExpectedWorkingFolder: strPtr(TestRootPath + "dev/.git/worktrees/folder_worktree"),
-			ExpectedRealFolder:    strPtr(TestRootPath + "dev/worktree"),
-			ExpectedRootFolder:    strPtr(TestRootPath + dotGit),
+			ExpectedWorkingFolder: new(TestRootPath + "dev/.git/worktrees/folder_worktree"),
+			ExpectedRealFolder:    new(TestRootPath + "dev/worktree"),
+			ExpectedRootFolder:    new(TestRootPath + dotGit),
 		},
 		{
 			// The discovered .git file sits in the submodule's own checkout, and the git
@@ -159,9 +155,9 @@ func TestEnabledInWorktree(t *testing.T) {
 			DiscoveredParent:      TestRootPath + "dev/sub",
 			ExpectedProbedDir:     TestRootPath + dotGitSubmodule,
 			TargetConfig:          "[core]\n\tworktree = ../../../sub",
-			ExpectedWorkingFolder: strPtr(TestRootPath + dotGitSubmodule),
-			ExpectedRealFolder:    strPtr(TestRootPath + dotGitSubmodule),
-			ExpectedRootFolder:    strPtr(TestRootPath + dotGitSubmodule),
+			ExpectedWorkingFolder: new(TestRootPath + dotGitSubmodule),
+			ExpectedRealFolder:    new(TestRootPath + dotGitSubmodule),
+			ExpectedRootFolder:    new(TestRootPath + dotGitSubmodule),
 		},
 		{
 			Case:                  "submodule with root working folder",
@@ -171,9 +167,9 @@ func TestEnabledInWorktree(t *testing.T) {
 			DiscoveredParent:      TestRootPath + "dev/sub",
 			ExpectedProbedDir:     TestRootPath + dotGitSubmodule,
 			TargetConfig:          "[core]\n\tworktree = ../../../sub",
-			ExpectedWorkingFolder: strPtr(TestRootPath + dotGitSubmodule),
-			ExpectedRealFolder:    strPtr(TestRootPath + dotGitSubmodule),
-			ExpectedRootFolder:    strPtr(TestRootPath + dotGitSubmodule),
+			ExpectedWorkingFolder: new(TestRootPath + dotGitSubmodule),
+			ExpectedRealFolder:    new(TestRootPath + dotGitSubmodule),
+			ExpectedRootFolder:    new(TestRootPath + dotGitSubmodule),
 		},
 		{
 			// Directory-role assertions are reserved for a later decision.
@@ -209,7 +205,7 @@ func TestEnabledInWorktree(t *testing.T) {
 			ExpectedProbedDir: TestRootPath + "srv/modules/project.git",
 			// A --separate-git-dir target records no core.worktree.
 			TargetConfig:       "[core]\n\trepositoryformatversion = 0",
-			ExpectedRealFolder: strPtr(TestRootPath + "work/project/"),
+			ExpectedRealFolder: new(TestRootPath + "work/project/"),
 		},
 		{
 			// A submodule's name is its path, so it can hold separators. Rejecting this
@@ -221,9 +217,9 @@ func TestEnabledInWorktree(t *testing.T) {
 			DiscoveredParent:      TestRootPath + "dev/vendor/libfoo",
 			ExpectedProbedDir:     TestRootPath + "dev/.git/modules/vendor/libfoo",
 			TargetConfig:          "[core]\n\tworktree = ../../../../vendor/libfoo",
-			ExpectedWorkingFolder: strPtr(TestRootPath + "dev/.git/modules/vendor/libfoo"),
-			ExpectedRealFolder:    strPtr(TestRootPath + "dev/.git/modules/vendor/libfoo"),
-			ExpectedRootFolder:    strPtr(TestRootPath + "dev/.git/modules/vendor/libfoo"),
+			ExpectedWorkingFolder: new(TestRootPath + "dev/.git/modules/vendor/libfoo"),
+			ExpectedRealFolder:    new(TestRootPath + "dev/.git/modules/vendor/libfoo"),
+			ExpectedRootFolder:    new(TestRootPath + "dev/.git/modules/vendor/libfoo"),
 		},
 		{
 			// When the superproject itself uses --separate-git-dir, the folder in front of
@@ -236,9 +232,9 @@ func TestEnabledInWorktree(t *testing.T) {
 			DiscoveredParent:      TestRootPath + "dev/sep/sub",
 			ExpectedProbedDir:     TestRootPath + "dev/sepgit/modules/sub",
 			TargetConfig:          "[core]\n\tworktree = ../../../sep/sub",
-			ExpectedWorkingFolder: strPtr(TestRootPath + "dev/sepgit/modules/sub"),
-			ExpectedRealFolder:    strPtr(TestRootPath + "dev/sepgit/modules/sub"),
-			ExpectedRootFolder:    strPtr(TestRootPath + "dev/sepgit/modules/sub"),
+			ExpectedWorkingFolder: new(TestRootPath + "dev/sepgit/modules/sub"),
+			ExpectedRealFolder:    new(TestRootPath + "dev/sepgit/modules/sub"),
+			ExpectedRootFolder:    new(TestRootPath + "dev/sepgit/modules/sub"),
 		},
 		{
 			// A submodule checked out at modules/foo doubles the segment. Rejecting this
@@ -251,9 +247,9 @@ func TestEnabledInWorktree(t *testing.T) {
 			DiscoveredParent:      TestRootPath + "dev/modules/foo",
 			ExpectedProbedDir:     TestRootPath + "dev/.git/modules/modules/foo",
 			TargetConfig:          "[core]\n\tworktree = ../../../../modules/foo",
-			ExpectedWorkingFolder: strPtr(TestRootPath + "dev/.git/modules/modules/foo"),
-			ExpectedRealFolder:    strPtr(TestRootPath + "dev/.git/modules/modules/foo"),
-			ExpectedRootFolder:    strPtr(TestRootPath + "dev/.git/modules/modules/foo"),
+			ExpectedWorkingFolder: new(TestRootPath + "dev/.git/modules/modules/foo"),
+			ExpectedRealFolder:    new(TestRootPath + "dev/.git/modules/modules/foo"),
+			ExpectedRootFolder:    new(TestRootPath + "dev/.git/modules/modules/foo"),
 		},
 		{
 			// core.worktree present but pointing at another checkout: the git dir is not
@@ -265,7 +261,7 @@ func TestEnabledInWorktree(t *testing.T) {
 			DiscoveredParent:   TestRootPath + "dev/sub",
 			ExpectedProbedDir:  TestRootPath + "dev/.git/modules/stale",
 			TargetConfig:       "[core]\n\tworktree = ../../../elsewhere",
-			ExpectedRealFolder: strPtr(TestRootPath + "dev/sub/"),
+			ExpectedRealFolder: new(TestRootPath + "dev/sub/"),
 		},
 		{
 			Case:                  "worktree with relative gitdir path",
@@ -277,9 +273,9 @@ func TestEnabledInWorktree(t *testing.T) {
 			MetadataAddon:         "gitdir",
 			MetadataContent:       "../../../worktree/.git\n",
 			ExpectedProbedDir:     TestRootPath + "dev/.git/worktrees/folder_worktree",
-			ExpectedWorkingFolder: strPtr(TestRootPath + "dev/.git/worktrees/folder_worktree"),
-			ExpectedRealFolder:    strPtr(TestRootPath + "dev/worktree"),
-			ExpectedRootFolder:    strPtr(TestRootPath + dotGit),
+			ExpectedWorkingFolder: new(TestRootPath + "dev/.git/worktrees/folder_worktree"),
+			ExpectedRealFolder:    new(TestRootPath + "dev/worktree"),
+			ExpectedRootFolder:    new(TestRootPath + dotGit),
 		},
 		{
 			Case:                  "worktree with relative gitdir path, no trailing newline",
@@ -291,9 +287,9 @@ func TestEnabledInWorktree(t *testing.T) {
 			MetadataAddon:         "gitdir",
 			MetadataContent:       "../../../worktree/.git",
 			ExpectedProbedDir:     TestRootPath + "dev/.git/worktrees/folder_worktree",
-			ExpectedWorkingFolder: strPtr(TestRootPath + "dev/.git/worktrees/folder_worktree"),
-			ExpectedRealFolder:    strPtr(TestRootPath + "dev/worktree"),
-			ExpectedRootFolder:    strPtr(TestRootPath + dotGit),
+			ExpectedWorkingFolder: new(TestRootPath + "dev/.git/worktrees/folder_worktree"),
+			ExpectedRealFolder:    new(TestRootPath + "dev/worktree"),
+			ExpectedRootFolder:    new(TestRootPath + dotGit),
 		},
 		{
 			// Shape matches, but metadata does not point back to the discovered .git file.

--- a/src/segments/git_test.go
+++ b/src/segments/git_test.go
@@ -215,6 +215,80 @@ func TestEnabledInWorktree(t *testing.T) {
 			ExpectedRealFolder:    strPtr(TestRootPath + "dev/worktree"),
 			ExpectedRootFolder:    strPtr(TestRootPath + dotGit),
 		},
+		{
+			// Shape matches, but metadata does not point back to the discovered .git file.
+			Case:              "bare layout in a dir named worktrees",
+			ExpectedEnabled:   true,
+			Pointer:           TestRootPath + "me/worktrees/.bare",
+			DiscoveredGitFile: TestRootPath + "me/worktrees/.git",
+			DiscoveredParent:  TestRootPath + "me/worktrees",
+			MetadataAddon:     "gitdir",
+			ExpectedProbedDir: TestRootPath + "me/worktrees/.bare",
+		},
+		{
+			Case:               "worktree metadata is whitespace only",
+			ExpectedEnabled:    true,
+			ExpectedIsWorkTree: false,
+			Pointer:            TestRootPath + "dev/.git/worktrees/folder_worktree",
+			DiscoveredGitFile:  TestRootPath + "dev/.git/worktrees/folder_worktree/.git",
+			DiscoveredParent:   TestRootPath + "dev/.git/worktrees/folder_worktree",
+			MetadataAddon:      "gitdir",
+			MetadataContent:    " \n",
+			ExpectedProbedDir:  TestRootPath + "dev/.git/worktrees/folder_worktree",
+		},
+		{
+			Case:               "worktree metadata points somewhere else",
+			ExpectedEnabled:    true,
+			ExpectedIsWorkTree: false,
+			Pointer:            TestRootPath + "dev/.git/worktrees/folder_worktree",
+			DiscoveredGitFile:  TestRootPath + "dev/worktree/.git",
+			DiscoveredParent:   TestRootPath + "dev/worktree",
+			MetadataAddon:      "gitdir",
+			MetadataContent:    TestRootPath + "dev/moved-elsewhere/.git\n",
+			ExpectedProbedDir:  TestRootPath + "dev/.git/worktrees/folder_worktree",
+		},
+		{
+			Case:               "worktree metadata spelled with a trailing separator",
+			ExpectedEnabled:    true,
+			ExpectedIsWorkTree: true,
+			Pointer:            TestRootPath + "dev/.git/worktrees/folder_worktree",
+			DiscoveredGitFile:  TestRootPath + "dev/worktree/.git",
+			DiscoveredParent:   TestRootPath + "dev/worktree",
+			MetadataAddon:      "gitdir",
+			MetadataContent:    TestRootPath + "dev/worktree/.git\n",
+			ExpectedProbedDir:  TestRootPath + "dev/.git/worktrees/folder_worktree",
+		},
+		{
+			Case:               "worktree metadata is garbage that resolves nowhere",
+			ExpectedEnabled:    true,
+			ExpectedIsWorkTree: false,
+			Pointer:            TestRootPath + "dev/.git/worktrees/folder_worktree",
+			DiscoveredGitFile:  TestRootPath + "dev/worktree/.git",
+			DiscoveredParent:   TestRootPath + "dev/worktree",
+			MetadataAddon:      "gitdir",
+			MetadataContent:    "not-a-path-at-all\n",
+			ExpectedProbedDir:  TestRootPath + "dev/.git/worktrees/folder_worktree",
+		},
+		{
+			// Both spelling forms must reject a shape match whose metadata does not match.
+			Case:              "repo under a worktrees path component, absolute spelling",
+			ExpectedEnabled:   true,
+			Pointer:           TestRootPath + "me/worktrees/proj/.bare",
+			DiscoveredGitFile: TestRootPath + "me/worktrees/proj/.git",
+			DiscoveredParent:  TestRootPath + "me/worktrees/proj",
+			ExpectedProbedDir: TestRootPath + "me/worktrees/proj/.bare",
+		},
+		{
+			Case:               "genuine worktree whose common dir is under a worktrees component",
+			ExpectedEnabled:    true,
+			ExpectedIsWorkTree: true,
+			Pointer:            TestRootPath + "me/worktrees/proj/.git/worktrees/feat",
+			DiscoveredGitFile:  TestRootPath + "me/checkouts/feat/.git",
+			DiscoveredParent:   TestRootPath + "me/checkouts/feat",
+			MetadataAddon:      "gitdir",
+			MetadataContent:    TestRootPath + "me/checkouts/feat/.git\n",
+			ExpectedProbedDir:  TestRootPath + "me/worktrees/proj/.git/worktrees/feat",
+		},
 	}
 
 	for _, tc := range cases {
@@ -1539,7 +1613,7 @@ func TestGitMainWorktreeSessionCache(t *testing.T) {
 	}
 	secondAdminDir := commonDir + "/worktrees/linked-two"
 	secondEnv.On("FileContent", secondGitFile.Path).Return("gitdir: ../main/.git/worktrees/linked-two")
-	secondEnv.On("FileContent", filepath.Join(secondAdminDir, "gitdir")).Return("../../../linked-two/.git")
+	secondEnv.On("FileContent", filepath.Join(secondAdminDir, "gitdir")).Return("../../../../linked-two/.git")
 	second := &Git{}
 	second.Init(options.Map{}, secondEnv)
 	require.True(t, second.hasWorktree(secondGitFile))

--- a/src/segments/git_windows_test.go
+++ b/src/segments/git_windows_test.go
@@ -3,8 +3,14 @@
 package segments
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -63,5 +69,55 @@ func TestWorktreeAdminIndexWindows(t *testing.T) {
 		}
 
 		assert.Equal(t, tc.Expected, got, tc.Case)
+	}
+}
+
+func TestEnabledInWorktreeWindows(t *testing.T) {
+	cases := []struct {
+		Case               string
+		Pointer            string
+		ExpectedProbedDir  string
+		ExpectedIsWorkTree bool
+	}{
+		{
+			Case:               "drive absolute with native separators",
+			Pointer:            `C:\repo\.git\worktrees\feat`,
+			ExpectedProbedDir:  `C:\repo\.git\worktrees\feat`,
+			ExpectedIsWorkTree: true,
+		},
+		{
+			Case:               "disk-relative pointer gains the volume",
+			Pointer:            "/repo/.git/worktrees/feat",
+			ExpectedProbedDir:  "C:/repo/.git/worktrees/feat",
+			ExpectedIsWorkTree: true,
+		},
+		{
+			Case:               "relative pointer resolves against the .git file's folder",
+			Pointer:            "./.bare",
+			ExpectedProbedDir:  "C:/repo/feat/.bare",
+			ExpectedIsWorkTree: false,
+		},
+	}
+
+	for _, tc := range cases {
+		fileInfo := &runtime.FileInfo{
+			Path:         `C:/repo/feat/.git`,
+			ParentFolder: `C:/repo/feat`,
+		}
+
+		env := new(mock.Environment)
+		env.On("FileContent", fileInfo.Path).Return(fmt.Sprintf("gitdir: %s", tc.Pointer))
+		env.On("FileContent", filepath.Join(tc.ExpectedProbedDir, "gitdir")).Return(`C:/repo/feat/.git` + "\n")
+		env.On("HasFilesInDir", tc.ExpectedProbedDir, "gitdir").Return(true)
+		env.On("HasFilesInDir", tc.ExpectedProbedDir, "HEAD").Return(true)
+		env.On("PathSeparator").Return(string(os.PathSeparator))
+
+		g := &Git{}
+		g.Init(options.Map{}, env)
+
+		assert.True(t, g.hasWorktree(fileInfo), tc.Case)
+		assert.Equal(t, tc.ExpectedIsWorkTree, g.IsWorkTree, tc.Case)
+		assert.True(t, filepath.IsAbs(g.mainSCMDir), tc.Case+": mainSCMDir must be absolute")
+		assert.True(t, filepath.IsAbs(g.scmDir), tc.Case+": scmDir must be absolute")
 	}
 }

--- a/src/segments/git_windows_test.go
+++ b/src/segments/git_windows_test.go
@@ -3,6 +3,7 @@
 package segments
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,5 +39,29 @@ func TestResolveGitPath(t *testing.T) {
 	}
 	for _, tc := range cases {
 		assert.Equal(t, tc.Expected, resolveGitPath(tc.Base, tc.Path), tc.Case)
+	}
+}
+
+func TestWorktreeAdminIndexWindows(t *testing.T) {
+	cases := []struct {
+		Case     string
+		Path     string
+		Expected string
+	}{
+		{Case: "drive absolute, native separators", Path: `C:\repo\.git\worktrees\feat`, Expected: "C:/repo/.git"},
+		{Case: "drive absolute, trailing separator", Path: `C:\repo\.git\worktrees\feat\`, Expected: "C:/repo/.git"},
+		{Case: "drive absolute, dot component", Path: `C:\repo\.git\worktrees\feat\.`, Expected: "C:/repo/.git"},
+		{Case: "UNC path", Path: `\\server\share\.git\worktrees\feat`, Expected: "//server/share/.git"},
+		{Case: "two components after worktrees", Path: `C:\repo\.git\worktrees\a\b`, Expected: ""},
+		{Case: "repo under a worktrees component", Path: `C:\me\worktrees\proj\.bare`, Expected: ""},
+	}
+
+	for _, tc := range cases {
+		var got string
+		if index := worktreeAdminIndex(tc.Path); index > -1 {
+			got = filepath.ToSlash(filepath.Clean(tc.Path))[:index]
+		}
+
+		assert.Equal(t, tc.Expected, got, tc.Case)
 	}
 }


### PR DESCRIPTION
Fixes #7797.

### Prerequisites

- [x] I have read and understood the contributing guide.
- [x] The commit message follows the conventional commits guidelines.
- [x] Tests for the changes have been added.
- [x] Docs have been added/updated where relevant.

### Description

`hasWorktree` stored a relative `gitdir:` pointer raw and only made it absolute when it started with
`..`, so any other relative spelling (`./.bare`, `.bare`, `subdir/git`) resolved against the process's
working directory instead of the directory holding the `.git` file — the segment simply vanished
outside that one directory, with no error. `isBareRepo` had the same class of bug through a bare
`filepath.Join` on an already-absolute second argument.

This PR:

- resolves the pointer unconditionally and consistently in both `hasWorktree` and `isBareRepo`,
- replaces the `strings.LastIndex(mainSCMDir, "/worktrees/")` substring test with a structural
  classifier (`worktreeAdminIndex`) that validates the match is a genuine worktree administrative
  directory rather than any path merely containing the word,
- extends the same idea to the `/modules/` submodule classifier, which had an equivalent
  false-positive: a `--separate-git-dir` or bare pointer under a path containing a `modules` component
  was misclassified as a submodule. The new `isModuleAdminDir` verifies a `core.worktree` back-reference
  to the checkout instead of testing the raw string.

None of this changes behaviour for any layout that resolves correctly today — verified with new tests
covering plain clones, linked worktrees, submodules, submodule worktrees, bare repositories via a `.git`
file, and `--separate-git-dir`, from multiple process working directories.

### This is part of a stacked series

This branch is the bottom of a four-part stack fixing related defects in the git segment's directory
handling, all opened against `main`:

```
main
 └─ fix/git-relative-gitdir            (this PR)      → #7797
     └─ fix/git-worktree-common-dir                    → #7798
         └─ fix/git-bare-head-upstream                 → #7799
             └─ feat/statusline-payload-pwd             → #7800
```

Each of the other three branches is rebased/merged on top of this one, so their diffs will include
this PR's commits until it merges — that's expected for a stack on plain GitHub (no base-branch
retargeting available across forks). This PR itself has no dependency and can be reviewed and merged
on its own.