### PR TITLE
fix(project): keep the full PowerShell module name

### DIFF
--- a/src/segments/project.go
+++ b/src/segments/project.go
@@ -454,7 +454,7 @@ func (n *Project) getPowerShellModuleData(_ ProjectItem) *ProjectData {
 		case "ModuleVersion":
 			data.Version = value
 		case "RootModule":
-			data.Name = strings.TrimRight(value, ".psm1")
+			data.Name = strings.TrimSuffix(value, filepath.Ext(value))
 		}
 	}
 

--- a/src/segments/project_test.go
+++ b/src/segments/project_test.go
@@ -953,6 +953,8 @@ func TestDotnetSolutionResolvesTargetFramework(t *testing.T) {
 func TestPowerShellModuleProject(t *testing.T) {
 	cases := []struct {
 		Case            string
+		FileName        string
+		Content         string
 		ExpectedString  string
 		HasFiles        bool
 		ExpectedEnabled bool
@@ -961,7 +963,24 @@ func TestPowerShellModuleProject(t *testing.T) {
 			Case:            "valid PowerShell module file",
 			HasFiles:        true,
 			ExpectedEnabled: true,
+			FileName:        "oh-my-posh.psd1",
 			ExpectedString:  "\uf487 1.0.0.0 oh-my-posh",
+		},
+		{
+			Case:            "root module name ending on a character of its extension",
+			HasFiles:        true,
+			ExpectedEnabled: true,
+			FileName:        "Terminal-Icons.psd1",
+			Content:         "@{\nModuleVersion = '0.11.0'\nRootModule = 'Terminal-Icons.psm1'\n}",
+			ExpectedString:  "\uf487 0.11.0 Terminal-Icons",
+		},
+		{
+			Case:            "binary root module",
+			HasFiles:        true,
+			ExpectedEnabled: true,
+			FileName:        "Microsoft.PowerShell.Archive.psd1",
+			Content:         "@{\nModuleVersion = '2.0.1'\nRootModule = 'Microsoft.PowerShell.Archive.dll'\n}",
+			ExpectedString:  "\uf487 2.0.1 Microsoft.PowerShell.Archive",
 		},
 	}
 
@@ -977,15 +996,15 @@ func TestPowerShellModuleProject(t *testing.T) {
 		env.On("Pwd").Return("posh")
 		env.On("LsDir", "posh").Return([]fs.DirEntry{
 			&MockDirEntry{
-				name: "oh-my-posh.psd1",
+				name: tc.FileName,
 			},
 		})
-		var moduleContent string
-		if tc.HasFiles {
+		moduleContent := tc.Content
+		if tc.HasFiles && moduleContent == "" {
 			content, _ := os.ReadFile("../test/oh-my-posh.psd1")
 			moduleContent = string(content)
 		}
-		env.On("FileContent", "oh-my-posh.psd1").Return(moduleContent)
+		env.On("FileContent", tc.FileName).Return(moduleContent)
 		pkg := &Project{}
 		pkg.Init(options.Map{}, env)
 		assert.Equal(t, tc.ExpectedEnabled, pkg.Enabled(), tc.Case)


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features). Nothing to update, the docs dont say how the name gets picked.

### Description

In a PowerShell module folder the project segment renders the name a letter short - `Terminal-Icons` shows as `Terminal-Icon` on v30.8.0. The `RootModule` value goes through `TrimRight` with `.psm1`, which is a cutset of characters rather than a suffix, so a trailing `.`, `p`, `s`, `m` or `1` in the real name gets eaten too. Plurals cop it worst: `PSScriptTools` comes out as `PSScriptTool`, `Az.Accounts` as `Az.Account`.

The one test covering this reads `src/test/oh-my-posh.psd1`, and `oh-my-posh` ends on an `h`, so its been green throughout.

I've used the same `TrimSuffix(x, filepath.Ext(x))` the file already uses for the .NET project name. That's a bit wider than the bug though: a `RootModule` pointing at a `.dll` keeps its extension today and wont after this.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
