### PR TITLE
fix(msix): drop OnLaunch update check causing App Installer popups

### DIFF
--- a/packages/msix/build.ps1
+++ b/packages/msix/build.ps1
@@ -234,7 +234,6 @@ try {
 <AppInstaller xmlns="http://schemas.microsoft.com/appx/appinstaller/2018" Version="$Version.0" Uri="$DownloadUrl/latest/install-$Architecture.appinstaller">
   <MainPackage Name="$($identity.Name)" Version="$Version.0" Publisher="$($identity.Publisher)" ProcessorArchitecture="$Architecture" Uri="$DownloadUrl/v$Version/install-$Architecture.msix" />
   <UpdateSettings>
-    <OnLaunch HoursBetweenUpdateChecks="24" />
     <AutomaticBackgroundTask />
     <ForceUpdateFromAnyVersion>true</ForceUpdateFromAnyVersion>
   </UpdateSettings>


### PR DESCRIPTION
The embedded appinstaller's OnLaunch setting gates every activation of
the app-execution alias on an App Installer update check. Since the
pwsh shell integration invokes oh-my-posh.exe through that alias on
every prompt render and several key handlers, this made App Installer
pop up (or fail to launch) on nearly every keystroke for MSIX/winget
installs. AutomaticBackgroundTask still keeps the package up to date
without gating foreground launches.

Fixes #7833