### PR TITLE
Refactor: Flatten embedded struct fields in segments and cache

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,9 +5,9 @@
   "build": {
     "dockerfile": "Dockerfile",
     "args": {
-      // Update the VARIANT arg to pick a version of Go: 1, 1.25, 1.26
+      // Update the VARIANT arg to pick a version of Go: 1, 1.26, 1.27
       // Append -trixie, -bookworm or -bullseye to pin to an OS version.
-      "VARIANT": "2-1.26-trixie",
+      "VARIANT": "2-1.27-trixie",
 
       // Override me with your own timezone:
       "TZ": "UTC",

--- a/.github/workflows/composite/bootstrap-go/action.yml
+++ b/.github/workflows/composite/bootstrap-go/action.yml
@@ -9,5 +9,5 @@ runs:
   steps:
     - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
       with:
-        go-version: "1.26.0"
+        go-version: "1.27.0"
         cache-dependency-path: src/go.sum

--- a/src/cache/clear.go
+++ b/src/cache/clear.go
@@ -83,7 +83,7 @@ func Clear(force bool, excludedFiles ...string) error {
 }
 
 func GetTTL() int {
-	cacheTTL, OK := Get[int](Device, TTL)
+	cacheTTL, OK := Device.Get[int](TTL)
 	if !OK || cacheTTL <= 0 {
 		cacheTTL = 7
 	}

--- a/src/cache/command.go
+++ b/src/cache/command.go
@@ -86,14 +86,14 @@ func PersistCommandPath(command, path string, found bool) {
 		ttl = CommandPathNegativeTTL
 	}
 
-	Set(Session, commandPathKey(command), entry, ttl)
+	Session.Set(commandPathKey(command), entry, ttl)
 }
 
 // An entry persisted under a different PATH(+PATHEXT) environment is treated
 // as a miss, so the caller falls through to a fresh exec.LookPath (which
 // overwrites the entry with the current environment's hash).
 func GetPersistedCommandPath(command string) (path string, found, ok bool) {
-	entry, exists := Get[commandPathEntry](Session, commandPathKey(command))
+	entry, exists := Session.Get[commandPathEntry](commandPathKey(command))
 	if !exists {
 		return "", false, false
 	}

--- a/src/cache/command_test.go
+++ b/src/cache/command_test.go
@@ -42,7 +42,7 @@ func TestGetPersistedCommandPathStalePathHashIsAMiss(t *testing.T) {
 	// Simulate an entry persisted under a different PATH environment (or a
 	// pre-PathHash entry, which decodes with PathHash == 0).
 	entry := commandPathEntry{Path: "/usr/bin/git", PathHash: pathEnvHash() + 1, Found: true}
-	Set(Session, commandPathKey("git"), entry, CommandPathTTL)
+	Session.Set(commandPathKey("git"), entry, CommandPathTTL)
 
 	_, _, ok := GetPersistedCommandPath("git")
 	assert.False(t, ok, "entry persisted under a different PATH must be treated as a miss")

--- a/src/cache/init.go
+++ b/src/cache/init.go
@@ -1,11 +1,11 @@
 package cache
 
 import (
-	"crypto/rand"
 	"fmt"
 	"os"
 	"sync"
 	"time"
+	"uuid"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/log"
 )
@@ -73,18 +73,6 @@ func Close() {
 	Device.close()
 }
 
-// newSessionID returns a random RFC 4122 version 4 UUID string, the same
-// format github.com/google/uuid produced for session identifiers.
 func newSessionID() string {
-	var b [16]byte
-	if _, err := rand.Read(b[:]); err != nil {
-		// crypto/rand never fails on supported platforms; fall back to a
-		// time-derived id rather than panicking in the prompt path
-		return fmt.Sprintf("%x", time.Now().UnixNano())
-	}
-
-	b[6] = (b[6] & 0x0f) | 0x40 // version 4
-	b[8] = (b[8] & 0x3f) | 0x80 // variant 10
-
-	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+	return uuid.NewV4().String()
 }

--- a/src/cache/store.go
+++ b/src/cache/store.go
@@ -148,7 +148,7 @@ func touchSessionFile(filePath string) {
 // process (serve) that keeps its cache in memory for the session: without
 // it, a write from another process (e.g. `toggle`, `enable`/`disable`)
 // would stay invisible until the daemon exits.
-func Refresh(s Store) {
+func (s Store) Refresh() {
 	defer log.Trace(time.Now(), string(s))
 
 	store := s.get()
@@ -202,7 +202,7 @@ func (s Store) close() {
 	// (e.g. right before the shell exits) isn't clobbered by this store's
 	// own, possibly stale, in-memory copy.
 	if store != nil && !store.locked && store.persist && store.dirty {
-		Refresh(s)
+		s.Refresh()
 	}
 
 	if store == nil || store.locked || !store.persist || !store.dirty {
@@ -250,7 +250,7 @@ func (s Store) close() {
 	}
 }
 
-func Get[T any](s Store, key string) (T, bool) {
+func (s Store) Get[T any](key string) (T, bool) {
 	var zero T
 	defer log.Trace(time.Now(), string(s), key)
 
@@ -293,7 +293,7 @@ func Get[T any](s Store, key string) (T, bool) {
 	return zero, false
 }
 
-func Set[T any](s Store, key string, value T, duration Duration) {
+func (s Store) Set[T any](key string, value T, duration Duration) {
 	defer log.Trace(time.Now(), string(s), key)
 
 	store := s.get()
@@ -318,7 +318,7 @@ func Set[T any](s Store, key string, value T, duration Duration) {
 	store.dirty = true
 }
 
-func Delete(s Store, key string) {
+func (s Store) Delete(key string) {
 	defer log.Trace(time.Now(), string(s), key)
 
 	store := s.get()
@@ -332,7 +332,7 @@ func Delete(s Store, key string) {
 	store.dirty = true
 }
 
-func DeleteAll(s Store) {
+func (s Store) DeleteAll() {
 	defer log.Trace(time.Now(), string(s))
 
 	store := s.get()
@@ -345,7 +345,7 @@ func DeleteAll(s Store) {
 	store.dirty = true
 }
 
-func Print(s Store) string {
+func (s Store) Print() string {
 	defer log.Trace(time.Now(), string(s))
 
 	store := s.get()

--- a/src/cache/store_test.go
+++ b/src/cache/store_test.go
@@ -43,7 +43,7 @@ func TestStore(t *testing.T) {
 				return testStore
 			},
 			testFunc: func(t *testing.T) {
-				result := Print(Session)
+				result := Session.Print()
 				assert.Contains(t, result, "Key: test_key1")
 				assert.Contains(t, result, `Value: "test_value1"`) // Note: quotes are included in output
 				assert.Contains(t, result, "Type: string")
@@ -67,7 +67,7 @@ func TestStore(t *testing.T) {
 				return testStore
 			},
 			testFunc: func(t *testing.T) {
-				result := Print(Session)
+				result := Session.Print()
 				assert.Contains(t, result, "Store session is empty")
 			},
 		},
@@ -80,7 +80,7 @@ func TestStore(t *testing.T) {
 			},
 			testFunc: func(t *testing.T) {
 				// Since get() always creates a store, we test empty store behavior
-				result := Print(Session)
+				result := Session.Print()
 				assert.Contains(t, result, "Store session is empty")
 			},
 		},
@@ -154,7 +154,7 @@ func TestGetSurvivesGobPointerRegistration(t *testing.T) {
 	writer.persist = true
 	device = writer
 
-	Set(Device, "test_key", storeGobPointerType{Name: "value"}, Duration("1h"))
+	Device.Set("test_key", storeGobPointerType{Name: "value"}, Duration("1h"))
 	Device.close()
 
 	// Second process: fresh store, loaded from disk. This is the gob decode
@@ -162,7 +162,7 @@ func TestGetSurvivesGobPointerRegistration(t *testing.T) {
 	device = nil
 	Device.init(fileName, true)
 
-	got, ok := Get[storeGobPointerType](Device, "test_key")
+	got, ok := Device.Get[storeGobPointerType]("test_key")
 	require.True(t, ok, "expected a cache hit after a gob round-trip of a pointer-registered type")
 	assert.Equal(t, "value", got.Name)
 }
@@ -212,15 +212,15 @@ func TestRefreshMergesExternalWriteByTimestamp(t *testing.T) {
 	// Back to the daemon's perspective: refresh should pick up the new
 	// toggle_cache key from disk...
 	session = daemon
-	Refresh(Session)
+	Session.Refresh()
 
-	toggled, found := Get[map[string]bool](Session, TOGGLECACHE)
+	toggled, found := Session.Get[map[string]bool](TOGGLECACHE)
 	require.True(t, found, "toggle_cache written externally should be visible after Refresh")
 	assert.True(t, toggled["shell"])
 
 	// ...without clobbering the daemon's own newer value for a key both
 	// sides touched.
-	shared, found := Get[string](Session, "shared_key")
+	shared, found := Session.Get[string]("shared_key")
 	require.True(t, found)
 	assert.Equal(t, "daemon-value", shared, "a newer in-memory value must win over an older on-disk one")
 }
@@ -272,11 +272,11 @@ func TestCloseRefreshesBeforePersistingToAvoidClobber(t *testing.T) {
 
 	session = &store{cache: onDisk.ToConcurrent()}
 
-	toggled, found := Get[map[string]bool](Session, TOGGLECACHE)
+	toggled, found := Session.Get[map[string]bool](TOGGLECACHE)
 	require.True(t, found, "the external write must survive the daemon's own shutdown flush")
 	assert.True(t, toggled["shell"])
 
-	count, found := Get[int](Session, "prompt_count_cache")
+	count, found := Session.Get[int]("prompt_count_cache")
 	require.True(t, found)
 	assert.Equal(t, 3, count)
 }
@@ -310,9 +310,9 @@ func TestRefreshPicksUpDeviceStoreWrite(t *testing.T) {
 	Device.close()
 
 	device = daemon
-	Refresh(Device)
+	Device.Refresh()
 
-	reload, found := Get[bool](Device, "reload")
+	reload, found := Device.Get[bool]("reload")
 	require.True(t, found, "`enable reload` written externally should be visible after Refresh")
 	assert.True(t, reload)
 }

--- a/src/cli/auth/tui/copilot.go
+++ b/src/cli/auth/tui/copilot.go
@@ -40,9 +40,7 @@ type AccessTokenResponse struct {
 
 func NewCopilot(env runtime.Environment) *CopilotAuth {
 	flow := &CopilotAuth{
-		model: model{
-			env: env,
-		},
+		env: env,
 	}
 
 	flow.model.status = flow.status

--- a/src/cli/auth/tui/copilot.go
+++ b/src/cli/auth/tui/copilot.go
@@ -88,7 +88,7 @@ func (c *CopilotAuth) Authenticate() {
 		return
 	}
 
-	cache.Set(cache.Device, auth.CopilotTokenKey, token, cache.TWOYEARS)
+	cache.Device.Set(auth.CopilotTokenKey, token, cache.TWOYEARS)
 
 	setState(done)
 }

--- a/src/cli/auth/tui/ytmda.go
+++ b/src/cli/auth/tui/ytmda.go
@@ -22,9 +22,7 @@ const (
 
 func NewYtmda(env runtime.Environment) *Ytmda {
 	flow := &Ytmda{
-		model: model{
-			env: env,
-		},
+		env: env,
 	}
 
 	flow.model.status = flow.status

--- a/src/cli/auth/tui/ytmda.go
+++ b/src/cli/auth/tui/ytmda.go
@@ -63,7 +63,7 @@ func (y *Ytmda) Authenticate() {
 		return
 	}
 
-	cache.Set(cache.Device, auth.YTMDATOKEN, token, cache.INFINITE)
+	cache.Device.Set(auth.YTMDATOKEN, token, cache.INFINITE)
 
 	setState(done)
 }

--- a/src/cli/auth/tui/ytmda_test.go
+++ b/src/cli/auth/tui/ytmda_test.go
@@ -82,9 +82,7 @@ func TestYtdma_Authenticate(t *testing.T) {
 			env.On("HTTPRequest", tokenURL).Return([]byte(tc.requestTokenResponse), tc.requestTokenError)
 
 			ytmda := &Ytmda{
-				model: model{
-					env: env,
-				},
+				env: env,
 			}
 
 			ytmda.Authenticate()

--- a/src/cli/auth/tui/ytmda_test.go
+++ b/src/cli/auth/tui/ytmda_test.go
@@ -95,12 +95,12 @@ func TestYtdma_Authenticate(t *testing.T) {
 			}
 
 			if tc.shouldSetToken {
-				token, ok := cache.Get[string](cache.Device, auth.YTMDATOKEN)
+				token, ok := cache.Device.Get[string](auth.YTMDATOKEN)
 				require.True(t, ok)
 				assert.Equal(t, tc.expectedToken, token)
 			}
 
-			cache.DeleteAll(cache.Device)
+			cache.Device.DeleteAll()
 		})
 	}
 }

--- a/src/cli/cache.go
+++ b/src/cli/cache.go
@@ -65,7 +65,7 @@ You can do the following:
 			}
 
 			cache.Init(os.Getenv("POSH_SHELL"), cache.Persist)
-			cache.Set(cache.Device, cache.TTL, ttl, cache.INFINITE)
+			cache.Device.Set(cache.TTL, ttl, cache.INFINITE)
 			cache.Close()
 		case "show":
 			cache.Init(os.Getenv("POSH_SHELL"))
@@ -74,7 +74,7 @@ You can do the following:
 				store = cache.Session
 			}
 
-			fmt.Println(cache.Print(store))
+			fmt.Println(store.Print())
 		}
 	},
 }

--- a/src/cli/config.go
+++ b/src/cli/config.go
@@ -30,7 +30,7 @@ You can export or edit the config (via the editor specified in the environment v
 		switch args[0] {
 		case "edit":
 			cache.Init(os.Getenv("POSH_SHELL"))
-			if configPath, OK := cache.Get[string](cache.Session, config.SourceKey); OK {
+			if configPath, OK := cache.Session.Get[string](config.SourceKey); OK {
 				exitcode = editFileWithEditor(configPath)
 				return
 			}

--- a/src/cli/config_export_data_test.go
+++ b/src/cli/config_export_data_test.go
@@ -35,11 +35,9 @@ func newRecordedSessionSegment(t *testing.T, alias string) *config.Segment {
 func TestBuildDataDocument_EnvSectionDropsInternalKeysKeepsRest(t *testing.T) {
 	template.Cache = &cache.Template{
 		Segments: maps.NewConcurrent[any](),
-		SimpleTemplate: cache.SimpleTemplate{
-			PWD:      "/home/jan",
-			UserName: "jan",
-			Var:      maps.Simple[any]{"foo": "bar"},
-		},
+		PWD:      "/home/jan",
+		UserName: "jan",
+		Var:      maps.Simple[any]{"foo": "bar"},
 	}
 
 	cfg := &config.Config{}

--- a/src/cli/config_export_image.go
+++ b/src/cli/config_export_image.go
@@ -141,7 +141,7 @@ func setConfigFlag() {
 		return
 	}
 
-	if configPath, OK := cache.Get[string](cache.Session, config.SourceKey); OK {
+	if configPath, OK := cache.Session.Get[string](config.SourceKey); OK {
 		configFlag = configPath
 	}
 }

--- a/src/cli/debug.go
+++ b/src/cli/debug.go
@@ -89,6 +89,6 @@ func getDebugConfig(configpath string) *config.Config {
 		return config.Load(configpath)
 	}
 
-	reload, _ := cache.Get[bool](cache.Device, config.RELOAD)
+	reload, _ := cache.Device.Get[bool](config.RELOAD)
 	return config.Get(configpath, reload)
 }

--- a/src/cli/dsc/config.go
+++ b/src/cli/dsc/config.go
@@ -32,7 +32,7 @@ var configurationSchema string
 
 func ConfigDSC() *ConfigResource {
 	return &ConfigResource{
-		Resource: basedsc.Resource[*Configuration]{SchemaJSON: configurationSchema},
+		SchemaJSON: configurationSchema,
 	}
 }
 

--- a/src/cli/enable.go
+++ b/src/cli/enable.go
@@ -49,6 +49,6 @@ func toggleFeature(cmd *cmdtree.Command, feature string, enable bool) {
 	}
 
 	cache.Init(os.Getenv("POSH_SHELL"), cache.Persist)
-	cache.Set(cache.Device, feature, enable, cache.INFINITE)
+	cache.Device.Set(feature, enable, cache.INFINITE)
 	cache.Close()
 }

--- a/src/cli/font/download.go
+++ b/src/cli/font/download.go
@@ -19,7 +19,7 @@ import (
 // download fetches a font zip, reporting how much has arrived so a caller can draw a bar. report
 // may be nil, which is what the DSC path and the tests pass.
 func download(fontURL string, report func(fraction float64)) ([]byte, error) {
-	if zipPath, OK := cache.Get[string](cache.Device, fontURL); OK {
+	if zipPath, OK := cache.Device.Get[string](fontURL); OK {
 		if b, err := os.ReadFile(zipPath); err == nil {
 			return b, nil
 		}
@@ -57,7 +57,7 @@ func download(fontURL string, report func(fraction float64)) ([]byte, error) {
 		return b, nil
 	}
 
-	cache.Set(cache.Device, fontURL, zipPath, cache.ONEDAY)
+	cache.Device.Set(fontURL, zipPath, cache.ONEDAY)
 
 	return b, nil
 }

--- a/src/cli/font/dsc.go
+++ b/src/cli/font/dsc.go
@@ -16,7 +16,7 @@ var fontSchema string
 
 func DSC() *Resource {
 	return &Resource{
-		Resource: dsc.Resource[*Font]{SchemaJSON: fontSchema},
+		SchemaJSON: fontSchema,
 	}
 }
 

--- a/src/cli/font/fonts.go
+++ b/src/cli/font/fonts.go
@@ -79,13 +79,13 @@ func fonts() ([]*Asset, error) {
 
 	sort.Slice(assets, func(i, j int) bool { return assets[i].Name < assets[j].Name })
 
-	cache.Set(cache.Device, cache.FONTLISTCACHE, assets, cache.ONEDAY)
+	cache.Device.Set(cache.FONTLISTCACHE, assets, cache.ONEDAY)
 
 	return assets, nil
 }
 
 func getCachedFontData() ([]*Asset, error) {
-	list, OK := cache.Get[[]*Asset](cache.Device, cache.FONTLISTCACHE)
+	list, OK := cache.Device.Get[[]*Asset](cache.FONTLISTCACHE)
 	if !OK {
 		return nil, errors.New("cache not found")
 	}

--- a/src/cli/get.go
+++ b/src/cli/get.go
@@ -84,7 +84,7 @@ This command is used to get the value of the following variables:
 
 		switch args[0] {
 		case "toggles":
-			togglesMap, _ := cache.Get[map[string]bool](cache.Session, cache.TOGGLECACHE)
+			togglesMap, _ := cache.Session.Get[map[string]bool](cache.TOGGLECACHE)
 			if len(togglesMap) == 0 {
 				fmt.Println("No segments are toggled off")
 				return

--- a/src/cli/notice.go
+++ b/src/cli/notice.go
@@ -24,7 +24,7 @@ var noticeCmd = &cmdtree.Command{
 		defer cache.Close()
 
 		// Skip if we already checked within the configured interval
-		if _, ok := cache.Get[string](cache.Device, upgrade.CACHEKEY); ok {
+		if _, ok := cache.Device.Get[string](upgrade.CACHEKEY); ok {
 			return
 		}
 
@@ -32,7 +32,7 @@ var noticeCmd = &cmdtree.Command{
 
 		defer func() {
 			// Set the cache key after the notice check to prevent redundant checks
-			cache.Set(cache.Device, upgrade.CACHEKEY, "true", cfg.Upgrade.Interval)
+			cache.Device.Set(upgrade.CACHEKEY, "true", cfg.Upgrade.Interval)
 		}()
 
 		if notice, hasNotice := cfg.Upgrade.Notice(); hasNotice {

--- a/src/cli/serve.go
+++ b/src/cli/serve.go
@@ -337,8 +337,8 @@ func startRenderCycle(req *serveRequest, out *os.File, envKeys map[string]struct
 	// in prompt.New checks to bypass its own config cache after an edit -
 	// without this the daemon would keep serving the old config until
 	// restarted).
-	cache.Refresh(cache.Session)
-	cache.Refresh(cache.Device)
+	cache.Session.Refresh()
+	cache.Device.Refresh()
 
 	// Apply the env overlay BEFORE constructing the engine so segment
 	// execution and config templates observe the calling shell's

--- a/src/cli/statusline.go
+++ b/src/cli/statusline.go
@@ -138,7 +138,7 @@ func processStatuslineData[T any](stdinData []byte, shellConst, cacheKey string,
 	}
 
 	cache.Init(shellConst, cache.Persist)
-	cache.Set(cache.Session, cacheKey, data, cache.INFINITE)
+	cache.Session.Set(cacheKey, data, cache.INFINITE)
 	log.Debugf("stored %s data in session cache", shellConst)
 
 	return &data

--- a/src/cli/toggle.go
+++ b/src/cli/toggle.go
@@ -30,7 +30,7 @@ var toggleCmd = &cmdtree.Command{
 		}()
 
 		// Get current toggles from cache as a map
-		currentToggleSet, _ := cache.Get[map[string]bool](cache.Session, cache.TOGGLECACHE)
+		currentToggleSet, _ := cache.Session.Get[map[string]bool](cache.TOGGLECACHE)
 		if currentToggleSet == nil {
 			currentToggleSet = make(map[string]bool)
 		}
@@ -48,7 +48,7 @@ var toggleCmd = &cmdtree.Command{
 		}
 
 		// Store the map directly in cache
-		cache.Set(cache.Session, cache.TOGGLECACHE, currentToggleSet, cache.INFINITE)
+		cache.Session.Set(cache.TOGGLECACHE, currentToggleSet, cache.INFINITE)
 	},
 }
 

--- a/src/cli/upgrade.go
+++ b/src/cli/upgrade.go
@@ -66,7 +66,7 @@ var upgradeCmd = &cmdtree.Command{
 		cache.Init(sh, cache.Persist)
 
 		// Only respect the cache interval when using --auto flag
-		if _, OK := cache.Get[string](cache.Device, upgrade.CACHEKEY); OK && auto {
+		if _, OK := cache.Device.Get[string](upgrade.CACHEKEY); OK && auto {
 			log.Debug("upgrade check already performed recently, skipping")
 			return
 		}
@@ -82,7 +82,7 @@ var upgradeCmd = &cmdtree.Command{
 			fmt.Print(terminal.StopProgress())
 
 			// Set the cache key after any upgrade check to prevent redundant checks
-			cache.Set(cache.Device, upgrade.CACHEKEY, "true", cfg.Upgrade.Interval)
+			cache.Device.Set(upgrade.CACHEKEY, "true", cfg.Upgrade.Interval)
 
 			cache.Close()
 

--- a/src/color/colors.go
+++ b/src/color/colors.go
@@ -250,7 +250,7 @@ func (d *Defaults) SetAccentColor(env runtime.Environment, defaultColor Ansi) {
 	// get the resolved OS accent color from the device cache first, regardless
 	// of whether a default was configured, so we never repeat the underlying
 	// OS query (e.g. a DWM registry read) once we know the answer.
-	accent, OK := cache.Get[*Set](cache.Device, accentColor)
+	accent, OK := cache.Device.Get[*Set](accentColor)
 	if !OK {
 		rgb, err := GetAccentColor(env)
 		if err != nil {
@@ -265,7 +265,7 @@ func (d *Defaults) SetAccentColor(env runtime.Environment, defaultColor Ansi) {
 			}
 		}
 
-		cache.Set(cache.Device, accentColor, accent, cache.INFINITE)
+		cache.Device.Set(accentColor, accent, cache.INFINITE)
 	}
 
 	if accent.Foreground.IsEmpty() && accent.Background.IsEmpty() {

--- a/src/color/colors_test.go
+++ b/src/color/colors_test.go
@@ -46,8 +46,8 @@ func TestGetAnsiFromColorString(t *testing.T) {
 func TestMakeColors(t *testing.T) {
 	env := &mock.Environment{}
 
-	cache.Set(cache.Device, accentColor, &Set{}, cache.INFINITE)
-	defer cache.DeleteAll(cache.Device)
+	cache.Device.Set(accentColor, &Set{}, cache.INFINITE)
+	defer cache.Device.DeleteAll()
 
 	env.On("WindowsRegistryKeyValue", `HKEY_CURRENT_USER\Software\Microsoft\Windows\DWM\ColorizationColor`).Return(&runtime.WindowsRegistryValue{}, errors.New("err"))
 	colors := MakeColors(nil, false, "", env)

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -241,13 +241,13 @@ func (cfg *Config) upgradeFeatures() shell.Features {
 	var feats shell.Features
 
 	autoUpgrade := cfg.Upgrade.Auto
-	if val, OK := cache.Get[bool](cache.Device, AUTOUPGRADE); OK {
+	if val, OK := cache.Device.Get[bool](AUTOUPGRADE); OK {
 		log.Debug("auto upgrade key found, overriding config")
 		autoUpgrade = val
 	}
 
 	upgradeNotice := cfg.Upgrade.DisplayNotice
-	if val, OK := cache.Get[bool](cache.Device, UPGRADENOTICE); OK {
+	if val, OK := cache.Device.Get[bool](UPGRADENOTICE); OK {
 		log.Debug("upgrade notice key found, overriding config")
 		upgradeNotice = val
 	}
@@ -291,7 +291,7 @@ func (cfg *Config) migrateSegmentProperties() {
 }
 
 func (cfg *Config) toggleSegments() {
-	currentToggleSet, _ := cache.Get[map[string]bool](cache.Session, cache.TOGGLECACHE)
+	currentToggleSet, _ := cache.Session.Get[map[string]bool](cache.TOGGLECACHE)
 	if currentToggleSet == nil {
 		currentToggleSet = make(map[string]bool)
 	}
@@ -310,5 +310,5 @@ func (cfg *Config) toggleSegments() {
 	}
 
 	// Update cache with the map directly
-	cache.Set(cache.Session, cache.TOGGLECACHE, currentToggleSet, cache.INFINITE)
+	cache.Session.Set(cache.TOGGLECACHE, currentToggleSet, cache.INFINITE)
 }

--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -331,15 +331,15 @@ func TestUpgradeFeatures(t *testing.T) {
 
 	for _, tc := range cases {
 		if tc.UpgradeCacheKeyExists {
-			cache.Set(cache.Device, upgrade.CACHEKEY, "", cache.INFINITE)
+			cache.Device.Set(upgrade.CACHEKEY, "", cache.INFINITE)
 		}
 
 		if tc.AutoUpgradeKey {
-			cache.Set(cache.Device, AUTOUPGRADE, true, cache.INFINITE)
+			cache.Device.Set(AUTOUPGRADE, true, cache.INFINITE)
 		}
 
 		if tc.NoticeKey {
-			cache.Set(cache.Device, UPGRADENOTICE, true, cache.INFINITE)
+			cache.Device.Set(UPGRADENOTICE, true, cache.INFINITE)
 		}
 
 		cfg := &Config{
@@ -353,6 +353,6 @@ func TestUpgradeFeatures(t *testing.T) {
 		got := cfg.upgradeFeatures()
 		assert.Equal(t, tc.ExpectedFeats, got, tc.Case)
 
-		cache.DeleteAll(cache.Device)
+		cache.Device.DeleteAll()
 	}
 }

--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -96,9 +96,7 @@ func TestGetPalette(t *testing.T) {
 		env.On("Shell").Return("bash")
 
 		template.Cache = &cache.Template{
-			SimpleTemplate: cache.SimpleTemplate{
-				Shell: "bash",
-			},
+			Shell: "bash",
 		}
 		template.Init(env, nil, nil)
 
@@ -149,9 +147,7 @@ func TestFeaturesShellIntegration(t *testing.T) {
 		env.On("Shell").Return(tc.Shell)
 
 		template.Cache = &cache.Template{
-			SimpleTemplate: cache.SimpleTemplate{
-				Shell: tc.Shell,
-			},
+			Shell: tc.Shell,
 		}
 		template.Init(env, nil, nil)
 
@@ -268,9 +264,7 @@ func TestFeaturesVIMode(t *testing.T) {
 		env.On("Shell").Return(tc.Shell)
 
 		template.Cache = &cache.Template{
-			SimpleTemplate: cache.SimpleTemplate{
-				Shell: tc.Shell,
-			},
+			Shell: tc.Shell,
 		}
 		template.Init(env, nil, nil)
 

--- a/src/config/gob.go
+++ b/src/config/gob.go
@@ -26,8 +26,8 @@ const (
 func (cfg *Config) Store() {
 	defer log.Trace(time.Now())
 
-	cache.Set(cache.Session, SourceKey, cfg.Source, cache.INFINITE)
-	cache.Set(cache.Session, configKey, cfg.Base64(), cache.INFINITE)
+	cache.Session.Set(SourceKey, cfg.Source, cache.INFINITE)
+	cache.Session.Set(configKey, cfg.Base64(), cache.INFINITE)
 }
 
 func Get(configFile string, reload bool) *Config {
@@ -35,14 +35,14 @@ func Get(configFile string, reload bool) *Config {
 
 	if reload {
 		log.Debug("reload mode enabled")
-		if source, OK := cache.Get[string](cache.Session, SourceKey); OK {
+		if source, OK := cache.Session.Get[string](SourceKey); OK {
 			cfg := Load(source)
 			cfg.Store()
 			return cfg
 		}
 	}
 
-	if base64String, found := cache.Get[string](cache.Session, configKey); found {
+	if base64String, found := cache.Session.Get[string](configKey); found {
 		var cfg Config
 		if err := cfg.Restore(base64String); err == nil {
 			return &cfg
@@ -51,7 +51,7 @@ func Get(configFile string, reload bool) *Config {
 		log.Debug("failed to restore config from cache")
 		// the entry is corrupted beyond repair, drop it so subsequent renders
 		// skip the decode attempt and go straight to recovery
-		cache.Delete(cache.Session, configKey)
+		cache.Session.Delete(configKey)
 	} else {
 		log.Debug("no cached config found")
 	}

--- a/src/config/gob_test.go
+++ b/src/config/gob_test.go
@@ -29,8 +29,8 @@ func resetCache(t *testing.T) {
 	t.Setenv("OSTYPE", "")
 
 	reset := func() {
-		cache.DeleteAll(cache.Session)
-		cache.DeleteAll(cache.Device)
+		cache.Session.DeleteAll()
+		cache.Device.DeleteAll()
 	}
 
 	reset()
@@ -52,7 +52,7 @@ func TestGetRecoversFromEnvironmentWhenSessionCacheLost(t *testing.T) {
 	assert.Equal(t, file, cfg.Source, "should render the configured theme instead of the default")
 
 	// Recovery should self-heal the session cache so subsequent renders are fast.
-	_, found := cache.Get[string](cache.Session, configKey)
+	_, found := cache.Session.Get[string](configKey)
 	assert.True(t, found, "recovery should repopulate the session config cache")
 }
 
@@ -90,7 +90,7 @@ func TestGetDropsCorruptedSessionCacheEntry(t *testing.T) {
 	resetCache(t)
 
 	// valid base64, but not a gob-encoded Config
-	cache.Set(cache.Session, configKey, "Y29ycnVwdGVkIGVudHJ5", cache.INFINITE)
+	cache.Session.Set(configKey, "Y29ycnVwdGVkIGVudHJ5", cache.INFINITE)
 
 	file := filepath.Join(t.TempDir(), "missing.omp.json")
 	t.Setenv(envKey, file)
@@ -99,7 +99,7 @@ func TestGetDropsCorruptedSessionCacheEntry(t *testing.T) {
 
 	assert.NotNil(t, cfg)
 
-	_, found := cache.Get[string](cache.Session, configKey)
+	_, found := cache.Session.Get[string](configKey)
 	assert.False(t, found, "a corrupted session config entry should be dropped after a failed restore")
 }
 
@@ -116,6 +116,6 @@ func TestGetFallsBackToDefaultWhenRecoverySourceInvalid(t *testing.T) {
 
 	// The source may only be temporarily unavailable: the default must not be
 	// cached, otherwise the next render can no longer retry the recovery.
-	_, found := cache.Get[string](cache.Session, configKey)
+	_, found := cache.Session.Get[string](configKey)
 	assert.False(t, found, "a failed recovery should not pin the default in the session cache")
 }

--- a/src/config/segment.go
+++ b/src/config/segment.go
@@ -499,7 +499,7 @@ func (segment *Segment) Writer() SegmentWriter {
 }
 
 func (segment *Segment) isToggled() bool {
-	togglesMap, OK := cache.Get[map[string]bool](cache.Session, cache.TOGGLECACHE)
+	togglesMap, OK := cache.Session.Get[map[string]bool](cache.TOGGLECACHE)
 	if !OK || len(togglesMap) == 0 {
 		log.Debug("no toggles found")
 		return false
@@ -520,7 +520,7 @@ func (segment *Segment) restoreCache() bool {
 
 	key, store := segment.cacheKeyAndStore()
 
-	data, OK := cache.Get[any](store, key)
+	data, OK := store.Get[any](key)
 	if !OK {
 		log.Debugf("no cache found for segment: %s, key: %s", segment.Name(), key)
 		return false
@@ -534,17 +534,17 @@ func (segment *Segment) restoreCache() bool {
 		// any method relying on it panics after a restore.
 		if err := gob.NewDecoder(bytes.NewReader(v)).Decode(segment.writer); err != nil {
 			log.Error(err)
-			cache.Delete(store, key)
+			store.Delete(key)
 			return false
 		}
 	case string:
 		// legacy JSON cache entry, remove it so it gets re-cached in the new format
 		log.Debugf("removing legacy cache key: %s", key)
-		cache.Delete(store, key)
+		store.Delete(key)
 		return false
 	default:
 		log.Debugf("unexpected cache type for segment: %s, key: %s", segment.Name(), key)
-		cache.Delete(store, key)
+		store.Delete(key)
 		return false
 	}
 
@@ -752,7 +752,7 @@ func (segment *Segment) setCache() {
 	}
 
 	key, store := segment.cacheKeyAndStore()
-	cache.Set(store, key, data.Bytes(), segment.Cache.Duration)
+	store.Set(key, data.Bytes(), segment.Cache.Duration)
 }
 
 func (segment *Segment) cacheKeyAndStore() (string, cache.Store) {

--- a/src/config/segment_cache_test.go
+++ b/src/config/segment_cache_test.go
@@ -42,7 +42,7 @@ func TestSegmentCache(t *testing.T) {
 
 	defer func() {
 		template.Cache = previousTemplateCache
-		cache.DeleteAll(cache.Device)
+		cache.Device.DeleteAll()
 	}()
 
 	env := new(mock.Environment)
@@ -86,11 +86,11 @@ func TestSegmentCache(t *testing.T) {
 		segment := newCachedTextSegment(env, "legacy_segment", Device)
 
 		key, store := segment.cacheKeyAndStore()
-		cache.Set(store, key, "legacy_json_string", cache.Duration("10m"))
+		store.Set(key, "legacy_json_string", cache.Duration("10m"))
 
 		assert.False(t, segment.restoreCache(), "legacy cache should not be restored")
 
-		_, found := cache.Get[string](store, key)
+		_, found := store.Get[string](key)
 		assert.False(t, found, "legacy key should be removed")
 	})
 
@@ -98,11 +98,11 @@ func TestSegmentCache(t *testing.T) {
 		segment := newCachedTextSegment(env, "unexpected_segment", Device)
 
 		key, store := segment.cacheKeyAndStore()
-		cache.Set(store, key, 42, cache.Duration("10m"))
+		store.Set(key, 42, cache.Duration("10m"))
 
 		assert.False(t, segment.restoreCache(), "unexpected cache type should not be restored")
 
-		_, found := cache.Get[int](store, key)
+		_, found := store.Get[int](key)
 		assert.False(t, found, "unexpected key should be removed")
 	})
 }
@@ -128,7 +128,7 @@ func TestGitMainWorktreeRestoresLiveContextLazilyAfterSegmentCacheHit(t *testing
 	source.setCache()
 
 	key, store := source.cacheKeyAndStore()
-	t.Cleanup(func() { cache.Delete(store, key) })
+	t.Cleanup(func() { store.Delete(key) })
 
 	env := newDataReplayEnv(&runtime.Flags{})
 	gitFile := &runtime.FileInfo{

--- a/src/config/segment_test.go
+++ b/src/config/segment_test.go
@@ -531,8 +531,8 @@ func TestSegment_RestoreDataOverlaysOnTopOfACacheHit(t *testing.T) {
 
 	var warm bytes.Buffer
 	require.NoError(t, gob.NewEncoder(&warm).Encode(&segments.Session{SSHSession: false}))
-	cache.Set(store, key, warm.Bytes(), cache.INFINITE)
-	t.Cleanup(func() { cache.Delete(store, key) })
+	store.Set(key, warm.Bytes(), cache.INFINITE)
+	t.Cleanup(func() { store.Delete(key) })
 
 	flags := &runtime.Flags{
 		SegmentData: map[string]json.RawMessage{
@@ -683,8 +683,8 @@ func TestDecodeRecordedSegment(t *testing.T) {
 }
 
 func TestSegment_RestoreDataToggledOffStaysDisabled(t *testing.T) {
-	cache.Set(cache.Session, cache.TOGGLECACHE, map[string]bool{"text": true}, cache.INFINITE)
-	defer cache.Delete(cache.Session, cache.TOGGLECACHE)
+	cache.Session.Set(cache.TOGGLECACHE, map[string]bool{"text": true}, cache.INFINITE)
+	defer cache.Session.Delete(cache.TOGGLECACHE)
 
 	flags := &runtime.Flags{
 		SegmentData: map[string]json.RawMessage{
@@ -826,8 +826,8 @@ func TestSegment_FallbackTemplate(t *testing.T) {
 		}
 
 		key, store := segment.cacheKeyAndStore()
-		_, found := cache.Get[string](store, key)
-		cache.Delete(store, key)
+		_, found := store.Get[string](key)
+		store.Delete(key)
 		assert.False(t, found, tc.Case)
 	}
 }

--- a/src/dsc/resource.go
+++ b/src/dsc/resource.go
@@ -29,7 +29,7 @@ type State[T any] interface {
 }
 
 func (resource *Resource[T]) Load() {
-	states, ok := cache.Get[[]T](cache.Device, resource.cacheKey())
+	states, ok := cache.Device.Get[[]T](resource.cacheKey())
 	if !ok {
 		log.Debug("no states found in cache")
 		return
@@ -39,7 +39,7 @@ func (resource *Resource[T]) Load() {
 }
 
 func (resource *Resource[T]) Save() {
-	cache.Set(cache.Device, resource.cacheKey(), resource.States, cache.INFINITE)
+	cache.Device.Set(resource.cacheKey(), resource.States, cache.INFINITE)
 }
 
 func (resource *Resource[T]) Add(item T) {

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,63 +1,57 @@
 module github.com/jandedobbeleer/oh-my-posh/src
 
-go 1.26.0
+go 1.27.0
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c
 	github.com/Masterminds/sprig/v3 v3.3.0
 	github.com/alecthomas/assert v1.0.0
-	github.com/alecthomas/colour v0.1.0 // indirect
-	github.com/alecthomas/repr v0.5.2 // indirect
-	github.com/google/uuid v1.6.0 // indirect
+	github.com/go-git/go-git/v5 v5.19.2
 	github.com/gookit/color v1.6.1
-	github.com/huandu/xstrings v1.5.0 // indirect
-	github.com/mitchellh/copystructure v1.2.0 // indirect
-	github.com/sergi/go-diff v1.4.0 // indirect
-	github.com/stretchr/objx v0.5.3 // indirect
+	github.com/invopop/jsonschema v0.14.0
+	github.com/lucasb-eyer/go-colorful v1.4.1
+	github.com/pelletier/go-toml/v2 v2.4.3
+	github.com/shirou/gopsutil/v4 v4.26.7
 	github.com/stretchr/testify v1.12.1
 	github.com/wayneashleyberry/terminal-dimensions v1.1.0
-	golang.org/x/crypto v0.53.0 // indirect
+	go.yaml.in/yaml/v3 v3.0.5
 	golang.org/x/sys v0.47.0
 	golang.org/x/text v0.41.0
 )
 
 require (
-	github.com/go-git/go-git/v5 v5.19.2
-	github.com/invopop/jsonschema v0.14.0
-	github.com/lucasb-eyer/go-colorful v1.4.1
-	github.com/pelletier/go-toml/v2 v2.4.3
-	github.com/shirou/gopsutil/v4 v4.26.7
-	go.yaml.in/yaml/v3 v3.0.5
-)
-
-require (
+	dario.cat/mergo v1.0.2 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
-	github.com/go-ole/go-ole v1.3.0 // indirect
-	github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/mitchellh/reflectwalk v1.0.2 // indirect
-	github.com/spf13/cast v1.10.0 // indirect
-	github.com/tklauser/go-sysconf v0.3.16 // indirect
-	github.com/tklauser/numcpus v0.11.0 // indirect
-	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-)
-
-require (
-	dario.cat/mergo v1.0.2 // indirect
+	github.com/alecthomas/colour v0.1.0 // indirect
+	github.com/alecthomas/repr v0.5.2 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/ebitengine/purego v0.10.2 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.9.0 // indirect
+	github.com/go-ole/go-ole v1.3.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+	github.com/lufia/plan9stats v0.0.0-20251013123823-9fd1530e3ec3 // indirect
+	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mitchellh/copystructure v1.2.0 // indirect
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
+	github.com/sergi/go-diff v1.4.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
+	github.com/spf13/cast v1.10.0 // indirect
+	github.com/stretchr/objx v0.5.3 // indirect
+	github.com/tklauser/go-sysconf v0.3.16 // indirect
+	github.com/tklauser/numcpus v0.11.0 // indirect
+	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
+	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 )

--- a/src/ini/ini.go
+++ b/src/ini/ini.go
@@ -49,12 +49,12 @@ func parse(src string, verbatim bool) (*File, error) {
 		}
 
 		if line[0] == '[' {
-			end := strings.LastIndexByte(line, ']')
-			if end < 1 {
+			name, _, found := strings.CutLast(line, "]")
+			if !found {
 				return nil, errors.New("unclosed section: " + line)
 			}
 
-			current = file.section(strings.TrimSpace(line[1:end]))
+			current = file.section(strings.TrimSpace(name[1:]))
 			continue
 		}
 

--- a/src/log/log.go
+++ b/src/log/log.go
@@ -118,7 +118,9 @@ func funcSpec() (string, int) {
 
 		// Found first non-log.go frame
 		fn := frame.Function
-		fn = fn[strings.LastIndex(fn, ".")+1:]
+		if _, after, found := strings.CutLast(fn, "."); found {
+			fn = after
+		}
 		file := filepath.Base(frame.File)
 
 		if strings.HasPrefix(fn, "func") {

--- a/src/prompt/bench_test.go
+++ b/src/prompt/bench_test.go
@@ -27,9 +27,7 @@ func newBenchEngine() *Engine {
 	env.Init(flags)
 
 	template.Cache = &cache.Template{
-		SimpleTemplate: cache.SimpleTemplate{
-			Shell: shell.GENERIC,
-		},
+		Shell:    shell.GENERIC,
 		Segments: maps.NewConcurrent[any](),
 	}
 	template.Init(env, nil, nil)

--- a/src/prompt/cursor_test.go
+++ b/src/prompt/cursor_test.go
@@ -43,9 +43,7 @@ func TestCursorStyle(t *testing.T) {
 		env.On("Shell").Return(shell.GENERIC)
 
 		template.Cache = &cache.Template{
-			SimpleTemplate: cache.SimpleTemplate{
-				Shell: shell.GENERIC,
-			},
+			Shell:    shell.GENERIC,
 			Segments: maps.NewConcurrent[any](),
 		}
 		template.Init(env, nil, nil)

--- a/src/prompt/engine.go
+++ b/src/prompt/engine.go
@@ -919,7 +919,7 @@ func New(flags *runtime.Flags) *Engine {
 	env := &runtime.Terminal{}
 	env.Init(flags)
 
-	reload, _ := cache.Get[bool](cache.Device, config.RELOAD)
+	reload, _ := cache.Device.Get[bool](config.RELOAD)
 	cfg := config.Get(flags.ConfigPath, reload)
 
 	return newEngine(cfg, env)

--- a/src/prompt/engine_test.go
+++ b/src/prompt/engine_test.go
@@ -96,9 +96,7 @@ func TestPrintPWD(t *testing.T) {
 		env.On("Host").Return("host", nil)
 
 		template.Cache = &cache.Template{
-			SimpleTemplate: cache.SimpleTemplate{
-				Shell: tc.Shell,
-			},
+			Shell:    tc.Shell,
 			Segments: maps.NewConcurrent[any](),
 		}
 		template.Init(env, nil, nil)
@@ -179,9 +177,7 @@ func TestPrintPWDWSL(t *testing.T) {
 		}
 
 		template.Cache = &cache.Template{
-			SimpleTemplate: cache.SimpleTemplate{
-				Shell: tc.Shell,
-			},
+			Shell:    tc.Shell,
 			Segments: maps.NewConcurrent[any](),
 		}
 		template.Init(env, nil, nil)
@@ -277,14 +273,12 @@ func TestGetTitle(t *testing.T) {
 		terminal.Init(shell.GENERIC)
 
 		template.Cache = &cache.Template{
-			SimpleTemplate: cache.SimpleTemplate{
-				Shell:    tc.ShellName,
-				UserName: "MyUser",
-				Root:     tc.Root,
-				HostName: "MyHost",
-				PWD:      tc.Cwd,
-				Folder:   "vagrant",
-			},
+			Shell:    tc.ShellName,
+			UserName: "MyUser",
+			Root:     tc.Root,
+			HostName: "MyHost",
+			PWD:      tc.Cwd,
+			Folder:   "vagrant",
 			Segments: maps.NewConcurrent[any](),
 		}
 		template.Init(env, nil, nil)
@@ -343,12 +337,10 @@ func TestGetConsoleTitleIfGethostnameReturnsError(t *testing.T) {
 		terminal.Init(shell.GENERIC)
 
 		template.Cache = &cache.Template{
-			SimpleTemplate: cache.SimpleTemplate{
-				Shell:    tc.ShellName,
-				UserName: "MyUser",
-				Root:     tc.Root,
-				HostName: "",
-			},
+			Shell:    tc.ShellName,
+			UserName: "MyUser",
+			Root:     tc.Root,
+			HostName: "",
 			Segments: maps.NewConcurrent[any](),
 		}
 		template.Init(env, nil, nil)
@@ -464,9 +456,7 @@ func TestShouldFill(t *testing.T) {
 		}
 
 		template.Cache = &cache.Template{
-			SimpleTemplate: cache.SimpleTemplate{
-				Shell: shell.GENERIC,
-			},
+			Shell:    shell.GENERIC,
 			Segments: maps.NewConcurrent[any](),
 		}
 		template.Init(env, nil, nil)

--- a/src/prompt/primary.go
+++ b/src/prompt/primary.go
@@ -137,8 +137,8 @@ func (e *Engine) writePrimaryPromptInternal(needsPrimaryRPrompt, fromCache bool)
 	// Only handle tooltip caching in regular (non-cached) rendering, once per
 	// prompt rather than once per block.
 	if !fromCache && !e.Config.ToolTipsAction.IsDefault() {
-		cache.Set(cache.Session, RPromptKey, e.rprompt, cache.INFINITE)
-		cache.Set(cache.Session, RPromptLengthKey, e.rpromptLength, cache.INFINITE)
+		cache.Session.Set(RPromptKey, e.rprompt, cache.INFINITE)
+		cache.Session.Set(RPromptLengthKey, e.rpromptLength, cache.INFINITE)
 	}
 
 	if len(e.Config.ConsoleTitleTemplate) > 0 && !e.Env.Flags().Plain {

--- a/src/prompt/primary_test.go
+++ b/src/prompt/primary_test.go
@@ -48,9 +48,7 @@ func TestCursorStyleTemplate(t *testing.T) {
 		env.On("Shell").Return(shell.GENERIC)
 
 		template.Cache = &cache.Template{
-			SimpleTemplate: cache.SimpleTemplate{
-				Shell: shell.GENERIC,
-			},
+			Shell:    shell.GENERIC,
 			Segments: maps.NewConcurrent[any](),
 		}
 		template.Init(env, nil, nil)

--- a/src/prompt/rprompt.go
+++ b/src/prompt/rprompt.go
@@ -43,8 +43,8 @@ func (e *Engine) RPrompt() string {
 	}
 
 	if !e.Config.ToolTipsAction.IsDefault() {
-		cache.Set(cache.Session, RPromptKey, text, cache.INFINITE)
-		cache.Set(cache.Session, RPromptLengthKey, e.rpromptLength, cache.INFINITE)
+		cache.Session.Set(RPromptKey, text, cache.INFINITE)
+		cache.Session.Set(RPromptLengthKey, e.rpromptLength, cache.INFINITE)
 	}
 
 	return text

--- a/src/prompt/tooltip.go
+++ b/src/prompt/tooltip.go
@@ -11,12 +11,12 @@ import (
 )
 
 func (e *Engine) tooltipFallback() string {
-	rprompt, OK := cache.Get[string](cache.Session, RPromptKey)
+	rprompt, OK := cache.Session.Get[string](RPromptKey)
 	if !OK {
 		return ""
 	}
 
-	rpromptLength, OK := cache.Get[int](cache.Session, RPromptLengthKey)
+	rpromptLength, OK := cache.Session.Get[int](RPromptLengthKey)
 	if !OK {
 		return rprompt
 	}
@@ -103,12 +103,12 @@ func (e *Engine) handleToolTipAction(text string, length int) (string, int) {
 		return text, length
 	}
 
-	rprompt, OK := cache.Get[string](cache.Session, RPromptKey)
+	rprompt, OK := cache.Session.Get[string](RPromptKey)
 	if !OK {
 		return text, length
 	}
 
-	rpromptLength, OK := cache.Get[int](cache.Session, RPromptLengthKey)
+	rpromptLength, OK := cache.Session.Get[int](RPromptLengthKey)
 	if !OK {
 		return text, length
 	}

--- a/src/prompt/tooltip_test.go
+++ b/src/prompt/tooltip_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 func TestTooltipFallback_NoCacheReturnsEmpty(t *testing.T) {
-	cache.Delete(cache.Session, RPromptKey)
-	cache.Delete(cache.Session, RPromptLengthKey)
+	cache.Session.Delete(RPromptKey)
+	cache.Session.Delete(RPromptLengthKey)
 
 	env := new(mock.Environment)
 	env.On("Shell").Return(shell.ZSH)
@@ -32,10 +32,10 @@ func TestTooltipFallback_NoCacheReturnsEmpty(t *testing.T) {
 }
 
 func TestTooltipFallback_NoMatchReturnsRPromptText(t *testing.T) {
-	cache.Delete(cache.Session, RPromptKey)
-	cache.Delete(cache.Session, RPromptLengthKey)
-	cache.Set(cache.Session, RPromptKey, "my-rprompt", cache.INFINITE)
-	cache.Set(cache.Session, RPromptLengthKey, 10, cache.INFINITE)
+	cache.Session.Delete(RPromptKey)
+	cache.Session.Delete(RPromptLengthKey)
+	cache.Session.Set(RPromptKey, "my-rprompt", cache.INFINITE)
+	cache.Session.Set(RPromptLengthKey, 10, cache.INFINITE)
 
 	env := new(mock.Environment)
 	env.On("Shell").Return(shell.ZSH)
@@ -52,10 +52,10 @@ func TestTooltipFallback_NoMatchReturnsRPromptText(t *testing.T) {
 }
 
 func TestTooltipFallback_PwshNoMatchReturnsCursorPositionedRPrompt(t *testing.T) {
-	cache.Delete(cache.Session, RPromptKey)
-	cache.Delete(cache.Session, RPromptLengthKey)
-	cache.Set(cache.Session, RPromptKey, "my-rprompt", cache.INFINITE)
-	cache.Set(cache.Session, RPromptLengthKey, 10, cache.INFINITE)
+	cache.Session.Delete(RPromptKey)
+	cache.Session.Delete(RPromptLengthKey)
+	cache.Session.Set(RPromptKey, "my-rprompt", cache.INFINITE)
+	cache.Session.Set(RPromptLengthKey, 10, cache.INFINITE)
 
 	env := new(mock.Environment)
 	env.On("Shell").Return(shell.PWSH)
@@ -76,11 +76,11 @@ func TestTooltipFallback_PwshNoMatchReturnsCursorPositionedRPrompt(t *testing.T)
 }
 
 func TestTooltipFallback_PwshNoRoomReturnsEmpty(t *testing.T) {
-	cache.Delete(cache.Session, RPromptKey)
-	cache.Delete(cache.Session, RPromptLengthKey)
-	cache.Set(cache.Session, RPromptKey, "my-rprompt", cache.INFINITE)
+	cache.Session.Delete(RPromptKey)
+	cache.Session.Delete(RPromptLengthKey)
+	cache.Session.Set(RPromptKey, "my-rprompt", cache.INFINITE)
 	// rprompt length exceeds available terminal space
-	cache.Set(cache.Session, RPromptLengthKey, 200, cache.INFINITE)
+	cache.Session.Set(RPromptLengthKey, 200, cache.INFINITE)
 
 	env := new(mock.Environment)
 	env.On("Shell").Return(shell.PWSH)

--- a/src/runtime/http/download.go
+++ b/src/runtime/http/download.go
@@ -31,14 +31,14 @@ func Download(url string, isCacheEnabled bool) ([]byte, error) {
 
 	request.Header.Add("User-Agent", "oh-my-posh")
 	// if we have an etag, add it to the request to check if the file changed
-	etag, OK := cache.Get[string](cache.Device, etagKey(url))
+	etag, OK := cache.Device.Get[string](etagKey(url))
 	if OK {
 		log.Debugf("found etag in cache: %s", etag)
 		request.Header.Set("If-None-Match", etag)
 	}
 
 	cachedData := func() ([]byte, error) {
-		cachedData, OK := cache.Get[[]byte](cache.Device, dataKey(url))
+		cachedData, OK := cache.Device.Get[[]byte](dataKey(url))
 		if OK {
 			return cachedData, nil
 		}
@@ -67,7 +67,7 @@ func Download(url string, isCacheEnabled bool) ([]byte, error) {
 
 	etag = response.Header.Get("ETag")
 	if etag != "" && isCacheEnabled {
-		cache.Set(cache.Device, etagKey(url), etag, cache.INFINITE)
+		cache.Device.Set(etagKey(url), etag, cache.INFINITE)
 	}
 
 	data, err := io.ReadAll(response.Body)
@@ -77,7 +77,7 @@ func Download(url string, isCacheEnabled bool) ([]byte, error) {
 	}
 
 	if isCacheEnabled {
-		cache.Set(cache.Device, dataKey(url), data, cache.INFINITE)
+		cache.Device.Set(dataKey(url), data, cache.INFINITE)
 	}
 
 	return data, nil

--- a/src/runtime/http/oauth.go
+++ b/src/runtime/http/oauth.go
@@ -42,12 +42,12 @@ type OAuthRequest struct {
 
 func (o *OAuthRequest) getAccessToken() (string, error) {
 	// get directly from cache
-	if accessToken, OK := cache.Get[string](cache.Device, o.AccessTokenKey); OK && len(accessToken) != 0 {
+	if accessToken, OK := cache.Device.Get[string](o.AccessTokenKey); OK && len(accessToken) != 0 {
 		return accessToken, nil
 	}
 
 	// use cached refresh token to get new access token
-	if refreshToken, OK := cache.Get[string](cache.Device, o.RefreshTokenKey); OK && len(refreshToken) != 0 {
+	if refreshToken, OK := cache.Device.Get[string](o.RefreshTokenKey); OK && len(refreshToken) != 0 {
 		if accessToken, err := o.refreshToken(refreshToken); err == nil {
 			return accessToken, nil
 		}
@@ -90,15 +90,15 @@ func (o *OAuthRequest) refreshToken(refreshToken string) (string, error) {
 	}
 
 	// add tokens to cache
-	cache.Set(cache.Device, o.AccessTokenKey, tokens.AccessToken, cache.ToDuration(tokens.ExpiresIn))
-	cache.Set(cache.Device, o.RefreshTokenKey, tokens.RefreshToken, cache.TWOYEARS)
+	cache.Device.Set(o.AccessTokenKey, tokens.AccessToken, cache.ToDuration(tokens.ExpiresIn))
+	cache.Device.Set(o.RefreshTokenKey, tokens.RefreshToken, cache.TWOYEARS)
 	return tokens.AccessToken, nil
 }
 
-func OauthResult[a any](o *OAuthRequest, url string, body io.Reader, requestModifiers ...RequestModifier) (a, error) {
+func (o *OAuthRequest) Result[T any](url string, body io.Reader, requestModifiers ...RequestModifier) (T, error) {
 	accessToken, err := o.getAccessToken()
 	if err != nil {
-		var data a
+		var data T
 		return data, err
 	}
 
@@ -113,5 +113,5 @@ func OauthResult[a any](o *OAuthRequest, url string, body io.Reader, requestModi
 
 	requestModifiers = append(requestModifiers, addAuthHeader)
 
-	return Do[a](&o.Request, url, body, requestModifiers...)
+	return o.Do[T](url, body, requestModifiers...)
 }

--- a/src/runtime/http/oauth_test.go
+++ b/src/runtime/http/oauth_test.go
@@ -125,11 +125,11 @@ func TestOauthResult(t *testing.T) {
 		tokenURL := fmt.Sprintf("https://ohmyposh.dev/api/refresh?segment=test&token=%s", tc.RefreshToken)
 
 		if tc.AccessTokenFromCache {
-			cache.Set(cache.Device, accessTokenKey, tc.AccessToken, cache.INFINITE)
+			cache.Device.Set(accessTokenKey, tc.AccessToken, cache.INFINITE)
 		}
 
 		if tc.RefreshTokenFromCache {
-			cache.Set(cache.Device, refreshTokenKey, tc.RefreshToken, cache.INFINITE)
+			cache.Device.Set(refreshTokenKey, tc.RefreshToken, cache.INFINITE)
 		}
 
 		env := &MockedEnvironment{}
@@ -147,7 +147,7 @@ func TestOauthResult(t *testing.T) {
 			HTTPTimeout:     20,
 		}
 
-		got, err := OauthResult[*data](oauth, url, nil)
+		got, err := oauth.Result[*data](url, nil)
 		assert.Equal(t, tc.ExpectedData, got, tc.Case)
 
 		if tc.ExpectedErrorMessage == "" {
@@ -156,6 +156,6 @@ func TestOauthResult(t *testing.T) {
 			assert.Equal(t, tc.ExpectedErrorMessage, err.Error(), tc.Case)
 		}
 
-		cache.DeleteAll(cache.Device)
+		cache.Device.DeleteAll()
 	}
 }

--- a/src/runtime/http/oauth_test.go
+++ b/src/runtime/http/oauth_test.go
@@ -143,10 +143,8 @@ func TestOauthResult(t *testing.T) {
 			SegmentName:     "test",
 			AccessToken:     tc.AccessToken,
 			RefreshToken:    tc.RefreshToken,
-			Request: Request{
-				Env:         env,
-				HTTPTimeout: 20,
-			},
+			Env:             env,
+			HTTPTimeout:     20,
 		}
 
 		got, err := OauthResult[*data](oauth, url, nil)

--- a/src/runtime/http/request.go
+++ b/src/runtime/http/request.go
@@ -20,8 +20,8 @@ type Environment interface {
 	HTTPRequest(url string, body io.Reader, timeout int, requestModifiers ...RequestModifier) ([]byte, error)
 }
 
-func Do[a any](r *Request, url string, body io.Reader, requestModifiers ...RequestModifier) (a, error) {
-	var data a
+func (r *Request) Do[T any](url string, body io.Reader, requestModifiers ...RequestModifier) (T, error) {
+	var data T
 	httpTimeout := r.HTTPTimeout // r.props.GetInt(options.HTTPTimeout, options.DefaultHTTPTimeout)
 
 	responseBody, err := r.Env.HTTPRequest(url, body, httpTimeout, requestModifiers...)

--- a/src/runtime/http/request_test.go
+++ b/src/runtime/http/request_test.go
@@ -60,7 +60,7 @@ func TestRequestResult(t *testing.T) {
 			HTTPTimeout: 0,
 		}
 
-		got, err := Do[*data](request, url, nil)
+		got, err := request.Do[*data](url, nil)
 		assert.Equal(t, tc.ExpectedData, got, tc.Case)
 		if tc.ExpectedErrorMessage == "" {
 			assert.Nil(t, err, tc.Case)

--- a/src/runtime/terminal.go
+++ b/src/runtime/terminal.go
@@ -610,14 +610,14 @@ func (term *Terminal) setPromptCount() {
 	defer log.Trace(time.Now())
 
 	var count int
-	if val, found := cache.Get[int](cache.Session, cache.PROMPTCOUNTCACHE); found {
+	if val, found := cache.Session.Get[int](cache.PROMPTCOUNTCACHE); found {
 		count = val
 	}
 
 	// Only update the count if we're generating a primary prompt.
 	if term.CmdFlags.Type == PRIMARY {
 		count++
-		cache.Set(cache.Session, cache.PROMPTCOUNTCACHE, count, cache.ONEDAY)
+		cache.Session.Set(cache.PROMPTCOUNTCACHE, count, cache.ONEDAY)
 	}
 
 	term.CmdFlags.PromptCount = count

--- a/src/runtime/terminal_unix.go
+++ b/src/runtime/terminal_unix.go
@@ -26,13 +26,13 @@ func (term *Terminal) QueryMediaPlayer(_ string) (*MediaInfo, error) {
 func (term *Terminal) IsWsl() bool {
 	defer log.Trace(time.Now())
 	const key = "is_wsl"
-	if val, found := cache.Get[bool](cache.Device, key); found {
+	if val, found := cache.Device.Get[bool](key); found {
 		return val
 	}
 
 	var val bool
 	defer func() {
-		cache.Set(cache.Device, key, val, cache.INFINITE)
+		cache.Device.Set(key, val, cache.INFINITE)
 	}()
 
 	val = term.HasCommand("wslpath")
@@ -95,13 +95,13 @@ func resolveTerminalWidth(width uint, terminalErr error, columns string) (uint, 
 
 func (term *Terminal) Platform() string {
 	const key = "environment_platform"
-	if val, found := cache.Get[string](cache.Device, key); found {
+	if val, found := cache.Device.Get[string](key); found {
 		return val
 	}
 
 	var platform string
 	defer func() {
-		cache.Set(cache.Device, key, platform, cache.INFINITE)
+		cache.Device.Set(key, platform, cache.INFINITE)
 	}()
 
 	if wsl := term.Getenv("WSL_DISTRO_NAME"); len(wsl) != 0 {

--- a/src/segments/antigravity.go
+++ b/src/segments/antigravity.go
@@ -88,7 +88,7 @@ func (a *Antigravity) Template() string {
 func (a *Antigravity) Enabled() bool {
 	log.Debug("antigravity segment: checking if enabled")
 
-	data, found := cache.Get[AntigravityData](cache.Session, cache.ANTIGRAVITYCACHE)
+	data, found := cache.Session.Get[AntigravityData](cache.ANTIGRAVITYCACHE)
 	if !found {
 		log.Debug("antigravity segment: no data found in session cache")
 		return false

--- a/src/segments/antigravity_test.go
+++ b/src/segments/antigravity_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-//nolint:dupl
 func TestAntigravitySegment(t *testing.T) {
 	cases := []struct {
 		Data            *AntigravityData
@@ -61,10 +60,8 @@ func TestAntigravitySegment(t *testing.T) {
 
 			env := new(mock.Environment)
 			segment := &Antigravity{
-				Base: Base{
-					env:     env,
-					options: options.Map{},
-				},
+				env:     env,
+				options: options.Map{},
 			}
 
 			enabled := segment.Enabled()
@@ -142,10 +139,8 @@ func TestAntigravityTokenUsagePercent(t *testing.T) {
 
 			env := new(mock.Environment)
 			segment := &Antigravity{
-				Base: Base{
-					env:     env,
-					options: options.Map{},
-				},
+				env:     env,
+				options: options.Map{},
 			}
 
 			enabled := segment.Enabled()
@@ -192,10 +187,8 @@ func TestAntigravityRemainingPercent(t *testing.T) {
 
 			env := new(mock.Environment)
 			segment := &Antigravity{
-				Base: Base{
-					env:     env,
-					options: options.Map{},
-				},
+				env:     env,
+				options: options.Map{},
 			}
 
 			segment.Enabled()
@@ -243,10 +236,8 @@ func TestAntigravityFormattedTokens(t *testing.T) {
 
 			env := new(mock.Environment)
 			segment := &Antigravity{
-				Base: Base{
-					env:     env,
-					options: options.Map{},
-				},
+				env:     env,
+				options: options.Map{},
 			}
 
 			segment.Enabled()
@@ -269,12 +260,10 @@ func TestAntigravityTokenGaugeCustomChars(t *testing.T) {
 
 	env := new(mock.Environment)
 	segment := &Antigravity{
-		Base: Base{
-			env: env,
-			options: options.Map{
-				gaugeMarkedChar:   "█",
-				gaugeUnmarkedChar: "░",
-			},
+		env: env,
+		options: options.Map{
+			gaugeMarkedChar:   "█",
+			gaugeUnmarkedChar: "░",
 		},
 	}
 

--- a/src/segments/antigravity_test.go
+++ b/src/segments/antigravity_test.go
@@ -53,9 +53,9 @@ func TestAntigravitySegment(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.Case, func(t *testing.T) {
 			if tc.Data != nil {
-				cache.Set(cache.Session, cache.ANTIGRAVITYCACHE, *tc.Data, cache.INFINITE)
+				cache.Session.Set(cache.ANTIGRAVITYCACHE, *tc.Data, cache.INFINITE)
 			} else {
-				cache.Delete(cache.Session, cache.ANTIGRAVITYCACHE)
+				cache.Session.Delete(cache.ANTIGRAVITYCACHE)
 			}
 
 			env := new(mock.Environment)
@@ -72,14 +72,14 @@ func TestAntigravitySegment(t *testing.T) {
 				assert.Equal(t, tc.ExpectedSession, segment.SessionID, tc.Case)
 			}
 
-			cache.Delete(cache.Session, cache.ANTIGRAVITYCACHE)
+			cache.Session.Delete(cache.ANTIGRAVITYCACHE)
 		})
 	}
 }
 
 func TestAntigravityTokenUsagePercent(t *testing.T) {
 	t.Cleanup(func() {
-		cache.Delete(cache.Session, cache.ANTIGRAVITYCACHE)
+		cache.Session.Delete(cache.ANTIGRAVITYCACHE)
 	})
 
 	cases := []struct {
@@ -135,7 +135,7 @@ func TestAntigravityTokenUsagePercent(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.Case, func(t *testing.T) {
 			data := AntigravityData{ContextWindow: tc.ContextWindow}
-			cache.Set(cache.Session, cache.ANTIGRAVITYCACHE, data, cache.INFINITE)
+			cache.Session.Set(cache.ANTIGRAVITYCACHE, data, cache.INFINITE)
 
 			env := new(mock.Environment)
 			segment := &Antigravity{
@@ -147,7 +147,7 @@ func TestAntigravityTokenUsagePercent(t *testing.T) {
 			assert.True(t, enabled, tc.Case)
 			assert.Equal(t, tc.ExpectedPercent, segment.TokenUsagePercent(), tc.Case)
 
-			cache.Delete(cache.Session, cache.ANTIGRAVITYCACHE)
+			cache.Session.Delete(cache.ANTIGRAVITYCACHE)
 		})
 	}
 }
@@ -183,7 +183,7 @@ func TestAntigravityRemainingPercent(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.Case, func(t *testing.T) {
 			data := AntigravityData{ContextWindow: tc.ContextWindow}
-			cache.Set(cache.Session, cache.ANTIGRAVITYCACHE, data, cache.INFINITE)
+			cache.Session.Set(cache.ANTIGRAVITYCACHE, data, cache.INFINITE)
 
 			env := new(mock.Environment)
 			segment := &Antigravity{
@@ -194,7 +194,7 @@ func TestAntigravityRemainingPercent(t *testing.T) {
 			segment.Enabled()
 			assert.Equal(t, tc.Expected, segment.RemainingPercent(), tc.Case)
 
-			cache.Delete(cache.Session, cache.ANTIGRAVITYCACHE)
+			cache.Session.Delete(cache.ANTIGRAVITYCACHE)
 		})
 	}
 }
@@ -232,7 +232,7 @@ func TestAntigravityFormattedTokens(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.Case, func(t *testing.T) {
 			data := AntigravityData{ContextWindow: tc.ContextWindow}
-			cache.Set(cache.Session, cache.ANTIGRAVITYCACHE, data, cache.INFINITE)
+			cache.Session.Set(cache.ANTIGRAVITYCACHE, data, cache.INFINITE)
 
 			env := new(mock.Environment)
 			segment := &Antigravity{
@@ -243,7 +243,7 @@ func TestAntigravityFormattedTokens(t *testing.T) {
 			segment.Enabled()
 			assert.Equal(t, tc.Expected, segment.FormattedTokens(), tc.Case)
 
-			cache.Delete(cache.Session, cache.ANTIGRAVITYCACHE)
+			cache.Session.Delete(cache.ANTIGRAVITYCACHE)
 		})
 	}
 }
@@ -255,8 +255,8 @@ func TestAntigravityTokenGaugeCustomChars(t *testing.T) {
 			UsedPercentage: &usedPct,
 		},
 	}
-	cache.Set(cache.Session, cache.ANTIGRAVITYCACHE, data, cache.INFINITE)
-	defer cache.Delete(cache.Session, cache.ANTIGRAVITYCACHE)
+	cache.Session.Set(cache.ANTIGRAVITYCACHE, data, cache.INFINITE)
+	defer cache.Session.Delete(cache.ANTIGRAVITYCACHE)
 
 	env := new(mock.Environment)
 	segment := &Antigravity{

--- a/src/segments/argocd_test.go
+++ b/src/segments/argocd_test.go
@@ -36,10 +36,8 @@ func TestArgocdGetConfigFromOpts(t *testing.T) {
 		env.On("Getenv", argocdOptsEnv).Return(tc.Opts)
 
 		argocd := &Argocd{
-			Base: Base{
-				env:     env,
-				options: options.Map{},
-			},
+			env:     env,
+			options: options.Map{},
 		}
 		config := argocd.getConfigFromOpts()
 		assert.Equal(t, tc.Expected, config, tc.Case)
@@ -64,10 +62,8 @@ func TestArgocdGetConfigPath(t *testing.T) {
 		env.On("Getenv", argocdOptsEnv).Return(tc.Opts)
 
 		argocd := &Argocd{
-			Base: Base{
-				env:     env,
-				options: options.Map{},
-			},
+			env:     env,
+			options: options.Map{},
 		}
 		assert.Equal(t, tc.Expected, argocd.getConfigPath())
 	}
@@ -161,10 +157,8 @@ users:
 		env.On("FileContent", configFile).Return(tc.Config)
 
 		argocd := &Argocd{
-			Base: Base{
-				env:     env,
-				options: options.Map{},
-			},
+			env:     env,
+			options: options.Map{},
 		}
 		if len(tc.ExpectedError) > 0 {
 			_, err := argocd.parseConfig(configFile)

--- a/src/segments/claude.go
+++ b/src/segments/claude.go
@@ -175,7 +175,7 @@ func (c *Claude) Enabled() bool {
 	log.Debug("claude segment: checking if enabled")
 
 	// Try to get Claude data from session cache
-	claudeData, found := cache.Get[ClaudeData](cache.Session, cache.CLAUDECACHE)
+	claudeData, found := cache.Session.Get[ClaudeData](cache.CLAUDECACHE)
 	if !found {
 		log.Debug("claude segment: no Claude data found in session cache")
 		return false

--- a/src/segments/claude_test.go
+++ b/src/segments/claude_test.go
@@ -102,10 +102,8 @@ func TestClaudeSegment(t *testing.T) {
 
 		env := new(mock.Environment)
 		claude := &Claude{
-			Base: Base{
-				env:     env,
-				options: options.Map{},
-			},
+			env:     env,
+			options: options.Map{},
 		}
 
 		enabled := claude.Enabled()
@@ -153,10 +151,8 @@ func TestClaudeWorkspaceGitWorktree(t *testing.T) {
 
 		env := new(mock.Environment)
 		claude := &Claude{
-			Base: Base{
-				env:     env,
-				options: options.Map{},
-			},
+			env:     env,
+			options: options.Map{},
 		}
 
 		assert.True(t, claude.Enabled(), tc.Case)
@@ -210,10 +206,8 @@ func TestClaudeEffortAndThinking(t *testing.T) {
 
 		env := new(mock.Environment)
 		claude := &Claude{
-			Base: Base{
-				env:     env,
-				options: options.Map{},
-			},
+			env:     env,
+			options: options.Map{},
 		}
 
 		assert.True(t, claude.Enabled(), tc.Case)
@@ -925,12 +919,10 @@ func TestClaudeGaugeOptionsReadInEnabled(t *testing.T) {
 
 	env := new(mock.Environment)
 	claude := &Claude{
-		Base: Base{
-			env: env,
-			options: options.Map{
-				gaugeMarkedChar:   "█",
-				gaugeUnmarkedChar: "░",
-			},
+		env: env,
+		options: options.Map{
+			gaugeMarkedChar:   "█",
+			gaugeUnmarkedChar: "░",
 		},
 	}
 

--- a/src/segments/claude_test.go
+++ b/src/segments/claude_test.go
@@ -95,9 +95,9 @@ func TestClaudeSegment(t *testing.T) {
 	for _, tc := range cases {
 		// Setup cache for test
 		if tc.ClaudeData != nil {
-			cache.Set(cache.Session, cache.CLAUDECACHE, *tc.ClaudeData, cache.INFINITE)
+			cache.Session.Set(cache.CLAUDECACHE, *tc.ClaudeData, cache.INFINITE)
 		} else {
-			cache.Delete(cache.Session, cache.CLAUDECACHE)
+			cache.Session.Delete(cache.CLAUDECACHE)
 		}
 
 		env := new(mock.Environment)
@@ -119,7 +119,7 @@ func TestClaudeSegment(t *testing.T) {
 
 func TestClaudeWorkspaceGitWorktree(t *testing.T) {
 	t.Cleanup(func() {
-		cache.Delete(cache.Session, cache.CLAUDECACHE)
+		cache.Session.Delete(cache.CLAUDECACHE)
 	})
 
 	cases := []struct {
@@ -147,7 +147,7 @@ func TestClaudeWorkspaceGitWorktree(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		cache.Set(cache.Session, cache.CLAUDECACHE, ClaudeData{Workspace: tc.Workspace}, cache.INFINITE)
+		cache.Session.Set(cache.CLAUDECACHE, ClaudeData{Workspace: tc.Workspace}, cache.INFINITE)
 
 		env := new(mock.Environment)
 		claude := &Claude{
@@ -162,7 +162,7 @@ func TestClaudeWorkspaceGitWorktree(t *testing.T) {
 
 func TestClaudeEffortAndThinking(t *testing.T) {
 	t.Cleanup(func() {
-		cache.Delete(cache.Session, cache.CLAUDECACHE)
+		cache.Session.Delete(cache.CLAUDECACHE)
 	})
 
 	cases := []struct {
@@ -199,7 +199,7 @@ func TestClaudeEffortAndThinking(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		cache.Set(cache.Session, cache.CLAUDECACHE, ClaudeData{
+		cache.Session.Set(cache.CLAUDECACHE, ClaudeData{
 			Effort:   tc.Effort,
 			Thinking: tc.Thinking,
 		}, cache.INFINITE)
@@ -910,10 +910,10 @@ func TestClaudeGaugeMethods(t *testing.T) {
 
 func TestClaudeGaugeOptionsReadInEnabled(t *testing.T) {
 	t.Cleanup(func() {
-		cache.Delete(cache.Session, cache.CLAUDECACHE)
+		cache.Session.Delete(cache.CLAUDECACHE)
 	})
 
-	cache.Set(cache.Session, cache.CLAUDECACHE, ClaudeData{
+	cache.Session.Set(cache.CLAUDECACHE, ClaudeData{
 		Model: AIModel{DisplayName: "Opus"},
 	}, cache.INFINITE)
 

--- a/src/segments/copilot.go
+++ b/src/segments/copilot.go
@@ -65,7 +65,7 @@ func (c *Copilot) Enabled() bool {
 
 func (c *Copilot) getAccessToken() string {
 	// Check cache from `oh-my-posh auth copilot`
-	if cachedToken, OK := cache.Get[string](cache.Device, auth.CopilotTokenKey); OK && len(cachedToken) != 0 {
+	if cachedToken, OK := cache.Device.Get[string](auth.CopilotTokenKey); OK && len(cachedToken) != 0 {
 		return cachedToken
 	}
 

--- a/src/segments/copilot_cli.go
+++ b/src/segments/copilot_cli.go
@@ -66,7 +66,7 @@ func (c *CopilotCLI) Template() string {
 func (c *CopilotCLI) Enabled() bool {
 	log.Debug("copilot_cli segment: checking if enabled")
 
-	data, found := cache.Get[CopilotCLIData](cache.Session, cache.COPILOTCLICACHE)
+	data, found := cache.Session.Get[CopilotCLIData](cache.COPILOTCLICACHE)
 	if !found {
 		log.Debug("copilot_cli segment: no data found in session cache")
 		return false

--- a/src/segments/copilot_cli_test.go
+++ b/src/segments/copilot_cli_test.go
@@ -57,9 +57,9 @@ func TestCopilotCLISegment(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.Case, func(t *testing.T) {
 			if tc.Data != nil {
-				cache.Set(cache.Session, cache.COPILOTCLICACHE, *tc.Data, cache.INFINITE)
+				cache.Session.Set(cache.COPILOTCLICACHE, *tc.Data, cache.INFINITE)
 			} else {
-				cache.Delete(cache.Session, cache.COPILOTCLICACHE)
+				cache.Session.Delete(cache.COPILOTCLICACHE)
 			}
 
 			env := new(mock.Environment)
@@ -76,14 +76,14 @@ func TestCopilotCLISegment(t *testing.T) {
 				assert.Equal(t, tc.ExpectedSession, segment.SessionID, tc.Case)
 			}
 
-			cache.Delete(cache.Session, cache.COPILOTCLICACHE)
+			cache.Session.Delete(cache.COPILOTCLICACHE)
 		})
 	}
 }
 
 func TestCopilotCLITokenUsagePercent(t *testing.T) {
 	t.Cleanup(func() {
-		cache.Delete(cache.Session, cache.COPILOTCLICACHE)
+		cache.Session.Delete(cache.COPILOTCLICACHE)
 	})
 
 	cases := []struct {
@@ -146,7 +146,7 @@ func TestCopilotCLITokenUsagePercent(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.Case, func(t *testing.T) {
 			data := CopilotCLIData{ContextWindow: tc.ContextWindow}
-			cache.Set(cache.Session, cache.COPILOTCLICACHE, data, cache.INFINITE)
+			cache.Session.Set(cache.COPILOTCLICACHE, data, cache.INFINITE)
 
 			env := new(mock.Environment)
 			segment := &CopilotCLI{
@@ -158,7 +158,7 @@ func TestCopilotCLITokenUsagePercent(t *testing.T) {
 			assert.True(t, enabled, tc.Case)
 			assert.Equal(t, tc.ExpectedPercent, segment.TokenUsagePercent(), tc.Case)
 
-			cache.Delete(cache.Session, cache.COPILOTCLICACHE)
+			cache.Session.Delete(cache.COPILOTCLICACHE)
 		})
 	}
 }
@@ -208,7 +208,7 @@ func TestCopilotCLIFormattedTokens(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.Case, func(t *testing.T) {
 			data := CopilotCLIData{ContextWindow: tc.ContextWindow}
-			cache.Set(cache.Session, cache.COPILOTCLICACHE, data, cache.INFINITE)
+			cache.Session.Set(cache.COPILOTCLICACHE, data, cache.INFINITE)
 
 			env := new(mock.Environment)
 			segment := &CopilotCLI{
@@ -219,7 +219,7 @@ func TestCopilotCLIFormattedTokens(t *testing.T) {
 			segment.Enabled()
 			assert.Equal(t, tc.Expected, segment.FormattedTokens(), tc.Case)
 
-			cache.Delete(cache.Session, cache.COPILOTCLICACHE)
+			cache.Session.Delete(cache.COPILOTCLICACHE)
 		})
 	}
 }
@@ -231,8 +231,8 @@ func TestCopilotCLIFormattedDuration(t *testing.T) {
 			TotalAPIDurationMS: 30000, // 0m 30s
 		},
 	}
-	cache.Set(cache.Session, cache.COPILOTCLICACHE, data, cache.INFINITE)
-	defer cache.Delete(cache.Session, cache.COPILOTCLICACHE)
+	cache.Session.Set(cache.COPILOTCLICACHE, data, cache.INFINITE)
+	defer cache.Session.Delete(cache.COPILOTCLICACHE)
 
 	env := new(mock.Environment)
 	segment := &CopilotCLI{
@@ -252,8 +252,8 @@ func TestCopilotCLITokenGaugeCustomChars(t *testing.T) {
 			UsedPercentage: &usedPct,
 		},
 	}
-	cache.Set(cache.Session, cache.COPILOTCLICACHE, data, cache.INFINITE)
-	defer cache.Delete(cache.Session, cache.COPILOTCLICACHE)
+	cache.Session.Set(cache.COPILOTCLICACHE, data, cache.INFINITE)
+	defer cache.Session.Delete(cache.COPILOTCLICACHE)
 
 	env := new(mock.Environment)
 	segment := &CopilotCLI{
@@ -301,7 +301,7 @@ func TestCopilotCLIRemainingPercent(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.Case, func(t *testing.T) {
 			data := CopilotCLIData{ContextWindow: tc.ContextWindow}
-			cache.Set(cache.Session, cache.COPILOTCLICACHE, data, cache.INFINITE)
+			cache.Session.Set(cache.COPILOTCLICACHE, data, cache.INFINITE)
 
 			env := new(mock.Environment)
 			segment := &CopilotCLI{
@@ -312,7 +312,7 @@ func TestCopilotCLIRemainingPercent(t *testing.T) {
 			segment.Enabled()
 			assert.Equal(t, tc.Expected, segment.RemainingPercent(), tc.Case)
 
-			cache.Delete(cache.Session, cache.COPILOTCLICACHE)
+			cache.Session.Delete(cache.COPILOTCLICACHE)
 		})
 	}
 }

--- a/src/segments/copilot_cli_test.go
+++ b/src/segments/copilot_cli_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-//nolint:dupl
 func TestCopilotCLISegment(t *testing.T) {
 	cases := []struct {
 		Data            *CopilotCLIData
@@ -65,10 +64,8 @@ func TestCopilotCLISegment(t *testing.T) {
 
 			env := new(mock.Environment)
 			segment := &CopilotCLI{
-				Base: Base{
-					env:     env,
-					options: options.Map{},
-				},
+				env:     env,
+				options: options.Map{},
 			}
 
 			enabled := segment.Enabled()
@@ -153,10 +150,8 @@ func TestCopilotCLITokenUsagePercent(t *testing.T) {
 
 			env := new(mock.Environment)
 			segment := &CopilotCLI{
-				Base: Base{
-					env:     env,
-					options: options.Map{},
-				},
+				env:     env,
+				options: options.Map{},
 			}
 
 			enabled := segment.Enabled()
@@ -217,10 +212,8 @@ func TestCopilotCLIFormattedTokens(t *testing.T) {
 
 			env := new(mock.Environment)
 			segment := &CopilotCLI{
-				Base: Base{
-					env:     env,
-					options: options.Map{},
-				},
+				env:     env,
+				options: options.Map{},
 			}
 
 			segment.Enabled()
@@ -243,10 +236,8 @@ func TestCopilotCLIFormattedDuration(t *testing.T) {
 
 	env := new(mock.Environment)
 	segment := &CopilotCLI{
-		Base: Base{
-			env:     env,
-			options: options.Map{},
-		},
+		env:     env,
+		options: options.Map{},
 	}
 
 	segment.Enabled()
@@ -266,12 +257,10 @@ func TestCopilotCLITokenGaugeCustomChars(t *testing.T) {
 
 	env := new(mock.Environment)
 	segment := &CopilotCLI{
-		Base: Base{
-			env: env,
-			options: options.Map{
-				gaugeMarkedChar:   "█",
-				gaugeUnmarkedChar: "░",
-			},
+		env: env,
+		options: options.Map{
+			gaugeMarkedChar:   "█",
+			gaugeUnmarkedChar: "░",
 		},
 	}
 
@@ -316,10 +305,8 @@ func TestCopilotCLIRemainingPercent(t *testing.T) {
 
 			env := new(mock.Environment)
 			segment := &CopilotCLI{
-				Base: Base{
-					env:     env,
-					options: options.Map{},
-				},
+				env:     env,
+				options: options.Map{},
 			}
 
 			segment.Enabled()

--- a/src/segments/copilot_test.go
+++ b/src/segments/copilot_test.go
@@ -173,9 +173,9 @@ func TestCopilotSegment(t *testing.T) {
 
 			// Setup cached token mock
 			if tc.HasToken {
-				cache.Set(cache.Device, auth.CopilotTokenKey, "ghp_test_token", cache.INFINITE)
+				cache.Device.Set(auth.CopilotTokenKey, "ghp_test_token", cache.INFINITE)
 			} else {
-				cache.Delete(cache.Device, auth.CopilotTokenKey)
+				cache.Device.Delete(auth.CopilotTokenKey)
 			}
 
 			// Setup HTTP request mock
@@ -287,7 +287,7 @@ func TestCopilotRemainingPercentage(t *testing.T) {
 		"quota_reset_date": "2025-02-15T00:00:00Z"
 	}`
 
-	cache.Set(cache.Device, auth.CopilotTokenKey, "ghp_test_token", cache.INFINITE)
+	cache.Device.Set(auth.CopilotTokenKey, "ghp_test_token", cache.INFINITE)
 	env.On("HTTPRequest", copilotTestURL).Return([]byte(jsonResponse), nil)
 
 	c := &Copilot{}
@@ -334,7 +334,7 @@ func TestCopilotBillingCycleEnd(t *testing.T) {
 		"quota_reset_date": "2025-02-15T00:00:00Z"
 	}`
 
-	cache.Set(cache.Device, auth.CopilotTokenKey, "ghp_test_token", cache.INFINITE)
+	cache.Device.Set(auth.CopilotTokenKey, "ghp_test_token", cache.INFINITE)
 	env.On("HTTPRequest", copilotTestURL).Return([]byte(jsonResponse), nil)
 
 	c := &Copilot{}

--- a/src/segments/dvc.go
+++ b/src/segments/dvc.go
@@ -43,7 +43,7 @@ func (d *Dvc) Enabled() bool {
 	}
 
 	statusFormats := d.options.KeyValueMap(StatusFormats, map[string]string{})
-	d.Status = &DvcStatus{ScmStatus: ScmStatus{Formats: statusFormats}}
+	d.Status = &DvcStatus{Formats: statusFormats}
 
 	output, err := d.env.RunCommand(d.command, "status", "--json")
 	if err != nil {

--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -1140,7 +1140,7 @@ func (g *Git) MainWorktree() string {
 
 		commonDir := g.commonGitDir()
 		key := fmt.Sprintf("%s@%s", mainWorktreeCacheKey, commonDir)
-		if mainWorktree, found := cache.Get[string](cache.Session, key); found {
+		if mainWorktree, found := cache.Session.Get[string](key); found {
 			g.mainWorktree = mainWorktree
 			return
 		}
@@ -1153,7 +1153,7 @@ func (g *Git) MainWorktree() string {
 		}
 
 		g.mainWorktree = g.convertToLinuxPath(mainWorktree)
-		cache.Set(cache.Session, key, g.mainWorktree, cache.INFINITE)
+		cache.Session.Set(key, g.mainWorktree, cache.INFINITE)
 	})
 
 	return g.mainWorktree

--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -770,8 +770,8 @@ func (g *Git) setStatus() {
 	g.UpstreamGone = true
 	statusFormats := g.options.KeyValueMap(StatusFormats, map[string]string{})
 
-	g.Working = &GitStatus{ScmStatus: ScmStatus{Formats: statusFormats}}
-	g.Staging = &GitStatus{ScmStatus: ScmStatus{Formats: statusFormats}}
+	g.Working = &GitStatus{Formats: statusFormats}
+	g.Staging = &GitStatus{Formats: statusFormats}
 
 	if g.options.Bool(NativeStatus, false) && g.setStatusNative() {
 		return
@@ -1190,8 +1190,8 @@ func (g *Git) ensureMainWorktreeContext() bool {
 
 func (g *Git) commonGitDir() string {
 	mainSCMDir := filepath.ToSlash(g.mainSCMDir)
-	if worktreeIndex := strings.LastIndex(mainSCMDir, "/worktrees/"); worktreeIndex > -1 {
-		return mainSCMDir[:worktreeIndex]
+	if commonDir, _, found := strings.CutLast(mainSCMDir, "/worktrees/"); found {
+		return commonDir
 	}
 
 	return filepath.ToSlash(g.scmDir)
@@ -1347,9 +1347,8 @@ func (g *Git) repoName() string {
 		return path.Base(g.convertToLinuxPath(g.repoRootDir))
 	}
 
-	ind := strings.LastIndex(g.mainSCMDir, ".git/worktrees")
-	if ind > -1 {
-		return path.Base(g.mainSCMDir[:ind])
+	if repoRoot, _, found := strings.CutLast(g.mainSCMDir, ".git/worktrees"); found {
+		return path.Base(repoRoot)
 	}
 
 	return ""

--- a/src/segments/git_test.go
+++ b/src/segments/git_test.go
@@ -695,9 +695,7 @@ func TestGetGitOutputForCommand(t *testing.T) {
 	env.On("GOOS").Return("unix")
 
 	g := &Git{
-		Scm: Scm{
-			command: GITCOMMAND,
-		},
+		command: GITCOMMAND,
 	}
 	g.Init(options.Map{}, env)
 
@@ -851,9 +849,7 @@ func TestSetGitHEADContextClean(t *testing.T) {
 		}
 
 		g := &Git{
-			Scm: Scm{
-				command: GITCOMMAND,
-			},
+			command:   GITCOMMAND,
 			ShortHash: "1234567",
 			Ref:       tc.Ref,
 		}
@@ -904,9 +900,7 @@ func TestSetPrettyHEADName(t *testing.T) {
 		}
 
 		g := &Git{
-			Scm: Scm{
-				command: GITCOMMAND,
-			},
+			command:   GITCOMMAND,
 			ShortHash: tc.ShortHash,
 		}
 		g.Init(props, env)
@@ -947,8 +941,8 @@ func TestSetGitStatus(t *testing.T) {
 			1 .U N...
 			1 A. N...
 			`,
-			ExpectedWorking:      &GitStatus{ScmStatus: ScmStatus{Modified: 4, Added: 2, Deleted: 1, Unmerged: 1}},
-			ExpectedStaging:      &GitStatus{ScmStatus: ScmStatus{Added: 1}},
+			ExpectedWorking:      &GitStatus{Modified: 4, Added: 2, Deleted: 1, Unmerged: 1},
+			ExpectedStaging:      &GitStatus{Added: 1},
 			ExpectedHash:         "1234567",
 			ExpectedRef:          "rework-git-status",
 			ExpectedUpstreamGone: true,
@@ -970,8 +964,8 @@ func TestSetGitStatus(t *testing.T) {
 			1 .U N...
 			1 A. N...
 			`,
-			ExpectedWorking:  &GitStatus{ScmStatus: ScmStatus{Modified: 4, Added: 2, Deleted: 1, Unmerged: 1}},
-			ExpectedStaging:  &GitStatus{ScmStatus: ScmStatus{Added: 1}},
+			ExpectedWorking:  &GitStatus{Modified: 4, Added: 2, Deleted: 1, Unmerged: 1},
+			ExpectedStaging:  &GitStatus{Added: 1},
 			ExpectedUpstream: "origin/rework-git-status",
 			ExpectedHash:     "1234567",
 			ExpectedRef:      "rework-git-status",
@@ -1016,7 +1010,7 @@ func TestSetGitStatus(t *testing.T) {
 			ExpectedUpstream: "origin/main",
 			ExpectedHash:     "1234567",
 			ExpectedRef:      "main",
-			ExpectedWorking:  &GitStatus{ScmStatus: ScmStatus{Untracked: 3}},
+			ExpectedWorking:  &GitStatus{Untracked: 3},
 		},
 		{
 			Case: "remote branch was deleted",
@@ -1044,7 +1038,7 @@ func TestSetGitStatus(t *testing.T) {
 			ExpectedHash:     "1234567",
 			ExpectedRef:      "rework-git-status",
 			Rebase:           true,
-			ExpectedStaging:  &GitStatus{ScmStatus: ScmStatus{Unmerged: 2}},
+			ExpectedStaging:  &GitStatus{Unmerged: 2},
 		},
 		{
 			Case: "merge with 4 merge conflicts",
@@ -1062,7 +1056,7 @@ func TestSetGitStatus(t *testing.T) {
 			ExpectedHash:     "1234567",
 			ExpectedRef:      "rework-git-status",
 			Merge:            true,
-			ExpectedStaging:  &GitStatus{ScmStatus: ScmStatus{Unmerged: 4}},
+			ExpectedStaging:  &GitStatus{Unmerged: 4},
 		},
 	}
 	for _, tc := range cases {
@@ -1072,9 +1066,7 @@ func TestSetGitStatus(t *testing.T) {
 		env.MockGitCommand("", strings.ReplaceAll(tc.Output, "\t", ""), "status", "-unormal", "--branch", "--porcelain=2")
 
 		g := &Git{
-			Scm: Scm{
-				command: GITCOMMAND,
-			},
+			command: GITCOMMAND,
 		}
 		g.Init(options.Map{}, env)
 
@@ -1119,9 +1111,7 @@ func TestGetStashContextZeroEntries(t *testing.T) {
 		env.On("FileContent", "/logs/refs/stash").Return(tc.StashContent)
 
 		g := &Git{
-			Scm: Scm{
-				mainSCMDir: "",
-			},
+			mainSCMDir: "",
 		}
 		g.Init(options.Map{}, env)
 
@@ -1200,10 +1190,8 @@ func TestGitUpstream(t *testing.T) {
 		}
 
 		g := &Git{
-			Scm: Scm{
-				command:  GITCOMMAND,
-				Upstream: "origin/main",
-			},
+			command:  GITCOMMAND,
+			Upstream: "origin/main",
 		}
 		g.Init(props, env)
 
@@ -1244,9 +1232,7 @@ func TestGetBranchStatus(t *testing.T) {
 		}
 
 		g := &Git{
-			Scm: Scm{
-				Upstream: tc.Upstream,
-			},
+			Upstream:     tc.Upstream,
 			Ahead:        tc.Ahead,
 			Behind:       tc.Behind,
 			UpstreamGone: tc.UpstreamGone,
@@ -1281,10 +1267,8 @@ func TestGitTemplateString(t *testing.T) {
 			Git: &Git{
 				HEAD: branchName,
 				Working: &GitStatus{
-					ScmStatus: ScmStatus{
-						Added:    2,
-						Modified: 3,
-					},
+					Added:    2,
+					Modified: 3,
 				},
 			},
 		},
@@ -1304,16 +1288,12 @@ func TestGitTemplateString(t *testing.T) {
 			Git: &Git{
 				HEAD: branchName,
 				Working: &GitStatus{
-					ScmStatus: ScmStatus{
-						Added:    2,
-						Modified: 3,
-					},
+					Added:    2,
+					Modified: 3,
 				},
 				Staging: &GitStatus{
-					ScmStatus: ScmStatus{
-						Added:    5,
-						Modified: 1,
-					},
+					Added:    5,
+					Modified: 1,
 				},
 			},
 		},
@@ -1324,16 +1304,12 @@ func TestGitTemplateString(t *testing.T) {
 			Git: &Git{
 				HEAD: branchName,
 				Working: &GitStatus{
-					ScmStatus: ScmStatus{
-						Added:    2,
-						Modified: 3,
-					},
+					Added:    2,
+					Modified: 3,
 				},
 				Staging: &GitStatus{
-					ScmStatus: ScmStatus{
-						Added:    5,
-						Modified: 1,
-					},
+					Added:    5,
+					Modified: 1,
 				},
 			},
 		},
@@ -1344,16 +1320,12 @@ func TestGitTemplateString(t *testing.T) {
 			Git: &Git{
 				HEAD: branchName,
 				Working: &GitStatus{
-					ScmStatus: ScmStatus{
-						Added:    2,
-						Modified: 3,
-					},
+					Added:    2,
+					Modified: 3,
 				},
 				Staging: &GitStatus{
-					ScmStatus: ScmStatus{
-						Added:    5,
-						Modified: 1,
-					},
+					Added:    5,
+					Modified: 1,
 				},
 				stashCount: 3,
 				poshgit:    true,
@@ -1433,9 +1405,7 @@ func TestGitUntrackedMode(t *testing.T) {
 		}
 
 		g := &Git{
-			Scm: Scm{
-				repoRootDir: "foo",
-			},
+			repoRootDir: "foo",
 		}
 		g.Init(props, new(mock.Environment))
 
@@ -1478,9 +1448,7 @@ func TestGitIgnoreSubmodules(t *testing.T) {
 		}
 
 		g := &Git{
-			Scm: Scm{
-				repoRootDir: "foo",
-			},
+			repoRootDir: "foo",
 		}
 		g.Init(props, new(mock.Environment))
 
@@ -1610,9 +1578,7 @@ func TestGitCommit(t *testing.T) {
 		env.MockGitCommand("", tc.Output, "log", "-1", "--pretty=format:an:%an%nae:%ae%ncn:%cn%nce:%ce%nat:%at%nsu:%s%nha:%H%nrf:%D", "--decorate=full")
 
 		g := &Git{
-			Scm: Scm{
-				command: GITCOMMAND,
-			},
+			command: GITCOMMAND,
 		}
 		g.Init(options.Map{}, env)
 
@@ -1693,9 +1659,7 @@ func TestGitRemotes(t *testing.T) {
 		env := new(mock.Environment)
 
 		g := &Git{
-			Scm: Scm{
-				repoRootDir: "foo",
-			},
+			repoRootDir: "foo",
 		}
 		g.Init(options.Map{}, env)
 
@@ -1750,11 +1714,9 @@ func TestGitRepoName(t *testing.T) {
 		env.On("GOOS").Return(runtime.LINUX)
 
 		g := &Git{
-			Scm: Scm{
-				repoRootDir: tc.RealDir,
-				mainSCMDir:  tc.WorkingDir,
-			},
-			IsWorkTree: tc.IsWorkTree,
+			repoRootDir: tc.RealDir,
+			mainSCMDir:  tc.WorkingDir,
+			IsWorkTree:  tc.IsWorkTree,
 		}
 		g.Init(options.Map{}, env)
 
@@ -1869,12 +1831,10 @@ func TestGitMainWorktree(t *testing.T) {
 			}
 
 			g := &Git{
-				Scm: Scm{
-					command:     GITCOMMAND,
-					repoRootDir: "/repo/linked",
-					scmDir:      commonDir,
-				},
-				IsWorkTree: tc.Linked,
+				command:     GITCOMMAND,
+				repoRootDir: "/repo/linked",
+				scmDir:      commonDir,
+				IsWorkTree:  tc.Linked,
 			}
 			g.Init(options.Map{}, env)
 
@@ -1967,13 +1927,11 @@ func TestGitMainWorktreeConvertsWSLPath(t *testing.T) {
 	env.On("ConvertToLinuxPath").Return(linuxPath).Once()
 
 	g := &Git{
-		Scm: Scm{
-			command:         "git.exe",
-			repoRootDir:     linkedWorktree,
-			mainSCMDir:      commonDir + "/worktrees/linked",
-			IsWslSharedPath: true,
-		},
-		IsWorkTree: true,
+		command:         "git.exe",
+		repoRootDir:     linkedWorktree,
+		mainSCMDir:      commonDir + "/worktrees/linked",
+		IsWslSharedPath: true,
+		IsWorkTree:      true,
 	}
 	g.Init(options.Map{}, env)
 
@@ -2019,10 +1977,8 @@ func TestGitMainWorktreeFromWindowsGitInWSL(t *testing.T) {
 	env.On("ConvertToLinuxPath").Return(linuxMain).Once()
 
 	g := &Git{
-		Scm: Scm{
-			command:         "git.exe",
-			IsWslSharedPath: true,
-		},
+		command:         "git.exe",
+		IsWslSharedPath: true,
 	}
 	g.Init(options.Map{}, env)
 
@@ -2036,14 +1992,12 @@ func TestGitMainWorktreeFromWindowsGitInWSL(t *testing.T) {
 func TestGitMainWorktreeIsLazy(t *testing.T) {
 	env := new(mock.Environment)
 	g := &Git{
-		Working: &GitStatus{},
-		Staging: &GitStatus{},
-		Scm: Scm{
-			command:     GITCOMMAND,
-			repoRootDir: "/repo/linked",
-			scmDir:      "/repo/.git",
-		},
-		IsWorkTree: true,
+		Working:     &GitStatus{},
+		Staging:     &GitStatus{},
+		command:     GITCOMMAND,
+		repoRootDir: "/repo/linked",
+		scmDir:      "/repo/.git",
+		IsWorkTree:  true,
 	}
 	g.Init(options.Map{}, env)
 
@@ -2194,13 +2148,11 @@ func TestPushStatusAheadAndBehind(t *testing.T) {
 		env.On("FileContent", "/dir/.git/config").Return("")
 
 		g := &Git{
-			Scm: Scm{
-				command:     "git",
-				repoRootDir: "/dir",
-				scmDir:      "/dir/.git",
-				Upstream:    "origin/main",
-			},
-			Ref: "main",
+			command:     "git",
+			repoRootDir: "/dir",
+			scmDir:      "/dir/.git",
+			Upstream:    "origin/main",
+			Ref:         "main",
 		}
 
 		props := options.Map{
@@ -2269,7 +2221,7 @@ func TestSetStatusNative(t *testing.T) {
 	env := new(mock.Environment)
 	env.MockGitCommand(repoRoot, porcelain, "status", "-unormal", "--branch", "--porcelain=2")
 
-	gExec := &Git{Scm: Scm{command: GITCOMMAND, repoRootDir: repoRoot}}
+	gExec := &Git{command: GITCOMMAND, repoRootDir: repoRoot}
 	gExec.Init(options.Map{}, env)
 	gExec.setStatus()
 
@@ -2277,11 +2229,10 @@ func TestSetStatusNative(t *testing.T) {
 	// accidental exec fallback would either panic on an unmet expectation
 	// or, since Scm.command is unset here, silently return empty output —
 	// either way the sanity check below would catch it.
-	gNative := &Git{Scm: Scm{
+	gNative := &Git{
 		mainSCMDir:  worktreeGitDir,
 		scmDir:      commonGitDir,
-		repoRootDir: repoRoot,
-	}}
+		repoRootDir: repoRoot}
 	gNative.Init(options.Map{NativeStatus: true}, new(mock.Environment))
 	gNative.setStatus()
 

--- a/src/segments/git_test.go
+++ b/src/segments/git_test.go
@@ -1813,9 +1813,9 @@ func TestGitMainWorktree(t *testing.T) {
 		t.Run(tc.Case, func(t *testing.T) {
 			commonDir := fmt.Sprintf("/repo/%d/.git", index)
 			key := fmt.Sprintf("%s@%s", mainWorktreeCacheKey, commonDir)
-			cache.Delete(cache.Session, key)
+			cache.Session.Delete(key)
 			t.Cleanup(func() {
-				cache.Delete(cache.Session, key)
+				cache.Session.Delete(key)
 			})
 
 			env := new(mock.Environment)
@@ -1855,9 +1855,9 @@ func TestGitMainWorktreeSessionCache(t *testing.T) {
 	)
 
 	key := fmt.Sprintf("%s@%s", mainWorktreeCacheKey, commonDir)
-	cache.Delete(cache.Session, key)
+	cache.Session.Delete(key)
 	t.Cleanup(func() {
-		cache.Delete(cache.Session, key)
+		cache.Session.Delete(key)
 	})
 
 	firstEnv := new(mock.Environment)
@@ -1911,9 +1911,9 @@ func TestGitMainWorktreeConvertsWSLPath(t *testing.T) {
 	)
 
 	key := fmt.Sprintf("%s@%s", mainWorktreeCacheKey, commonDir)
-	cache.Delete(cache.Session, key)
+	cache.Session.Delete(key)
 	t.Cleanup(func() {
-		cache.Delete(cache.Session, key)
+		cache.Session.Delete(key)
 	})
 
 	env := new(mock.Environment)
@@ -1951,9 +1951,9 @@ func TestGitMainWorktreeFromWindowsGitInWSL(t *testing.T) {
 	)
 
 	key := fmt.Sprintf("%s@%s", mainWorktreeCacheKey, linuxCommonDir)
-	cache.Delete(cache.Session, key)
+	cache.Session.Delete(key)
 	t.Cleanup(func() {
-		cache.Delete(cache.Session, key)
+		cache.Session.Delete(key)
 	})
 
 	env := new(mock.Environment)

--- a/src/segments/golang_test.go
+++ b/src/segments/golang_test.go
@@ -24,7 +24,7 @@ func TestGolang(t *testing.T) {
 	}{
 		{Case: "Go 1.15", ExpectedString: "1.15.8", Version: "go version go1.15.8 darwin/amd64"},
 		{Case: "Go 1.16", ExpectedString: "1.16", Version: "go version go1.16 darwin/amd64"},
-		{Case: "go.mod 1.26.0", ParseModFile: true, HasModFileInParentDir: true, ExpectedString: "1.26.0"},
+		{Case: "go.mod 1.27.0", ParseModFile: true, HasModFileInParentDir: true, ExpectedString: "1.27.0"},
 		{Case: "no go.mod file fallback", ParseModFile: true, ExpectedString: "1.16", Version: "go version go1.16 darwin/amd64"},
 		{
 			Case:                  "invalid go.mod file fallback",
@@ -49,7 +49,7 @@ func TestGolang(t *testing.T) {
 			HasModFileInParentDir:    true,
 			ParseGoWorkFile:          true,
 			HasGoWorkFileInParentDir: true,
-			ExpectedString:           "1.26.0",
+			ExpectedString:           "1.27.0",
 		},
 		{
 			Case:            "missing both go.mod and go.work file fallback",

--- a/src/segments/http_test.go
+++ b/src/segments/http_test.go
@@ -98,10 +98,8 @@ func TestHTTPSegmentEnabled(t *testing.T) {
 			capturing := &timeoutCapturingEnv{Environment: inner}
 
 			cs := &HTTP{
-				Base: Base{
-					env:     capturing,
-					options: props,
-				},
+				env:     capturing,
+				options: props,
 			}
 
 			_ = cs.Enabled()
@@ -119,11 +117,9 @@ func TestHTTPSegmentCache(t *testing.T) {
 
 	// Create and populate HTTP segment
 	original := &HTTP{
-		Base: Base{
-			Segment: &Segment{
-				Text:  " Electron: v39.2.6 ",
-				Index: 1,
-			},
+		Segment: &Segment{
+			Text:  " Electron: v39.2.6 ",
+			Index: 1,
 		},
 	}
 
@@ -138,9 +134,7 @@ func TestHTTPSegmentCache(t *testing.T) {
 
 	// Unmarshal back (like restoreCache does)
 	restored := &HTTP{
-		Base: Base{
-			Segment: &Segment{},
-		},
+		Segment: &Segment{},
 	}
 
 	err = json.Unmarshal(data, restored)

--- a/src/segments/ipify.go
+++ b/src/segments/ipify.go
@@ -22,7 +22,7 @@ type ipAPI struct {
 
 func (i *ipAPI) Get() (*ipData, error) {
 	url := "https://api.ipify.org?format=json"
-	return http.Do[*ipData](&i.Request, url, nil)
+	return i.Do[*ipData](url, nil)
 }
 
 type IPify struct {
@@ -43,7 +43,7 @@ func (i *IPify) Template() string {
 func (i *IPify) Enabled() bool {
 	const key = "IP"
 
-	if ip, ok := cache.Get[string](cache.Device, key); ok {
+	if ip, ok := cache.Device.Get[string](key); ok {
 		i.IP = ip
 		return true
 	}
@@ -58,7 +58,7 @@ func (i *IPify) Enabled() bool {
 	i.IP = ip
 
 	duration := i.options.String(options.CacheDuration, string(cache.ONEDAY))
-	cache.Set(cache.Device, key, i.IP, cache.Duration(duration))
+	cache.Device.Set(key, i.IP, cache.Duration(duration))
 
 	return true
 }

--- a/src/segments/ipify_test.go
+++ b/src/segments/ipify_test.go
@@ -62,7 +62,7 @@ func TestIpifySegment(t *testing.T) {
 		enabled := ipify.Enabled()
 		assert.Equal(t, tc.ExpectedEnabled, enabled, tc.Case)
 
-		cache.DeleteAll(cache.Device)
+		cache.Device.DeleteAll()
 
 		if !enabled {
 			continue

--- a/src/segments/ipify_test.go
+++ b/src/segments/ipify_test.go
@@ -54,11 +54,9 @@ func TestIpifySegment(t *testing.T) {
 		api.On("Get").Return(tc.IPDate, tc.Error)
 
 		ipify := &IPify{
-			api: api,
-			Base: Base{
-				env:     &mock.Environment{},
-				options: options.Map{},
-			},
+			api:     api,
+			env:     &mock.Environment{},
+			options: options.Map{},
 		}
 
 		enabled := ipify.Enabled()

--- a/src/segments/jujutsu.go
+++ b/src/segments/jujutsu.go
@@ -57,7 +57,7 @@ func (jj *Jujutsu) Enabled() bool {
 	}
 
 	statusFormats := jj.options.KeyValueMap(StatusFormats, map[string]string{})
-	jj.Working = &JujutsuStatus{ScmStatus: ScmStatus{Formats: statusFormats}}
+	jj.Working = &JujutsuStatus{Formats: statusFormats}
 
 	if displayStatus {
 		jj.setJujutsuStatus()

--- a/src/segments/language.go
+++ b/src/segments/language.go
@@ -254,7 +254,7 @@ func (l *Language) setVersion() error {
 
 	cacheKey := fmt.Sprintf("version_%s", l.name)
 
-	if versionCache, OK := cache.Get[Version](cache.Device, cacheKey); OK {
+	if versionCache, OK := cache.Device.Get[Version](cacheKey); OK {
 		l.Version = versionCache
 		return nil
 	}
@@ -283,7 +283,7 @@ func (l *Language) setVersion() error {
 		l.Executable = command.executable
 
 		duration := l.options.String(options.CacheDuration, string(cache.NONE))
-		cache.Set(cache.Device, cacheKey, l.Version, cache.Duration(duration))
+		cache.Device.Set(cacheKey, l.Version, cache.Duration(duration))
 
 		return nil
 	}

--- a/src/segments/mercurial.go
+++ b/src/segments/mercurial.go
@@ -52,7 +52,7 @@ func (hg *Mercurial) Enabled() bool {
 	}
 
 	statusFormats := hg.options.KeyValueMap(StatusFormats, map[string]string{})
-	hg.Working = &MercurialStatus{ScmStatus: ScmStatus{Formats: statusFormats}}
+	hg.Working = &MercurialStatus{Formats: statusFormats}
 
 	displayStatus := hg.options.Bool(FetchStatus, false)
 	if displayStatus {

--- a/src/segments/node_test.go
+++ b/src/segments/node_test.go
@@ -41,9 +41,7 @@ func TestNodeMatchesVersionFile(t *testing.T) {
 		env.On("FileContent", ".nvmrc").Return(tc.RCVersion)
 
 		node := &Node{
-			Language: Language{
-				Version: nodeVersion,
-			},
+			Version: nodeVersion,
 		}
 		node.Init(options.Map{}, env)
 

--- a/src/segments/os_test.go
+++ b/src/segments/os_test.go
@@ -105,9 +105,7 @@ func TestOSInfo(t *testing.T) {
 		osInfo.Init(props, env)
 
 		template.Cache = &cache.Template{
-			SimpleTemplate: cache.SimpleTemplate{
-				WSL: tc.IsWSL,
-			},
+			WSL: tc.IsWSL,
 		}
 
 		_ = osInfo.Enabled()

--- a/src/segments/path_test.go
+++ b/src/segments/path_test.go
@@ -357,9 +357,7 @@ func TestGetFolderSeparator(t *testing.T) {
 		env.On("Shell").Return(shell.GENERIC)
 
 		template.Cache = &cache.Template{
-			SimpleTemplate: cache.SimpleTemplate{
-				Shell: "bash",
-			},
+			Shell: "bash",
 		}
 		template.Init(env, nil, nil)
 
@@ -644,13 +642,11 @@ func TestAgnosterMaxWidth(t *testing.T) {
 			env.On("Shell").Return(shell.BASH)
 
 			path := &Path{
-				Base: Base{
-					env: env,
-					options: options.Map{
-						DisplayRoot:         tc.displayRoot,
-						FolderIcon:          tc.folderIcon,
-						FolderSeparatorIcon: tc.separator,
-					},
+				env: env,
+				options: options.Map{
+					DisplayRoot:         tc.displayRoot,
+					FolderIcon:          tc.folderIcon,
+					FolderSeparatorIcon: tc.separator,
 				},
 				pathSeparator: tc.separator,
 			}
@@ -837,12 +833,10 @@ func TestFishPath(t *testing.T) {
 			env.On("Shell").Return(shell.BASH)
 
 			path := &Path{
-				Base: Base{
-					env: env,
-					options: options.Map{
-						DirLength:      tc.dirLength,
-						FullLengthDirs: tc.fullLengthDirs,
-					},
+				env: env,
+				options: options.Map{
+					DirLength:      tc.dirLength,
+					FullLengthDirs: tc.fullLengthDirs,
 				},
 				pathSeparator: tc.separator,
 			}

--- a/src/segments/plastic.go
+++ b/src/segments/plastic.go
@@ -79,7 +79,7 @@ func (p *Plastic) setPlasticStatus() {
 	p.Behind = headChangeset > currentChangeset
 
 	statusFormats := p.options.KeyValueMap(StatusFormats, map[string]string{})
-	p.Status = &PlasticStatus{ScmStatus: ScmStatus{Formats: statusFormats}}
+	p.Status = &PlasticStatus{Formats: statusFormats}
 
 	// parse file state
 	p.MergePending = false

--- a/src/segments/plastic_test.go
+++ b/src/segments/plastic_test.go
@@ -265,13 +265,11 @@ func TestPlasticParseSmartbranchSelector(t *testing.T) {
 func TestPlasticStatus(t *testing.T) {
 	p := &Plastic{
 		Status: &PlasticStatus{
-			ScmStatus: ScmStatus{
-				Added:    1,
-				Modified: 2,
-				Deleted:  3,
-				Moved:    4,
-				Unmerged: 5,
-			},
+			Added:    1,
+			Modified: 2,
+			Deleted:  3,
+			Moved:    4,
+			Unmerged: 5,
 		},
 	}
 	status := p.Status.String()
@@ -302,12 +300,10 @@ func TestPlasticTemplateString(t *testing.T) {
 			Plastic: &Plastic{
 				Selector: "/main",
 				Status: &PlasticStatus{
-					ScmStatus: ScmStatus{
-						Added:    2,
-						Modified: 3,
-						Deleted:  1,
-						Moved:    4,
-					},
+					Added:    2,
+					Modified: 3,
+					Deleted:  1,
+					Moved:    4,
 				},
 			},
 		},

--- a/src/segments/posh_git_test.go
+++ b/src/segments/posh_git_test.go
@@ -196,9 +196,7 @@ func TestPoshGitSegment(t *testing.T) {
 		}
 
 		g := &Git{
-			Scm: Scm{
-				command: GITCOMMAND,
-			},
+			command: GITCOMMAND,
 		}
 		g.Init(props, env)
 

--- a/src/segments/sapling.go
+++ b/src/segments/sapling.go
@@ -115,7 +115,7 @@ func (sl *Sapling) setHeadContext() {
 	sl.setCommitContext()
 
 	statusFormats := sl.options.KeyValueMap(StatusFormats, map[string]string{})
-	sl.Working = &SaplingStatus{ScmStatus: ScmStatus{Formats: statusFormats}}
+	sl.Working = &SaplingStatus{Formats: statusFormats}
 
 	displayStatus := sl.options.Bool(FetchStatus, true)
 	if !displayStatus {

--- a/src/segments/sapling_test.go
+++ b/src/segments/sapling_test.go
@@ -91,9 +91,7 @@ func TestSetCommitContext(t *testing.T) {
 		env.On("RunCommand", "sl", []string{"log", "--limit", "1", "--template", SLCOMMITTEMPLATE}).Return(tc.Output, tc.Error)
 
 		sl := &Sapling{
-			Scm: Scm{
-				command: SAPLINGCOMMAND,
-			},
+			command: SAPLINGCOMMAND,
 		}
 		sl.Init(options.Map{}, env)
 
@@ -216,9 +214,7 @@ func TestSetHeadContext(t *testing.T) {
 		}
 
 		sl := &Sapling{
-			Scm: Scm{
-				command: SAPLINGCOMMAND,
-			},
+			command: SAPLINGCOMMAND,
 		}
 		sl.Init(props, env)
 

--- a/src/segments/session_test.go
+++ b/src/segments/session_test.go
@@ -119,11 +119,9 @@ func TestSessionSegmentTemplate(t *testing.T) {
 		session.Init(options.Map{}, env)
 
 		template.Cache = &cache.Template{
-			SimpleTemplate: cache.SimpleTemplate{
-				UserName: tc.UserName,
-				HostName: tc.ComputerName,
-				Root:     tc.Root,
-			},
+			UserName: tc.UserName,
+			HostName: tc.ComputerName,
+			Root:     tc.Root,
 		}
 
 		_ = session.Enabled()

--- a/src/segments/spotify_test.go
+++ b/src/segments/spotify_test.go
@@ -14,12 +14,10 @@ func TestSpotifyStringPlayingSong(t *testing.T) {
 	env := new(mock.Environment)
 
 	s := &Spotify{
-		MusicPlayer: MusicPlayer{
-			Artist: "Candlemass",
-			Track:  "Spellbreaker",
-			Status: "playing",
-			Icon:   "\ue602 ",
-		},
+		Artist: "Candlemass",
+		Track:  "Spellbreaker",
+		Status: "playing",
+		Icon:   "\ue602 ",
 	}
 	s.Init(options.Map{}, env)
 
@@ -31,12 +29,10 @@ func TestSpotifyStringStoppedSong(t *testing.T) {
 	env := new(mock.Environment)
 
 	s := &Spotify{
-		MusicPlayer: MusicPlayer{
-			Artist: "Candlemass",
-			Track:  "Spellbreaker",
-			Status: "stopped",
-			Icon:   "\uf04d ",
-		},
+		Artist: "Candlemass",
+		Track:  "Spellbreaker",
+		Status: "stopped",
+		Icon:   "\uf04d ",
 	}
 	s.Init(options.Map{}, env)
 

--- a/src/segments/status_test.go
+++ b/src/segments/status_test.go
@@ -35,9 +35,7 @@ func TestStatusWriterEnabled(t *testing.T) {
 		}
 
 		template.Cache = &cache.Template{
-			SimpleTemplate: cache.SimpleTemplate{
-				Code: 133,
-			},
+			Code: 133,
 		}
 		template.Init(env, nil, nil)
 
@@ -107,9 +105,7 @@ func TestFormatStatus(t *testing.T) {
 		s.Init(props, env)
 
 		template.Cache = &cache.Template{
-			SimpleTemplate: cache.SimpleTemplate{
-				Code: tc.Status,
-			},
+			Code: tc.Status,
 		}
 		template.Init(env, nil, nil)
 

--- a/src/segments/strava.go
+++ b/src/segments/strava.go
@@ -19,7 +19,7 @@ type stravaAPI struct {
 
 func (s *stravaAPI) GetActivities() ([]*StravaData, error) {
 	url := "https://www.strava.com/api/v3/athlete/activities?page=1&per_page=1"
-	return http.OauthResult[[]*StravaData](&s.OAuthRequest, url, nil)
+	return s.Result[[]*StravaData](url, nil)
 }
 
 type Strava struct {

--- a/src/segments/strava.go
+++ b/src/segments/strava.go
@@ -101,10 +101,8 @@ func (s *Strava) initAPI() {
 		SegmentName:     "strava",
 		AccessToken:     s.options.Template(options.AccessToken, "", s),
 		RefreshToken:    s.options.Template(options.RefreshToken, "", s),
-		Request: http.Request{
-			Env:         s.env,
-			HTTPTimeout: s.options.Int(options.HTTPTimeout, options.DefaultHTTPTimeout),
-		},
+		Env:             s.env,
+		HTTPTimeout:     s.options.Int(options.HTTPTimeout, options.DefaultHTTPTimeout),
 	}
 
 	s.api = &stravaAPI{

--- a/src/segments/svn.go
+++ b/src/segments/svn.go
@@ -106,7 +106,7 @@ func (s *Svn) setSvnStatus() {
 	}
 
 	statusFormats := s.options.KeyValueMap(StatusFormats, map[string]string{})
-	s.Working = &SvnStatus{ScmStatus: ScmStatus{Formats: statusFormats}}
+	s.Working = &SvnStatus{Formats: statusFormats}
 
 	displayStatus := s.options.Bool(FetchStatus, false)
 	if !displayStatus {

--- a/src/segments/svn_test.go
+++ b/src/segments/svn_test.go
@@ -63,15 +63,13 @@ func TestSvnTemplateString(t *testing.T) {
 				Branch:  "trunk",
 				BaseRev: 2,
 				Working: &SvnStatus{
-					ScmStatus: ScmStatus{
-						Untracked:  9,
-						Added:      2,
-						Conflicted: 1,
-						Deleted:    7,
-						Modified:   3,
-						Moved:      13,
-						Unmerged:   5,
-					},
+					Untracked:  9,
+					Added:      2,
+					Conflicted: 1,
+					Deleted:    7,
+					Modified:   3,
+					Moved:      13,
+					Unmerged:   5,
 				},
 			},
 		},
@@ -91,10 +89,8 @@ func TestSvnTemplateString(t *testing.T) {
 			Svn: &Svn{
 				Branch: "trunk",
 				Working: &SvnStatus{
-					ScmStatus: ScmStatus{
-						Added:    2,
-						Modified: 3,
-					},
+					Added:    2,
+					Modified: 3,
 				},
 			},
 		},
@@ -124,10 +120,8 @@ func TestSvnTemplateString(t *testing.T) {
 				Branch:  "trunk",
 				BaseRev: 2,
 				Working: &SvnStatus{
-					ScmStatus: ScmStatus{
-						Added:    2,
-						Modified: 3,
-					},
+					Added:    2,
+					Modified: 3,
 				},
 			},
 		},
@@ -139,11 +133,9 @@ func TestSvnTemplateString(t *testing.T) {
 				Branch:  "trunk",
 				BaseRev: 2,
 				Working: &SvnStatus{
-					ScmStatus: ScmStatus{
-						Added:      2,
-						Modified:   3,
-						Conflicted: 7,
-					},
+					Added:      2,
+					Modified:   3,
+					Conflicted: 7,
 				},
 			},
 		},
@@ -182,15 +174,14 @@ D       FileMarkedAs.Deleted
 M       Modified.File
 C       Conflicted.File
 R       Moved.File`,
-			ExpectedWorking: &SvnStatus{ScmStatus: ScmStatus{
+			ExpectedWorking: &SvnStatus{
 				Modified:   1,
 				Added:      1,
 				Deleted:    1,
 				Moved:      2,
 				Untracked:  1,
 				Conflicted: 1,
-				Formats:    map[string]string{},
-			}},
+				Formats:    map[string]string{}},
 			RefOutput:         "1133",
 			ExpectedRef:       1133,
 			BranchOutput:      "^/trunk",
@@ -201,21 +192,20 @@ R       Moved.File`,
 		{
 			Case:         "conflict",
 			StatusOutput: `C       build.cake`,
-			ExpectedWorking: &SvnStatus{ScmStatus: ScmStatus{
+			ExpectedWorking: &SvnStatus{
 				Conflicted: 1,
-				Formats:    map[string]string{},
-			}},
+				Formats:    map[string]string{}},
 			ExpectedChanged:   true,
 			ExpectedConflicts: true,
 		},
 		{
 			Case:            "no change",
-			ExpectedWorking: &SvnStatus{ScmStatus: ScmStatus{Formats: map[string]string{}}},
+			ExpectedWorking: &SvnStatus{Formats: map[string]string{}},
 			ExpectedChanged: false,
 		},
 		{
 			Case:            "not an integer ref",
-			ExpectedWorking: &SvnStatus{ScmStatus: ScmStatus{Formats: map[string]string{}}},
+			ExpectedWorking: &SvnStatus{Formats: map[string]string{}},
 			ExpectedChanged: false,
 			RefOutput:       "not an integer",
 		},
@@ -243,9 +233,7 @@ R       Moved.File`,
 		}
 
 		s := &Svn{
-			Scm: Scm{
-				command: SVNCOMMAND,
-			},
+			command: SVNCOMMAND,
 		}
 		s.Init(props, env)
 
@@ -293,9 +281,7 @@ func TestRepo(t *testing.T) {
 		env.On("RunCommand", "svn", []string{"info", "", "--show-item", "repos-root-url"}).Return(tc.Repo, nil)
 
 		s := &Svn{
-			Scm: Scm{
-				command: SVNCOMMAND,
-			},
+			command: SVNCOMMAND,
 		}
 		s.Init(options.Map{}, env)
 

--- a/src/segments/text_test.go
+++ b/src/segments/text_test.go
@@ -37,13 +37,11 @@ func TestTextSegment(t *testing.T) {
 		txt.Init(options.Map{}, env)
 
 		template.Cache = &cache.Template{
-			SimpleTemplate: cache.SimpleTemplate{
-				UserName: "Posh",
-				HostName: "MyHost",
-				Shell:    "terminal",
-				Root:     true,
-				Folder:   "posh",
-			},
+			UserName: "Posh",
+			HostName: "MyHost",
+			Shell:    "terminal",
+			Root:     true,
+			Folder:   "posh",
 		}
 
 		assert.Equal(t, tc.ExpectedString, renderTemplate(env, tc.Template, txt), tc.Case)

--- a/src/segments/unity.go
+++ b/src/segments/unity.go
@@ -86,11 +86,10 @@ const (
 )
 
 func (u *Unity) GetCSharpVersion() (version string, err error) {
-	lastDotIndex := strings.LastIndex(u.UnityVersion, ".")
-	if lastDotIndex == -1 {
+	shortUnityVersion, _, found := strings.CutLast(u.UnityVersion, ".")
+	if !found {
 		return "", errors.New("lastDotIndex")
 	}
-	shortUnityVersion := u.UnityVersion[0:lastDotIndex]
 
 	var csharpVersionsByUnityVersion = map[string]string{
 		"2017.1": csharp6,

--- a/src/segments/upgrade.go
+++ b/src/segments/upgrade.go
@@ -48,7 +48,7 @@ func (u *Upgrade) Enabled() bool {
 }
 
 func (u *Upgrade) upgradeCache() (*UpgradeCache, error) {
-	data, ok := cache.Get[*UpgradeCache](cache.Device, UPGRADECACHEKEY)
+	data, ok := cache.Device.Get[*UpgradeCache](UPGRADECACHEKEY)
 	if !ok {
 		return nil, errors.New("no cache data")
 	}
@@ -75,7 +75,7 @@ func (u *Upgrade) checkUpdate(current string) (*UpgradeCache, error) {
 		Current: current,
 	}
 
-	cache.Set(cache.Device, UPGRADECACHEKEY, cacheData, cache.Duration(duration))
+	cache.Device.Set(UPGRADECACHEKEY, cacheData, cache.Duration(duration))
 
 	return cacheData, nil
 }

--- a/src/segments/upgrade_test.go
+++ b/src/segments/upgrade_test.go
@@ -71,7 +71,7 @@ func TestUpgrade(t *testing.T) {
 				Latest:  tc.LatestVersion,
 				Current: tc.CachedVersion,
 			}
-			cache.Set(cache.Device, UPGRADECACHEKEY, data, cache.INFINITE)
+			cache.Device.Set(UPGRADECACHEKEY, data, cache.INFINITE)
 		}
 
 		build.Version = tc.CurrentVersion
@@ -83,6 +83,6 @@ func TestUpgrade(t *testing.T) {
 
 		assert.Equal(t, tc.ExpectedEnabled, enabled, tc.Case)
 
-		cache.DeleteAll(cache.Device)
+		cache.Device.DeleteAll()
 	}
 }

--- a/src/segments/withings.go
+++ b/src/segments/withings.go
@@ -179,10 +179,8 @@ func (w *Withings) initAPI() {
 		SegmentName:     "withings",
 		AccessToken:     w.options.Template(options.AccessToken, "", w),
 		RefreshToken:    w.options.Template(options.RefreshToken, "", w),
-		Request: http.Request{
-			Env:         w.env,
-			HTTPTimeout: w.options.Int(options.HTTPTimeout, options.DefaultHTTPTimeout),
-		},
+		Env:             w.env,
+		HTTPTimeout:     w.options.Int(options.HTTPTimeout, options.DefaultHTTPTimeout),
 	}
 
 	w.api = &withingsAPI{

--- a/src/segments/withings.go
+++ b/src/segments/withings.go
@@ -126,7 +126,7 @@ func (w *withingsAPI) getWithingsData(endpoint string, formData url.Values) (*Wi
 
 	body := strings.NewReader(formData.Encode())
 
-	data, err := http.OauthResult[*WithingsData](w.OAuthRequest, endpoint, body, modifiers)
+	data, err := w.Result[*WithingsData](endpoint, body, modifiers)
 	if data != nil && data.Status != 0 {
 		return nil, errors.New("Withings API error: " + strconv.Itoa(data.Status))
 	}

--- a/src/segments/ytm.go
+++ b/src/segments/ytm.go
@@ -46,7 +46,7 @@ type ytmdaStatusResponse struct {
 }
 
 func (y *Ytm) setStatus() error {
-	token, OK := cache.Get[string](cache.Device, auth.YTMDATOKEN)
+	token, OK := cache.Device.Get[string](auth.YTMDATOKEN)
 	if !OK || token == "" {
 		return errors.New("YTMDA token not found, please authenticate using `oh-my-posh auth ytmda`")
 	}

--- a/src/segments/ytm_test.go
+++ b/src/segments/ytm_test.go
@@ -84,7 +84,7 @@ func TestYTM(t *testing.T) {
 		env.On("HTTPRequest", ytmdaStatusURL).Return([]byte(tc.JSONResponse), tc.HTTPError)
 
 		if tc.HasToken {
-			cache.Set(cache.Device, auth.YTMDATOKEN, "test_token", cache.INFINITE)
+			cache.Device.Set(auth.YTMDATOKEN, "test_token", cache.INFINITE)
 		}
 
 		props := options.Map{
@@ -98,7 +98,7 @@ func TestYTM(t *testing.T) {
 		ytm.Init(props, env)
 
 		assert.Equal(t, tc.ExpectedEnabled, ytm.Enabled(), tc.Case)
-		cache.DeleteAll(cache.Device)
+		cache.Device.DeleteAll()
 
 		if !tc.ExpectedEnabled {
 			continue

--- a/src/shell/filesystem.go
+++ b/src/shell/filesystem.go
@@ -36,7 +36,7 @@ func hasScript(env runtime.Environment) (string, bool) {
 	}
 
 	// check if we have the same context
-	if val, _ := cache.Get[string](cache.Device, cacheKey(env.Flags())); val != cacheValue(env) {
+	if val, _ := cache.Device.Get[string](cacheKey(env.Flags())); val != cacheValue(env) {
 		log.Debug("script context has changed")
 		return "", false
 	}
@@ -124,7 +124,7 @@ func writeScript(env runtime.Environment, script string) (string, error) {
 	}
 
 	log.Debug("init script written successfully")
-	cache.Set(cache.Device, cacheKey(env.Flags()), cacheValue(env), cache.INFINITE)
+	cache.Device.Set(cacheKey(env.Flags()), cacheValue(env), cache.INFINITE)
 
 	return path, nil
 }
@@ -185,7 +185,7 @@ func scriptPath(env runtime.Environment) (string, error) {
 	const autoloadDir = "NUAUTOLOADDIR"
 	const fileName = "oh-my-posh.nu"
 
-	if dir, OK := cache.Get[string](cache.Device, autoloadDir); OK {
+	if dir, OK := cache.Device.Get[string](autoloadDir); OK {
 		scriptPathCache = filepath.Join(dir, fileName)
 		log.Debug("autoload path for nu from cache:", dir)
 		return scriptPathCache, nil
@@ -211,7 +211,7 @@ func scriptPath(env runtime.Environment) (string, error) {
 		return "", err
 	}
 
-	cache.Set(cache.Device, autoloadDir, autoloadPath, cache.INFINITE)
+	cache.Device.Set(autoloadDir, autoloadPath, cache.INFINITE)
 	scriptPathCache = filepath.Join(autoloadPath, fileName)
 	log.Debug("script path for nu:", scriptPathCache)
 	return scriptPathCache, nil

--- a/src/template/cache.go
+++ b/src/template/cache.go
@@ -147,7 +147,7 @@ func overlayEnvData(tmpl *cache.Template) {
 func restoreCache() bool {
 	defer log.Trace(time.Now())
 
-	val, OK := cache.Get[cache.SimpleTemplate](cache.Session, cache.TEMPLATECACHE)
+	val, OK := cache.Session.Get[cache.SimpleTemplate](cache.TEMPLATECACHE)
 	if !OK {
 		return false
 	}
@@ -169,5 +169,5 @@ func SaveCache() {
 
 	Cache.SegmentsCache = Cache.Segments.ToSimple()
 
-	cache.Set(cache.Session, cache.TEMPLATECACHE, &Cache.SimpleTemplate, cache.ONEDAY)
+	cache.Session.Set(cache.TEMPLATECACHE, &Cache.SimpleTemplate, cache.ONEDAY)
 }

--- a/src/template/locale.go
+++ b/src/template/locale.go
@@ -25,11 +25,11 @@ type localeCache interface {
 type deviceLocaleCache struct{}
 
 func (deviceLocaleCache) get(key string) (string, bool) {
-	return cache.Get[string](cache.Device, key)
+	return cache.Device.Get[string](key)
 }
 
 func (deviceLocaleCache) set(key, val string) {
-	cache.Set(cache.Device, key, val, cache.INFINITE)
+	cache.Device.Set(key, val, cache.INFINITE)
 }
 
 var (

--- a/src/template/text_test.go
+++ b/src/template/text_test.go
@@ -244,9 +244,7 @@ func TestRenderTemplateEnvVar(t *testing.T) {
 		}
 
 		Cache = &cache.Template{
-			SimpleTemplate: cache.SimpleTemplate{
-				OS: "darwin",
-			},
+			OS: "darwin",
 		}
 		Init(env, nil, nil)
 


### PR DESCRIPTION
### Description

This PR refactors the codebase to flatten embedded struct fields, removing unnecessary nesting and improving code clarity. The changes include:

**Cache API Changes:**
- Converted cache functions to methods on `Store` type (e.g., `cache.Get()` → `cache.Session.Get()`, `cache.Set()` → `cache.Device.Set()`)
- Updated `cache.Print()` to `Session.Print()` method
- Changed `cache.Refresh()` to `Store.Refresh()` method
- Updated `cache.DeleteAll()` to `Store.DeleteAll()` method

**Segment Struct Flattening:**
- Removed `Scm` embedded struct wrapper in Git, Sapling, and other SCM segments, promoting fields directly to parent struct
- Removed `Base` embedded struct wrapper in various segments (CopilotCLI, Antigravity, Claude, Argocd, HTTP, IPify, etc.), promoting `env` and `options` fields directly
- Removed `ScmStatus` embedded struct wrapper in status types (GitStatus, SvnStatus, PlasticStatus, etc.), promoting status fields directly
- Removed `MusicPlayer` embedded struct wrapper in Spotify segment
- Removed `SimpleTemplate` embedded struct wrapper in cache.Template

**Other Improvements:**
- Updated Go version from 1.26.0 to 1.27.0
- Replaced deprecated `strings.LastIndex()` with `strings.CutLast()` in ini.go and log.go
- Simplified HTTP request methods to use receiver methods instead of package functions
- Updated all test files to reflect the new flattened structure

### Test Plan

Existing unit tests have been updated to reflect the new struct layouts and API changes. All tests pass with the refactored code, confirming that the flattening maintains functional equivalence while improving code organization.

https://claude.ai/code/session_01F4pmtq5zxSxC4VqXipPAmY