### PR TITLE
fix(golang): read the documented parse_go_work_file option

### DIFF
--- a/src/segments/golang.go
+++ b/src/segments/golang.go
@@ -12,8 +12,8 @@ type Golang struct {
 }
 
 const (
-	ParseModFile  options.Option = "parse_mod_file"
-	ParseWorkFile options.Option = "parse_work_file"
+	ParseModFile    options.Option = "parse_mod_file"
+	ParseGoWorkFile options.Option = "parse_go_work_file"
 )
 
 func (g *Golang) Template() string {
@@ -44,7 +44,7 @@ func (g *Golang) getVersion() (string, error) {
 		return g.parseModFile()
 	}
 
-	if g.options.Bool(ParseWorkFile, false) {
+	if g.options.Bool(ParseGoWorkFile, false) {
 		return g.parseWorkFile()
 	}
 

--- a/src/segments/golang_test.go
+++ b/src/segments/golang_test.go
@@ -94,7 +94,7 @@ func TestGolang(t *testing.T) {
 		}
 
 		if tc.ParseGoWorkFile {
-			props[ParseWorkFile] = tc.ParseGoWorkFile
+			props[ParseGoWorkFile] = true
 			fileInfo := &runtime.FileInfo{
 				Path:         "../test/go.work",
 				ParentFolder: "./",


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features). Nothing to change, the docs are the half thats already right.

### Description

Turn on `parse_go_work_file` and the go segment carries on showing whatever `go version` prints, so you get the toolchain you happen to have instaled rather than the one your `go.work` pins. With no `go` on PATH it renders empty.

This is so that it behaves how you documented it, and how the schema autocompletes it

<img width="1652" height="842" alt="image" src="https://github.com/user-attachments/assets/1fc5535a-ac3d-4ac6-a705-46df49b25bb7" />

It does mean `parse_work_file` stops working, but that spelling is in neither the docs nor the schema - I doubt anyone has it set. The existing test set the option through the constant, wich meant it passed either way. It uses the literal key now and fails on main.

Small change, close it if you'd rather not.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
