### PR TITLE
fix(pwsh): disable streaming in editor services

### DIFF
--- a/src/shell/scripts/omp.ps1
+++ b/src/shell/scripts/omp.ps1
@@ -993,6 +993,11 @@ New-Module -Name "oh-my-posh-core" -ScriptBlock {
     }
 
     function Enable-PoshStreaming {
+        # PSES processes idle events through its own pipelines, which can race the streaming repaint pipeline.
+        if ($null -ne (Get-Variable -Name psEditor -Scope Global -ErrorAction Ignore -ValueOnly)) {
+            return
+        }
+
         $global:_ompStreaming = $true
 
         if (-not $script:ServeSupported) {

--- a/website/docs/configuration/streaming.mdx
+++ b/website/docs/configuration/streaming.mdx
@@ -64,7 +64,9 @@ differs per shell:
 <TabItem value="powershell">
 
 Requires PowerShell 6 or later for the background process; Windows PowerShell 5.1 and
-sessions in `ConstrainedLanguage` mode use a streaming process per prompt instead.
+sessions in `ConstrainedLanguage` mode use a streaming process per prompt instead. Streaming
+is disabled in PowerShell Editor Services sessions, including the VS Code PowerShell extension,
+because its idle event processing can run pipelines concurrently.
 
 - **live updates**: the prompt repaints in place as pending segments resolve, even while
   you're already typing


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been added/updated (for bug fixes / features).

### Description

Fixes #7809.

PowerShell Editor Services processes idle events through its own runspace pipelines. The streaming repaint action also invokes the prompt from `PowerShell.OnIdle`, allowing the two pipeline invocations to race and crash PSReadLine.

Skip `Enable-PoshStreaming` when PSES exposes `$psEditor`. This leaves the normal synchronous prompt path active and avoids registering streaming event subscribers or starting the serve daemon.

The streaming documentation now records the PSES limitation. This host-specific behavior requires manual verification in a PSES session.

### Verification

Local commands could not run because the desktop sandbox failed before process creation. GitHub Actions provide the executable verification for this PR.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary