### PR TITLE
feat(msix): add embedded App Installer updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,7 @@ jobs:
           name: msix-artifact-${{ matrix.arch }}
           path: |
             packages/msix/out/install-${{ matrix.arch }}.msix
+            packages/msix/out/install-${{ matrix.arch }}.appinstaller
   release:
     runs-on: ubuntu-latest
     needs:
@@ -143,13 +144,20 @@ jobs:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           merge-multiple: true
-      - name: Upload version file
+      - name: Upload versioned files
         env:
           AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.CDN_CONNECTIONSTRING }}
         run: |
           echo v${{ needs.changelog.outputs.version }} > version.txt
           az storage blob upload-batch --destination releases/v${{ needs.changelog.outputs.version }} --source .
-          az storage blob upload-batch --destination releases/latest --overwrite true --source .
+          for architecture in x64 arm64; do
+            az storage blob upload \
+              --container-name releases \
+              --name "v${{ needs.changelog.outputs.version }}/install-${architecture}.appinstaller" \
+              --file "install-${architecture}.appinstaller" \
+              --content-type application/appinstaller \
+              --overwrite true
+          done
       - name: Create draft release 📝
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228
         with:
@@ -164,6 +172,19 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: gh release edit ${{ needs.changelog.outputs.tag }} --draft=false --repo ${{ github.repository }}
+      - name: Update latest files
+        env:
+          AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.CDN_CONNECTIONSTRING }}
+        run: |
+          az storage blob upload-batch --destination releases/latest --overwrite true --source .
+          for architecture in x64 arm64; do
+            az storage blob upload \
+              --container-name releases \
+              --name "latest/install-${architecture}.appinstaller" \
+              --file "install-${architecture}.appinstaller" \
+              --content-type application/appinstaller \
+              --overwrite true
+          done
   winget:
     runs-on: windows-latest
     needs:

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ src/test/umbraco/obj/
 src/keys
 *.prof
 packages/msix/Microsoft.Trusted.Signing.Client
+packages/msix/Update.appinstaller
+packages/msix/out/*.appinstaller
 .claude
 .styles
 

--- a/packages/msix/README.md
+++ b/packages/msix/README.md
@@ -15,12 +15,17 @@ the repository's `dist` folder.
 ./build.ps1 -Architecture x64 -Version "1.3.37"
 ```
 
-The package is created at `out/install-x64.msix`.
+The package is created at `out/install-x64.msix`. The architecture-specific App Installer feed is
+created at `out/install-x64.appinstaller` and embedded in the MSIX as `Update.appinstaller`.
 
 ## Install the package
 
 ```powershell
 Add-AppxPackage -Path ./out/install-x64.msix
 ```
+
+On Windows 11 build 22000 and later, direct MSIX installations register the embedded App Installer
+feed and check for updates on launch when the previous check was at least 24 hours ago. Earlier
+supported Windows versions ignore the update metadata and install the package normally.
 
 [Windows SDK]: https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/

--- a/packages/msix/appxmanifest.xml
+++ b/packages/msix/appxmanifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5" xmlns:desktop6="http://schemas.microsoft.com/appx/manifest/desktop/windows10/6" IgnorableNamespaces="rescap uap uap3 uap5 desktop6">
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap3="http://schemas.microsoft.com/appx/manifest/uap/windows10/3" xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5" xmlns:uap13="http://schemas.microsoft.com/appx/manifest/uap/windows10/13" xmlns:desktop6="http://schemas.microsoft.com/appx/manifest/desktop/windows10/6" IgnorableNamespaces="rescap uap uap3 uap5 uap13 desktop6">
   <Identity Name="ohmyposh.cli" Version="28.0.0.0" Publisher="CN=Jan Joris De Dobbeleer, O=Jan Joris De Dobbeleer, L=Diest, C=BE" ProcessorArchitecture="arm64" />
   <Properties>
     <DisplayName>Oh My Posh</DisplayName>
@@ -7,6 +7,9 @@
     <Description>A prompt theme engine for any shell.</Description>
     <Logo>icons\icon.png</Logo>
     <desktop6:RegistryWriteVirtualization>disabled</desktop6:RegistryWriteVirtualization>
+    <uap13:AutoUpdate>
+      <uap13:AppInstaller File="Update.appinstaller" />
+    </uap13:AutoUpdate>
   </Properties>
   <Resources>
     <Resource Language="en-us" />

--- a/packages/msix/build.ps1
+++ b/packages/msix/build.ps1
@@ -3,8 +3,8 @@
     Builds the MSIX package for Oh My Posh.
 
 .DESCRIPTION
-    This script creates the MSIX installer package for Oh My Posh with the specified architecture and version.
-    It can optionally copy the executable and sign the package.
+    This script creates the MSIX installer package and App Installer update feed for Oh My Posh with the
+    specified architecture and version. It can optionally copy the executable and sign the package.
 
 .PARAMETER Architecture
     The target architecture for the package. Must be either 'x64' or 'arm64'.
@@ -32,7 +32,7 @@
     Creates and signs the MSIX package for arm64 architecture with version 1.2.3.
 
 .OUTPUTS
-    Creates install-{Architecture}.msix in the 'out' directory.
+    Creates install-{Architecture}.msix and install-{Architecture}.appinstaller in the 'out' directory.
 
 .NOTES
     Requires the Windows SDK for MSIX packaging and signing.
@@ -149,6 +149,91 @@ function Invoke-PackageSigning {
     }
 }
 
+function New-AppInstallerFile {
+    <#
+    .SYNOPSIS
+        Creates the architecture-specific App Installer update feed.
+
+    .PARAMETER Architecture
+        The target package architecture.
+
+    .PARAMETER Name
+        The package identity name.
+
+    .PARAMETER Publisher
+        The package identity publisher.
+
+    .PARAMETER PackageVersion
+        The four-part package version.
+
+    .PARAMETER ReleaseVersion
+        The three-part GitHub release version.
+
+    .PARAMETER Path
+        The output path for the App Installer file.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('x64', 'arm64')]
+        [string]$Architecture,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Publisher,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$PackageVersion,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$ReleaseVersion,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Path
+    )
+
+    $namespace = 'http://schemas.microsoft.com/appx/appinstaller/2021'
+    $feedUri = "https://cdn.ohmyposh.dev/releases/latest/install-$Architecture.appinstaller"
+    $packageUri = "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v$ReleaseVersion/install-$Architecture.msix"
+    $settings = [System.Xml.XmlWriterSettings]::new()
+    $settings.Encoding = [System.Text.UTF8Encoding]::new($false)
+    $settings.Indent = $true
+
+    $writer = [System.Xml.XmlWriter]::Create($Path, $settings)
+    try {
+        $writer.WriteStartDocument()
+        $writer.WriteStartElement($null, 'AppInstaller', $namespace)
+        $writer.WriteAttributeString('Version', $PackageVersion)
+        $writer.WriteAttributeString('Uri', $feedUri)
+
+        $writer.WriteStartElement($null, 'MainPackage', $namespace)
+        $writer.WriteAttributeString('Name', $Name)
+        $writer.WriteAttributeString('Publisher', $Publisher)
+        $writer.WriteAttributeString('Version', $PackageVersion)
+        $writer.WriteAttributeString('ProcessorArchitecture', $Architecture)
+        $writer.WriteAttributeString('Uri', $packageUri)
+        $writer.WriteEndElement()
+
+        $writer.WriteStartElement($null, 'UpdateSettings', $namespace)
+        $writer.WriteStartElement($null, 'OnLaunch', $namespace)
+        $writer.WriteAttributeString('HoursBetweenUpdateChecks', '24')
+        $writer.WriteEndElement()
+        $writer.WriteEndElement()
+        $writer.WriteEndElement()
+        $writer.WriteEndDocument()
+    }
+    finally {
+        $writer.Dispose()
+    }
+}
+
 #endregion
 
 #region Main Script
@@ -194,6 +279,8 @@ try {
     $manifestPath = "$currentPath/appxmanifest.xml"
     $mappingFilePath = "$currentPath/mapping.txt"
     $msixPackagePath = "$currentPath/out/install-$Architecture.msix"
+    $appInstallerPath = "$currentPath/Update.appinstaller"
+    $appInstallerFeedPath = "$currentPath/out/install-$Architecture.appinstaller"
     $makeappxPath = "C:/Program Files (x86)/Windows Kits/10/bin/$SDKVersion/x64/makeappx.exe"
 
     # Validate required files exist
@@ -207,11 +294,27 @@ try {
         throw "makeappx.exe not found at: $makeappxPath"
     }
 
-    # Update manifest with version and architecture
+    if ($Version -notmatch '^[0-9]+\.[0-9]+\.[0-9]+$') {
+        throw "Version must contain three numeric components: $Version"
+    }
+
+    [version]$packageVersion = "$Version.0"
+    $packageVersionString = $packageVersion.ToString(4)
+    $releaseVersion = $packageVersion.ToString(3)
+
+    # Update manifest and App Installer feed with version and architecture
     [xml]$manifestDocument = Get-Content $manifestPath
-    $manifestDocument.Package.Identity.Version = "$Version.0"
+    $manifestDocument.Package.Identity.Version = $packageVersionString
     $manifestDocument.Package.Identity.ProcessorArchitecture = $Architecture
     $manifestDocument.Save($manifestPath)
+
+    New-AppInstallerFile `
+        -Architecture $Architecture `
+        -Name $manifestDocument.Package.Identity.Name `
+        -Publisher $manifestDocument.Package.Identity.Publisher `
+        -PackageVersion $packageVersionString `
+        -ReleaseVersion $releaseVersion `
+        -Path $appInstallerPath
 
     # Build MSIX package
     Write-Verbose "Building MSIX: $msixPackagePath" -Verbose
@@ -230,6 +333,8 @@ if ($Sign) {
     $signingTools = Initialize-SigningEnvironment -SDKVersion $SDKVersion
     Invoke-PackageSigning -PackagePath $msixPackagePath -SigningTools $signingTools
 }
+
+Copy-Item -Path $appInstallerPath -Destination $appInstallerFeedPath -Force
 
 Write-Verbose "Successfully completed building the MSIX package" -Verbose
 

--- a/packages/msix/mapping.txt
+++ b/packages/msix/mapping.txt
@@ -4,6 +4,7 @@
 
 [Files]
 "./dist/oh-my-posh.exe" "oh-my-posh.exe"
+"./Update.appinstaller" "Update.appinstaller"
 "./icons/icon.png" "/icons/icon.png"
 "./icons/44.png" "/icons/44.png"
 "./dsc/oh-my-posh.config.dsc.resource.json" "oh-my-posh.config.dsc.resource.json"

--- a/website/docs/installation/prompt.mdx
+++ b/website/docs/installation/prompt.mdx
@@ -217,16 +217,18 @@ to only require remote scripts to be signed using `Set-ExecutionPolicy -Executio
 Add the following snippet as the last line to your PowerShell profile script:
 
 ```powershell
-oh-my-posh init pwsh | Invoke-Expression
+$(if (Get-Command 'oh-my-posh' -ErrorAction Ignore) {
+    oh-my-posh init pwsh
+    # Set output encoding to UTF-8
+    [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+    # Set input encoding to UTF-8 (for reading user input with non-ASCII chars)
+    [Console]::InputEncoding = [System.Text.Encoding]::UTF8
+}) | Invoke-Expression
 ```
 
 :::tip Execution policy
 In case the execution policy disables executing unsigned scripts on your system, you can fallback to evaluating
-the script instead. Use the `--eval` flag to do so:
-
-```powershell
-oh-my-posh init pwsh --eval | Invoke-Expression
-```
+the script instead. Add the `--eval` flag to the `oh-my-posh init pwsh` command above.
 
 Be aware this will make initializing the shell slower.
 :::

--- a/website/static/skills/ohmyposh/shell/powershell.md
+++ b/website/static/skills/ohmyposh/shell/powershell.md
@@ -18,7 +18,13 @@ notepad $PROFILE
 Add this as the **last line**:
 
 ```powershell
-oh-my-posh init pwsh | Invoke-Expression
+$(if (Get-Command 'oh-my-posh' -ErrorAction Ignore) {
+    oh-my-posh init pwsh
+    # Set output encoding to UTF-8
+    [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+    # Set input encoding to UTF-8 (for reading user input with non-ASCII chars)
+    [Console]::InputEncoding = [System.Text.Encoding]::UTF8
+}) | Invoke-Expression
 ```
 
 Reload the profile:
@@ -35,11 +41,7 @@ Reload the profile:
 Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope LocalMachine
 ```
 
-Or use the `--eval` flag (slightly slower startup):
-
-```powershell
-oh-my-posh init pwsh --eval | Invoke-Expression
-```
+Or add the `--eval` flag to the `oh-my-posh init pwsh` command above (slightly slower startup).
 
 ## Next step
 


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features). No dedicated MSIX test harness exists; package and functional validation is listed below.
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Direct installations of the architecture-specific MSIX packages now register an embedded App Installer update feed. On launch, supported Windows versions check the architecture-specific feed when the previous check was at least 24 hours ago.

Each embedded `Update.appinstaller` points to the stable project-owned `https://cdn.ohmyposh.dev/releases/latest/install-<arch>.appinstaller` route. Release automation publishes x64 and arm64 feeds there with the `application/appinstaller` content type only after the GitHub release is public. The feed payloads use immutable, versioned `install-x64.msix` and `install-arm64.msix` GitHub Release URLs, so GitHub Releases remain the signed binary source of truth.

The `uap13:AutoUpdate` declaration is ignorable. Windows 11 21H2/build 22000 and later process the production schema (which originated in the build 21300 preview line); older supported Windows versions ignore it and continue to install normally. The package keeps its existing identity, publisher, signer flow, `MinVersion="10.0.17134.0"`, `MaxVersionTested="10.0.22631.0"`, and four-part versions.

The public PowerShell profile guidance now guards `oh-my-posh` discovery with `-ErrorAction Ignore`, so synced profiles produce neither visible output nor an error record when the command is absent. When it is installed, the snippet sets console input and output encoding to UTF-8 before evaluating the generated init script, avoiding the encoding flash and preserving non-ASCII input/output.

### Validation

- Built unsigned x64 and arm64 MSIX packages with Windows SDK 10.0.26100 MakeAppx using architecture-correct release binaries.
- Unpacked both packages and confirmed identity, publisher, four-part version, architecture, unchanged OS version bounds, `uap13:AutoUpdate`, embedded `Update.appinstaller`, 24-hour `OnLaunch`, stable feed URI, immutable GitHub payload URI, and byte-identical embedded/published feed files.
- Confirmed the immutable x64 and arm64 GitHub Release URL pattern resolves successfully.
- Parsed `build.ps1`, parsed `release.yml`, and exercised the missing-command snippet in both Windows PowerShell 5.1 and pwsh 7.6 with an empty error collection.
- Ran markdownlint on the changed Markdown files and completed a production Docusaurus build for the MDX guidance.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary