### PR TITLE
Indicate .Jobs is supported for bash

### DIFF
--- a/website/docs/configuration/templates.mdx
+++ b/website/docs/configuration/templates.mdx
@@ -18,27 +18,27 @@ These properties can be used anywhere, in any segment. If a segment contains a p
 the segment property value will be used instead. In case you want to use the global property, you can prefix
 it with `.$` to reference it directly.
 
-| Name            | Type                  | Description                                                                      |
-| --------------- | --------------------- | -------------------------------------------------------------------------------- |
-| `.Root`         | `boolean`             | is the current user root/admin or not                                            |
-| `.PWD`          | `string`              | the current working directory (`~` for `$HOME`)                                  |
-| `.AbsolutePWD`  | `string`              | the current working directory (unaltered)                                        |
-| `.PSWD`         | `string`              | the current non-filesystem working directory in PowerShell                       |
-| `.Folder`       | `string`              | the current working folder                                                       |
-| `.Shell`        | `string`              | the current shell name. The value may be overriden by [`maps.shell_name`][maps]. |
-| `.ShellVersion` | `string`              | the current shell version                                                        |
-| `.SHLVL`        | `int`                 | the current shell level                                                          |
-| `.UserName`     | `string`              | the current user name                                                            |
-| `.HostName`     | `string`              | the host name                                                                    |
-| `.Code`         | `int`                 | the last exit code                                                               |
-| `.Executed`     | `boolean`             | false when the shell just started or enter was pressed without a command         |
-| `.Jobs`         | `int`                 | number of background jobs (only available for zsh, bash, PowerShell, and Nushell)|
-| `.OS`           | `string`              | the operating system                                                             |
-| `.WSL`          | `boolean`             | in WSL yes/no                                                                    |
-| `.Templates`    | `string`              | the [templates][templates] result                                                |
-| `.PromptCount`  | `int`                 | the prompt counter, increments with 1 for every prompt invocation                |
-| `.Version`      | `string`              | the Oh My Posh version                                                           |
-| `.Segment`      | [`Segment`](#segment) | the current segment's metadata                                                   |
+| Name            | Type                  | Description                                                                       |
+| --------------- | --------------------- | --------------------------------------------------------------------------------- |
+| `.Root`         | `boolean`             | is the current user root/admin or not                                             |
+| `.PWD`          | `string`              | the current working directory (`~` for `$HOME`)                                   |
+| `.AbsolutePWD`  | `string`              | the current working directory (unaltered)                                         |
+| `.PSWD`         | `string`              | the current non-filesystem working directory in PowerShell                        |
+| `.Folder`       | `string`              | the current working folder                                                        |
+| `.Shell`        | `string`              | the current shell name. The value may be overriden by [`maps.shell_name`][maps].  |
+| `.ShellVersion` | `string`              | the current shell version                                                         |
+| `.SHLVL`        | `int`                 | the current shell level                                                           |
+| `.UserName`     | `string`              | the current user name                                                             |
+| `.HostName`     | `string`              | the host name                                                                     |
+| `.Code`         | `int`                 | the last exit code                                                                |
+| `.Executed`     | `boolean`             | false when the shell just started or enter was pressed without a command          |
+| `.Jobs`         | `int`                 | number of background jobs (only available for zsh, bash, PowerShell, and Nushell) |
+| `.OS`           | `string`              | the operating system                                                              |
+| `.WSL`          | `boolean`             | in WSL yes/no                                                                     |
+| `.Templates`    | `string`              | the [templates][templates] result                                                 |
+| `.PromptCount`  | `int`                 | the prompt counter, increments with 1 for every prompt invocation                 |
+| `.Version`      | `string`              | the Oh My Posh version                                                            |
+| `.Segment`      | [`Segment`](#segment) | the current segment's metadata                                                    |
 
 ### Segment
 

--- a/website/docs/configuration/templates.mdx
+++ b/website/docs/configuration/templates.mdx
@@ -32,7 +32,7 @@ it with `.$` to reference it directly.
 | `.HostName`     | `string`              | the host name                                                                    |
 | `.Code`         | `int`                 | the last exit code                                                               |
 | `.Executed`     | `boolean`             | false when the shell just started or enter was pressed without a command         |
-| `.Jobs`         | `int`                 | number of background jobs (only available for zsh, PowerShell, and Nushell)      |
+| `.Jobs`         | `int`                 | number of background jobs (only available for zsh, bash, PowerShell, and Nushell)|
 | `.OS`           | `string`              | the operating system                                                             |
 | `.WSL`          | `boolean`             | in WSL yes/no                                                                    |
 | `.Templates`    | `string`              | the [templates][templates] result                                                |


### PR DESCRIPTION
### Prerequisites

- [X ] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [ X] The commit message follows the [conventional commits][cc] guidelines.
- [ X] Tests for the changes have been added (for bug fixes / features).
- [ X] Docs have been added/updated (for bug fixes / features).

### Description

#7463 addressed this problem, but the documentation still indicates `.Jobs` is not available for bash. This PR fixes that.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
