### PR TITLE
fix(git): repair the mainSCMDir/scmDir directory-role invariant

### DIFF
--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -116,30 +116,30 @@ type Rebase struct {
 }
 
 type Git struct {
-	configErr      error
-	config         *ini.File
+	commonCfgErr   error
 	Working        *GitStatus
 	Staging        *GitStatus
 	commit         *Commit
 	Rebase         *Rebase
 	User           *User
-	ShortHash      string
+	commonCfg      *ini.File
 	Hash           string
-	BranchStatus   string
 	HEAD           string
 	UpstreamIcon   string
 	UpstreamURL    string
 	Ref            string
 	RawUpstreamURL string
 	mainWorktree   string
+	BranchStatus   string
+	ShortHash      string
 	Scm
-	stashCount       int
 	Ahead            int
-	PushAhead        int
 	PushBehind       int
 	Behind           int
 	worktreeCount    int
-	configOnce       sync.Once
+	PushAhead        int
+	stashCount       int
+	commonCfgOnce    sync.Once
 	mainWorktreeOnce sync.Once
 	IsWorkTree       bool
 	Merge            bool
@@ -397,15 +397,16 @@ func (g *Git) setUser() {
 func (g *Git) isBareRepo(gitDir *runtime.FileInfo) bool {
 	defer log.Trace(time.Now())
 
-	if gitDir.IsDir {
-		g.mainSCMDir = gitDir.Path
-	} else {
+	bareDir := gitDir.Path
+	if !gitDir.IsDir {
 		content := g.fileContent(gitDir.ParentFolder, ".git")
 		dir := strings.TrimPrefix(content, "gitdir: ")
-		g.mainSCMDir = resolveGitPath(gitDir.ParentFolder, g.convertToLinuxPath(dir))
+		bareDir = resolveGitPath(gitDir.ParentFolder, g.convertToLinuxPath(dir))
 	}
 
-	cfg, err := g.getGitConfig()
+	g.mainSCMDir = bareDir
+
+	cfg, err := loadGitConfig(g.env, bareDir)
 	if err != nil {
 		log.Error(err)
 		return false
@@ -484,8 +485,8 @@ func (g *Git) hasWorktree(gitdir *runtime.FileInfo) bool {
 			g.repoRootDir = g.convertToLinuxPath(g.repoRootDir)
 			// resolve relative paths (worktree.useRelativePaths = true)
 			g.repoRootDir = resolveGitPath(g.scmDir, g.repoRootDir)
-			g.scmDir = moduleDir[:worktreeIndex]
 			g.mainSCMDir = g.scmDir
+			g.scmDir = moduleDir[:worktreeIndex]
 			g.IsWorkTree = true
 			return true
 		}
@@ -512,13 +513,9 @@ func (g *Git) hasWorktree(gitdir *runtime.FileInfo) bool {
 		}
 	}
 
-	// check for separate git folder(--separate-git-dir)
-	// check if the folder contains a HEAD file
 	if g.env.HasFilesInDir(g.mainSCMDir, "HEAD") {
-		gitFolder := strings.TrimSuffix(g.scmDir, ".git")
+		g.repoRootDir = strings.TrimSuffix(g.scmDir, ".git")
 		g.scmDir = g.mainSCMDir
-		g.mainSCMDir = gitFolder
-		g.repoRootDir = gitFolder
 		return true
 	}
 
@@ -561,7 +558,7 @@ func (g *Git) setPushStatus() {
 		return
 	}
 
-	pushRemote := g.getPushRemote()
+	pushRemote := g.pushRef()
 	if pushRemote == "" {
 		return
 	}
@@ -583,64 +580,68 @@ func (g *Git) setPushStatus() {
 	wg.Wait()
 }
 
+// pushRef resolves the destination of a push once, so both counts below describe the
+// same comparison. An empty rev-list result is a genuine failure, never a retry signal.
+func (g *Git) pushRef() string {
+	if ref := g.getGitCommandOutput("rev-parse", "--abbrev-ref", "@{push}"); ref != "" {
+		return ref
+	}
+
+	return g.getPushRemote()
+}
+
 func (g *Git) getPushRemote() string {
-	upstream := g.Upstream
-	if idx := strings.Index(upstream, "/"); idx != -1 {
-		upstream = upstream[:idx]
-	}
-
-	if upstream == "" {
-		upstream = origin
-	}
-
 	branch := g.Ref
 	if branch == "" {
 		return ""
 	}
 
-	cfg, err := g.getGitConfig()
-	if err != nil {
-		pushRemote := g.getGitCommandOutput("config", "--get", "remote.pushDefault")
-		if pushRemote == "" {
-			pushRemote = upstream
-		}
-
-		return strings.TrimSpace(pushRemote) + "/" + branch
-	}
-
-	sectionName := fmt.Sprintf(`branch "%s"`, branch)
-	section := cfg.Section(sectionName)
-	pushRemote := section.Key("pushRemote").String()
+	pushRemote := g.getGitCommandOutput("config", "--get", fmt.Sprintf("branch.%s.pushRemote", branch))
 	if pushRemote == "" {
-		pushRemote = cfg.Section("remote").Key("pushDefault").String()
+		pushRemote = g.getGitCommandOutput("config", "--get", "remote.pushDefault")
 	}
 
 	if pushRemote == "" {
-		pushRemote = upstream
+		pushRemote = regex.ReplaceAllString("/.*", g.Upstream, "")
 	}
 
-	return pushRemote + "/" + branch
+	if pushRemote == "" {
+		pushRemote = origin
+	}
+
+	return strings.TrimSpace(pushRemote) + "/" + branch
 }
 
-func (g *Git) getGitConfig() (*ini.File, error) {
-	g.configOnce.Do(func() {
-		configData := g.fileContent(g.mainSCMDir, "config")
-		if configData == "" {
-			log.Debug("git config file not found")
-			g.configErr = fmt.Errorf("git config file not found")
-			return
-		}
+func loadGitConfigFile(env runtime.Environment, dir, file string) (*ini.File, error) {
+	if dir == "" {
+		return nil, fmt.Errorf("no git directory to read %s from", file)
+	}
 
-		cfg, err := ini.Load(configData)
-		if err != nil {
-			g.configErr = err
-			return
-		}
+	configData := strings.Trim(env.FileContent(dir+"/"+file), " \r\n")
+	if configData == "" {
+		return nil, fmt.Errorf("%s not found", file)
+	}
 
-		g.config = cfg
+	return ini.Load(configData)
+}
+
+func loadGitConfig(env runtime.Environment, dir string) (*ini.File, error) {
+	return loadGitConfigFile(env, dir, "config")
+}
+
+// commonConfig reads the repository's shared config. It refuses to memoize a failure
+// against an unknown directory, which a cache-restored segment would otherwise poison.
+func (g *Git) commonConfig() (*ini.File, error) {
+	commonDir := g.commonGitDir()
+	if commonDir == "" {
+		return nil, fmt.Errorf("common git directory is unknown")
+	}
+
+	g.commonCfgOnce.Do(func() {
+		g.commonCfg, g.commonCfgErr = loadGitConfig(g.env, commonDir)
 	})
 
-	return g.config, g.configErr
+	return g.commonCfg, g.commonCfgErr
 }
 
 func (g *Git) cleanUpstreamURL(url string) string {
@@ -1111,15 +1112,19 @@ func (g *Git) WorktreeCount() int {
 		return g.worktreeCount
 	}
 
-	worktreesFolder := filepath.Join(g.mainSCMDir, "worktrees")
+	commonDir := g.commonGitDir()
+	if commonDir == "" {
+		return 0
+	}
+
+	worktreesFolder := filepath.Join(commonDir, "worktrees")
 
 	if !g.env.HasFolder(worktreesFolder) {
 		return 0
 	}
 
-	worktreeFolders := g.env.LsDir(worktreesFolder)
 	var count int
-	for _, folder := range worktreeFolders {
+	for _, folder := range g.env.LsDir(worktreesFolder) {
 		if folder.IsDir() {
 			count++
 		}
@@ -1189,12 +1194,18 @@ func (g *Git) ensureMainWorktreeContext() bool {
 }
 
 func (g *Git) commonGitDir() string {
+	// scmDir is the common git directory at every discovery exit. The worktrees cut
+	// below is only for partially initialized state, where scmDir is not yet set.
+	if g.scmDir != "" {
+		return filepath.ToSlash(g.scmDir)
+	}
+
 	mainSCMDir := filepath.ToSlash(g.mainSCMDir)
 	if worktreeIndex := strings.LastIndex(mainSCMDir, "/worktrees/"); worktreeIndex > -1 {
 		return mainSCMDir[:worktreeIndex]
 	}
 
-	return filepath.ToSlash(g.scmDir)
+	return ""
 }
 
 // isModuleAdminDir reports whether target is a submodule administrative directory
@@ -1220,9 +1231,12 @@ func (g *Git) isModuleAdminDir(target, parent string) bool {
 		return true
 	}
 
-	cfg, err := ini.Load(g.fileContent(target, "config"))
+	// A missing or unreadable config is simply not a submodule git dir, not an error
+	// worth reporting: every --separate-git-dir target spelled with a modules component
+	// lands here.
+	cfg, err := loadGitConfig(g.env, target)
 	if err != nil {
-		log.Error(err)
+		log.Debug("no readable config in", target, "- not a submodule git dir")
 		return false
 	}
 
@@ -1282,24 +1296,23 @@ func (g *Git) getRemoteURL() string {
 		upstream = origin
 	}
 
-	cfg, err := g.getGitConfig()
-	if err != nil {
-		return g.getGitCommandOutput("remote", "get-url", upstream)
-	}
-
-	url := cfg.Section("remote \"" + upstream + "\"").Key("url").String()
-	if len(url) != 0 {
-		log.Debug("remote url found in config:", url)
+	// Ask git first because it applies insteadOf rewriting and reads the merged configuration.
+	if url := g.getGitCommandOutput("remote", "get-url", upstream); url != "" {
 		return url
 	}
 
-	return g.getGitCommandOutput("remote", "get-url", upstream)
+	cfg, err := g.commonConfig()
+	if err != nil {
+		return ""
+	}
+
+	return cfg.Section("remote \"" + upstream + "\"").Key("url").String()
 }
 
 func (g *Git) Remotes() map[string]string {
 	var remotes = make(map[string]string)
 
-	cfg, err := g.getGitConfig()
+	cfg, err := g.commonConfig()
 	if err != nil {
 		return remotes
 	}
@@ -1347,10 +1360,50 @@ func (g *Git) repoName() string {
 		return path.Base(g.convertToLinuxPath(g.repoRootDir))
 	}
 
-	ind := strings.LastIndex(g.mainSCMDir, ".git/worktrees")
-	if ind > -1 {
-		return path.Base(g.mainSCMDir[:ind])
+	commonDir := g.commonGitDir()
+	if commonDir == "" {
+		return ""
+	}
+
+	if parent := filepath.Dir(commonDir); g.gitEntryResolvesTo(parent, commonDir) {
+		return path.Base(g.convertToLinuxPath(parent))
+	}
+
+	for _, file := range []string{"config.worktree", "config"} {
+		cfg, err := loadGitConfigFile(g.env, commonDir, file)
+		if err != nil {
+			continue
+		}
+
+		worktree := cfg.Section("core").Key("worktree").String()
+		if worktree == "" {
+			continue
+		}
+
+		return path.Base(g.convertToLinuxPath(resolveGitPath(commonDir, worktree)))
 	}
 
 	return ""
+}
+
+func (g *Git) gitEntryResolvesTo(parent, commonDir string) bool {
+	gitEntry := parent + "/.git"
+	commonDir = filepath.ToSlash(filepath.Clean(commonDir))
+
+	if g.env.HasFolder(gitEntry) {
+		return filepath.ToSlash(filepath.Clean(gitEntry)) == commonDir
+	}
+
+	if !g.env.HasFilesInDir(parent, ".git") {
+		return false
+	}
+
+	content := strings.Trim(g.env.FileContent(gitEntry), " \r\n")
+	target, found := strings.CutPrefix(content, "gitdir: ")
+	if !found {
+		return false
+	}
+
+	target = g.convertToLinuxPath(target)
+	return filepath.ToSlash(filepath.Clean(resolveGitPath(parent, target))) == commonDir
 }

--- a/src/segments/git_test.go
+++ b/src/segments/git_test.go
@@ -4,17 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/cache"
-	"github.com/jandedobbeleer/oh-my-posh/src/ini"
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
 	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
@@ -60,6 +58,50 @@ func TestWorktreeAdminIndex(t *testing.T) {
 		}
 
 		assert.Equal(t, tc.Expected, got, tc.Case)
+	}
+}
+
+func TestCommonGitDir(t *testing.T) {
+	cases := []struct {
+		Case       string
+		ScmDir     string
+		MainSCMDir string
+		Expected   string
+	}{
+		{
+			Case:       "scmDir wins over the worktrees cut",
+			ScmDir:     "/repo/.git",
+			MainSCMDir: "/repo/.git/worktrees/linked",
+			Expected:   "/repo/.git",
+		},
+		{
+			Case:       "checkout path containing worktrees does not fool the cut",
+			ScmDir:     "/x/sepdir",
+			MainSCMDir: "/x/worktrees/trap/",
+			Expected:   "/x/sepdir",
+		},
+		{
+			Case:       "falls back to the cut when scmDir is empty",
+			MainSCMDir: "/repo/.git/worktrees/linked",
+			Expected:   "/repo/.git",
+		},
+		{
+			Case:     "empty when nothing is known",
+			Expected: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Case, func(t *testing.T) {
+			g := &Git{
+				Scm: Scm{
+					scmDir:     tc.ScmDir,
+					mainSCMDir: tc.MainSCMDir,
+				},
+			}
+
+			assert.Equal(t, tc.Expected, g.commonGitDir())
+		})
 	}
 }
 
@@ -122,19 +164,19 @@ func TestEnabledInWorktree(t *testing.T) {
 		MetadataAddon     string
 		MetadataContent   string
 		ExpectedProbedDir string
-		// TargetConfig is the config file found in the directory the pointer names. The
-		// modules classifier reads core.worktree out of it to tell a submodule git dir
-		// from a --separate-git-dir target, which has no core.worktree at all.
-		TargetConfig string
-		Case         string
-		Pointer      string
+		Case              string
+		Pointer           string
 		// DiscoveredGitFile is the .git file HasParentFilePath found, whose parent is
 		// DiscoveredParent above.
 		DiscoveredGitFile string
 		// RawGitFile overrides the whole .git file body. Use it when the test is about
 		// the file's syntax rather than the pointer it carries; leave it empty and the
 		// loop writes "gitdir: <Pointer>".
-		RawGitFile         string
+		RawGitFile string
+		// TargetConfig is the config file found in the directory the pointer names. The
+		// modules classifier reads core.worktree out of it to tell a submodule git dir
+		// from a --separate-git-dir target, which has no core.worktree at all.
+		TargetConfig       string
 		ExpectedIsWorkTree bool
 		ExpectedEnabled    bool
 	}{
@@ -179,25 +221,68 @@ func TestEnabledInWorktree(t *testing.T) {
 			ExpectedRootFolder:    new(TestRootPath + dotGitSubmodule),
 		},
 		{
-			// Directory-role assertions are reserved for a later decision.
-			Case:               "submodule with worktrees",
-			ExpectedEnabled:    true,
-			ExpectedIsWorkTree: true,
-			Pointer:            TestRootPath + "dev/.git/modules/module/path/worktrees/location",
-			DiscoveredGitFile:  TestRootPath + dotGit,
-			DiscoveredParent:   TestRootPath + "dev",
-			MetadataAddon:      "gitdir",
-			MetadataContent:    TestRootPath + "dev/worktree.git\n",
-			ExpectedProbedDir:  TestRootPath + "dev/.git/modules/module/path/worktrees/location",
+			Case:                  "submodule with worktrees",
+			ExpectedEnabled:       true,
+			ExpectedIsWorkTree:    true,
+			Pointer:               TestRootPath + "dev/.git/modules/module/path/worktrees/location",
+			DiscoveredGitFile:     TestRootPath + dotGit,
+			DiscoveredParent:      TestRootPath + "dev",
+			MetadataAddon:         "gitdir",
+			MetadataContent:       TestRootPath + "dev/worktree.git\n",
+			ExpectedProbedDir:     TestRootPath + "dev/.git/modules/module/path/worktrees/location",
+			ExpectedWorkingFolder: new(TestRootPath + "dev/.git/modules/module/path/worktrees/location"),
+			ExpectedRealFolder:    new(TestRootPath + "dev/worktree"),
+			ExpectedRootFolder:    new(TestRootPath + "dev/.git/modules/module/path"),
 		},
 		{
-			// Directory-role assertions are reserved for a later decision.
-			Case:              "separate git dir",
-			ExpectedEnabled:   true,
-			Pointer:           TestRootPath + "dev/separate/.git/posh",
-			DiscoveredGitFile: TestRootPath + dotGit,
-			DiscoveredParent:  TestRootPath + "dev",
-			ExpectedProbedDir: TestRootPath + "dev/separate/.git/posh",
+			Case:                  "submodule worktree with a relative gitdir path",
+			ExpectedEnabled:       true,
+			ExpectedIsWorkTree:    true,
+			Pointer:               TestRootPath + "dev/.git/modules/module/path/worktrees/location",
+			DiscoveredGitFile:     TestRootPath + dotGit,
+			DiscoveredParent:      TestRootPath + "dev",
+			MetadataAddon:         "gitdir",
+			MetadataContent:       "../../../../../../worktree/.git\n",
+			ExpectedProbedDir:     TestRootPath + "dev/.git/modules/module/path/worktrees/location",
+			ExpectedWorkingFolder: new(TestRootPath + "dev/.git/modules/module/path/worktrees/location"),
+			ExpectedRealFolder:    new(TestRootPath + "dev/worktree"),
+			ExpectedRootFolder:    new(TestRootPath + "dev/.git/modules/module/path"),
+		},
+		{
+			Case:                  "nested submodule worktree",
+			ExpectedEnabled:       true,
+			ExpectedIsWorkTree:    true,
+			Pointer:               TestRootPath + "dev/.git/modules/outer/modules/inner/worktrees/location",
+			DiscoveredGitFile:     TestRootPath + dotGit,
+			DiscoveredParent:      TestRootPath + "dev",
+			MetadataAddon:         "gitdir",
+			MetadataContent:       TestRootPath + "dev/inner-wt.git\n",
+			ExpectedProbedDir:     TestRootPath + "dev/.git/modules/outer/modules/inner/worktrees/location",
+			ExpectedWorkingFolder: new(TestRootPath + "dev/.git/modules/outer/modules/inner/worktrees/location"),
+			ExpectedRealFolder:    new(TestRootPath + "dev/inner-wt"),
+			ExpectedRootFolder:    new(TestRootPath + "dev/.git/modules/outer/modules/inner"),
+		},
+		{
+			Case:                  "separate git dir",
+			ExpectedEnabled:       true,
+			Pointer:               TestRootPath + "dev/separate/.git/posh",
+			DiscoveredGitFile:     TestRootPath + dotGit,
+			DiscoveredParent:      TestRootPath + "dev",
+			ExpectedProbedDir:     TestRootPath + "dev/separate/.git/posh",
+			ExpectedWorkingFolder: new(TestRootPath + "dev/separate/.git/posh"),
+			ExpectedRealFolder:    new(TestRootPath + "dev/"),
+			ExpectedRootFolder:    new(TestRootPath + "dev/separate/.git/posh"),
+		},
+		{
+			Case:                  "bare repo through a .git pointer",
+			ExpectedEnabled:       true,
+			Pointer:               TestRootPath + "dev/.bare",
+			DiscoveredGitFile:     TestRootPath + dotGit,
+			DiscoveredParent:      TestRootPath + "dev",
+			ExpectedProbedDir:     TestRootPath + "dev/.bare",
+			ExpectedWorkingFolder: new(TestRootPath + "dev/.bare"),
+			ExpectedRealFolder:    new(TestRootPath + "dev/"),
+			ExpectedRootFolder:    new(TestRootPath + "dev/.bare"),
 		},
 		{
 			// The pointer's spelling contains a "modules" component, but the directory
@@ -519,7 +604,9 @@ func TestEnabledInBareLayout(t *testing.T) {
 		env.On("FileContent", root+"/.git").Return("gitdir: ./.bare")
 		env.On("HasFilesInDir", root+"/.bare", "HEAD").Return(true)
 		env.On("FileContent", root+"/.bare/config").Return("[core]\n\tbare = true")
-		env.On("FileContent", root+"//HEAD").Return("")
+		// HEAD lives in the bare git dir, not the working tree root: mainSCMDir holds the
+		// current checkout's git directory now.
+		env.On("FileContent", root+"/.bare/HEAD").Return("")
 		env.MockGitCommand(root+"/", "1234567890abcdef1234567890abcdef12345678", "rev-parse", "HEAD")
 		env.MockGitCommand(root+"/", "", "describe", "--tags", "--exact-match")
 		env.MockGitCommand(root+"/", "", "remote")
@@ -639,50 +726,89 @@ func TestShouldDisplayInitializesWSLBeforeBareRepoDetection(t *testing.T) {
 
 func TestEnabledInBareRepo(t *testing.T) {
 	cases := []struct {
-		Case   string
-		HEAD   string
-		IsBare bool
+		Case            string
+		HEAD            string
+		GitDirPath      string
+		GitFileContent  string
+		Config          string
+		ExpectedRemotes int
+		GitDirIsDir     bool
+		IsBare          bool
 	}{
 		{
-			Case:   "Bare repo on main",
-			IsBare: true,
-			HEAD:   "ref: refs/heads/main",
+			Case:        "Bare repo on main",
+			IsBare:      true,
+			GitDirPath:  "git",
+			GitDirIsDir: true,
+			HEAD:        "ref: refs/heads/main",
+			Config:      "[core]\n\tbare = true",
 		},
 		{
-			Case:   "Not a bare repo",
-			HEAD:   "ref: refs/heads/main",
-			IsBare: false,
+			Case:        "Not a bare repo",
+			IsBare:      false,
+			GitDirPath:  "git",
+			GitDirIsDir: true,
+			HEAD:        "ref: refs/heads/main",
+			Config:      "[core]\n\tbare = false",
+		},
+		{
+			Case:            "Linked worktree probe does not poison the remotes memo",
+			IsBare:          false,
+			GitDirPath:      "/repo/.git",
+			GitDirIsDir:     false,
+			GitFileContent:  "gitdir: /repo/.git/worktrees/linked",
+			Config:          "[remote \"origin\"]\n\turl = git@github.com:JanDeDobbeleer/test.git",
+			ExpectedRemotes: 1,
 		},
 	}
 	for _, tc := range cases {
-		path := "git"
-		env := new(mock.Environment)
-		env.On("InWSLSharedDrive").Return(false)
-		env.On("GOOS").Return("")
-		env.On("HasCommand", "git").Return(true)
+		t.Run(tc.Case, func(t *testing.T) {
+			env := new(mock.Environment)
+			env.On("InWSLSharedDrive").Return(false)
+			env.On("GOOS").Return("")
+			env.On("HasCommand", "git").Return(true)
+			env.On("PathSeparator").Return("/")
 
-		configData := fmt.Sprintf(`[core]
-		bare = %s`, strconv.FormatBool(tc.IsBare))
+			fileInfo := &runtime.FileInfo{
+				IsDir:        tc.GitDirIsDir,
+				Path:         tc.GitDirPath,
+				ParentFolder: "/repo",
+			}
+			env.On("HasParentFilePath", ".git", true).Return(fileInfo, nil)
+			env.On("FileContent", tc.GitDirPath).Return(tc.GitFileContent)
+			env.On("FileContent", "/repo/.git/worktrees/linked/gitdir").Return("/repo/linked/.git\n")
+			env.On("FileContent", tc.GitDirPath+"/HEAD").Return(tc.HEAD)
+			env.On("FileContent", testify_.Anything).Return(tc.Config)
+			env.On("HasFilesInDir", testify_.Anything, testify_.Anything).Return(true)
+			env.On("HasFolder", testify_.Anything).Return(false)
+			env.On("RunCommand", testify_.Anything, testify_.Anything).Return("", nil)
 
-		env.On("HasParentFilePath", ".git", true).Return(&runtime.FileInfo{IsDir: true, Path: path}, nil)
-		env.On("FileContent", "git/HEAD").Return(tc.HEAD)
+			props := options.Map{FetchBareInfo: true}
 
-		props := options.Map{
-			FetchBareInfo: true,
-		}
+			g := &Git{}
+			g.Init(props, env)
 
-		g := &Git{}
-		g.Init(props, env)
+			_ = g.Enabled()
 
-		g.configOnce = sync.Once{}
-		g.configOnce.Do(func() {
-			g.config, g.configErr = ini.Load(configData)
+			assert.Equal(t, tc.IsBare, g.IsBare, tc.Case)
+
+			if tc.ExpectedRemotes > 0 {
+				assert.Len(t, g.Remotes(), tc.ExpectedRemotes, "%s: remotes must survive the bare probe", tc.Case)
+			}
 		})
-
-		_ = g.Enabled()
-
-		assert.Equal(t, tc.IsBare, g.IsBare, tc.Case)
 	}
+}
+
+func TestIsBareRepoDoesNotReuseConfigMemo(t *testing.T) {
+	env := new(mock.Environment)
+	env.On("FileContent", "first/config").Return("[core]\n\tbare = false")
+	env.On("FileContent", "second/config").Return("[core]\n\tbare = true")
+
+	g := &Git{}
+	g.Init(options.Map{}, env)
+
+	assert.False(t, g.isBareRepo(&runtime.FileInfo{Path: "first", IsDir: true}))
+	assert.True(t, g.isBareRepo(&runtime.FileInfo{Path: "second", IsDir: true}))
 }
 
 func TestGetGitOutputForCommand(t *testing.T) {
@@ -863,6 +989,33 @@ func TestSetGitHEADContextClean(t *testing.T) {
 		g.setHEADStatus()
 		assert.Equal(t, tc.Expected, g.HEAD, tc.Case)
 	}
+}
+
+func TestSubmoduleWorktreeReadsItsOwnHEAD(t *testing.T) {
+	const (
+		commonDir = "/super/.git/modules/sub"
+		adminDir  = commonDir + "/worktrees/subwt"
+	)
+
+	env := new(mock.Environment)
+	env.On("FileContent", adminDir+"/HEAD").Return("ref: refs/heads/subfeature")
+	env.On("FileContent", commonDir+"/HEAD").Return("ref: refs/heads/main")
+	env.On("HasFilesInDir", testify_.Anything, testify_.Anything).Return(false)
+	env.On("HasFolder", testify_.Anything).Return(false)
+	env.On("GOOS").Return("unix")
+
+	g := &Git{
+		Scm: Scm{
+			scmDir:     commonDir,
+			mainSCMDir: adminDir,
+		},
+		IsWorkTree: true,
+	}
+	g.Init(options.Map{}, env)
+
+	g.updateHEADReference()
+
+	assert.Equal(t, "subfeature", g.Ref)
 }
 
 func TestSetPrettyHEADName(t *testing.T) {
@@ -1206,11 +1359,6 @@ func TestGitUpstream(t *testing.T) {
 			},
 		}
 		g.Init(props, env)
-
-		g.configOnce = sync.Once{}
-		g.configOnce.Do(func() {
-			g.configErr = errors.New("no config")
-		})
 
 		upstreamIcon := g.getUpstreamIcon()
 		assert.Equal(t, tc.Expected, upstreamIcon, tc.Case)
@@ -1626,23 +1774,24 @@ func TestGitRemotes(t *testing.T) {
 		ExpectedRemotes map[string]string
 		Case            string
 		Config          string
+		ScmDir          string
 		Expected        int
 	}{
 		{
 			Case:            "Empty config file",
+			ScmDir:          "/repo/.git",
 			Expected:        0,
 			ExpectedRemotes: map[string]string{},
 		},
 		{
 			Case:     "Two remotes",
+			ScmDir:   "/repo/.git",
 			Expected: 2,
 			Config: `
 [remote "origin"]
 	url = git@github.com:JanDeDobbeleer/test.git
-	fetch = +refs/heads/*:refs/remotes/origin/*
 [remote "upstream"]
 	url = git@github.com:microsoft/test.git
-	fetch = +refs/heads/*:refs/remotes/upstream/*
 `,
 			ExpectedRemotes: map[string]string{
 				"origin":   "https://github.com/JanDeDobbeleer/test",
@@ -1651,11 +1800,11 @@ func TestGitRemotes(t *testing.T) {
 		},
 		{
 			Case:     "One remote",
+			ScmDir:   "/repo/.git",
 			Expected: 1,
 			Config: `
 [remote "origin"]
 	url = git@github.com:JanDeDobbeleer/test.git
-	fetch = +refs/heads/*:refs/remotes/origin/*
 `,
 			ExpectedRemotes: map[string]string{
 				"origin": "https://github.com/JanDeDobbeleer/test",
@@ -1663,12 +1812,14 @@ func TestGitRemotes(t *testing.T) {
 		},
 		{
 			Case:            "Broken config",
+			ScmDir:          "/repo/.git",
 			Expected:        0,
 			Config:          "{{}}",
 			ExpectedRemotes: map[string]string{},
 		},
 		{
 			Case:     "Three remotes with different URL formats",
+			ScmDir:   "/repo/.git",
 			Expected: 3,
 			Config: `
 [remote "origin"]
@@ -1687,79 +1838,152 @@ func TestGitRemotes(t *testing.T) {
 				"fork":     "https://gitlab.com/user/test",
 			},
 		},
+		{
+			Case:     "Linked worktree reads the common config",
+			ScmDir:   "/repo/.git",
+			Expected: 1,
+			Config: `
+[remote "origin"]
+	url = git@github.com:JanDeDobbeleer/test.git
+`,
+			ExpectedRemotes: map[string]string{
+				"origin": "https://github.com/JanDeDobbeleer/test",
+			},
+		},
+		{
+			Case:            "Empty common dir returns empty without reading",
+			ScmDir:          "",
+			Expected:        0,
+			ExpectedRemotes: map[string]string{},
+		},
 	}
 
 	for _, tc := range cases {
-		env := new(mock.Environment)
+		t.Run(tc.Case, func(t *testing.T) {
+			env := new(mock.Environment)
+			if tc.ScmDir != "" {
+				env.On("FileContent", tc.ScmDir+"/config").Return(tc.Config)
+			}
 
-		g := &Git{
-			Scm: Scm{
-				repoRootDir: "foo",
-			},
-		}
-		g.Init(options.Map{}, env)
+			g := &Git{
+				Scm: Scm{
+					repoRootDir: "foo",
+					scmDir:      tc.ScmDir,
+				},
+			}
+			g.Init(options.Map{}, env)
 
-		g.configOnce = sync.Once{}
-		g.configOnce.Do(func() {
-			g.config, g.configErr = ini.Load(tc.Config)
+			got := g.Remotes()
+			assert.Equal(t, tc.Expected, len(got), tc.Case)
+
+			for name, expectedURL := range tc.ExpectedRemotes {
+				actualURL, exists := got[name]
+				assert.True(t, exists, "%s: expected remote '%s' to exist", tc.Case, name)
+				assert.Equal(t, expectedURL, actualURL, "%s: remote '%s' URL mismatch", tc.Case, name)
+			}
+
+			if tc.ScmDir == "" {
+				env.AssertNotCalled(t, "FileContent", testify_.Anything)
+			}
 		})
-
-		got := g.Remotes()
-		assert.Equal(t, tc.Expected, len(got), tc.Case)
-
-		// Verify the actual remote names and URLs
-		for name, expectedURL := range tc.ExpectedRemotes {
-			actualURL, exists := got[name]
-			assert.True(t, exists, "%s: expected remote '%s' to exist", tc.Case, name)
-			assert.Equal(t, expectedURL, actualURL, "%s: remote '%s' URL mismatch", tc.Case, name)
-		}
 	}
 }
 
 func TestGitRepoName(t *testing.T) {
 	cases := []struct {
-		Case       string
-		Expected   string
-		WorkingDir string
-		RealDir    string
-		IsWorkTree bool
+		Case            string
+		Expected        string
+		ScmDir          string
+		RepoRootDir     string
+		ParentGitFile   string
+		WorktreeConfig  string
+		CommonConfig    string
+		ConvertedGitDir string
+		ConvertedParent string
+		ParentGitIsDir  bool
+		IsWorkTree      bool
+		IsWslSharedPath bool
 	}{
 		{
-			Case:       "In worktree",
-			Expected:   "oh-my-posh",
-			IsWorkTree: true,
-			WorkingDir: "/Users/jan/Code/oh-my-posh/.git/worktrees/oh-my-posh2",
+			Case:        "not in a worktree",
+			Expected:    "oh-my-posh",
+			RepoRootDir: "/Users/jan/Code/oh-my-posh",
 		},
 		{
-			Case:       "Not in worktree",
-			Expected:   "oh-my-posh",
-			IsWorkTree: false,
-			RealDir:    "/Users/jan/Code/oh-my-posh",
+			Case:           "ordinary linked worktree",
+			Expected:       "normal",
+			IsWorkTree:     true,
+			ScmDir:         "/code/normal/.git",
+			ParentGitIsDir: true,
 		},
 		{
-			Case:       "In worktree, unexpected dir",
+			Case:          "bare-backed linked worktree",
+			Expected:      "barelayout",
+			IsWorkTree:    true,
+			ScmDir:        "/code/barelayout/.bare",
+			ParentGitFile: "gitdir: ./.bare",
+		},
+		{
+			Case:            "bare-backed linked worktree through Windows git in WSL",
+			Expected:        "barelayout",
+			IsWorkTree:      true,
+			IsWslSharedPath: true,
+			ScmDir:          "/mnt/c/code/barelayout/.bare",
+			ParentGitFile:   "gitdir: C:/code/barelayout/.bare",
+			ConvertedGitDir: "/mnt/c/code/barelayout/.bare",
+			ConvertedParent: "/mnt/c/code/barelayout",
+		},
+		{
+			Case:         "submodule linked worktree resolves core.worktree",
+			Expected:     "sub",
+			IsWorkTree:   true,
+			ScmDir:       "/super/.git/modules/logical",
+			CommonConfig: "[core]\n\tworktree = ../../../sub",
+		},
+		{
+			Case:           "submodule linked worktree with extensions.worktreeConfig",
+			Expected:       "sub",
+			IsWorkTree:     true,
+			ScmDir:         "/super/.git/modules/logical",
+			WorktreeConfig: "[core]\n\tworktree = ../../../sub",
+		},
+		{
+			Case:       "external separate git dir stays empty",
 			Expected:   "",
 			IsWorkTree: true,
-			WorkingDir: "/Users/jan/Code/oh-my-posh2",
+			ScmDir:     "/x/sepdir",
 		},
 	}
 
 	for _, tc := range cases {
-		env := new(mock.Environment)
-		env.On("PathSeparator").Return("/")
-		env.On("GOOS").Return(runtime.LINUX)
+		t.Run(tc.Case, func(t *testing.T) {
+			env := new(mock.Environment)
+			env.On("PathSeparator").Return("/")
+			env.On("GOOS").Return(runtime.LINUX)
 
-		g := &Git{
-			Scm: Scm{
-				repoRootDir: tc.RealDir,
-				mainSCMDir:  tc.WorkingDir,
-			},
-			IsWorkTree: tc.IsWorkTree,
-		}
-		g.Init(options.Map{}, env)
+			parent := filepath.Dir(tc.ScmDir)
+			env.On("HasFolder", parent+"/.git").Return(tc.ParentGitIsDir)
+			env.On("HasFilesInDir", parent, ".git").Return(tc.ParentGitFile != "")
+			env.On("FileContent", parent+"/.git").Return(tc.ParentGitFile)
+			env.On("FileContent", tc.ScmDir+"/config.worktree").Return(tc.WorktreeConfig)
+			env.On("FileContent", tc.ScmDir+"/config").Return(tc.CommonConfig)
+			if tc.ConvertedGitDir != "" {
+				env.On("ConvertToLinuxPath").Return(tc.ConvertedGitDir).Once()
+				env.On("ConvertToLinuxPath").Return(tc.ConvertedParent).Once()
+			}
 
-		got := g.repoName()
-		assert.Equal(t, tc.Expected, got, tc.Case)
+			g := &Git{
+				Scm: Scm{
+					repoRootDir:     tc.RepoRootDir,
+					scmDir:          tc.ScmDir,
+					IsWslSharedPath: tc.IsWslSharedPath,
+				},
+				IsWorkTree: tc.IsWorkTree,
+			}
+			g.Init(options.Map{}, env)
+
+			assert.Equal(t, tc.Expected, g.repoName(), tc.Case)
+		})
 	}
 }
 
@@ -2137,7 +2361,6 @@ func TestPushStatusAheadAndBehind(t *testing.T) {
 		Case               string
 		PushAheadCount     string
 		PushBehindCount    string
-		Config             string
 		ExpectedPushAhead  int
 		ExpectedPushBehind int
 	}{
@@ -2169,22 +2392,14 @@ func TestPushStatusAheadAndBehind(t *testing.T) {
 			ExpectedPushAhead:  0,
 			ExpectedPushBehind: 0,
 		},
-		{
-			Case:               "remote from config",
-			PushAheadCount:     "2",
-			PushBehindCount:    "0",
-			ExpectedPushAhead:  2,
-			ExpectedPushBehind: 0,
-			Config: `
-			[branch "main"]
-				remote = origin
-				merge = refs/heads/main
-			`,
-		},
 	}
 
 	for _, tc := range cases {
 		env := new(mock.Environment)
+		env.On("RunCommand", "git", []string{"-C", "/dir", "--no-optional-locks", "-c", "core.quotepath=false",
+			"-c", "color.status=false", "rev-parse", "--abbrev-ref", "@{push}"}).Return("", nil)
+		env.On("RunCommand", "git", []string{"-C", "/dir", "--no-optional-locks", "-c", "core.quotepath=false",
+			"-c", "color.status=false", "config", "--get", "branch.main.pushRemote"}).Return("", nil)
 		env.On("RunCommand", "git", []string{"-C", "/dir", "--no-optional-locks", "-c", "core.quotepath=false",
 			"-c", "color.status=false", "config", "--get", "remote.pushDefault"}).Return("", nil)
 		env.On("RunCommand", "git", []string{"-C", "/dir", "--no-optional-locks", "-c", "core.quotepath=false",
@@ -2209,21 +2424,142 @@ func TestPushStatusAheadAndBehind(t *testing.T) {
 
 		g.Init(props, env)
 
-		g.configOnce = sync.Once{}
-		g.configOnce.Do(func() {
-			if len(tc.Config) > 0 {
-				g.config, g.configErr = ini.Load(tc.Config)
-				return
-			}
-
-			g.configErr = errors.New("no config")
-		})
-
 		g.setPushStatus()
 
 		assert.Equal(t, tc.ExpectedPushAhead, g.PushAhead, tc.Case)
 		assert.Equal(t, tc.ExpectedPushBehind, g.PushBehind, tc.Case)
 	}
+}
+
+func TestPushRef(t *testing.T) {
+	args := func(extra ...string) []string {
+		return append([]string{
+			"-C", "/repo", "--no-optional-locks", "-c", "core.quotepath=false",
+			"-c", "color.status=false",
+		}, extra...)
+	}
+
+	t.Run("uses @{push} when it resolves", func(t *testing.T) {
+		env := new(mock.Environment)
+		env.On("IsWsl").Return(false)
+		env.On("GOOS").Return("unix")
+		env.On("RunCommand", GITCOMMAND, args("rev-parse", "--abbrev-ref", "@{push}")).Return("origin/main", nil)
+
+		g := &Git{
+			Scm: Scm{command: GITCOMMAND, repoRootDir: "/repo"},
+			Ref: "main",
+		}
+		g.Init(options.Map{}, env)
+
+		assert.Equal(t, "origin/main", g.pushRef())
+		env.AssertNotCalled(t, "RunCommand", GITCOMMAND, args("config", "--get", "remote.pushDefault"))
+	})
+
+	t.Run("falls back to per-branch pushRemote when @{push} is unresolvable", func(t *testing.T) {
+		env := new(mock.Environment)
+		env.On("IsWsl").Return(false)
+		env.On("GOOS").Return("unix")
+		env.On("RunCommand", GITCOMMAND, args("rev-parse", "--abbrev-ref", "@{push}")).Return("", errors.New("cannot resolve 'simple' push to a single destination"))
+		env.On("RunCommand", GITCOMMAND, args("config", "--get", "branch.main.pushRemote")).Return("fork", nil)
+
+		g := &Git{
+			Scm: Scm{command: GITCOMMAND, repoRootDir: "/repo"},
+			Ref: "main",
+		}
+		g.Init(options.Map{}, env)
+
+		assert.Equal(t, "fork/main", g.pushRef())
+	})
+
+	t.Run("falls back to remote.pushDefault when the branch has no pushRemote", func(t *testing.T) {
+		env := new(mock.Environment)
+		env.On("IsWsl").Return(false)
+		env.On("GOOS").Return("unix")
+		env.On("RunCommand", GITCOMMAND, args("rev-parse", "--abbrev-ref", "@{push}")).Return("", errors.New("cannot resolve push destination"))
+		env.On("RunCommand", GITCOMMAND, args("config", "--get", "branch.main.pushRemote")).Return("", nil)
+		env.On("RunCommand", GITCOMMAND, args("config", "--get", "remote.pushDefault")).Return("fork", nil)
+
+		g := &Git{
+			Scm: Scm{command: GITCOMMAND, repoRootDir: "/repo"},
+			Ref: "main",
+		}
+		g.Init(options.Map{}, env)
+
+		assert.Equal(t, "fork/main", g.pushRef())
+	})
+}
+
+func TestSetStatusNativeDirRoles(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found on PATH")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+
+	t.Run("separate git dir", func(t *testing.T) {
+		root := t.TempDir()
+		repo := filepath.Join(root, "worktree")
+		gitDir := filepath.Join(root, "gitdir")
+		runRealGit(t, root, "init", "-q", "-b", "main", "--separate-git-dir", gitDir, repo)
+		prepareNativeStatusRepo(t, repo)
+
+		g := nativeStatusGit(t, repo)
+		require.Equal(t, g.scmDir, g.mainSCMDir)
+		require.True(t, g.setStatusNative())
+		assert.Equal(t, 1, g.Working.Modified)
+		assert.Equal(t, "main", g.Ref)
+	})
+
+	t.Run("submodule worktree", func(t *testing.T) {
+		root := t.TempDir()
+		source := filepath.Join(root, "source")
+		super := filepath.Join(root, "super")
+		subWorktree := filepath.Join(root, "sub-worktree")
+
+		runRealGit(t, root, "init", "-q", "-b", "main", source)
+		prepareNativeStatusRepo(t, source)
+		runRealGit(t, root, "init", "-q", "-b", "main", super)
+		prepareNativeStatusRepo(t, super)
+		runRealGit(t, super, "-c", "protocol.file.allow=always", "submodule", "add", "-q", source, "sub")
+		runRealGit(t, super, "commit", "-q", "-m", "add submodule")
+		runRealGit(t, filepath.Join(super, "sub"), "worktree", "add", "-q", "-b", "feature", subWorktree)
+		require.NoError(t, os.WriteFile(filepath.Join(subWorktree, "a.txt"), []byte("changed again\n"), 0o644))
+
+		g := nativeStatusGit(t, subWorktree)
+		require.NotEqual(t, g.scmDir, g.mainSCMDir)
+		require.True(t, g.setStatusNative())
+		assert.Equal(t, 1, g.Working.Modified)
+		assert.Equal(t, "feature", g.Ref)
+	})
+}
+
+func prepareNativeStatusRepo(t *testing.T, repo string) {
+	t.Helper()
+	runRealGit(t, repo, "config", "user.email", "test@example.com")
+	runRealGit(t, repo, "config", "user.name", "Test")
+	runRealGit(t, repo, "config", "core.autocrlf", "false")
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "a.txt"), []byte("a\n"), 0o644))
+	runRealGit(t, repo, "add", ".")
+	runRealGit(t, repo, "commit", "-q", "-m", "init")
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "a.txt"), []byte("changed\n"), 0o644))
+}
+
+func nativeStatusGit(t *testing.T, repo string) *Git {
+	t.Helper()
+	g := &Git{
+		Scm: Scm{
+			mainSCMDir:  realGitPath(t, repo, "--git-dir"),
+			scmDir:      realGitPath(t, repo, "--git-common-dir"),
+			repoRootDir: realGitPath(t, repo, "--show-toplevel"),
+		},
+		Working: &GitStatus{},
+		Staging: &GitStatus{},
+	}
+	g.Init(options.Map{}, new(mock.Environment))
+	return g
 }
 
 // TestSetStatusNative builds a real temp repo with the git CLI (skipped when
@@ -2315,4 +2651,151 @@ func realGitPath(t *testing.T, dir, arg string) string {
 	t.Helper()
 	out := runRealGit(t, dir, "rev-parse", "--path-format=absolute", arg)
 	return filepath.FromSlash(strings.TrimSpace(out))
+}
+
+func TestGetRemoteURL(t *testing.T) {
+	const configWithOrigin = "[remote \"origin\"]\n\turl = gh:example/repo.git"
+
+	cases := []struct {
+		Case      string
+		Upstream  string
+		CLIOutput string
+		CLIError  error
+		Config    string
+		ScmDir    string
+		Expected  string
+	}{
+		{
+			Case:      "CLI wins over the raw config value (insteadOf is applied)",
+			Upstream:  "origin/main",
+			CLIOutput: "https://github.com/example/repo.git",
+			Config:    configWithOrigin,
+			ScmDir:    "/repo/.git",
+			Expected:  "https://github.com/example/repo.git",
+		},
+		{
+			Case:     "falls back to the common config when the CLI fails",
+			Upstream: "origin/main",
+			CLIError: errors.New("git unavailable"),
+			Config:   configWithOrigin,
+			ScmDir:   "/repo/.git",
+			Expected: "gh:example/repo.git",
+		},
+		{
+			Case:     "empty when the CLI fails and there is no common config",
+			Upstream: "origin/main",
+			CLIError: errors.New("git unavailable"),
+			Config:   configWithOrigin,
+			ScmDir:   "",
+			Expected: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Case, func(t *testing.T) {
+			env := new(mock.Environment)
+			env.On("IsWsl").Return(false)
+			env.On("GOOS").Return("unix")
+			env.On("RunCommand", GITCOMMAND, []string{
+				"-C", "/repo", "--no-optional-locks", "-c", "core.quotepath=false",
+				"-c", "color.status=false", "remote", "get-url", "origin",
+			}).Return(tc.CLIOutput, tc.CLIError)
+
+			if tc.ScmDir != "" {
+				env.On("FileContent", tc.ScmDir+"/config").Return(tc.Config)
+			}
+
+			g := &Git{
+				Scm: Scm{
+					command:     GITCOMMAND,
+					repoRootDir: "/repo",
+					scmDir:      tc.ScmDir,
+					Upstream:    tc.Upstream,
+				},
+			}
+			g.Init(options.Map{}, env)
+
+			assert.Equal(t, tc.Expected, g.getRemoteURL())
+		})
+	}
+}
+
+func TestWorktreeCount(t *testing.T) {
+	cases := []struct {
+		Case       string
+		ScmDir     string
+		MainSCMDir string
+		Entries    []fs.DirEntry
+		Expected   int
+		HasFolder  bool
+	}{
+		{
+			Case:       "plain clone with no registry",
+			ScmDir:     "/repo/.git",
+			MainSCMDir: "/repo/.git",
+			HasFolder:  false,
+			Expected:   0,
+		},
+		{
+			Case:       "linked worktree counts the common registry",
+			ScmDir:     "/repo/.git",
+			MainSCMDir: "/repo/.git/worktrees/linked",
+			HasFolder:  true,
+			Entries: []fs.DirEntry{
+				&MockDirEntry{name: "linked", isDir: true},
+				&MockDirEntry{name: "other", isDir: true},
+			},
+			Expected: 2,
+		},
+		{
+			Case:       "files in the registry are not counted",
+			ScmDir:     "/repo/.git",
+			MainSCMDir: "/repo/.git",
+			HasFolder:  true,
+			Entries: []fs.DirEntry{
+				&MockDirEntry{name: "linked", isDir: true},
+				&MockDirEntry{name: "README", isDir: false},
+			},
+			Expected: 1,
+		},
+		{
+			Case:       "separate git dir counts its external registry",
+			ScmDir:     "/x/sepdir",
+			MainSCMDir: "/x/worktrees/trap/",
+			HasFolder:  true,
+			Entries:    []fs.DirEntry{&MockDirEntry{name: "wt", isDir: true}},
+			Expected:   1,
+		},
+		{
+			Case:     "unknown common dir touches nothing",
+			Expected: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Case, func(t *testing.T) {
+			env := new(mock.Environment)
+
+			if tc.ScmDir != "" {
+				worktrees := filepath.Join(tc.ScmDir, "worktrees")
+				env.On("HasFolder", worktrees).Return(tc.HasFolder)
+				env.On("LsDir", worktrees).Return(tc.Entries)
+			}
+
+			g := &Git{
+				Scm: Scm{
+					scmDir:     tc.ScmDir,
+					mainSCMDir: tc.MainSCMDir,
+				},
+			}
+			g.Init(options.Map{}, env)
+
+			assert.Equal(t, tc.Expected, g.WorktreeCount())
+
+			if tc.ScmDir == "" {
+				env.AssertNotCalled(t, "HasFolder", testify_.Anything)
+				env.AssertNotCalled(t, "LsDir", testify_.Anything)
+			}
+		})
+	}
 }

--- a/src/segments/posh_git_test.go
+++ b/src/segments/posh_git_test.go
@@ -1,8 +1,6 @@
 package segments
 
 import (
-	"errors"
-	"sync"
 	"testing"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
@@ -201,11 +199,6 @@ func TestPoshGitSegment(t *testing.T) {
 			},
 		}
 		g.Init(props, env)
-
-		g.configOnce = sync.Once{}
-		g.configOnce.Do(func() {
-			g.configErr = errors.New("no config")
-		})
 
 		if tc.Template == "" {
 			tc.Template = g.Template()


### PR DESCRIPTION
Fixes #7798.

Supersedes #7802, which GitHub cannot reopen after its base ref was deleted and the head branch was force-pushed.

### Prerequisites

- [x] I have read and understood the contributing guide.
- [x] The commit message follows the conventional commits guidelines.
- [x] Tests for the changes have been added.
- [x] Docs have been added/updated where relevant.

### Description

`mainSCMDir` is meant to be the current checkout's own git directory (where `HEAD`, `index` and
rebase/merge state live) and `scmDir` the repository's shared directory (`config`, `refs/stash`,
`worktrees/`). Several discovery branches assigned these backwards — a linked worktree's, a
`--separate-git-dir` clone's and a bare-via-`.git`-file layout's, plus a submodule's own linked
worktree, which needed the split the other way round. Every reader that expects the shared directory
but gets the per-checkout one breaks the same way: `.Remotes` comes back empty, `.WorktreeCount` reads
zero, `repoName()` returns an empty string, and a submodule's linked worktree can even display its
parent's branch instead of its own.

This PR establishes the invariant properly across every layout (plain clone, linked worktree, bare,
submodule, submodule worktree, `--separate-git-dir`) and repoints the affected readers —
`getGitConfig()`/`Remotes()`, `WorktreeCount()`, `repoName()`, native git status, and the git config
memoisation that was poisoning subsequent reads — at the correct directory for each. A structural
check guards against acting on an empty directory when a segment is restored from cache before
discovery has run, so a cache-restore race cannot silently poison a memoised lookup.

Verified end to end across all measured positions with the regression tests.

### This is part of a stacked series

```text
next (includes #7801)
 └─ fix/git-worktree-common-dir      (this PR)
     └─ fix/git-bare-head-upstream   → #7803
         └─ feat/statusline-payload-pwd → #7804
```

Each branch contributes one commit. The later PRs temporarily include their predecessors and shrink
to their own commit as the stack is merged in order.
