### PR TITLE
feat(cli): render the statusline claude/copilot commands in the payload's directory

### DIFF
--- a/src/cli/claude.go
+++ b/src/cli/claude.go
@@ -27,10 +27,15 @@ Example usage in Claude Code settings:
 		shell.CLAUDE,
 		cache.CLAUDECACHE,
 		func(d *segments.ClaudeData) string { return d.SessionID },
+		claudePWD,
 		config.Claude,
 	),
 }
 
 func init() {
 	RootCmd.AddCommand(claudeCmd)
+}
+
+func claudePWD(d *segments.ClaudeData) string {
+	return workingDirectory(d.Workspace.CurrentDir, d.CWD)
 }

--- a/src/cli/copilot.go
+++ b/src/cli/copilot.go
@@ -28,10 +28,15 @@ Example usage in GitHub Copilot CLI settings (%USERPROFILE%\.copilot\statusline.
 		shell.COPILOTCLI,
 		cache.COPILOTCLICACHE,
 		func(d *segments.CopilotCLIData) string { return d.SessionID },
+		copilotPWD,
 		config.CopilotCLI,
 	),
 }
 
 func init() {
 	RootCmd.AddCommand(copilotCmd)
+}
+
+func copilotPWD(d *segments.CopilotCLIData) string {
+	return workingDirectory(d.Workspace.CurrentDir, d.CWD)
 }

--- a/src/cli/statusline.go
+++ b/src/cli/statusline.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/cache"
 	"github.com/jandedobbeleer/oh-my-posh/src/config"
@@ -17,26 +18,8 @@ import (
 	"github.com/jandedobbeleer/oh-my-posh/src/cmdtree"
 )
 
-// statuslineRun returns a cmdtree Run function for statusline commands.
-// T is the type of the JSON data read from stdin.
-// shellConst identifies the shell (used for cache init and terminal init).
-// cacheKey is the session cache key under which data is stored.
-// sessionID extracts the session ID from parsed data so it can be set as POSH_SESSION_ID.
-// defaultCfg is called when no --config flag is provided or parsing fails.
-func statuslineRun[T any](shellConst, cacheKey string, sessionID func(*T) string, defaultCfg func() *config.Config) func(*cmdtree.Command, []string) {
+func statuslineRun[T any](shellConst, cacheKey string, sessionID, pwd func(*T) string, defaultCfg func() *config.Config) func(*cmdtree.Command, []string) {
 	return func(cmd *cmdtree.Command, _ []string) {
-		log.Debugf("%s command started", shellConst)
-
-		stdinData, err := io.ReadAll(os.Stdin)
-		if err != nil {
-			log.Error(err)
-			return
-		}
-
-		log.Debugf("received data from stdin: %s", string(stdinData))
-
-		processStatuslineData(stdinData, shellConst, cacheKey, sessionID)
-
 		// Only use a config file when --config was explicitly passed on the command line.
 		// POSH_CONFIG is intentionally ignored here: statusline commands always render their
 		// own dedicated layout and must not inherit the user's regular shell prompt config.
@@ -46,50 +29,107 @@ func statuslineRun[T any](shellConst, cacheKey string, sessionID func(*T) string
 			log.Debugf("using explicit config: %s", explicitConfig)
 		}
 
-		flags := &runtime.Flags{
-			ConfigPath: explicitConfig,
-			Shell:      shellConst,
-		}
-
-		env := &runtime.Terminal{}
-		env.Init(flags)
-
-		cfg, err := config.Parse(explicitConfig)
-		if err != nil {
-			log.Debug("no config found, using default")
-			cfg = defaultCfg()
-		}
-
-		template.Init(env, cfg.Var, cfg.Maps)
-		terminal.Init(shellConst)
-		terminal.BackgroundColor = cfg.TerminalBackground.ResolveTemplate()
-		terminal.Colors = cfg.MakeColors(env)
-
-		eng := &prompt.Engine{
-			Config: cfg,
-			Env:    env,
-		}
-
-		defer func() {
-			template.SaveCache()
-			cache.Close()
-		}()
-
-		fmt.Print(eng.Status())
+		runStatusline(os.Stdin, os.Stdout, explicitConfig, shellConst, cacheKey, sessionID, pwd, defaultCfg)
 	}
 }
 
-func processStatuslineData[T any](stdinData []byte, shellConst, cacheKey string, sessionID func(*T) string) {
+func runStatusline[T any](in io.Reader, out io.Writer, explicitConfig, shellConst, cacheKey string,
+	sessionID, pwd func(*T) string, defaultCfg func() *config.Config,
+) {
+	log.Debugf("%s command started", shellConst)
+
+	stdinData, err := io.ReadAll(in)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	log.Debugf("received data from stdin: %s", string(stdinData))
+
+	data := processStatuslineData(stdinData, shellConst, cacheKey, sessionID)
+
+	flags := statuslineFlags(explicitConfig, shellConst, data, pwd)
+
+	env := &runtime.Terminal{}
+	env.Init(flags)
+
+	cfg, err := config.Parse(explicitConfig)
+	if err != nil {
+		log.Debug("no config found, using default")
+		cfg = defaultCfg()
+	}
+
+	template.Init(env, cfg.Var, cfg.Maps)
+	terminal.Init(shellConst)
+	terminal.BackgroundColor = cfg.TerminalBackground.ResolveTemplate()
+	terminal.Colors = cfg.MakeColors(env)
+
+	eng := &prompt.Engine{
+		Config: cfg,
+		Env:    env,
+	}
+
+	defer func() {
+		template.SaveCache()
+		cache.Close()
+	}()
+
+	fmt.Fprint(out, eng.Status())
+}
+
+func statuslinePWD(candidate string) string {
+	if candidate == "" {
+		return ""
+	}
+
+	if !filepath.IsAbs(candidate) {
+		log.Debugf("ignoring relative payload directory: %s", candidate)
+		return ""
+	}
+
+	info, err := os.Stat(candidate)
+	if err != nil || !info.IsDir() {
+		log.Debugf("ignoring unusable payload directory: %s", candidate)
+		return ""
+	}
+
+	return candidate
+}
+
+func workingDirectory(currentDir, cwd string) string {
+	if currentDir != "" {
+		return currentDir
+	}
+
+	return cwd
+}
+
+func statuslineFlags[T any](explicitConfig, shellConst string, data *T, pwd func(*T) string) *runtime.Flags {
+	flags := &runtime.Flags{
+		ConfigPath: explicitConfig,
+		Shell:      shellConst,
+	}
+
+	if data == nil {
+		return flags
+	}
+
+	flags.PWD = statuslinePWD(pwd(data))
+
+	return flags
+}
+
+func processStatuslineData[T any](stdinData []byte, shellConst, cacheKey string, sessionID func(*T) string) *T {
 	if len(stdinData) == 0 {
 		cache.Init(shellConst, cache.Persist, cache.NoSession)
-		return
+		return nil
 	}
 
 	var data T
 	if err := json.Unmarshal(stdinData, &data); err != nil {
 		log.Error(err)
 		cache.Init(shellConst, cache.Persist, cache.NoSession)
-		return
+		return nil
 	}
 
 	if id := sessionID(&data); id != "" {
@@ -100,4 +140,6 @@ func processStatuslineData[T any](stdinData []byte, shellConst, cacheKey string,
 	cache.Init(shellConst, cache.Persist)
 	cache.Set(cache.Session, cacheKey, data, cache.INFINITE)
 	log.Debugf("stored %s data in session cache", shellConst)
+
+	return &data
 }

--- a/src/cli/statusline_test.go
+++ b/src/cli/statusline_test.go
@@ -1,0 +1,283 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/cache"
+	"github.com/jandedobbeleer/oh-my-posh/src/config"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments"
+	"github.com/jandedobbeleer/oh-my-posh/src/shell"
+	"github.com/jandedobbeleer/oh-my-posh/src/template"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatuslinePWD(t *testing.T) {
+	dir := t.TempDir()
+
+	file := filepath.Join(dir, "file")
+	require.NoError(t, os.WriteFile(file, []byte("x"), 0o600))
+
+	child := filepath.Join(dir, "child")
+	require.NoError(t, os.Mkdir(child, 0o755))
+
+	// filepath.Join would clean the dot component before the test sees it.
+	dotted := child + string(os.PathSeparator) + ".."
+
+	link := filepath.Join(dir, "link")
+	symlinked := true
+	if err := os.Symlink(child, link); err != nil {
+		symlinked = false
+	}
+
+	cases := []struct {
+		Case      string
+		Candidate string
+		Expected  string
+		Skip      bool
+	}{
+		{Case: "existing directory", Candidate: dir, Expected: dir},
+		{Case: "empty", Candidate: "", Expected: ""},
+		{Case: "relative", Candidate: "sub/deep", Expected: ""},
+		{Case: "missing", Candidate: filepath.Join(dir, "nope"), Expected: ""},
+		{Case: "a file", Candidate: file, Expected: ""},
+		{Case: "dot components kept verbatim", Candidate: dotted, Expected: dotted},
+		{Case: "symlink to a directory kept verbatim", Candidate: link, Expected: link, Skip: !symlinked},
+	}
+
+	for _, tc := range cases {
+		if tc.Skip {
+			continue
+		}
+
+		assert.Equal(t, tc.Expected, statuslinePWD(tc.Candidate), tc.Case)
+	}
+}
+
+func TestClaudePWD(t *testing.T) {
+	cases := []struct {
+		Case     string
+		Data     *segments.ClaudeData
+		Expected string
+	}{
+		{
+			Case:     "both set, disagreeing: current_dir wins",
+			Data:     &segments.ClaudeData{CWD: "/b", Workspace: segments.ClaudeWorkspace{CurrentDir: "/a"}},
+			Expected: "/a",
+		},
+		{
+			Case:     "only current_dir",
+			Data:     &segments.ClaudeData{Workspace: segments.ClaudeWorkspace{CurrentDir: "/a"}},
+			Expected: "/a",
+		},
+		{
+			Case:     "only cwd",
+			Data:     &segments.ClaudeData{CWD: "/b"},
+			Expected: "/b",
+		},
+		{
+			Case:     "neither",
+			Data:     &segments.ClaudeData{},
+			Expected: "",
+		},
+		{
+			Case:     "project_dir is not a fallback",
+			Data:     &segments.ClaudeData{Workspace: segments.ClaudeWorkspace{ProjectDir: "/p"}},
+			Expected: "",
+		},
+		{
+			Case:     "worktree.path is not a fallback",
+			Data:     &segments.ClaudeData{Worktree: &segments.ClaudeWorktree{Path: "/w"}},
+			Expected: "",
+		},
+	}
+
+	for _, tc := range cases {
+		assert.Equal(t, tc.Expected, claudePWD(tc.Data), tc.Case)
+	}
+}
+
+func TestCopilotPWD(t *testing.T) {
+	cases := []struct {
+		Case     string
+		Data     *segments.CopilotCLIData
+		Expected string
+	}{
+		{
+			Case:     "both set, disagreeing: current_dir wins",
+			Data:     &segments.CopilotCLIData{CWD: "/b", Workspace: segments.CopilotCLIWorkspace{CurrentDir: "/a"}},
+			Expected: "/a",
+		},
+		{
+			Case:     "only cwd",
+			Data:     &segments.CopilotCLIData{CWD: "/b"},
+			Expected: "/b",
+		},
+		{
+			Case:     "neither",
+			Data:     &segments.CopilotCLIData{},
+			Expected: "",
+		},
+	}
+
+	for _, tc := range cases {
+		assert.Equal(t, tc.Expected, copilotPWD(tc.Data), tc.Case)
+	}
+}
+
+func TestRunStatuslineRendersToWriter(t *testing.T) {
+	t.Setenv("OMP_CACHE_DIR", t.TempDir())
+	t.Setenv("POSH_SESSION_ID", "d4-writer")
+
+	cfgPath := filepath.Join(t.TempDir(), "writer.omp.yaml")
+	cfgBody := `version: 3
+final_space: false
+blocks:
+  - type: prompt
+    alignment: left
+    segments:
+      - type: text
+        style: plain
+        template: 'SEAM-OK'
+`
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfgBody), 0o600))
+
+	payload, err := json.Marshal(segments.ClaudeData{SessionID: "d4-writer"})
+	require.NoError(t, err)
+
+	template.ResetCache()
+
+	var out bytes.Buffer
+	runStatusline(bytes.NewReader(payload), &out, cfgPath, shell.CLAUDE, cache.CLAUDECACHE,
+		func(d *segments.ClaudeData) string { return d.SessionID }, claudePWD, config.Claude)
+
+	assert.Contains(t, out.String(), "SEAM-OK")
+}
+
+func TestStatuslineFlags(t *testing.T) {
+	dir := t.TempDir()
+
+	cases := []struct {
+		Case     string
+		Data     *segments.ClaudeData
+		Expected string
+	}{
+		{
+			Case:     "usable current_dir reaches Flags.PWD",
+			Data:     &segments.ClaudeData{Workspace: segments.ClaudeWorkspace{CurrentDir: dir}},
+			Expected: dir,
+		},
+		{
+			Case:     "nil data leaves PWD empty",
+			Data:     nil,
+			Expected: "",
+		},
+		{
+			Case:     "non-empty but invalid primary fails closed",
+			Data:     &segments.ClaudeData{Workspace: segments.ClaudeWorkspace{CurrentDir: filepath.Join(dir, "nope")}, CWD: dir},
+			Expected: "",
+		},
+	}
+
+	for _, tc := range cases {
+		flags := statuslineFlags("cfg.yaml", shell.CLAUDE, tc.Data, claudePWD)
+
+		assert.Equal(t, tc.Expected, flags.PWD, tc.Case)
+		assert.Equal(t, "cfg.yaml", flags.ConfigPath, tc.Case)
+		assert.Equal(t, shell.CLAUDE, flags.Shell, tc.Case)
+
+		env := &runtime.Terminal{}
+		env.Init(flags)
+
+		if tc.Expected != "" {
+			assert.Equal(t, tc.Expected, env.Pwd(), tc.Case)
+		}
+	}
+}
+
+func TestRunStatuslineUsesPayloadPWD(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found on PATH")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("OMP_CACHE_DIR", t.TempDir())
+	t.Setenv("POSH_SESSION_ID", "d4-integration")
+
+	root := t.TempDir()
+	repo := filepath.Join(root, "payload-repo")
+
+	runStatuslineGit(t, root, "init", "-q", "-b", "payload-branch", repo)
+	runStatuslineGit(t, repo, "config", "user.email", "test@example.com")
+	runStatuslineGit(t, repo, "config", "user.name", "Test")
+	runStatuslineGit(t, repo, "config", "core.autocrlf", "false")
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "a.txt"), []byte("a\n"), 0o644))
+	runStatuslineGit(t, repo, "add", ".")
+	runStatuslineGit(t, repo, "commit", "-q", "-m", "init")
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "a.txt"), []byte("changed\n"), 0o644))
+
+	cfgPath := filepath.Join(t.TempDir(), "d4.omp.yaml")
+	cfgBody := `version: 3
+final_space: false
+blocks:
+  - type: prompt
+    alignment: left
+    segments:
+      - type: text
+        style: plain
+        template: 'Folder=[{{ .Folder }}]'
+      - type: git
+        style: plain
+        properties:
+          fetch_status: true
+        template: ' Ref=[{{ .Ref }}] Dirty=[{{ .Working.Changed }}]'
+`
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfgBody), 0o600))
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NotEqual(t, repo, cwd, "the payload directory must differ from the process directory")
+
+	// Marshal the payload so Windows path separators are escaped correctly.
+	payload, err := json.Marshal(segments.ClaudeData{
+		SessionID: "d4-integration",
+		CWD:       repo,
+		Workspace: segments.ClaudeWorkspace{CurrentDir: repo},
+	})
+	require.NoError(t, err)
+
+	template.ResetCache()
+
+	var out bytes.Buffer
+	runStatusline(bytes.NewReader(payload), &out, cfgPath, shell.CLAUDE, cache.CLAUDECACHE,
+		func(d *segments.ClaudeData) string { return d.SessionID }, claudePWD, config.Claude)
+
+	rendered := out.String()
+
+	assert.Contains(t, rendered, "Folder=["+filepath.Base(repo)+"]", rendered)
+	assert.Contains(t, rendered, "Ref=[payload-branch]", rendered)
+	assert.Contains(t, rendered, "Dirty=[true]", rendered)
+}
+
+func runStatuslineGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+
+	cmd := exec.CommandContext(context.Background(), "git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "git %s failed: %s", strings.Join(args, " "), out)
+}

--- a/website/docs/segments/cli/claude.mdx
+++ b/website/docs/segments/cli/claude.mdx
@@ -12,6 +12,19 @@ Shows a visual gauge of context window usage and formatted cost/token informatio
 This segment integrates with [Claude Code's statusline functionality][claude-docs]
 to provide real-time session data in your prompt.
 
+:::info Working directory
+
+`oh-my-posh claude` renders directory-aware segments — `path`, `git`, `project` and the language segments — and the
+`.PWD`, `.Folder` and `.AbsolutePWD` template values against the directory the payload reports in
+`workspace.current_dir`, falling back to `cwd`. When the payload reports neither, or reports a path that is not an
+existing absolute directory, the renderer's own working directory is used, as before.
+
+The renderer's working directory itself is not changed, so external commands — including version manager shims — and
+the `cmd`, `readFile` and `glob` template functions still resolve relative to the directory Claude Code started the
+renderer in, not to `workspace.current_dir`.
+
+:::
+
 ## Sample Configuration
 
 import Config from "@site/src/components/Config.js";

--- a/website/docs/segments/cli/copilot-cli.mdx
+++ b/website/docs/segments/cli/copilot-cli.mdx
@@ -15,6 +15,19 @@ to provide real-time session data in your prompt.
 
 For setup instructions, see [Change your prompt](/docs/installation/prompt?shell=copilot).
 
+:::info Working directory
+
+`oh-my-posh copilot` renders directory-aware segments — `path`, `git`, `project` and the language segments — and the
+`.PWD`, `.Folder` and `.AbsolutePWD` template values against the directory the payload reports in
+`workspace.current_dir`, falling back to `cwd`. When the payload reports neither, or reports a path that is not an
+existing absolute directory, the renderer's own working directory is used, as before.
+
+The renderer's working directory itself is not changed, so external commands — including version manager shims — and
+the `cmd`, `readFile` and `glob` template functions still resolve relative to the directory GitHub Copilot CLI started
+the renderer in, not to `workspace.current_dir`.
+
+:::
+
 ## Sample Configuration
 
 import Config from "@site/src/components/Config.js";


### PR DESCRIPTION
Closes #7800.

### Prerequisites

- [x] I have read and understood the contributing guide.
- [x] The commit message follows the conventional commits guidelines.
- [x] Tests for the changes have been added.
- [x] Docs have been added/updated where relevant.

### Description

`oh-my-posh claude` and `oh-my-posh copilot` parse the host's statusline payload but never used the
directory it reports, so `runtime.Flags.PWD` stayed unset and every directory-aware segment (`path`,
`git`, `project`, language segments, and the `.PWD`/`.Folder`/`.AbsolutePWD` template fields) rendered
against wherever the host happened to spawn the renderer process instead of the session's actual
working directory.

This PR adds a validated accessor for each host's payload (preferring the most specific directory field
it reports, falling back through less specific ones) and threads it into `runtime.Flags.PWD` in
`statuslineRun`. When a payload doesn't name a usable directory, behaviour is unchanged — this is purely
additive.

Verified end to end: with the payload's directory wired through, all six measured lab positions across
five layouts match the shell's own view of the directory; without it, five of six differ, each
reporting the renderer's own directory instead of the session's.

### This is part of a stacked series

```text
next (includes #7801)
 └─ fix/git-worktree-common-dir                     → #7825
     └─ fix/git-bare-head-upstream                  → #7803
         └─ feat/statusline-payload-pwd  (this PR)  → #7800
```

This branch adds one commit on top of `fix/git-bare-head-upstream` (#7803) and transitively depends on
#7825. Until #7825 and #7803 merge, this PR's diff includes their commits too; it will then shrink to
this PR's own commit.
