### PR TITLE
chore(schema): add a missing segment type to enums

### DIFF
--- a/themes/schema.json
+++ b/themes/schema.json
@@ -456,6 +456,7 @@
             "julia",
             "kotlin",
             "kubectl",
+            "language",
             "lastfm",
             "lua",
             "mercurial",
@@ -5447,7 +5448,11 @@
     "pwd": {
       "anyOf": [
         {
-          "enum": ["osc99", "osc7", "osc51"]
+          "enum": [
+            "osc99",
+            "osc7",
+            "osc51"
+          ]
         },
         {
           "type": "string"


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

Add a missing segment type `language` to enums in the config schema.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary