### PR TITLE
style(website): align code blocks and SVG chrome on one window frame

### DIFF
--- a/.agents/skills/project-knowledge/references/codebase.md
+++ b/.agents/skills/project-knowledge/references/codebase.md
@@ -20,6 +20,21 @@
   `git config core.autocrlf false` for the duration of the rebase (restore it after), rather than
   trying to resolve a conflict that doesn't reflect the actual diff.
 
+## SVG renderer (src/svg)
+
+- The window chrome's "shadow" must be a filled silhouette rect offset +4/+4 behind the window
+  (`writeWindowChrome`, `shadowOffset`), never an `feDropShadow` filter (verified 2026-09-04).
+  A filter casts the silhouette of what is actually painted; the window's border rect is
+  `fill="none"`, so a filter shadows only the 1px stroke and no solid block appears on the
+  right/bottom. The CSS it mirrors is `box-shadow: 4px 4px 0 var(--omp-frame-shadow)` on
+  `.theme-code-block` in `website/src/css/custom.css` - a solid offset block, black-ish in
+  light mode, white in dark mode.
+- The canvas grows by exactly `shadowOffset` on the right/bottom so the silhouette is not
+  clipped by the viewBox; tests that count `<rect` elements must include the shadow rect.
+- After changing `src/svg/`, regenerate the website previews or the homepage/theme gallery stay
+  stale: build from `src/` (`go build -o ..\oh-my-posh.exe .`), then run
+  `node website/export_themes.mjs` with `OMP_BIN` pointing at that binary.
+
 ## Dev environment
 
 - The Go module root is `src/`, not the repo root - run all `go` commands from there.

--- a/src/svg/svg_test.go
+++ b/src/svg/svg_test.go
@@ -124,13 +124,14 @@ func TestEncodeSkipsZeroCellRuns(t *testing.T) {
 	assert.Contains(t, doc, `x="`+formatFloat(wantX)+`"`)
 
 	// One <rect> for each of the two visible runs, plus the window's own
-	// border rect (see writeWindowChrome; the header/content fills are now
-	// <path> elements, not <rect>s); one <text> for each of the two visible
-	// runs, plus the cursor, the watermark decorate always appends (see
-	// decorate), and the "−"/"▢"/"×" window-control glyphs the chrome draws
-	// (no title/tab-control text since those were dropped — see
+	// border rect and the shadow silhouette (see writeWindowChrome; the
+	// header/content fills are now <path> elements, not <rect>s); one
+	// <text> for each of the two visible runs, plus the cursor, the
+	// watermark decorate always appends (see decorate), and the
+	// "−"/"▢"/"×" window-control glyphs the chrome draws (no
+	// title/tab-control text since those were dropped — see
 	// writeWindowChrome's doc comment).
-	assert.Equal(t, 3, strings.Count(doc, "<rect"))
+	assert.Equal(t, 4, strings.Count(doc, "<rect"))
 	assert.Equal(t, 7, strings.Count(doc, "<text"))
 }
 
@@ -248,7 +249,9 @@ func TestEncodeCarriesForwardOnEmptySource(t *testing.T) {
 	red := hexString(color.RGB{R: 222, G: 56, B: 43})
 
 	assert.Equal(t, 2, strings.Count(doc, `fill="`+red+`"`))
-	assert.Equal(t, 2, strings.Count(doc, "<rect"))
+	// One <rect> for the run's own background, plus the window chrome's
+	// border rect and shadow silhouette (see writeWindowChrome).
+	assert.Equal(t, 3, strings.Count(doc, "<rect"))
 }
 
 // TestEncodeClearsBackgroundOnEmptySource ensures a separator-like run with no
@@ -264,7 +267,9 @@ func TestEncodeClearsBackgroundOnEmptySource(t *testing.T) {
 	doc := Encode(rows, testOptions())
 	decodeXML(t, doc)
 
-	assert.Equal(t, 2, strings.Count(doc, "<rect"))
+	// One <rect> for the first run's background, plus the window chrome's
+	// border rect and shadow silhouette (see writeWindowChrome).
+	assert.Equal(t, 3, strings.Count(doc, "<rect"))
 }
 
 // TestEncodeAttributes maps every Run.Attributes slot (see knownStyles'

--- a/src/svg/window.go
+++ b/src/svg/window.go
@@ -19,11 +19,12 @@ import (
 // proportions at this package's actual FontSize (16px by default) instead
 // of reproducing the PNG renderer's pixel values verbatim.
 //
-// The PNG renderer's own margin 96 and its stackblur drop shadow are gone.
-// The margin existed only to give that shadow somewhere to fall, and drawing
-// both meant every export carried a transparent gutter — 32px a side at the
-// default font size — that a caller then had to crop or lay out around. The
-// canvas is the window now, edge to edge.
+// The PNG renderer's own margin 96 is gone. Its stackblur drop shadow is
+// replaced with a hard offset silhouette (see shadowOffset) so the window
+// reads like the website's framed code blocks without carrying a transparent
+// gutter that a caller then had to crop or lay out around. The canvas grows
+// by exactly the shadow's offset on the right and bottom so the silhouette
+// is never clipped by the viewBox.
 //
 // The header's own controlSize/controlGap are new with the two-tone header
 // (see writeWindowChrome): unlike the retired PNG renderer's fixed macOS
@@ -41,15 +42,22 @@ type windowGeometry struct {
 }
 
 // minStrokeWidth is the floor writeWindowChrome's border stroke never
-// scales below: below the default FontSize (16, scale ~0.33) the plain
-// 2*scale formula drops under 1px - thin enough that anti-aliasing fades it
-// to near-nothing, which is what left the window's rounded corners barely
-// visible at every FontSize this package is actually used at (the website's
-// theme gallery and Studio preview both render at the default). 1px is
-// still crisp at FontSize 48's own scale=1 (2*1 > 1, so the clamp is a
-// no-op there and TestNewWindowGeometryScalesWithFontSize's pinned value of
-// 2 is untouched).
+// scales below. The website's framed code blocks draw every line — the
+// outer border and the title-bar divider alike — at 1px in
+// --omp-card-border-color (see custom.css's .theme-code-block), with the
+// bold right/bottom edge coming from the offset silhouette (shadowOffset),
+// not from a heavier stroke. The SVG window uses the same 1px weight so its
+// lines read as the same frame rather than a heavier lookalike.
 const minStrokeWidth = 1.0
+
+// shadowOffset mirrors the website's framed code blocks exactly: custom.css
+// gives them box-shadow 4px 4px 0, a solid silhouette of the whole box
+// shifted 4px right and down with no blur. writeWindowChrome reproduces that
+// as a filled rounded rect behind the window rather than an feDropShadow
+// filter — a filter casts the silhouette of what is actually painted, and
+// the window's border rect is fill="none", so a filter would shadow only the
+// 1px stroke instead of the solid block the CSS shadow produces.
+const shadowOffset = 4.0
 
 func newWindowGeometry(opts *Options) windowGeometry {
 	scale := opts.FontSize / 48.0
@@ -58,7 +66,7 @@ func newWindowGeometry(opts *Options) windowGeometry {
 		padding:     48 * scale,
 		titleOffset: 80 * scale,
 		corner:      12 * scale,
-		strokeWidth: max(2*scale, minStrokeWidth),
+		strokeWidth: max(scale, minStrokeWidth),
 	}
 
 	geo.controlSize = geo.titleOffset * 0.55
@@ -70,9 +78,10 @@ func newWindowGeometry(opts *Options) windowGeometry {
 // canvasSize is every box the window chrome and content grid need, computed
 // once from a row count and geometry: the window itself (the rounded rect
 // with the title bar and content inside it) and the content grid's own
-// top-left corner inside it. The window fills the canvas exactly, so the two
-// share an origin; windowX/windowY are kept rather than folded away because
-// every chrome coordinate is written relative to them.
+// top-left corner inside it. The window sits at the canvas origin; the
+// canvas itself is shadowOffset wider and taller than the window so the
+// hard offset silhouette (see shadowOffset) has room to paint on the right
+// and bottom instead of being clipped by the viewBox.
 type canvasSize struct {
 	width, height             float64 // the full <svg> canvas
 	windowX, windowY          float64
@@ -88,8 +97,8 @@ func newCanvasSize(geo *windowGeometry, columns int, cellWidth float64, rows int
 	windowHeight := contentHeight + 2*geo.padding + geo.titleOffset
 
 	return canvasSize{
-		width:  windowWidth,
-		height: windowHeight,
+		width:  windowWidth + shadowOffset,
+		height: windowHeight + shadowOffset,
 
 		windowX:      0,
 		windowY:      0,
@@ -104,8 +113,9 @@ func newCanvasSize(geo *windowGeometry, columns int, cellWidth float64, rows int
 // writeWindowChrome draws the terminal window itself: a header bar across
 // the top (the window's own rounded top corners) and the content pane below
 // it (the rounded bottom corners), each its own fill, plus the border
-// stroke and the "−"/"▢"/"×" minimize/maximize/close glyphs flush against
-// the header's right edge. No title text and no "+"/"⌄" tab controls: this
+// stroke, the header/content divider line (same color and weight, matching
+// the code blocks' title-bar border-bottom), and the "−"/"▢"/"×"
+// minimize/maximize/close glyphs flush against the header's right edge. No title text and no "+"/"⌄" tab controls: this
 // package tried a title/tab-strip row too (see the now-removed macOS
 // traffic-light and Windows Terminal tab-control chrome this replaced), but
 // a window this small never has real room for a title next to controls
@@ -132,6 +142,20 @@ func writeWindowChrome(b *strings.Builder, size canvasSize, geo *windowGeometry,
 	w, h, r := size.windowWidth, size.windowHeight, geo.corner
 
 	header := headerColor(contentFill)
+	border := windowBorderColor(contentFill)
+	borderOpacity := windowBorderOpacity(contentFill)
+	shadow := windowShadowColor(contentFill)
+	shadowOpacity := windowShadowOpacity(contentFill)
+
+	// The shadow is a filled silhouette of the whole window shifted
+	// shadowOffset right and down — see shadowOffset's doc comment on why
+	// this is a real rect and not an feDropShadow filter. Painted first so
+	// the window covers its left and top, leaving the solid block visible
+	// only on the right and bottom edges, exactly like the CSS box-shadow.
+	fmt.Fprintf(b, `<rect class="omp-window-shadow" x="%s" y="%s" width="%s" height="%s" rx="%s" `+
+		`fill="%s" fill-opacity="%s"/>`+"\n",
+		formatFloat(x0+shadowOffset), formatFloat(y0+shadowOffset), formatFloat(w), formatFloat(h),
+		formatFloat(r), hexString(shadow), formatFloat(shadowOpacity))
 
 	fmt.Fprintf(b, `<path class="omp-window-header" fill="%s" d="M %s,%s H %s A %s,%s 0 0 1 %s,%s `+
 		`V %s H %s V %s A %s,%s 0 0 1 %s,%s Z"/>`+"\n",
@@ -158,10 +182,18 @@ func writeWindowChrome(b *strings.Builder, size canvasSize, geo *windowGeometry,
 	// every edge instead of only the top/left ever reading as intended.
 	half := geo.strokeWidth / 2
 
+	// The header/content divider matches the code block's title bar, which
+	// carries border-bottom: 1px solid --omp-card-border-color — same color,
+	// same weight as the outer border.
+	fmt.Fprintf(b, `<line class="omp-window-divider" x1="%s" y1="%s" x2="%s" y2="%s" stroke="%s" `+
+		`stroke-width="%s" stroke-opacity="%s"/>`+"\n",
+		formatFloat(x0), formatFloat(y0+geo.titleOffset), formatFloat(x0+w), formatFloat(y0+geo.titleOffset),
+		hexString(border), formatFloat(geo.strokeWidth), formatFloat(borderOpacity))
+
 	fmt.Fprintf(b, `<rect class="omp-window" x="%s" y="%s" width="%s" height="%s" rx="%s" fill="none" `+
-		`stroke="#404040" stroke-width="%s"/>`+"\n",
+		`stroke="%s" stroke-width="%s" stroke-opacity="%s"/>`+"\n",
 		formatFloat(x0+half), formatFloat(y0+half), formatFloat(w-geo.strokeWidth), formatFloat(h-geo.strokeWidth),
-		formatFloat(r), formatFloat(geo.strokeWidth))
+		formatFloat(r), hexString(border), formatFloat(geo.strokeWidth), formatFloat(borderOpacity))
 
 	barMidY := y0 + geo.titleOffset/2
 	rightEdge := x0 + w
@@ -205,6 +237,43 @@ func controlColor(header color.RGB) color.RGB {
 	}
 
 	return defaultForegroundNearBlack
+}
+
+// windowBorderColor and windowBorderOpacity mirror the docs code blocks'
+// --omp-card-border-color exactly (custom.css): Infima's
+// --ifm-color-emphasis-300 (#dadde1) in light mode, rgba(255, 255, 255, 0.8)
+// in dark mode — the latter split into color and opacity so it composites
+// over the window fill the same way the CSS rgba value does.
+func windowBorderColor(bg color.RGB) color.RGB {
+	if luminance(bg) < 128 {
+		return color.RGB{R: 0xff, G: 0xff, B: 0xff}
+	}
+
+	return color.RGB{R: 0xda, G: 0xdd, B: 0xe1}
+}
+
+func windowBorderOpacity(bg color.RGB) float64 {
+	if luminance(bg) < 128 {
+		return 0.8
+	}
+
+	return 1
+}
+
+func windowShadowColor(bg color.RGB) color.RGB {
+	if luminance(bg) < 128 {
+		return color.RGB{R: 0xff, G: 0xff, B: 0xff}
+	}
+
+	return color.RGB{R: 0x0f, G: 0x17, B: 0x22}
+}
+
+func windowShadowOpacity(bg color.RGB) float64 {
+	if luminance(bg) < 128 {
+		return 0.72
+	}
+
+	return 0.82
 }
 
 // headerColor gives the header bar a shade related to bg but visually

--- a/src/svg/window_test.go
+++ b/src/svg/window_test.go
@@ -71,10 +71,11 @@ func TestEncodeColumnsScalesCanvasWidth(t *testing.T) {
 }
 
 // TestEncodeWindowChromeElements pins every distinct piece of window chrome:
-// the header bar path, the content pane path, the border rect (stroked,
-// unfilled), and the "−"/"▢"/"×" window-control glyphs in fixed left-to-right
-// order - no drop shadow, and so no filter to reference (see
-// windowGeometry's doc comment), and no title or "+"/"⌄" tab-control glyphs
+// the hard offset shadow silhouette that matches the website's framed code
+// blocks (a filled rect, not a filter — see shadowOffset's doc comment), the
+// header bar path, the content pane path, the border rect (stroked,
+// unfilled), and the "−"/"▢"/"×" window-control glyphs in fixed
+// left-to-right order. No title or "+"/"⌄" tab-control glyphs are present
 // (see writeWindowChrome's doc comment on why those were dropped).
 func TestEncodeWindowChromeElements(t *testing.T) {
 	rows := [][]terminal.Run{{contentRun("hi")}}
@@ -82,14 +83,23 @@ func TestEncodeWindowChromeElements(t *testing.T) {
 	doc := Encode(rows, testOptions())
 	decodeXML(t, doc)
 
+	assert.Contains(t, doc, `class="omp-window-shadow"`)
 	assert.Contains(t, doc, `class="omp-window-header"`)
 	assert.Contains(t, doc, `class="omp-window-content"`)
+	assert.Contains(t, doc, `class="omp-window-divider"`)
 	assert.Contains(t, doc, `class="omp-window" x="`)
 	assert.Contains(t, doc, `rx="`)
-	assert.Contains(t, doc, `stroke="#404040"`)
+	assert.Contains(t, doc, `stroke="#ffffff"`)
+	assert.Contains(t, doc, `stroke-width="1"`)
+	assert.Contains(t, doc, `stroke-opacity="0.8"`)
 	assert.Contains(t, doc, `fill="none"`)
 	assert.NotContains(t, doc, "<feDropShadow")
 	assert.NotContains(t, doc, "filter=")
+
+	// The shadow must be painted before the window it sits behind.
+	shadowIdx := strings.Index(doc, `class="omp-window-shadow"`)
+	windowIdx := strings.Index(doc, `class="omp-window" x="`)
+	assert.Less(t, shadowIdx, windowIdx, "the shadow silhouette must be painted before the window covering it")
 
 	assert.NotContains(t, doc, `class="omp-window-title"`)
 	assert.NotContains(t, doc, `class="omp-tab-control"`)
@@ -140,6 +150,23 @@ func TestEncodeWindowControlsStayLegibleOnLightHeader(t *testing.T) {
 
 	assert.Contains(t, doc, `fill="`+hexString(defaultForegroundNearBlack)+`" text-anchor="middle">`+"\u2212</text>")
 	assert.NotContains(t, doc, `fill="#cfcfcf"`)
+}
+
+func TestEncodeWindowBorderUsesThemeAwareStrokeAndShadow(t *testing.T) {
+	lightOpts := testOptions()
+	light := color.RGB{R: 0xf5, G: 0xf5, B: 0xf0}
+	lightOpts.CanvasBackground = &light
+	lightDoc := Encode([][]terminal.Run{{contentRun("hi")}}, lightOpts)
+	assert.Contains(t, lightDoc, `stroke="#dadde1"`)
+	assert.Contains(t, lightDoc, `class="omp-window-shadow"`)
+	assert.Contains(t, lightDoc, `fill="#0f1722"`)
+
+	darkOpts := testOptions()
+	dark := color.RGB{R: 0x0f, G: 0x17, B: 0x22}
+	darkOpts.CanvasBackground = &dark
+	darkDoc := Encode([][]terminal.Run{{contentRun("hi")}}, darkOpts)
+	assert.Contains(t, darkDoc, `stroke="#ffffff"`)
+	assert.Contains(t, darkDoc, `fill="#ffffff"`)
 }
 
 // TestEncodeWindowFillMatchesCanvasBackground pins Options.CanvasBackground's
@@ -193,8 +220,9 @@ func TestEncodeAppendsCursorAndWatermark(t *testing.T) {
 	assert.Contains(t, doc[textStart:watermarkIdx], `font-weight="bold"`)
 
 	// The cursor paints no rect of its own: exactly one <rect> for "hi"'s
-	// own background, plus the window's, none for the cursor.
-	assert.Equal(t, 2, strings.Count(doc, "<rect"))
+	// own background, plus the window's border rect and the shadow
+	// silhouette (see writeWindowChrome), none for the cursor.
+	assert.Equal(t, 3, strings.Count(doc, "<rect"))
 }
 
 // TestEncodeEmptyRowsStillGetsChromeAndDecoration pins that even a
@@ -211,9 +239,10 @@ func TestEncodeEmptyRowsStillGetsChromeAndDecoration(t *testing.T) {
 }
 
 // TestNewWindowGeometryScalesWithFontSize pins the FontSize/48 scaling the
-// task brief specifies: at FontSize 48 (the retired PNG renderer's own
-// reference em), padding/titleOffset/corner/strokeWidth equal the PNG
-// renderer's own pixel value verbatim.
+// task brief specifies: at FontSize 48, the window retains the reference
+// padding/titleOffset/corner ratios while the border stays at the website
+// code blocks' 1px (see minStrokeWidth) rather than the retired PNG
+// renderer's thicker 2px line.
 func TestNewWindowGeometryScalesWithFontSize(t *testing.T) {
 	opts := Options{FontSize: 48}
 	geo := newWindowGeometry(&opts)
@@ -221,7 +250,7 @@ func TestNewWindowGeometryScalesWithFontSize(t *testing.T) {
 	assert.InDelta(t, 48, geo.padding, 0.001)
 	assert.InDelta(t, 80, geo.titleOffset, 0.001)
 	assert.InDelta(t, 12, geo.corner, 0.001)
-	assert.InDelta(t, 2, geo.strokeWidth, 0.001)
+	assert.InDelta(t, 1, geo.strokeWidth, 0.001)
 	assert.InDelta(t, 80*0.55, geo.controlSize, 0.001)
 	assert.InDelta(t, 80*1.15, geo.controlGap, 0.001)
 
@@ -234,9 +263,10 @@ func TestNewWindowGeometryScalesWithFontSize(t *testing.T) {
 	assert.InDelta(t, geo.controlGap/2, geoHalf.controlGap, 0.001)
 }
 
-// TestNewCanvasSizeHasNoOuterMargin pins that the window fills the canvas
-// exactly: no transparent gutter on any side, which is what a caller
-// embedding the SVG gets to lay out against.
+// TestNewCanvasSizeHasNoOuterMargin pins that the window sits flush at the
+// canvas origin with no transparent gutter on the top or left, and that the
+// canvas grows by exactly shadowOffset on the right and bottom so the hard
+// offset silhouette (see shadowOffset) is never clipped by the viewBox.
 func TestNewCanvasSizeHasNoOuterMargin(t *testing.T) {
 	opts := Options{FontSize: 48}
 	geo := newWindowGeometry(&opts)
@@ -244,6 +274,6 @@ func TestNewCanvasSizeHasNoOuterMargin(t *testing.T) {
 
 	assert.Zero(t, size.windowX)
 	assert.Zero(t, size.windowY)
-	assert.InDelta(t, size.width, size.windowWidth, 0.001)
-	assert.InDelta(t, size.height, size.windowHeight, 0.001)
+	assert.InDelta(t, size.windowWidth+shadowOffset, size.width, 0.001)
+	assert.InDelta(t, size.windowHeight+shadowOffset, size.height, 0.001)
 }

--- a/website/docs/installation/customize.mdx
+++ b/website/docs/installation/customize.mdx
@@ -278,6 +278,6 @@ segments section covers how to configure each available segment.
 
 [configuration]: configuration/general.mdx
 [prompt]: prompt.mdx
-[jandedobbeleer]: /docs/themes#jandedobbeleer
+[jandedobbeleer]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/themes/jandedobbeleer.omp.json
 [sign]: https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_signing?view=powershell-7.5#methods-of-signing-scripts
 [transient prompt]: /docs/configuration/transient

--- a/website/docs/segments/system/vimode.mdx
+++ b/website/docs/segments/system/vimode.mdx
@@ -67,7 +67,7 @@ import Config from "@site/src/components/Config.js";
 | `.Keymap` | `string` | the raw mode value ([`$KEYMAP`][zsh-keymap] in ZSH, e.g. `main`, `viins`, `vicmd`, `visual`, `viopp`; `viins` or `vicmd` in PowerShell PSReadLine; `viins`, `vicmd`, `visual` or `replace` in fish) |
 
 [templates]: /docs/configuration/templates
-[cursor-style]: /docs/configuration/general#properties
+[cursor-style]: /docs/configuration/general#settings
 [zsh-vi-mode]: https://zsh.sourceforge.io/Doc/Release/Zsh-Line-Editor.html#Keymaps
 [zsh-keymap]: https://zsh.sourceforge.io/Doc/Release/Zsh-Line-Editor.html#index-KEYMAP
 [pwsh-vi-mode]: https://learn.microsoft.com/en-us/powershell/module/psreadline/set-psreadlineoption#-vimodechangehandler

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -26,8 +26,7 @@ export default {
     },
   ],
   stylesheets: [
-    "https://rsms.me/inter/inter.css",
-    "https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap"
+    "https://rsms.me/inter/inter.css"
   ],
   themeConfig: {
     metadata: [

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -51,12 +51,14 @@ export default {
       respectPrefersColorScheme: false,
     },
     prism: {
-      // Matches ConfigEditor's own DARK_CODE_THEME/LIGHT_CODE_THEME pair (see
-      // src/components/ConfigEditor/index.js) so every fenced code block in the docs follows
-      // the site's light/dark switch the same way the config editor does, instead of staying on
-      // one theme regardless of colour mode.
-      theme: prismThemes.github,
-      darkTheme: prismThemes.palenight,
+      // Matches ConfigEditor's own DARK_COLORS/LIGHT_COLORS pair (see
+      // src/components/ConfigEditor/editorTheme.js) so every fenced code block in the docs
+      // follows the site's light/dark switch the same way the config editor does, instead of
+      // staying on one theme regardless of colour mode. Night Owl: a blue-forward pair that
+      // sits close to the site's own palette while coloring far more token types than the
+      // previous github/palenight pair, which read flat inside the framed blocks.
+      theme: prismThemes.nightOwlLight,
+      darkTheme: prismThemes.nightOwl,
       additionalLanguages: ['powershell', 'lua', 'jsstacktrace', 'toml'],
     },
     docs: {

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -26,7 +26,8 @@ export default {
     },
   ],
   stylesheets: [
-    "https://rsms.me/inter/inter.css"
+    "https://rsms.me/inter/inter.css",
+    "https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap"
   ],
   themeConfig: {
     metadata: [

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -20,6 +20,7 @@
         "@docusaurus/core": "^3.10.2",
         "@docusaurus/preset-classic": "^3.10.2",
         "@docusaurus/theme-search-algolia": "^3.10.2",
+        "@fontsource/commit-mono": "^5.3.0",
         "@lezer/highlight": "^1.2.3",
         "@mdx-js/react": "^3.1.1",
         "classnames": "^2.5.1",
@@ -4236,6 +4237,15 @@
       "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@fontsource/commit-mono": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/commit-mono/-/commit-mono-5.3.0.tgz",
+      "integrity": "sha512-Bs+zlEWHDgk/cCVWEMJJaA7LbBU3Ixi5Zums+SSwMKdm2N7RJ4P7jCJTwsMHRt5WFiXYB0tu0q9HMfkn0YsLsQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",

--- a/website/package.json
+++ b/website/package.json
@@ -27,6 +27,7 @@
     "@docusaurus/core": "^3.10.2",
     "@docusaurus/preset-classic": "^3.10.2",
     "@docusaurus/theme-search-algolia": "^3.10.2",
+    "@fontsource/commit-mono": "^5.3.0",
     "@lezer/highlight": "^1.2.3",
     "@mdx-js/react": "^3.1.1",
     "classnames": "^2.5.1",

--- a/website/src/components/ConfigEditor/editorTheme.js
+++ b/website/src/components/ConfigEditor/editorTheme.js
@@ -1,32 +1,38 @@
 // The editor's colors, kept independent of the language extensions (editorExtensions.js) and
 // swapped into index.js's own theme Compartment whenever @docusaurus/theme-common's colorMode
-// flips - the same two palettes the old prism-react-renderer setup used (see the removed
-// DARK_CODE_THEME/LIGHT_CODE_THEME in index.js's git history: palenight for dark, github for
-// light), reproduced as a CodeMirror HighlightStyle/EditorView.theme pair so a doc's fenced code
-// (still prism-react-renderer, via @theme/CodeBlock) and this editor keep reading as the same
-// family even though the two no longer share a tokenizer.
+// flips - the same two palettes the docs' fenced code blocks use (docusaurus.config.js's
+// prism.theme/darkTheme: Night Owl Light for light, Night Owl for dark), reproduced as a
+// CodeMirror HighlightStyle/EditorView.theme pair so a doc's fenced code
+// (prism-react-renderer via @theme/CodeBlock) and this editor keep reading as the same
+// family even though the two do not share a tokenizer.
 import { EditorView } from '@codemirror/view';
 import { HighlightStyle, syntaxHighlighting } from '@codemirror/language';
 import { tags } from '@lezer/highlight';
 
+// Night Owl: prism-react-renderer's nightOwl values. Number and boolean differ there
+// (#f78c6c vs #ff5874); the editor's single literal role takes the number's color.
 const DARK_COLORS = {
-  background: '#292d3e',
-  foreground: '#bfc7d5',
-  property: '#c792ea',
-  string: '#c3e88d',
+  background: '#011627',
+  foreground: '#d6deeb',
+  keyword: '#7fdbca',
+  property: '#80cbc4',
+  string: '#addb67',
   literal: '#f78c6c',
-  comment: '#697098',
-  punctuation: '#89ddff',
+  comment: '#637777',
+  punctuation: '#c792ea',
 };
 
+// Night Owl Light: prism-react-renderer's nightOwlLight values. Number and boolean differ
+// there (#aa0982 vs #bc5454); the editor's single literal role takes the number's color.
 const LIGHT_COLORS = {
-  background: '#f6f8fa',
-  foreground: '#24292e',
-  property: '#005cc5',
-  string: '#032f62',
-  literal: '#005cc5',
-  comment: '#6a737d',
-  punctuation: '#24292e',
+  background: '#fbfbfb',
+  foreground: '#403f53',
+  keyword: '#0c969b',
+  property: '#0c969b',
+  string: '#4876d6',
+  literal: '#aa0982',
+  comment: '#989fb1',
+  punctuation: '#994cc3',
 };
 
 // Shared between both palettes: only the color values differ, not which tags map to which
@@ -38,7 +44,7 @@ function buildHighlightStyle(colors) {
     { tag: [tags.propertyName, tags.definition(tags.propertyName), tags.attributeName], color: colors.property },
     { tag: tags.string, color: colors.string },
     { tag: [tags.number, tags.bool, tags.null], color: colors.literal },
-    { tag: tags.keyword, color: colors.property },
+    { tag: tags.keyword, color: colors.keyword },
     { tag: tags.comment, color: colors.comment, fontStyle: 'italic' },
     { tag: tags.punctuation, color: colors.punctuation },
   ]);

--- a/website/src/components/ConfigEditor/index.js
+++ b/website/src/components/ConfigEditor/index.js
@@ -310,9 +310,9 @@ function ConfigEditor({
       </label>
       <div className={styles.editorWindow}>
         <div className={styles.editorChrome} aria-hidden="true">
-          <span className={styles.chromeDot} />
-          <span className={styles.chromeDot} />
-          <span className={styles.chromeDot} />
+          <span className={styles.chromeControl}>−</span>
+          <span className={styles.chromeControl}>□</span>
+          <span className={styles.chromeControl}>×</span>
         </div>
         <div className={styles.editorBody}>
           <div ref={hostRef} className={styles.editorHost} />

--- a/website/src/components/ConfigEditor/styles.module.css
+++ b/website/src/components/ConfigEditor/styles.module.css
@@ -70,6 +70,7 @@ ul.formatTabs li + li {
   border: 1px solid var(--omp-card-border-color);
   border-radius: var(--omp-card-radius);
   overflow: visible;
+  box-shadow: 4px 4px 0 var(--omp-frame-shadow);
 }
 
 .editorWindow:focus-within {
@@ -80,19 +81,27 @@ ul.formatTabs li + li {
    window - it has nothing to click and nothing to announce, hence aria-hidden in index.js. */
 .editorChrome {
   display: flex;
+  justify-content: flex-end;
   align-items: center;
-  gap: 0.35rem;
-  padding: var(--omp-space-1) var(--omp-space-2);
+  gap: 0.45rem;
+  min-height: 2.25rem;
+  padding: 0.7rem 0.9rem;
   background: var(--omp-card-background);
   border-bottom: 1px solid var(--omp-card-border-color);
   border-radius: var(--omp-card-radius) var(--omp-card-radius) 0 0;
 }
 
-.chromeDot {
-  width: 0.6rem;
-  height: 0.6rem;
-  border-radius: 50%;
-  background: var(--ifm-color-emphasis-300);
+.chromeControl {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0.9rem;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.75rem;
+  line-height: 1;
+  font-weight: 600;
+  color: var(--omp-text-secondary);
+  opacity: 0.9;
 }
 
 /* No position: relative needed here any more - CodeMirror's own gutter is a child of

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -1,4 +1,11 @@
 /* stylelint-disable docusaurus/copyright-header */
+/* Commit Mono is the site's body and code face. Self-hosted via Fontsource (it's not on
+   Google Fonts) so the site carries no third-party font request for it; only the latin
+   subsets of the four weights the design uses are bundled. */
+@import "@fontsource/commit-mono/latin-400.css";
+@import "@fontsource/commit-mono/latin-500.css";
+@import "@fontsource/commit-mono/latin-600.css";
+@import "@fontsource/commit-mono/latin-700.css";
 /**
  * Any CSS included here will be global. The classic template
  * bundles Infima by default. Infima is a CSS framework designed to
@@ -290,9 +297,9 @@ iframe.youtube {
 }
 
 :root {
-  --ifm-font-family-monospace: "JetBrains Mono", "Victor Mono", "Symbols Nerd Font Mono",
+  --ifm-font-family-monospace: "Commit Mono", "Victor Mono", "Symbols Nerd Font Mono",
     "Symbols Nerd Font", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  --ifm-font-family-base: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  --ifm-font-family-base: "Commit Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   --ifm-heading-font-weight: 600;
   --ifm-heading-line-height: 1.2;
 }

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -28,7 +28,7 @@
      unrelated scales. 14px was tried and read as too small; the ratios below are what
      matter and they are unchanged. */
   --ifm-font-size-base: 100%;
-  --ifm-pre-background: #232136;
+  --ifm-pre-background: var(--omp-card-background);
 }
 
 html[data-theme="dark"] {
@@ -39,6 +39,7 @@ html[data-theme="dark"] {
   --ifm-color-primary-light: #6eadf1;
   --ifm-color-primary-lighter: #7ab5f3;
   --ifm-color-primary-lightest: #a3cbf7;
+  --ifm-pre-background: var(--omp-card-background);
 }
 
 /* Card surface: the border/background/radius recipe shared by the homepage feature cards
@@ -48,15 +49,16 @@ html[data-theme="dark"] {
    segment catalog's) as the one true value going forward. The dark-mode override is the piece
    most likely to drift again if left duplicated, so it lives here once instead of per-page. */
 :root {
-  --omp-card-border-color: var(--ifm-color-emphasis-200);
+  --omp-card-border-color: var(--ifm-color-emphasis-300);
   --omp-card-background: var(--ifm-color-emphasis-100);
   --omp-card-radius: 8px;
-  --omp-frame-shadow: var(--ifm-color-emphasis-400);
+  --omp-frame-shadow: rgba(15, 23, 34, 0.82);
 }
 
 html[data-theme="dark"] {
+  --omp-card-border-color: rgba(255, 255, 255, 0.8);
   --omp-card-background: var(--ifm-background-surface-color);
-  --omp-frame-shadow: var(--ifm-color-emphasis-900);
+  --omp-frame-shadow: rgba(255, 255, 255, 0.72);
 }
 
 /* Shared "show only the render matching the reader's light/dark toggle" pair - any component
@@ -95,6 +97,9 @@ html[data-theme="dark"] .omp-dark-only.omp-dark-only {
   --omp-text-body: 1rem;
   --omp-label-size: 0.8rem;
   --omp-label-tracking: 0.12em;
+  --omp-window-title-size: 0.75rem;
+  --omp-window-title-tracking: 0.14em;
+  --omp-window-title-weight: 600;
   --omp-text-secondary: var(--ifm-color-emphasis-700);
   --omp-radius-sm: 4px;
   --omp-space-1: 0.375rem;
@@ -341,30 +346,159 @@ pre[class*="language-"] {
    the treatment in the site's own blue and purple palette while applying it to Docusaurus's
    generated code block wrappers. */
 .theme-code-block {
+  position: relative;
   overflow: hidden;
-  border: 1px solid var(--omp-card-border-color);
-  border-radius: var(--omp-card-radius);
-  box-shadow: 3px 3px 0 var(--omp-frame-shadow);
+  border: 1px solid var(--omp-card-border-color) !important;
+  border-radius: var(--omp-card-radius) !important;
+  box-shadow: 4px 4px 0 var(--omp-frame-shadow) !important;
+  background: var(--omp-card-background) !important;
+}
+
+html[data-theme="dark"] .theme-code-block {
+  border-color: rgba(255, 255, 255, 0.8) !important;
+  box-shadow: 4px 4px 0 rgba(255, 255, 255, 0.72) !important;
+}
+
+/* The title bar height mirrors the SVG window chrome's header (src/svg/window.go's
+   titleOffset: 80 units at the PNG renderer's 48px reference em, i.e. 26.7px at the website
+   previews' 16px font size, which render at natural size on desktop). The control glyphs'
+   vertical offset below centers them in that same bar height. */
+.theme-code-block::before {
+  content: "";
+  display: block;
+  height: 1.67rem;
+  background: var(--omp-card-background);
+  border-bottom: 1px solid var(--omp-card-border-color);
+}
+
+.theme-code-block:has(> [class*="codeBlockTitle"])::before {
+  display: none;
+}
+
+.theme-code-block::after {
+  content: "−\00a0\00a0□\00a0\00a0×";
+  position: absolute;
+  top: 0.45rem;
+  right: 0.82rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.78rem;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: 0.02em;
+  color: rgba(15, 23, 34, 0.7);
+  z-index: 1;
+}
+
+html[data-theme="dark"] .theme-code-block::after {
+  color: rgba(255, 255, 255, 0.85);
 }
 
 .theme-code-block [class*="codeBlockTitle"] {
-  padding: var(--omp-space-1) var(--omp-space-2);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.35rem;
+  padding: 0.45rem 0.9rem;
   border-bottom: 1px solid var(--omp-card-border-color);
   background: var(--omp-card-background);
   color: var(--omp-text-secondary);
   font-family: var(--ifm-font-family-monospace);
-  font-size: var(--omp-label-size);
-  font-weight: 500;
-  letter-spacing: var(--omp-label-tracking);
+  font-size: var(--omp-window-title-size);
+  font-weight: var(--omp-window-title-weight);
+  letter-spacing: var(--omp-window-title-tracking);
+  line-height: 1;
   text-transform: uppercase;
+  min-height: 1.67rem;
+}
+
+.theme-code-block [class*="codeBlockTitle"]::before {
+  content: "−\00a0\00a0□\00a0\00a0×";
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  margin-left: auto;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.78rem;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: 0.02em;
+  color: rgba(15, 23, 34, 0.7);
+}
+
+html[data-theme="dark"] .theme-code-block [class*="codeBlockTitle"]::before {
+  color: rgba(255, 255, 255, 0.85);
 }
 
 .theme-code-block [class*="codeBlockContent"] {
+  position: relative;
   border-radius: 0;
+  padding: 0.15rem 0;
+  background: var(--omp-card-background) !important;
+  border: 0 !important;
+  box-shadow: none !important;
+}
+
+.theme-code-block pre.prism-code,
+.theme-code-block pre.prism-code code,
+.theme-code-block code[class*="codeBlockLines"] {
+  background: var(--omp-card-background) !important;
+  border: 0 !important;
+  border-width: 0 !important;
+  box-shadow: none !important;
+}
+
+.theme-code-block pre.prism-code {
+  background-color: var(--omp-card-background) !important;
+}
+
+/* The copy/wrap buttons only appear while the block is hovered (or one of them has keyboard
+   focus, so tabbing still reaches them) - the framed window reads as a clean render until the
+   reader actually needs the actions. */
+.theme-code-block [class*="buttonGroup"] {
+  position: absolute;
+  top: 0.55rem;
+  right: 0.55rem;
+  z-index: 2;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.15s ease;
+}
+
+.theme-code-block:hover [class*="buttonGroup"],
+.theme-code-block:focus-within [class*="buttonGroup"] {
+  opacity: 1;
+  visibility: visible;
+}
+
+.theme-code-block [class*="buttonGroup"] button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  padding: 0.25rem;
+  border: 1px solid var(--omp-card-border-color);
+  border-radius: 0.35rem;
+  background: rgba(255, 255, 255, 0.28);
+  color: var(--omp-text-secondary);
+  opacity: 0.8;
+}
+
+html[data-theme="dark"] .theme-code-block [class*="buttonGroup"] button {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.theme-code-block [class*="buttonGroup"] button:hover,
+.theme-code-block [class*="buttonGroup"] button:focus-visible {
+  opacity: 1;
 }
 
 .theme-code-block pre {
   border-radius: 0;
+  padding: 0.9rem 0.95rem 1rem;
 }
 
 /* Tabs use the same title-bar rhythm as code blocks, with a blue active rule instead of a
@@ -381,9 +515,9 @@ pre[class*="language-"] {
   padding: var(--omp-space-1) var(--omp-space-2);
   color: var(--omp-text-secondary);
   font-family: var(--ifm-font-family-monospace);
-  font-size: var(--omp-label-size);
-  font-weight: 500;
-  letter-spacing: var(--omp-label-tracking);
+  font-size: var(--omp-window-title-size);
+  font-weight: var(--omp-window-title-weight);
+  letter-spacing: var(--omp-window-title-tracking);
   text-transform: uppercase;
 }
 
@@ -395,6 +529,13 @@ pre[class*="language-"] {
 .tabs__item--active {
   border-bottom-color: var(--ifm-color-primary);
   color: var(--ifm-color-primary);
+}
+
+.theme-code-block code:not([class*="language-"]) {
+  border: none !important;
+  border-radius: 0;
+  background: transparent !important;
+  padding: 0;
 }
 
 code:not([class*="language-"]) {

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -44,10 +44,12 @@ html[data-theme="dark"] {
   --omp-card-border-color: var(--ifm-color-emphasis-200);
   --omp-card-background: var(--ifm-color-emphasis-100);
   --omp-card-radius: 8px;
+  --omp-frame-shadow: var(--ifm-color-emphasis-400);
 }
 
 html[data-theme="dark"] {
   --omp-card-background: var(--ifm-background-surface-color);
+  --omp-frame-shadow: var(--ifm-color-emphasis-900);
 }
 
 /* Shared "show only the render matching the reader's light/dark toggle" pair - any component
@@ -288,9 +290,9 @@ iframe.youtube {
 }
 
 :root {
-  --ifm-font-family-monospace: "Victor Mono", "Symbols Nerd Font Mono",
+  --ifm-font-family-monospace: "JetBrains Mono", "Victor Mono", "Symbols Nerd Font Mono",
     "Symbols Nerd Font", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  --ifm-font-family-base: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --ifm-font-family-base: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   --ifm-heading-font-weight: 600;
   --ifm-heading-line-height: 1.2;
 }
@@ -326,6 +328,73 @@ pre[class*="language-"] {
   font-family: var(--ifm-font-family-monospace);
   font-variant-ligatures: none;
   font-feature-settings: "liga" 0, "calt" 0;
+}
+
+/* Hunk's code windows use a compact title bar, a strong outline and a small offset shadow. Keep
+   the treatment in the site's own blue and purple palette while applying it to Docusaurus's
+   generated code block wrappers. */
+.theme-code-block {
+  overflow: hidden;
+  border: 1px solid var(--omp-card-border-color);
+  border-radius: var(--omp-card-radius);
+  box-shadow: 3px 3px 0 var(--omp-frame-shadow);
+}
+
+.theme-code-block [class*="codeBlockTitle"] {
+  padding: var(--omp-space-1) var(--omp-space-2);
+  border-bottom: 1px solid var(--omp-card-border-color);
+  background: var(--omp-card-background);
+  color: var(--omp-text-secondary);
+  font-family: var(--ifm-font-family-monospace);
+  font-size: var(--omp-label-size);
+  font-weight: 500;
+  letter-spacing: var(--omp-label-tracking);
+  text-transform: uppercase;
+}
+
+.theme-code-block [class*="codeBlockContent"] {
+  border-radius: 0;
+}
+
+.theme-code-block pre {
+  border-radius: 0;
+}
+
+/* Tabs use the same title-bar rhythm as code blocks, with a blue active rule instead of a
+   separate pill for each item. */
+.tabs {
+  margin-bottom: var(--omp-space-2);
+  border-bottom: 1px solid var(--omp-card-border-color);
+  gap: 0;
+}
+
+.tabs__item {
+  border-bottom: 3px solid transparent;
+  border-radius: 0;
+  padding: var(--omp-space-1) var(--omp-space-2);
+  color: var(--omp-text-secondary);
+  font-family: var(--ifm-font-family-monospace);
+  font-size: var(--omp-label-size);
+  font-weight: 500;
+  letter-spacing: var(--omp-label-tracking);
+  text-transform: uppercase;
+}
+
+.tabs__item:hover {
+  background: var(--omp-card-background);
+  color: var(--ifm-color-primary);
+}
+
+.tabs__item--active {
+  border-bottom-color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary);
+}
+
+code:not([class*="language-"]) {
+  border: 1px solid var(--omp-card-border-color);
+  border-radius: var(--omp-radius-sm);
+  background: var(--omp-card-background);
+  padding: 0.1rem 0.3rem;
 }
 
 table {


### PR DESCRIPTION
## Summary

Unifies the docs code blocks, the config editor, and the SVG-rendered prompt windows (hero, theme gallery) on a single framed-window visual language, and refreshes the site's typography and syntax highlighting to match.

- **Code blocks**: framed window with right-aligned `− □ ×` controls, a title bar matched to the SVG header height (26.7px), a solid offset shadow (`4px 4px 0`) in theme-aware colors, flattened inner layers so code sits on the frame's own background, and copy/wrap buttons that only appear on hover or keyboard focus.
- **Config editor**: same chrome treatment — control glyphs instead of dots, right-aligned, same shadow.
- **SVG renderer** (`src/svg/window.go`): the "shadow" is now a filled silhouette rect offset +4/+4 behind the window, structurally identical to the CSS `box-shadow` (an `feDropShadow` filter can't reproduce it — a filter shadows only what's painted, and the border rect is `fill="none"`). Border is 1px in the code blocks' own color (`#dadde1` light, white at 0.8 dark), with a matching header/content divider line. The canvas grows by the shadow offset so the silhouette isn't clipped.
- **Font**: body and code switch from JetBrains Mono to Commit Mono, self-hosted via Fontsource (no third-party request). Victor Mono is untouched — still the SVG render font and Nerd Font fallback.
- **Syntax highlighting**: github/palenight → Night Owl Light/Night Owl, with the editor's CodeMirror palettes carrying the same colors.

## Validation

- `go test ./svg/...` — all pass (window chrome tests updated for the silhouette, divider, and theme-aware border)
- `npm run build` — succeeds; website previews regenerated (hero + 125 themes)
- Verified live in both light and dark mode against the reference screenshots

## Notes

The SVG renderer constants deliberately mirror `custom.css`'s `--omp-card-border-color` / `--omp-frame-shadow` values, with comments pointing at each other so the two don't drift. The same gotcha is recorded in `project-knowledge` (`codebase.md`).