### PR TITLE
fix(zsh): quote zle_bracketed_paste subscript to avoid glob expansion

### DIFF
--- a/.agents/skills/project-knowledge/references/zsh.md
+++ b/.agents/skills/project-knowledge/references/zsh.md
@@ -40,6 +40,25 @@
 - Never pass a possibly-zero pid to `kill -0` - `kill -0 0` signals the caller's own process group
   and always succeeds.
 
+## GLOB_SUBST footgun (verified 2026-08-24, issue #7816)
+
+- An unquoted `$var`/`$var[n]` expansion used as a command argument is normally only
+  word-split, never glob-expanded - **unless** the user's zsh has `setopt GLOB_SUBST`
+  active anywhere (their own config, a framework, a distro snippet). Under `GLOB_SUBST`
+  the expansion result is treated as if typed literally and becomes eligible for filename
+  generation.
+- `_omp_zle-line-init`'s bracketed-paste signal - `print -r -n - $zle_bracketed_paste[1]`,
+  copied from zsh's own `zshzle(1)` example - expands to the raw escape sequence
+  `\e[?2004h`. Under `GLOB_SUBST`, `[?2004h` parses as an unterminated bracket expression;
+  zsh's default `BAD_PATTERN` option turns that into a hard error
+  (`_omp_zle-line-init:N: bad pattern: ^[[?2004h`) that aborts the widget mid-execution,
+  before it reaches `zle .recursive-edit`.
+- Fix: quote the expansion (`"$zle_bracketed_paste[1]"`). Reproduces reliably with
+  `zsh -c 'setopt glob_subst; zle_bracketed_paste=($'"'"'\e[?2004h'"'"' ...); print -r -n - $zle_bracketed_paste[1]'`.
+- General lesson: any unquoted parameter expansion fed to a zsh command argument in this
+  codebase is a latent `GLOB_SUBST` footgun if its value can ever contain `[`, `?`, `*`,
+  or `#` - quote it even when the current default options make it look safe.
+
 ## Footguns
 
 - A redirection-only `exec` applies EVERY listed redirection to the shell permanently:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,7 @@ jobs:
           name: msix-artifact-${{ matrix.arch }}
           path: |
             packages/msix/out/install-${{ matrix.arch }}.msix
+            packages/msix/out/install-${{ matrix.arch }}.appinstaller
   release:
     runs-on: ubuntu-latest
     needs:
@@ -149,7 +150,9 @@ jobs:
         run: |
           echo v${{ needs.changelog.outputs.version }} > version.txt
           az storage blob upload-batch --destination releases/v${{ needs.changelog.outputs.version }} --source .
+          az storage blob upload-batch --destination releases/v${{ needs.changelog.outputs.version }} --overwrite true --source . --pattern "*.appinstaller" --content-type "application/appinstaller"
           az storage blob upload-batch --destination releases/latest --overwrite true --source .
+          az storage blob upload-batch --destination releases/latest --overwrite true --source . --pattern "*.appinstaller" --content-type "application/appinstaller"
       - name: Create draft release 📝
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228
         with:

--- a/packages/msix/README.md
+++ b/packages/msix/README.md
@@ -15,12 +15,24 @@ the repository's `dist` folder.
 ./build.ps1 -Architecture x64 -Version "1.3.37"
 ```
 
-The package is created at `out/install-x64.msix`.
+The package is created at `out/install-x64.msix`, along with an App Installer
+file at `out/install-x64.appinstaller`.
+
+The `.appinstaller` file references the published package on the CDN and enables
+automatic updates: Windows re-checks the stable URL it was installed from
+(daily on launch and via a background task) and updates the package silently
+when a new version is available.
 
 ## Install the package
 
 ```powershell
 Add-AppxPackage -Path ./out/install-x64.msix
+```
+
+## Install via App Installer (with auto-update)
+
+```powershell
+Add-AppxPackage -AppInstallerFile https://cdn.ohmyposh.dev/releases/latest/install-x64.appinstaller
 ```
 
 [Windows SDK]: https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/

--- a/packages/msix/build.ps1
+++ b/packages/msix/build.ps1
@@ -21,6 +21,10 @@
 .PARAMETER Copy
     When specified, copies the appropriate executable from the dist folder before packaging.
 
+.PARAMETER DownloadUrl
+    The base URL where releases are published, used in the generated App Installer file.
+    Defaults to "https://cdn.ohmyposh.dev/releases".
+
 .EXAMPLE
     .\build.ps1 -Architecture x64 -Version "1.2.3" -Copy
 
@@ -32,7 +36,7 @@
     Creates and signs the MSIX package for arm64 architecture with version 1.2.3.
 
 .OUTPUTS
-    Creates install-{Architecture}.msix in the 'out' directory.
+    Creates install-{Architecture}.msix and install-{Architecture}.appinstaller in the 'out' directory.
 
 .NOTES
     Requires the Windows SDK for MSIX packaging and signing.
@@ -56,7 +60,11 @@ param(
     [switch]$Sign,
 
     [Parameter()]
-    [switch]$Copy
+    [switch]$Copy,
+
+    [Parameter()]
+    [ValidateNotNullOrEmpty()]
+    [string]$DownloadUrl = "https://cdn.ohmyposh.dev/releases"
 )
 
 # Set error handling preferences
@@ -223,6 +231,35 @@ try {
 }
 catch {
     Write-Error "Failed to create MSIX package: ${_}"
+    throw
+}
+
+Write-Verbose "Creating App Installer file" -Verbose
+
+try {
+    $appInstallerPath = "$currentPath/out/install-$Architecture.appinstaller"
+    $identity = $manifestDocument.Package.Identity
+
+    # The App Installer file lives at a stable URL so Windows can poll it for updates,
+    # while the package URL is immutable per version to avoid mid-publish races.
+    $appInstaller = @"
+<?xml version="1.0" encoding="utf-8"?>
+<AppInstaller xmlns="http://schemas.microsoft.com/appx/appinstaller/2018" Version="$Version.0" Uri="$DownloadUrl/latest/install-$Architecture.appinstaller">
+  <MainPackage Name="$($identity.Name)" Version="$Version.0" Publisher="$($identity.Publisher)" ProcessorArchitecture="$Architecture" Uri="$DownloadUrl/v$Version/install-$Architecture.msix" />
+  <UpdateSettings>
+    <OnLaunch HoursBetweenUpdateChecks="24" />
+    <AutomaticBackgroundTask />
+    <ForceUpdateFromAnyVersion>true</ForceUpdateFromAnyVersion>
+  </UpdateSettings>
+</AppInstaller>
+"@
+
+    $appInstaller | Out-File -FilePath $appInstallerPath -Encoding UTF8
+
+    Write-Verbose "Created App Installer file: $appInstallerPath" -Verbose
+}
+catch {
+    Write-Error "Failed to create App Installer file: ${_}"
     throw
 }
 

--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -57,6 +57,16 @@ linters:
       - third_party$
       - builtin$
       - examples$
+    rules:
+      # GetAccentColor's unix stub (colors_unix.go) always errors, so staticcheck
+      # sees the success path here as statically unreachable when analyzed under
+      # a unix GOOS - even though the darwin/windows implementations can succeed.
+      # An inline //nolint would be flagged as unused (nolintlint) on those
+      # platforms' builds, so exclude by config instead.
+      - path: cli/get.go
+        linters:
+          - staticcheck
+        text: SA4023
 formatters:
   enable:
     - gofmt

--- a/src/go.mod
+++ b/src/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
-	github.com/stretchr/testify v1.12.0
+	github.com/stretchr/testify v1.12.1
 	github.com/wayneashleyberry/terminal-dimensions v1.1.0
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/sys v0.47.0
@@ -60,5 +60,4 @@ require (
 	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/src/go.sum
+++ b/src/go.sum
@@ -95,8 +95,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.5.3 h1:jmXUvGomnU1o3W/V5h2VEradbpJDwGrzugQQvL0POH4=
 github.com/stretchr/objx v0.5.3/go.mod h1:rDQraq+vQZU7Fde9LOZLr8Tax6zZvy4kuNKF+QYS+U0=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/stretchr/testify v1.12.0 h1:K6Mr6jO9JICuend/5xzTM03ydSV3vdNRYAdPSukj8uI=
-github.com/stretchr/testify v1.12.0/go.mod h1:bOYBZb5qJ00vPzWfIqBUZPaxK8jWiXc6d3ErP4Ca9Gw=
+github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWDWE=
+github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=
@@ -134,5 +134,3 @@ gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/src/runtime/http/client_default.go
+++ b/src/runtime/http/client_default.go
@@ -11,9 +11,9 @@ import (
 
 var defaultTransport http.RoundTripper = &http.Transport{
 	Proxy: http.ProxyFromEnvironment,
-	Dial: (&net.Dialer{
+	DialContext: (&net.Dialer{
 		Timeout: 10 * time.Second,
-	}).Dial,
+	}).DialContext,
 	TLSHandshakeTimeout:   10 * time.Second,
 	ResponseHeaderTimeout: 10 * time.Second,
 }

--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -347,12 +347,12 @@ func (g *Git) shouldDisplay() bool {
 		return false
 	}
 
-	if g.options.Bool(FetchBareInfo, false) {
-		g.IsBare = g.isBareRepo(gitdir)
-	}
-
 	if !g.hasCommand(GITCOMMAND) {
 		return false
+	}
+
+	if g.options.Bool(FetchBareInfo, false) {
+		g.IsBare = g.isBareRepo(gitdir)
 	}
 
 	return g.isRepo(gitdir)
@@ -402,7 +402,7 @@ func (g *Git) isBareRepo(gitDir *runtime.FileInfo) bool {
 	} else {
 		content := g.fileContent(gitDir.ParentFolder, ".git")
 		dir := strings.TrimPrefix(content, "gitdir: ")
-		g.mainSCMDir = filepath.Join(gitDir.ParentFolder, dir)
+		g.mainSCMDir = resolveGitPath(gitDir.ParentFolder, g.convertToLinuxPath(dir))
 	}
 
 	cfg, err := g.getGitConfig()
@@ -458,23 +458,25 @@ func (g *Git) hasWorktree(gitdir *runtime.FileInfo) bool {
 		return false
 	}
 
-	// if we open a worktree file in a WSL shared folder, we have to convert it back
-	// to the mounted path
-	g.mainSCMDir = g.convertToLinuxPath(matches["dir"])
+	// Convert before resolving because filepath.IsAbs("C:/repo/.git") is false on Linux.
+	raw := g.convertToLinuxPath(matches["dir"])
+	g.mainSCMDir = resolveGitPath(gitdir.ParentFolder, raw)
 
-	// in worktrees, the path looks like this: gitdir: path/.git/worktrees/branch
-	// scmDir needs to become path/.git
-	// repoRootDir needs to become path
-	worktreeIndex := strings.LastIndex(g.mainSCMDir, "/worktrees/")
+	// The returned index only applies to the normalized path.
+	adminDir := filepath.ToSlash(filepath.Clean(g.mainSCMDir))
+	worktreeIndex := worktreeAdminIndex(adminDir)
 
 	// in submodules, the path looks like this: gitdir: ../.git/modules/test-submodule
-	// we need the parent folder to detect where the real .git folder is
-	if strings.Contains(g.mainSCMDir, "/modules/") {
-		g.scmDir = resolveGitPath(gitdir.ParentFolder, g.mainSCMDir)
+	// we need the parent folder to detect where the real .git folder is. Test raw rather
+	// than the resolved path: a checkout below a folder named modules would otherwise
+	// drag every genuine worktree in it into this branch.
+	if strings.Contains(raw, "/modules/") && g.isModuleAdminDir(g.mainSCMDir, gitdir.ParentFolder) {
+		g.scmDir = g.mainSCMDir
 		// this might be both a worktree and a submodule, where the path would look like
 		// this: path/.git/modules/module/path/worktrees/location. We cannot distinguish
 		// between worktree and a module path containing the word 'worktree,' however.
-		worktreeIndex = strings.LastIndex(g.scmDir, "/worktrees/")
+		moduleDir := filepath.ToSlash(filepath.Clean(g.scmDir))
+		worktreeIndex = worktreeAdminIndex(moduleDir)
 		if worktreeIndex > -1 && g.env.HasFilesInDir(g.scmDir, "gitdir") {
 			gitDir := filepath.Join(g.scmDir, "gitdir")
 			realGitFolder := g.env.FileContent(gitDir)
@@ -482,7 +484,7 @@ func (g *Git) hasWorktree(gitdir *runtime.FileInfo) bool {
 			g.repoRootDir = g.convertToLinuxPath(g.repoRootDir)
 			// resolve relative paths (worktree.useRelativePaths = true)
 			g.repoRootDir = resolveGitPath(g.scmDir, g.repoRootDir)
-			g.scmDir = g.scmDir[:worktreeIndex]
+			g.scmDir = moduleDir[:worktreeIndex]
 			g.mainSCMDir = g.scmDir
 			g.IsWorkTree = true
 			return true
@@ -493,22 +495,21 @@ func (g *Git) hasWorktree(gitdir *runtime.FileInfo) bool {
 		return true
 	}
 
-	// convert to absolute path for worktrees only
-	if strings.HasPrefix(g.mainSCMDir, "..") {
-		g.mainSCMDir = resolveGitPath(gitdir.ParentFolder, g.mainSCMDir)
-		worktreeIndex = strings.LastIndex(g.mainSCMDir, "/worktrees/")
-	}
-
 	if worktreeIndex > -1 {
-		gitDir := filepath.Join(g.mainSCMDir, "gitdir")
-		g.scmDir = g.mainSCMDir[:worktreeIndex]
-		gitDirContent := g.env.FileContent(gitDir)
-		g.repoRootDir = strings.TrimSuffix(strings.TrimRight(gitDirContent, "\n\r "), ".git")
-		g.repoRootDir = g.convertToLinuxPath(g.repoRootDir)
+		gitDirContent := g.env.FileContent(filepath.Join(g.mainSCMDir, "gitdir"))
+		gitDirPath := strings.TrimRight(gitDirContent, "\n\r ")
+		root := strings.TrimSuffix(gitDirPath, ".git")
+		root = g.convertToLinuxPath(root)
 		// resolve relative paths (worktree.useRelativePaths = true)
-		g.repoRootDir = resolveGitPath(g.mainSCMDir, g.repoRootDir)
-		g.IsWorkTree = true
-		return true
+		root = resolveGitPath(g.mainSCMDir, root)
+
+		// A genuine worktree's metadata points back at the .git file we just read.
+		if gitDirPath != "" && filepath.Clean(root) == filepath.Clean(gitdir.ParentFolder) {
+			g.scmDir = adminDir[:worktreeIndex]
+			g.repoRootDir = root
+			g.IsWorkTree = true
+			return true
+		}
 	}
 
 	// check for separate git folder(--separate-git-dir)
@@ -1194,6 +1195,65 @@ func (g *Git) commonGitDir() string {
 	}
 
 	return filepath.ToSlash(g.scmDir)
+}
+
+// isModuleAdminDir reports whether target is a submodule administrative directory
+// belonging to the checkout at parent, or a linked worktree inside one.
+//
+// A pointer whose spelling merely contains a modules component is not enough: a
+// --separate-git-dir target such as /srv/modules/project.git spells the same substring
+// without being a submodule. Nor does the shape help the way it does for worktrees. A
+// submodule's name is its path, so it may hold separators (.git/modules/vendor/libfoo),
+// it may nest (.../modules/vendor/libfoo/modules/inner), and the folder in front of
+// modules is only called .git when the superproject has no --separate-git-dir of its own
+// (../../sepgit/modules/sub is a real pointer).
+//
+// What does hold is that git records core.worktree in a submodule's git dir, pointing
+// back at the checkout, and never records it in a --separate-git-dir target. That
+// back-reference is the same kind of proof the worktree branch takes from its gitdir
+// metadata.
+func (g *Git) isModuleAdminDir(target, parent string) bool {
+	// A linked worktree inside a module dir keeps no config of its own, so it cannot
+	// carry core.worktree. Its gitdir metadata identifies it instead, which is what the
+	// worktree case in the caller goes on to validate.
+	if worktreeAdminIndex(target) > -1 && g.env.HasFilesInDir(target, "gitdir") {
+		return true
+	}
+
+	cfg, err := ini.Load(g.fileContent(target, "config"))
+	if err != nil {
+		log.Error(err)
+		return false
+	}
+
+	worktree := cfg.Section("core").Key("worktree").String()
+	if worktree == "" {
+		log.Debug("no core.worktree in", target, "- not a submodule git dir")
+		return false
+	}
+
+	// core.worktree is relative to the git dir holding it, and may need the same WSL
+	// conversion as the pointer itself.
+	root := resolveGitPath(target, g.convertToLinuxPath(worktree))
+
+	return filepath.Clean(root) == filepath.Clean(parent)
+}
+
+func worktreeAdminIndex(dir string) int {
+	const segment = "/worktrees/"
+
+	normalised := filepath.ToSlash(filepath.Clean(dir))
+	index := strings.LastIndex(normalised, segment)
+	if index < 0 {
+		return -1
+	}
+
+	name := normalised[index+len(segment):]
+	if name == "" || strings.Contains(name, "/") {
+		return -1
+	}
+
+	return index
 }
 
 func parseMainWorktree(output string) (string, bool) {

--- a/src/segments/git_test.go
+++ b/src/segments/git_test.go
@@ -30,6 +30,39 @@ const (
 	dotGitSubmodule = "dev/.git/modules/submodule"
 )
 
+func TestWorktreeAdminIndex(t *testing.T) {
+	cases := []struct {
+		Case string
+		Path string
+		// Expected is the common git directory a caller slices out, or "" when Path is
+		// not a worktree administrative directory.
+		Expected string
+	}{
+		{Case: "admin dir", Path: "/repo/.git/worktrees/feat", Expected: "/repo/.git"},
+		{Case: "trailing separator", Path: "/repo/.git/worktrees/feat/", Expected: "/repo/.git"},
+		{Case: "dot component", Path: "/repo/.git/worktrees/feat/.", Expected: "/repo/.git"},
+		{Case: "doubled separator", Path: "/repo/.git/worktrees//feat", Expected: "/repo/.git"},
+		{Case: "nested worktrees keeps the last", Path: "/a/.git/worktrees/x/.git/worktrees/y", Expected: "/a/.git/worktrees/x/.git"},
+		{Case: "two components after worktrees", Path: "/repo/.git/worktrees/a/b", Expected: ""},
+		{Case: "repo under a worktrees component", Path: "/home/me/worktrees/proj/.bare", Expected: ""},
+		{Case: "no name after worktrees", Path: "/repo/.git/worktrees/", Expected: ""},
+		{Case: "no worktrees segment", Path: "/repo/.git", Expected: ""},
+		{Case: "empty", Path: "", Expected: ""},
+		// Shape alone cannot reject this one: the remainder is a single component. Task 2's
+		// metadata back-reference check is what keeps it out of the worktree branch.
+		{Case: "bare layout in a dir named worktrees", Path: "/home/me/worktrees/.bare", Expected: "/home/me"},
+	}
+
+	for _, tc := range cases {
+		var got string
+		if index := worktreeAdminIndex(tc.Path); index > -1 {
+			got = filepath.ToSlash(filepath.Clean(tc.Path))[:index]
+		}
+
+		assert.Equal(t, tc.Expected, got, tc.Case)
+	}
+}
+
 func TestEnabledGitNotFound(t *testing.T) {
 	env := new(mock.Environment)
 	env.On("InWSLSharedDrive").Return(false)
@@ -76,101 +109,532 @@ func TestResolveEmptyGitPath(t *testing.T) {
 }
 
 func TestEnabledInWorktree(t *testing.T) {
+	// Field order below is what fieldalignment wants, so the groups a reader would expect
+	// together are not adjacent. The comments travel with the fields instead.
 	cases := []struct {
-		Case                  string
-		WorkingFolder         string
-		WorkingFolderAddon    string
-		WorkingFolderContent  string
-		ExpectedRealFolder    string
-		ExpectedWorkingFolder string
-		ExpectedRootFolder    string
-		ExpectedEnabled       bool
+		// nil reserves directory-role assertions for a later decision.
+		ExpectedWorkingFolder *string
+		ExpectedRootFolder    *string
+		ExpectedRealFolder    *string
+		// For a worktree topology, the discovered parent is the worktree root and must
+		// match the metadata back-reference. See DiscoveredGitFile below.
+		DiscoveredParent  string
+		MetadataAddon     string
+		MetadataContent   string
+		ExpectedProbedDir string
+		// TargetConfig is the config file found in the directory the pointer names. The
+		// modules classifier reads core.worktree out of it to tell a submodule git dir
+		// from a --separate-git-dir target, which has no core.worktree at all.
+		TargetConfig string
+		Case         string
+		Pointer      string
+		// DiscoveredGitFile is the .git file HasParentFilePath found, whose parent is
+		// DiscoveredParent above.
+		DiscoveredGitFile string
+		// RawGitFile overrides the whole .git file body. Use it when the test is about
+		// the file's syntax rather than the pointer it carries; leave it empty and the
+		// loop writes "gitdir: <Pointer>".
+		RawGitFile         string
+		ExpectedIsWorkTree bool
+		ExpectedEnabled    bool
 	}{
 		{
 			Case:                  "worktree",
 			ExpectedEnabled:       true,
-			WorkingFolder:         TestRootPath + "dev/.git/worktrees/folder_worktree",
-			WorkingFolderAddon:    "gitdir",
-			WorkingFolderContent:  TestRootPath + "dev/worktree.git\n",
-			ExpectedWorkingFolder: TestRootPath + "dev/.git/worktrees/folder_worktree",
-			ExpectedRealFolder:    TestRootPath + "dev/worktree",
-			ExpectedRootFolder:    TestRootPath + dotGit,
+			ExpectedIsWorkTree:    true,
+			Pointer:               TestRootPath + "dev/.git/worktrees/folder_worktree",
+			DiscoveredGitFile:     TestRootPath + "dev/worktree/.git",
+			DiscoveredParent:      TestRootPath + "dev/worktree",
+			MetadataAddon:         "gitdir",
+			MetadataContent:       TestRootPath + "dev/worktree.git\n",
+			ExpectedProbedDir:     TestRootPath + "dev/.git/worktrees/folder_worktree",
+			ExpectedWorkingFolder: new(TestRootPath + "dev/.git/worktrees/folder_worktree"),
+			ExpectedRealFolder:    new(TestRootPath + "dev/worktree"),
+			ExpectedRootFolder:    new(TestRootPath + dotGit),
 		},
 		{
+			// The discovered .git file sits in the submodule's own checkout, and the git
+			// dir points back at it through core.worktree. Both are what git writes.
 			Case:                  "submodule",
 			ExpectedEnabled:       true,
-			WorkingFolder:         "./.git/modules/submodule",
-			ExpectedWorkingFolder: TestRootPath + dotGitSubmodule,
-			ExpectedRealFolder:    TestRootPath + dotGitSubmodule,
-			ExpectedRootFolder:    TestRootPath + dotGitSubmodule,
+			Pointer:               "../.git/modules/submodule",
+			DiscoveredGitFile:     TestRootPath + "dev/sub/.git",
+			DiscoveredParent:      TestRootPath + "dev/sub",
+			ExpectedProbedDir:     TestRootPath + dotGitSubmodule,
+			TargetConfig:          "[core]\n\tworktree = ../../../sub",
+			ExpectedWorkingFolder: new(TestRootPath + dotGitSubmodule),
+			ExpectedRealFolder:    new(TestRootPath + dotGitSubmodule),
+			ExpectedRootFolder:    new(TestRootPath + dotGitSubmodule),
 		},
 		{
 			Case:                  "submodule with root working folder",
 			ExpectedEnabled:       true,
-			WorkingFolder:         TestRootPath + dotGitSubmodule,
-			ExpectedWorkingFolder: TestRootPath + dotGitSubmodule,
-			ExpectedRealFolder:    TestRootPath + dotGitSubmodule,
-			ExpectedRootFolder:    TestRootPath + dotGitSubmodule,
+			Pointer:               TestRootPath + dotGitSubmodule,
+			DiscoveredGitFile:     TestRootPath + "dev/sub/.git",
+			DiscoveredParent:      TestRootPath + "dev/sub",
+			ExpectedProbedDir:     TestRootPath + dotGitSubmodule,
+			TargetConfig:          "[core]\n\tworktree = ../../../sub",
+			ExpectedWorkingFolder: new(TestRootPath + dotGitSubmodule),
+			ExpectedRealFolder:    new(TestRootPath + dotGitSubmodule),
+			ExpectedRootFolder:    new(TestRootPath + dotGitSubmodule),
 		},
 		{
-			Case:                  "submodule with worktrees",
-			ExpectedEnabled:       true,
-			WorkingFolder:         TestRootPath + "dev/.git/modules/module/path/worktrees/location",
-			WorkingFolderAddon:    "gitdir",
-			WorkingFolderContent:  TestRootPath + "dev/worktree.git\n",
-			ExpectedWorkingFolder: TestRootPath + "dev/.git/modules/module/path",
-			ExpectedRealFolder:    TestRootPath + "dev/worktree",
-			ExpectedRootFolder:    TestRootPath + "dev/.git/modules/module/path",
+			// Directory-role assertions are reserved for a later decision.
+			Case:               "submodule with worktrees",
+			ExpectedEnabled:    true,
+			ExpectedIsWorkTree: true,
+			Pointer:            TestRootPath + "dev/.git/modules/module/path/worktrees/location",
+			DiscoveredGitFile:  TestRootPath + dotGit,
+			DiscoveredParent:   TestRootPath + "dev",
+			MetadataAddon:      "gitdir",
+			MetadataContent:    TestRootPath + "dev/worktree.git\n",
+			ExpectedProbedDir:  TestRootPath + "dev/.git/modules/module/path/worktrees/location",
 		},
 		{
-			Case:                  "separate git dir",
+			// Directory-role assertions are reserved for a later decision.
+			Case:              "separate git dir",
+			ExpectedEnabled:   true,
+			Pointer:           TestRootPath + "dev/separate/.git/posh",
+			DiscoveredGitFile: TestRootPath + dotGit,
+			DiscoveredParent:  TestRootPath + "dev",
+			ExpectedProbedDir: TestRootPath + "dev/separate/.git/posh",
+		},
+		{
+			// The pointer's spelling contains a "modules" component, but the directory
+			// before it is an ordinary folder, not a superproject git dir. This is a
+			// separate git dir, so repoRootDir must be the working tree root and not the
+			// git dir the pointer names.
+			Case:              "separate git dir under a modules path component",
+			ExpectedEnabled:   true,
+			Pointer:           TestRootPath + "srv/modules/project.git",
+			DiscoveredGitFile: TestRootPath + "work/project/.git",
+			DiscoveredParent:  TestRootPath + "work/project",
+			ExpectedProbedDir: TestRootPath + "srv/modules/project.git",
+			// A --separate-git-dir target records no core.worktree.
+			TargetConfig:       "[core]\n\trepositoryformatversion = 0",
+			ExpectedRealFolder: new(TestRootPath + "work/project/"),
+		},
+		{
+			// A submodule's name is its path, so it can hold separators. Rejecting this
+			// is what a "one component after modules" rule would do.
+			Case:                  "submodule at a nested path",
 			ExpectedEnabled:       true,
-			WorkingFolder:         TestRootPath + "dev/separate/.git/posh",
-			ExpectedWorkingFolder: TestRootPath + "dev/",
-			ExpectedRealFolder:    TestRootPath + "dev/",
-			ExpectedRootFolder:    TestRootPath + "dev/separate/.git/posh",
+			Pointer:               "../../.git/modules/vendor/libfoo",
+			DiscoveredGitFile:     TestRootPath + "dev/vendor/libfoo/.git",
+			DiscoveredParent:      TestRootPath + "dev/vendor/libfoo",
+			ExpectedProbedDir:     TestRootPath + "dev/.git/modules/vendor/libfoo",
+			TargetConfig:          "[core]\n\tworktree = ../../../../vendor/libfoo",
+			ExpectedWorkingFolder: new(TestRootPath + "dev/.git/modules/vendor/libfoo"),
+			ExpectedRealFolder:    new(TestRootPath + "dev/.git/modules/vendor/libfoo"),
+			ExpectedRootFolder:    new(TestRootPath + "dev/.git/modules/vendor/libfoo"),
+		},
+		{
+			// When the superproject itself uses --separate-git-dir, the folder in front of
+			// modules is not called .git. Rejecting this is what a ".git/modules" rule
+			// would do.
+			Case:                  "submodule of a separate-git-dir superproject",
+			ExpectedEnabled:       true,
+			Pointer:               "../../sepgit/modules/sub",
+			DiscoveredGitFile:     TestRootPath + "dev/sep/sub/.git",
+			DiscoveredParent:      TestRootPath + "dev/sep/sub",
+			ExpectedProbedDir:     TestRootPath + "dev/sepgit/modules/sub",
+			TargetConfig:          "[core]\n\tworktree = ../../../sep/sub",
+			ExpectedWorkingFolder: new(TestRootPath + "dev/sepgit/modules/sub"),
+			ExpectedRealFolder:    new(TestRootPath + "dev/sepgit/modules/sub"),
+			ExpectedRootFolder:    new(TestRootPath + "dev/sepgit/modules/sub"),
+		},
+		{
+			// A submodule checked out at modules/foo doubles the segment. Rejecting this
+			// is what keying on the last modules occurrence would do, because the prefix
+			// then lands on .git/modules, which is a container and not a git dir.
+			Case:                  "submodule checked out below a modules folder",
+			ExpectedEnabled:       true,
+			Pointer:               "../../.git/modules/modules/foo",
+			DiscoveredGitFile:     TestRootPath + "dev/modules/foo/.git",
+			DiscoveredParent:      TestRootPath + "dev/modules/foo",
+			ExpectedProbedDir:     TestRootPath + "dev/.git/modules/modules/foo",
+			TargetConfig:          "[core]\n\tworktree = ../../../../modules/foo",
+			ExpectedWorkingFolder: new(TestRootPath + "dev/.git/modules/modules/foo"),
+			ExpectedRealFolder:    new(TestRootPath + "dev/.git/modules/modules/foo"),
+			ExpectedRootFolder:    new(TestRootPath + "dev/.git/modules/modules/foo"),
+		},
+		{
+			// core.worktree present but pointing at another checkout: the git dir is not
+			// this checkout's, so it must not be treated as its submodule.
+			Case:               "module dir whose core.worktree points elsewhere",
+			ExpectedEnabled:    true,
+			Pointer:            TestRootPath + "dev/.git/modules/stale",
+			DiscoveredGitFile:  TestRootPath + "dev/sub/.git",
+			DiscoveredParent:   TestRootPath + "dev/sub",
+			ExpectedProbedDir:  TestRootPath + "dev/.git/modules/stale",
+			TargetConfig:       "[core]\n\tworktree = ../../../elsewhere",
+			ExpectedRealFolder: new(TestRootPath + "dev/sub/"),
 		},
 		{
 			Case:                  "worktree with relative gitdir path",
 			ExpectedEnabled:       true,
-			WorkingFolder:         TestRootPath + "dev/.git/worktrees/folder_worktree",
-			WorkingFolderAddon:    "gitdir",
-			WorkingFolderContent:  "../../../worktree/.git\n",
-			ExpectedWorkingFolder: TestRootPath + "dev/.git/worktrees/folder_worktree",
-			ExpectedRealFolder:    TestRootPath + "dev/worktree",
-			ExpectedRootFolder:    TestRootPath + dotGit,
+			ExpectedIsWorkTree:    true,
+			Pointer:               TestRootPath + "dev/.git/worktrees/folder_worktree",
+			DiscoveredGitFile:     TestRootPath + "dev/worktree/.git",
+			DiscoveredParent:      TestRootPath + "dev/worktree",
+			MetadataAddon:         "gitdir",
+			MetadataContent:       "../../../worktree/.git\n",
+			ExpectedProbedDir:     TestRootPath + "dev/.git/worktrees/folder_worktree",
+			ExpectedWorkingFolder: new(TestRootPath + "dev/.git/worktrees/folder_worktree"),
+			ExpectedRealFolder:    new(TestRootPath + "dev/worktree"),
+			ExpectedRootFolder:    new(TestRootPath + dotGit),
 		},
 		{
 			Case:                  "worktree with relative gitdir path, no trailing newline",
 			ExpectedEnabled:       true,
-			WorkingFolder:         TestRootPath + "dev/.git/worktrees/folder_worktree",
-			WorkingFolderAddon:    "gitdir",
-			WorkingFolderContent:  "../../../worktree/.git",
-			ExpectedWorkingFolder: TestRootPath + "dev/.git/worktrees/folder_worktree",
-			ExpectedRealFolder:    TestRootPath + "dev/worktree",
-			ExpectedRootFolder:    TestRootPath + dotGit,
+			ExpectedIsWorkTree:    true,
+			Pointer:               TestRootPath + "dev/.git/worktrees/folder_worktree",
+			DiscoveredGitFile:     TestRootPath + "dev/worktree/.git",
+			DiscoveredParent:      TestRootPath + "dev/worktree",
+			MetadataAddon:         "gitdir",
+			MetadataContent:       "../../../worktree/.git",
+			ExpectedProbedDir:     TestRootPath + "dev/.git/worktrees/folder_worktree",
+			ExpectedWorkingFolder: new(TestRootPath + "dev/.git/worktrees/folder_worktree"),
+			ExpectedRealFolder:    new(TestRootPath + "dev/worktree"),
+			ExpectedRootFolder:    new(TestRootPath + dotGit),
+		},
+		{
+			// Shape matches, but metadata does not point back to the discovered .git file.
+			Case:              "bare layout in a dir named worktrees",
+			ExpectedEnabled:   true,
+			Pointer:           TestRootPath + "me/worktrees/.bare",
+			DiscoveredGitFile: TestRootPath + "me/worktrees/.git",
+			DiscoveredParent:  TestRootPath + "me/worktrees",
+			MetadataAddon:     "gitdir",
+			ExpectedProbedDir: TestRootPath + "me/worktrees/.bare",
+		},
+		{
+			Case:               "worktree metadata is whitespace only",
+			ExpectedEnabled:    true,
+			ExpectedIsWorkTree: false,
+			Pointer:            TestRootPath + "dev/.git/worktrees/folder_worktree",
+			DiscoveredGitFile:  TestRootPath + "dev/.git/worktrees/folder_worktree/.git",
+			DiscoveredParent:   TestRootPath + "dev/.git/worktrees/folder_worktree",
+			MetadataAddon:      "gitdir",
+			MetadataContent:    " \n",
+			ExpectedProbedDir:  TestRootPath + "dev/.git/worktrees/folder_worktree",
+		},
+		{
+			Case:               "worktree metadata points somewhere else",
+			ExpectedEnabled:    true,
+			ExpectedIsWorkTree: false,
+			Pointer:            TestRootPath + "dev/.git/worktrees/folder_worktree",
+			DiscoveredGitFile:  TestRootPath + "dev/worktree/.git",
+			DiscoveredParent:   TestRootPath + "dev/worktree",
+			MetadataAddon:      "gitdir",
+			MetadataContent:    TestRootPath + "dev/moved-elsewhere/.git\n",
+			ExpectedProbedDir:  TestRootPath + "dev/.git/worktrees/folder_worktree",
+		},
+		{
+			Case:               "worktree metadata spelled with a trailing separator",
+			ExpectedEnabled:    true,
+			ExpectedIsWorkTree: true,
+			Pointer:            TestRootPath + "dev/.git/worktrees/folder_worktree",
+			DiscoveredGitFile:  TestRootPath + "dev/worktree/.git",
+			DiscoveredParent:   TestRootPath + "dev/worktree",
+			MetadataAddon:      "gitdir",
+			MetadataContent:    TestRootPath + "dev/worktree/.git\n",
+			ExpectedProbedDir:  TestRootPath + "dev/.git/worktrees/folder_worktree",
+		},
+		{
+			Case:               "worktree metadata is garbage that resolves nowhere",
+			ExpectedEnabled:    true,
+			ExpectedIsWorkTree: false,
+			Pointer:            TestRootPath + "dev/.git/worktrees/folder_worktree",
+			DiscoveredGitFile:  TestRootPath + "dev/worktree/.git",
+			DiscoveredParent:   TestRootPath + "dev/worktree",
+			MetadataAddon:      "gitdir",
+			MetadataContent:    "not-a-path-at-all\n",
+			ExpectedProbedDir:  TestRootPath + "dev/.git/worktrees/folder_worktree",
+		},
+		{
+			// Both spelling forms must reject a shape match whose metadata does not match.
+			Case:              "repo under a worktrees path component, absolute spelling",
+			ExpectedEnabled:   true,
+			Pointer:           TestRootPath + "me/worktrees/proj/.bare",
+			DiscoveredGitFile: TestRootPath + "me/worktrees/proj/.git",
+			DiscoveredParent:  TestRootPath + "me/worktrees/proj",
+			ExpectedProbedDir: TestRootPath + "me/worktrees/proj/.bare",
+		},
+		{
+			Case:               "genuine worktree whose common dir is under a worktrees component",
+			ExpectedEnabled:    true,
+			ExpectedIsWorkTree: true,
+			Pointer:            TestRootPath + "me/worktrees/proj/.git/worktrees/feat",
+			DiscoveredGitFile:  TestRootPath + "me/checkouts/feat/.git",
+			DiscoveredParent:   TestRootPath + "me/checkouts/feat",
+			MetadataAddon:      "gitdir",
+			MetadataContent:    TestRootPath + "me/checkouts/feat/.git\n",
+			ExpectedProbedDir:  TestRootPath + "me/worktrees/proj/.git/worktrees/feat",
+		},
+		{
+			Case:              "bare layout, dot-slash relative pointer",
+			ExpectedEnabled:   true,
+			Pointer:           "./.bare",
+			DiscoveredGitFile: TestRootPath + "repo/.git",
+			DiscoveredParent:  TestRootPath + "repo",
+			ExpectedProbedDir: TestRootPath + "repo/.bare",
+		},
+		{
+			Case:              "bare layout, bare relative pointer",
+			ExpectedEnabled:   true,
+			Pointer:           ".bare",
+			DiscoveredGitFile: TestRootPath + "repo/.git",
+			DiscoveredParent:  TestRootPath + "repo",
+			ExpectedProbedDir: TestRootPath + "repo/.bare",
+		},
+		{
+			Case:              "relative pointer into a subdirectory",
+			ExpectedEnabled:   true,
+			Pointer:           "sub/git",
+			DiscoveredGitFile: TestRootPath + "repo/.git",
+			DiscoveredParent:  TestRootPath + "repo",
+			ExpectedProbedDir: TestRootPath + "repo/sub/git",
+		},
+		{
+			// Absolute pointers retain their trailing separator; filepath.Join cleans relative ones.
+			Case:               "absolute pointer ending in a separator",
+			ExpectedEnabled:    true,
+			ExpectedIsWorkTree: true,
+			Pointer:            TestRootPath + "repo/.git/worktrees/feat/",
+			DiscoveredGitFile:  TestRootPath + "repo/feat/.git",
+			DiscoveredParent:   TestRootPath + "repo/feat",
+			MetadataAddon:      "gitdir",
+			MetadataContent:    TestRootPath + "repo/feat/.git\n",
+			ExpectedProbedDir:  TestRootPath + "repo/.git/worktrees/feat/",
+		},
+		{
+			// This pins the existing trim; Git treats a trailing space as part of the path.
+			Case:              "pointer with trailing whitespace is trimmed",
+			ExpectedEnabled:   true,
+			RawGitFile:        "gitdir: ./.bare \n",
+			DiscoveredGitFile: TestRootPath + "repo/.git",
+			DiscoveredParent:  TestRootPath + "repo",
+			ExpectedProbedDir: TestRootPath + "repo/.bare",
+		},
+		{
+			Case:              "malformed .git file with no gitdir line",
+			ExpectedEnabled:   false,
+			RawGitFile:        "not a gitdir line",
+			DiscoveredGitFile: TestRootPath + "repo/.git",
+			DiscoveredParent:  TestRootPath + "repo",
+			ExpectedProbedDir: TestRootPath + "repo",
+		},
+		{
+			Case:              "gitdir line with an empty pointer",
+			ExpectedEnabled:   false,
+			RawGitFile:        "gitdir: ",
+			DiscoveredGitFile: TestRootPath + "repo/.git",
+			DiscoveredParent:  TestRootPath + "repo",
+			ExpectedProbedDir: TestRootPath + "repo",
+		},
+		{
+			// Keep this check on the raw pointer: resolving it first changes the branch.
+			Case:               "worktree with a relative pointer under a modules component",
+			ExpectedEnabled:    true,
+			ExpectedIsWorkTree: true,
+			Pointer:            "../.git/worktrees/feat",
+			DiscoveredGitFile:  TestRootPath + "modules/repo/feat/.git",
+			DiscoveredParent:   TestRootPath + "modules/repo/feat",
+			MetadataAddon:      "gitdir",
+			MetadataContent:    TestRootPath + "modules/repo/feat/.git\n",
+			ExpectedProbedDir:  TestRootPath + "modules/repo/.git/worktrees/feat",
 		},
 	}
-	fileInfo := &runtime.FileInfo{
-		Path:         TestRootPath + dotGit,
-		ParentFolder: TestRootPath + "dev",
-	}
+
 	for _, tc := range cases {
+		fileInfo := &runtime.FileInfo{Path: tc.DiscoveredGitFile, ParentFolder: tc.DiscoveredParent}
 		env := new(mock.Environment)
-		env.On("FileContent", TestRootPath+dotGit).Return(fmt.Sprintf("gitdir: %s", tc.WorkingFolder))
-		env.On("FileContent", filepath.Join(tc.WorkingFolder, tc.WorkingFolderAddon)).Return(tc.WorkingFolderContent)
-		env.On("HasFilesInDir", tc.WorkingFolder, tc.WorkingFolderAddon).Return(true)
-		env.On("HasFilesInDir", tc.WorkingFolder, "HEAD").Return(true)
+		gitFileContent := fmt.Sprintf("gitdir: %s", tc.Pointer)
+		if tc.RawGitFile != "" {
+			gitFileContent = tc.RawGitFile
+		}
+		env.On("FileContent", tc.DiscoveredGitFile).Return(gitFileContent)
+		env.On("FileContent", filepath.Join(tc.ExpectedProbedDir, tc.MetadataAddon)).Return(tc.MetadataContent)
+		env.On("HasFilesInDir", tc.ExpectedProbedDir, tc.MetadataAddon).Return(tc.MetadataAddon != "")
+		env.On("HasFilesInDir", tc.ExpectedProbedDir, "HEAD").Return(true)
+		env.On("FileContent", tc.ExpectedProbedDir+"/config").Return(tc.TargetConfig)
 		env.On("PathSeparator").Return(string(os.PathSeparator))
 
 		g := &Git{}
 		g.Init(options.Map{}, env)
 
 		assert.Equal(t, tc.ExpectedEnabled, g.hasWorktree(fileInfo), tc.Case)
-		assert.Equal(t, tc.ExpectedWorkingFolder, g.mainSCMDir, tc.Case)
-		assert.Equal(t, tc.ExpectedRealFolder, g.repoRootDir, tc.Case)
-		assert.Equal(t, tc.ExpectedRootFolder, g.scmDir, tc.Case)
+		assert.Equal(t, tc.ExpectedIsWorkTree, g.IsWorkTree, tc.Case)
+
+		if tc.ExpectedWorkingFolder != nil {
+			assert.Equal(t, *tc.ExpectedWorkingFolder, g.mainSCMDir, tc.Case)
+		}
+
+		if tc.ExpectedRealFolder != nil {
+			assert.Equal(t, *tc.ExpectedRealFolder, g.repoRootDir, tc.Case)
+		}
+
+		if tc.ExpectedRootFolder != nil {
+			assert.Equal(t, *tc.ExpectedRootFolder, g.scmDir, tc.Case)
+		}
+
+		if tc.ExpectedEnabled {
+			assert.True(t, filepath.IsAbs(g.mainSCMDir), tc.Case+": mainSCMDir must be absolute")
+			assert.True(t, filepath.IsAbs(g.scmDir), tc.Case+": scmDir must be absolute")
+		}
 	}
+}
+
+func TestEnabledInBareLayout(t *testing.T) {
+	cases := []struct {
+		Case          string
+		FetchBareInfo bool
+	}{
+		{Case: "bare layout without fetch_bare_info", FetchBareInfo: false},
+		{Case: "bare layout with fetch_bare_info", FetchBareInfo: true},
+	}
+
+	for _, tc := range cases {
+		// Fixtures are built from TestRootPath so the paths are absolute on the platform
+		// the test binary runs on. filepath.IsAbs below is the real one, not the mocked
+		// GOOS, so a literal "/repo" would not be absolute on Windows.
+		root := TestRootPath + "repo"
+
+		fileInfo := &runtime.FileInfo{
+			Path:         root + "/.git",
+			ParentFolder: root,
+		}
+
+		env := new(mock.Environment)
+		env.On("InWSLSharedDrive").Return(false)
+		env.On("HasCommand", "git").Return(true)
+		env.On("GOOS").Return("")
+		env.On("IsWsl").Return(false)
+		env.On("HasParentFilePath", ".git", true).Return(fileInfo, nil)
+		env.On("PathSeparator").Return("/")
+		env.On("Home").Return(poshHome)
+		env.On("Getenv", poshGitEnv).Return("")
+		env.On("DirMatchesOneOf", testify_.Anything, testify_.Anything).Return(false)
+		env.On("FileContent", root+"/.git").Return("gitdir: ./.bare")
+		env.On("HasFilesInDir", root+"/.bare", "HEAD").Return(true)
+		env.On("FileContent", root+"/.bare/config").Return("[core]\n\tbare = true")
+		env.On("FileContent", root+"//HEAD").Return("")
+		env.MockGitCommand(root+"/", "1234567890abcdef1234567890abcdef12345678", "rev-parse", "HEAD")
+		env.MockGitCommand(root+"/", "", "describe", "--tags", "--exact-match")
+		env.MockGitCommand(root+"/", "", "remote")
+
+		props := options.Map{}
+		if tc.FetchBareInfo {
+			props = options.Map{FetchBareInfo: true}
+		}
+
+		g := &Git{}
+		g.Init(props, env)
+
+		assert.True(t, g.Enabled(), tc.Case)
+		assert.Equal(t, tc.FetchBareInfo, g.IsBare, tc.Case)
+		assert.True(t, filepath.IsAbs(g.mainSCMDir), tc.Case+": mainSCMDir must be absolute")
+		assert.True(t, filepath.IsAbs(g.scmDir), tc.Case+": scmDir must be absolute")
+	}
+}
+
+func TestIsBareRepoResolvesPointer(t *testing.T) {
+	// Fixtures are built from TestRootPath so that "absolute pointer" really is absolute
+	// on the platform the test binary runs on. A literal "/repo/.bare" is only
+	// disk-relative on Windows, which would exercise a different resolveGitPath branch
+	// than the one these cases are about.
+	root := TestRootPath + "repo"
+
+	cases := []struct {
+		Case              string
+		Pointer           string
+		ExpectedProbedDir string
+		ExpectedIsBare    bool
+	}{
+		{
+			Case:              "relative pointer",
+			Pointer:           "./.bare",
+			ExpectedProbedDir: root + "/.bare",
+			ExpectedIsBare:    true,
+		},
+		{
+			Case:              "absolute pointer",
+			Pointer:           root + "/.bare",
+			ExpectedProbedDir: root + "/.bare",
+			ExpectedIsBare:    true,
+		},
+		{
+			Case:              "absolute pointer to a non-bare git dir",
+			Pointer:           TestRootPath + "elsewhere/gitdir",
+			ExpectedProbedDir: TestRootPath + "elsewhere/gitdir",
+			ExpectedIsBare:    false,
+		},
+	}
+
+	for _, tc := range cases {
+		fileInfo := &runtime.FileInfo{
+			Path:         root + "/.git",
+			ParentFolder: root,
+		}
+
+		expectedConfig := tc.ExpectedProbedDir + "/config"
+		// What the old filepath.Join produced: the same path for a relative pointer, and
+		// the pointer concatenated onto the parent for an absolute one. Derived rather
+		// than written out so it stays correct under Windows path semantics too.
+		oldConfig := filepath.Join(fileInfo.ParentFolder, tc.Pointer) + "/config"
+
+		env := new(mock.Environment)
+		env.On("InWSLSharedDrive").Return(false)
+		env.On("HasCommand", "git").Return(true)
+		env.On("GOOS").Return("")
+		env.On("HasParentFilePath", ".git", true).Return(fileInfo, nil)
+		env.On("FileContent", root+"/.git").Return(fmt.Sprintf("gitdir: %s", tc.Pointer))
+		env.On("FileContent", expectedConfig).Return(fmt.Sprintf("[core]\n\tbare = %t", tc.ExpectedIsBare))
+		env.On("HasFilesInDir", tc.ExpectedProbedDir, "HEAD").Return(true)
+
+		if oldConfig != expectedConfig {
+			env.On("FileContent", oldConfig).Return("")
+		}
+
+		g := &Git{}
+		g.Init(options.Map{FetchBareInfo: true}, env)
+
+		assert.True(t, g.shouldDisplay(), tc.Case)
+		assert.Equal(t, tc.ExpectedIsBare, g.IsBare, tc.Case)
+		env.AssertCalled(t, "FileContent", expectedConfig)
+
+		if oldConfig != expectedConfig {
+			env.AssertNotCalled(t, "FileContent", oldConfig)
+		}
+	}
+}
+
+func TestShouldDisplayInitializesWSLBeforeBareRepoDetection(t *testing.T) {
+	fileInfo := &runtime.FileInfo{
+		Path:         "/repo/.git",
+		ParentFolder: "/repo",
+	}
+
+	env := new(mock.Environment)
+	env.On("InWSLSharedDrive").Return(true)
+	env.On("HasCommand", "git.exe").Return(true)
+	env.On("GOOS").Return("")
+	env.On("HasParentFilePath", ".git", true).Return(fileInfo, nil)
+	env.On("ConvertToLinuxPath").Return("/mnt/c/repo/.bare")
+	env.On("FileContent", "/repo/.git").Return("gitdir: C:/repo/.bare")
+	env.On("FileContent", "/repo/C:/repo/.bare/config").Return("")
+	env.On("FileContent", "/mnt/c/repo/.bare/config").Return("[core]\n\tbare = true")
+	env.On("HasFilesInDir", "/mnt/c/repo/.bare", "HEAD").Return(true)
+	env.On("ConvertToWindowsPath", "/repo/").Return("C:/repo")
+
+	g := &Git{}
+	g.Init(options.Map{FetchBareInfo: true}, env)
+
+	assert.True(t, g.shouldDisplay())
+	assert.True(t, g.IsBare)
+	env.AssertNumberOfCalls(t, "ConvertToLinuxPath", 2)
+	env.AssertCalled(t, "FileContent", "/mnt/c/repo/.bare/config")
 }
 
 func TestEnabledInBareRepo(t *testing.T) {
@@ -1461,7 +1925,7 @@ func TestGitMainWorktreeSessionCache(t *testing.T) {
 	}
 	secondAdminDir := commonDir + "/worktrees/linked-two"
 	secondEnv.On("FileContent", secondGitFile.Path).Return("gitdir: ../main/.git/worktrees/linked-two")
-	secondEnv.On("FileContent", filepath.Join(secondAdminDir, "gitdir")).Return("../../../linked-two/.git")
+	secondEnv.On("FileContent", filepath.Join(secondAdminDir, "gitdir")).Return("../../../../linked-two/.git")
 	second := &Git{}
 	second.Init(options.Map{}, secondEnv)
 	require.True(t, second.hasWorktree(secondGitFile))

--- a/src/segments/git_windows_test.go
+++ b/src/segments/git_windows_test.go
@@ -3,7 +3,14 @@
 package segments
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -38,5 +45,79 @@ func TestResolveGitPath(t *testing.T) {
 	}
 	for _, tc := range cases {
 		assert.Equal(t, tc.Expected, resolveGitPath(tc.Base, tc.Path), tc.Case)
+	}
+}
+
+func TestWorktreeAdminIndexWindows(t *testing.T) {
+	cases := []struct {
+		Case     string
+		Path     string
+		Expected string
+	}{
+		{Case: "drive absolute, native separators", Path: `C:\repo\.git\worktrees\feat`, Expected: "C:/repo/.git"},
+		{Case: "drive absolute, trailing separator", Path: `C:\repo\.git\worktrees\feat\`, Expected: "C:/repo/.git"},
+		{Case: "drive absolute, dot component", Path: `C:\repo\.git\worktrees\feat\.`, Expected: "C:/repo/.git"},
+		{Case: "UNC path", Path: `\\server\share\.git\worktrees\feat`, Expected: "//server/share/.git"},
+		{Case: "two components after worktrees", Path: `C:\repo\.git\worktrees\a\b`, Expected: ""},
+		{Case: "repo under a worktrees component", Path: `C:\me\worktrees\proj\.bare`, Expected: ""},
+	}
+
+	for _, tc := range cases {
+		var got string
+		if index := worktreeAdminIndex(tc.Path); index > -1 {
+			got = filepath.ToSlash(filepath.Clean(tc.Path))[:index]
+		}
+
+		assert.Equal(t, tc.Expected, got, tc.Case)
+	}
+}
+
+func TestEnabledInWorktreeWindows(t *testing.T) {
+	cases := []struct {
+		Case               string
+		Pointer            string
+		ExpectedProbedDir  string
+		ExpectedIsWorkTree bool
+	}{
+		{
+			Case:               "drive absolute with native separators",
+			Pointer:            `C:\repo\.git\worktrees\feat`,
+			ExpectedProbedDir:  `C:\repo\.git\worktrees\feat`,
+			ExpectedIsWorkTree: true,
+		},
+		{
+			Case:               "disk-relative pointer gains the volume",
+			Pointer:            "/repo/.git/worktrees/feat",
+			ExpectedProbedDir:  "C:/repo/.git/worktrees/feat",
+			ExpectedIsWorkTree: true,
+		},
+		{
+			Case:               "relative pointer resolves against the .git file's folder",
+			Pointer:            "./.bare",
+			ExpectedProbedDir:  "C:/repo/feat/.bare",
+			ExpectedIsWorkTree: false,
+		},
+	}
+
+	for _, tc := range cases {
+		fileInfo := &runtime.FileInfo{
+			Path:         `C:/repo/feat/.git`,
+			ParentFolder: `C:/repo/feat`,
+		}
+
+		env := new(mock.Environment)
+		env.On("FileContent", fileInfo.Path).Return(fmt.Sprintf("gitdir: %s", tc.Pointer))
+		env.On("FileContent", filepath.Join(tc.ExpectedProbedDir, "gitdir")).Return(`C:/repo/feat/.git` + "\n")
+		env.On("HasFilesInDir", tc.ExpectedProbedDir, "gitdir").Return(true)
+		env.On("HasFilesInDir", tc.ExpectedProbedDir, "HEAD").Return(true)
+		env.On("PathSeparator").Return(string(os.PathSeparator))
+
+		g := &Git{}
+		g.Init(options.Map{}, env)
+
+		assert.True(t, g.hasWorktree(fileInfo), tc.Case)
+		assert.Equal(t, tc.ExpectedIsWorkTree, g.IsWorkTree, tc.Case)
+		assert.True(t, filepath.IsAbs(g.mainSCMDir), tc.Case+": mainSCMDir must be absolute")
+		assert.True(t, filepath.IsAbs(g.scmDir), tc.Case+": scmDir must be absolute")
 	}
 }

--- a/src/segments/golang.go
+++ b/src/segments/golang.go
@@ -12,8 +12,8 @@ type Golang struct {
 }
 
 const (
-	ParseModFile  options.Option = "parse_mod_file"
-	ParseWorkFile options.Option = "parse_work_file"
+	ParseModFile    options.Option = "parse_mod_file"
+	ParseGoWorkFile options.Option = "parse_go_work_file"
 )
 
 func (g *Golang) Template() string {
@@ -44,7 +44,7 @@ func (g *Golang) getVersion() (string, error) {
 		return g.parseModFile()
 	}
 
-	if g.options.Bool(ParseWorkFile, false) {
+	if g.options.Bool(ParseGoWorkFile, false) {
 		return g.parseWorkFile()
 	}
 

--- a/src/segments/golang_test.go
+++ b/src/segments/golang_test.go
@@ -94,7 +94,7 @@ func TestGolang(t *testing.T) {
 		}
 
 		if tc.ParseGoWorkFile {
-			props[ParseWorkFile] = tc.ParseGoWorkFile
+			props[ParseGoWorkFile] = true
 			fileInfo := &runtime.FileInfo{
 				Path:         "../test/go.work",
 				ParentFolder: "./",

--- a/src/shell/scripts/omp.zsh
+++ b/src/shell/scripts/omp.zsh
@@ -615,7 +615,7 @@ function _omp_zle-line-init() {
     zvm_zle-line-init
   fi
 
-  (( $+zle_bracketed_paste )) && print -r -n - $zle_bracketed_paste[1]
+  (( $+zle_bracketed_paste )) && print -r -n - "$zle_bracketed_paste[1]"
 
   local -i ret=0
   if [[ $POSH_MULTILINE_KEEPPROMPT == "true" ]]; then
@@ -640,7 +640,7 @@ function _omp_zle-line-init() {
     ret=$?
   fi
 
-  (( $+zle_bracketed_paste )) && print -r -n - $zle_bracketed_paste[2]
+  (( $+zle_bracketed_paste )) && print -r -n - "$zle_bracketed_paste[2]"
 
   # We need this workaround because when the `filler` is set,
   # there will be a redundant blank line below the transient prompt if the input is empty.

--- a/src/shell/zsh_test.go
+++ b/src/shell/zsh_test.go
@@ -42,6 +42,40 @@ func zshIsBufferComplete(t *testing.T) string {
 	return signature + body + "\n}\n"
 }
 
+// Under setopt GLOB_SUBST, an unquoted parameter expansion is eligible for
+// filename generation as if it had been typed literally. The bracketed-paste
+// escape sequence (\e[?2004h) then parses as an unterminated bracket
+// expression, which zsh's default BAD_PATTERN option turns into a hard
+// error - see https://github.com/JanDeDobbeleer/oh-my-posh/issues/7816.
+func TestZshBracketedPasteGlobSubst(t *testing.T) {
+	if _, err := exec.LookPath("zsh"); err != nil {
+		t.Skip("zsh is not installed")
+	}
+
+	const signature = "function _omp_zle-line-init() {"
+	_, body, found := strings.Cut(zshInit, signature)
+	require.True(t, found, "_omp_zle-line-init is missing from omp.zsh")
+
+	var lines []string
+	for line := range strings.SplitSeq(body, "\n") {
+		if strings.Contains(line, "zle_bracketed_paste") {
+			lines = append(lines, strings.TrimSpace(line))
+		}
+	}
+	require.Len(t, lines, 2, "expected exactly two zle_bracketed_paste statements in _omp_zle-line-init")
+
+	script := "setopt glob_subst\n" +
+		`zle_bracketed_paste=($'\e[?2004h' $'\e[?2004l')` + "\n" +
+		strings.Join(lines, "\n")
+
+	home := t.TempDir()
+	cmd := exec.CommandContext(t.Context(), "zsh", "-f", "-c", script)
+	cmd.Env = []string{"HOME=" + home, "PATH=" + os.Getenv("PATH")}
+
+	out, err := cmd.CombinedOutput()
+	assert.NoError(t, err, string(out))
+}
+
 // Zsh reports an unterminated here-document as syntactically fine, so the
 // here-document cases below are the interesting ones.
 func TestZshIsBufferComplete(t *testing.T) {

--- a/website/docs/configuration/templates.mdx
+++ b/website/docs/configuration/templates.mdx
@@ -18,27 +18,27 @@ These properties can be used anywhere, in any segment. If a segment contains a p
 the segment property value will be used instead. In case you want to use the global property, you can prefix
 it with `.$` to reference it directly.
 
-| Name            | Type                  | Description                                                                      |
-| --------------- | --------------------- | -------------------------------------------------------------------------------- |
-| `.Root`         | `boolean`             | is the current user root/admin or not                                            |
-| `.PWD`          | `string`              | the current working directory (`~` for `$HOME`)                                  |
-| `.AbsolutePWD`  | `string`              | the current working directory (unaltered)                                        |
-| `.PSWD`         | `string`              | the current non-filesystem working directory in PowerShell                       |
-| `.Folder`       | `string`              | the current working folder                                                       |
-| `.Shell`        | `string`              | the current shell name. The value may be overriden by [`maps.shell_name`][maps]. |
-| `.ShellVersion` | `string`              | the current shell version                                                        |
-| `.SHLVL`        | `int`                 | the current shell level                                                          |
-| `.UserName`     | `string`              | the current user name                                                            |
-| `.HostName`     | `string`              | the host name                                                                    |
-| `.Code`         | `int`                 | the last exit code                                                               |
-| `.Executed`     | `boolean`             | false when the shell just started or enter was pressed without a command         |
-| `.Jobs`         | `int`                 | number of background jobs (only available for zsh, PowerShell, and Nushell)      |
-| `.OS`           | `string`              | the operating system                                                             |
-| `.WSL`          | `boolean`             | in WSL yes/no                                                                    |
-| `.Templates`    | `string`              | the [templates][templates] result                                                |
-| `.PromptCount`  | `int`                 | the prompt counter, increments with 1 for every prompt invocation                |
-| `.Version`      | `string`              | the Oh My Posh version                                                           |
-| `.Segment`      | [`Segment`](#segment) | the current segment's metadata                                                   |
+| Name            | Type                  | Description                                                                       |
+| --------------- | --------------------- | --------------------------------------------------------------------------------- |
+| `.Root`         | `boolean`             | is the current user root/admin or not                                             |
+| `.PWD`          | `string`              | the current working directory (`~` for `$HOME`)                                   |
+| `.AbsolutePWD`  | `string`              | the current working directory (unaltered)                                         |
+| `.PSWD`         | `string`              | the current non-filesystem working directory in PowerShell                        |
+| `.Folder`       | `string`              | the current working folder                                                        |
+| `.Shell`        | `string`              | the current shell name. The value may be overriden by [`maps.shell_name`][maps].  |
+| `.ShellVersion` | `string`              | the current shell version                                                         |
+| `.SHLVL`        | `int`                 | the current shell level                                                           |
+| `.UserName`     | `string`              | the current user name                                                             |
+| `.HostName`     | `string`              | the host name                                                                     |
+| `.Code`         | `int`                 | the last exit code                                                                |
+| `.Executed`     | `boolean`             | false when the shell just started or enter was pressed without a command          |
+| `.Jobs`         | `int`                 | number of background jobs (only available for zsh, bash, PowerShell, and Nushell) |
+| `.OS`           | `string`              | the operating system                                                              |
+| `.WSL`          | `boolean`             | in WSL yes/no                                                                     |
+| `.Templates`    | `string`              | the [templates][templates] result                                                 |
+| `.PromptCount`  | `int`                 | the prompt counter, increments with 1 for every prompt invocation                 |
+| `.Version`      | `string`              | the Oh My Posh version                                                            |
+| `.Segment`      | [`Segment`](#segment) | the current segment's metadata                                                    |
 
 ### Segment
 

--- a/website/docs/installation/windows.mdx
+++ b/website/docs/installation/windows.mdx
@@ -29,6 +29,7 @@ When using oh-my-posh inside the WSL, make sure to follow the [Linux][linux] ins
   values={[
     { label: 'winget', value: 'winget', },
     { label: 'manual', value: 'manual', },
+    { label: 'App Installer', value: 'appinstaller', },
     { label: 'chocolatey', value: 'chocolatey'},
   ]
 }>
@@ -48,6 +49,21 @@ Open a PowerShell prompt and run the following command:
 ```powershell
 Set-ExecutionPolicy Bypass -Scope Process -Force; Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://ohmyposh.dev/install.ps1'))
 ```
+
+</TabItem>
+<TabItem value="appinstaller">
+
+Installing via App Installer keeps Oh My Posh up to date automatically:
+Windows checks for a new version in the background and updates the package
+without any interaction needed.
+
+Open a PowerShell prompt and run the following command:
+
+```powershell
+Add-AppxPackage -AppInstallerFile https://cdn.ohmyposh.dev/releases/latest/install-x64.appinstaller
+```
+
+For ARM64, use `install-arm64.appinstaller` instead.
 
 </TabItem>
 <TabItem value="chocolatey">
@@ -76,6 +92,7 @@ choco install oh-my-posh
   values={[
     { label: 'winget', value: 'winget', },
     { label: 'manual', value: 'manual', },
+    { label: 'App Installer', value: 'appinstaller', },
     { label: 'chocolatey', value: 'chocolatey'},
   ]
 }>
@@ -85,6 +102,16 @@ Open a PowerShell prompt and run the following command:
 
 ```powershell
 winget upgrade JanDeDobbeleer.OhMyPosh --source winget
+```
+
+</TabItem>
+<TabItem value="appinstaller">
+
+No action needed, Windows updates Oh My Posh automatically in the background.
+To force an update check, run the install command again:
+
+```powershell
+Add-AppxPackage -AppInstallerFile https://cdn.ohmyposh.dev/releases/latest/install-x64.appinstaller
 ```
 
 </TabItem>

--- a/website/docs/installation/windows.mdx
+++ b/website/docs/installation/windows.mdx
@@ -60,10 +60,9 @@ without any interaction needed.
 Open a PowerShell prompt and run the following command:
 
 ```powershell
-Add-AppxPackage -AppInstallerFile https://cdn.ohmyposh.dev/releases/latest/install-x64.appinstaller
+$arch = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq 'Arm64') { 'arm64' } else { 'x64' }
+Add-AppxPackage -AppInstallerFile "https://cdn.ohmyposh.dev/releases/latest/install-$arch.appinstaller"
 ```
-
-For ARM64, use `install-arm64.appinstaller` instead.
 
 </TabItem>
 <TabItem value="chocolatey">
@@ -111,7 +110,8 @@ No action needed, Windows updates Oh My Posh automatically in the background.
 To force an update check, run the install command again:
 
 ```powershell
-Add-AppxPackage -AppInstallerFile https://cdn.ohmyposh.dev/releases/latest/install-x64.appinstaller
+$arch = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq 'Arm64') { 'arm64' } else { 'x64' }
+Add-AppxPackage -AppInstallerFile "https://cdn.ohmyposh.dev/releases/latest/install-$arch.appinstaller"
 ```
 
 </TabItem>


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

Fixes #7816.

`_omp_zle-line-init` signals bracketed-paste support to the terminal with:

```zsh
(( $+zle_bracketed_paste )) && print -r -n - $zle_bracketed_paste[1]
```

`$zle_bracketed_paste[1]` expands to the raw escape sequence `\e[?2004h`. An unquoted parameter expansion is normally only subject to word-splitting, not filename generation — but if the user's zsh config has `setopt GLOB_SUBST` set anywhere, the expansion result becomes eligible for pattern matching. `[?2004h` then parses as an unterminated bracket expression, and zsh's default `BAD_PATTERN` option turns that into a hard error that aborts the widget mid-execution:

```
_omp_zle-line-init:15: bad pattern: ^[[?2004h
```

This matches the reporter's exact error and explains the secondary symptom ("prevents shell functions from working"): the widget errors out before reaching `zle .recursive-edit`, so the editing session it manages gets skipped.

Fix: quote both `zle_bracketed_paste` subscript expansions so they're never eligible for glob expansion, regardless of `GLOB_SUBST`/`SH_GLOB`/etc. These were the only two unquoted array-subscript expansions used as command arguments in `omp.zsh`.

Also adds a regression test that extracts the shipped `zle_bracketed_paste` statements from the embedded init script (so it drives the code we actually ship, not a copy) and runs them under `setopt glob_subst`, confirmed to fail against the pre-fix code with the identical error message and pass with the fix.

### Test plan

- [x] `go test ./shell/...` passes, including the new `TestZshBracketedPasteGlobSubst`
- [x] Verified the new test fails with the exact reported error (`bad pattern: ^[[?2004h`) against the pre-fix script, and passes against the fix
- [x] `go build ./...` succeeds

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAb3Bs4xBBQhweDvCh59b7)_