### PR TITLE
fix(template): escape chevrons in rendered action output

### DIFF
--- a/.agents/skills/project-knowledge/references/codebase.md
+++ b/.agents/skills/project-knowledge/references/codebase.md
@@ -95,10 +95,12 @@
   `JoinMarkup` (composition). Segment fields composed from option strings with anchors
   (icons, `branch_icon`, `folder_separator_icon`, `status_formats` - all evidenced in shipped
   themes) MUST be `template.Markup` or their anchors render as literal text.
-- Known limitations: template funcs typed `string` error on Markup args except the adapted set
-  in `markupStringFuncs` (lower/upper/title/trunc/...). `mapped_branches` values keep anchors
-  only when no `branch_template` is set (the sub-template receives `.Branch` as a plain string
-  so `trunc` keeps working).
+- Every func-map entry is wrapped by `markupAware` (src/template/markup.go): Markup arguments
+  feed `string` parameters as text, a string result becomes Markup when any argument was Markup,
+  and the plain-string arguments of such a call are escaped first. Common signatures have
+  reflection-free fast paths (`markupAwareTyped`); the reflect path costs a few allocations
+  per call, so add a typed case there before optimizing anything else when a function shows
+  up hot. `print`/`printf`/`println` are overridden in the local map for the same reason.
 - `terminal.write`'s `isHyperlink` branch (OSC 8 URI region) applies shell escaping
   (`formats.EscapeSequences`) since 2026-09-05 - bash `@P` would otherwise re-interpret a URI
   backslash as a prompt escape. Never bypass it there.

--- a/.agents/skills/project-knowledge/references/codebase.md
+++ b/.agents/skills/project-knowledge/references/codebase.md
@@ -80,6 +80,33 @@
 - `terminal.AnsiRegex`'s final-byte class intentionally omits `!`, `_`, `X` and `\`; do not
   extend it as a sanitization fix - strip control runes instead.
 
+## Template markup trust boundary (2026-09-05, markup-injection fix)
+
+- The renderer escapes chevrons in every print action's output (`__esc` appended to each
+  pipeline post-parse, `template/render.go` `escapePrintActions`). Literal template text keeps
+  its `<...>` anchors; action output only keeps them when typed `template.Markup`. A new
+  segment that stores attacker-controlled strings (VCS refs, manifest fields, API responses,
+  folder names) in plain string fields is safe by default - do NOT call `template.RawMarkup`
+  on data.
+- `template.Markup` (src/template/markup.go) is the bypass type: a named string, never a
+  struct (text/template treats every struct as true, which broke the `{{ if .BranchStatus }}`
+  guards in 60 shipped themes, and `eq` cannot compare a struct to a string). Constructors:
+  `RawMarkup` (user config only), `EscapeMarkup` (data),
+  `JoinMarkup` (composition). Segment fields composed from option strings with anchors
+  (icons, `branch_icon`, `folder_separator_icon`, `status_formats` - all evidenced in shipped
+  themes) MUST be `template.Markup` or their anchors render as literal text.
+- Known limitations: template funcs typed `string` error on Markup args except the adapted set
+  in `markupStringFuncs` (lower/upper/title/trunc/...). `mapped_branches` values keep anchors
+  only when no `branch_template` is set (the sub-template receives `.Branch` as a plain string
+  so `trunc` keeps working).
+- `terminal.write`'s `isHyperlink` branch (OSC 8 URI region) applies shell escaping
+  (`formats.EscapeSequences`) since 2026-09-05 - bash `@P` would otherwise re-interpret a URI
+  backslash as a prompt escape. Never bypass it there.
+- Regression net: `src/prompt/golden_test.go` renders all 125 shipped themes byte-exact; if a
+  markup change alters golden output, the theme relied on the old (insecure) behavior -
+  regenerate with `go test ./prompt/... -run TestGoldenThemes -update` only after inspecting
+  the diff.
+
 ## Cache
 
 - Cache persistence only happens with the hidden `--save-cache` flag (print/stream commands);

--- a/.agents/skills/project-knowledge/references/codebase.md
+++ b/.agents/skills/project-knowledge/references/codebase.md
@@ -69,6 +69,17 @@
   line, that field is lost. Use a record format that retains a final non-whitespace delimiter or
   sentinel, and validate the record before assigning parsed state.
 
+## Terminal output sanitization
+
+- `prompt.Engine.write` (src/prompt/engine.go) appends straight to the prompt builder and
+  bypasses the per-rune control filter in `terminal.write` (src/terminal/writer.go). Any
+  attacker-influenceable string passed to `e.write` in one shot (console title, OSC payloads)
+  must sanitize itself with `terminal.stripControlRunes`; `trimAnsi` alone is insufficient -
+  it ignores strings without ESC (a bare BEL survives) and its regex misses CSI `! p`, APC,
+  SOS, and ST (verified 2026-09-05, GHSA-fwjx-9p69-h25h follow-up in `FormatTitle`).
+- `terminal.AnsiRegex`'s final-byte class intentionally omits `!`, `_`, `X` and `\`; do not
+  extend it as a sanitization fix - strip control runes instead.
+
 ## Cache
 
 - Cache persistence only happens with the hidden `--save-cache` flag (print/stream commands);

--- a/.agents/skills/project-knowledge/references/codebase.md
+++ b/.agents/skills/project-knowledge/references/codebase.md
@@ -56,9 +56,10 @@
 
 ## Segments and panics
 
-- Segment `Execute` runs in bare goroutines with **no recover** (`src/prompt/segments.go`), and
-  template rendering re-panics runtime errors. Any panic there kills the whole process - the user
-  sees a completely blank prompt. So when a user reports a blank prompt: find the panic.
+- Segment `Execute` goroutines recover a panic since 2026-09-05 (`src/prompt/segments.go`): the
+  segment logs the panic and renders as disabled, and the serve daemon survives. Template
+  rendering still re-panics runtime errors in the producer, which the streaming producer also
+  recovers. A completely blank prompt therefore points at a panic outside those two places.
 - If the panic trigger persists (e.g. a poisoned cache entry with a TTL), every prompt crashes
   until the entry expires.
 - Segment writers gob-encode only exported fields. `segments.Base.env/options` are unexported and
@@ -150,3 +151,31 @@
 - `config.Get` prefers the session gob cache over `POSH_THEME`.
 - Go guarantees exactly 2 records per wait-mode serve request even on segment panic
   (`renderComplete`) - blocking clients (Clink) rely on this.
+- Streaming lifecycle (rewritten 2026-09-07, `src/prompt/streaming.go`): one `streamCycle` per
+  `StreamPrimary` run. Segment goroutines send `timedOut` / `completed` / `abandoned` events on a
+  channel sized `2*segments+1`, so a send never blocks and is never dropped (plain sends, no
+  `select`/`default`). The producer goroutine owns the `pending` set, folds events into it, and
+  loops until it is empty; the last record is therefore always rendered after the last state
+  change. `timedOut` is queued before the segment's block result is delivered, so the
+  `absorb()` after `drainBlockResults` sees every timeout of the first pass. A panicking
+  `Execute` is recovered in `executeSegment` and still reports `completed`; a segment still
+  running after `pendingSegmentLimit` (30s, package var) is `abandoned`, its children killed, and
+  the cycle finishes without it. The producer's recover logs with a stack; a silent recover is what
+  hid the original bug.
+- The streaming bug that motivated the rewrite (git segment stuck on "..." with native status
+  and `streaming: 5`) was never in the bookkeeping: four loop rewrites left it in place. The render
+  goroutine touched the live writer of a pending segment (SetText, SetIndex, color and style
+  templates, `Needs`) while `Execute` was writing it. Rule now: a pending segment renders through
+  `Segment.RenderPlaceholder`, which reads configuration only (`Placeholder`, raw
+  `Foreground`/`Background`, style resolved with a nil context) and stores its text in the
+  writer-less `text` field; `canRenderSegment` is skipped for pending segments; `Name()` is
+  resolved before the goroutines start. Never read or write `segment.writer` for a segment the
+  cycle still has as pending, and never reintroduce a `Pending` flag on `config.Segment`.
+- `-race` is unavailable on the arm64 Windows dev machine and in its WSL (no C compiler, no sudo).
+  CI's `Race Detector` step (`code.yml`, ubuntu only) is the only race gate; the fake writer in
+  `prompt/streaming_writer_test.go` writes multi-word fields late on purpose so that step has
+  something to catch when a render touches a pending writer again.
+- Reproducing timing races in the daemon: `oh-my-posh debug` timings are cold-process numbers;
+  the warm in-daemon segment duration is what has to straddle `streaming`. Sweep the timeout in
+  a config copy against a scripted serve session (JSON line + env blob on stdin, count cycles
+  whose last record still holds the placeholder) instead of trusting a single value.

--- a/.agents/skills/project-knowledge/references/codebase.md
+++ b/.agents/skills/project-knowledge/references/codebase.md
@@ -88,6 +88,11 @@
   segment that stores attacker-controlled strings (VCS refs, manifest fields, API responses,
   folder names) in plain string fields is safe by default - do NOT call `template.RawMarkup`
   on data.
+- Untrusted templates (`RenderUntrusted`, used for the path segment where folder names are
+  template source) bind the output escape to `escapeUntrustedActionValue`, which escapes Markup
+  results too: `{{ url ... }}` or `{{ date "<red>" }}` in a folder name must not forge anchors.
+  The path segment escapes folder names on every branch of `replaceMappedLocations` (no mapped
+  locations, regex mappings, prefix mappings); a new early return there needs its own escape.
 - `template.Markup` (src/template/markup.go) is the bypass type: a named string, never a
   struct (text/template treats every struct as true, which broke the `{{ if .BranchStatus }}`
   guards in 60 shipped themes, and `eq` cannot compare a struct to a string). Constructors:
@@ -96,11 +101,15 @@
   (icons, `branch_icon`, `folder_separator_icon`, `status_formats` - all evidenced in shipped
   themes) MUST be `template.Markup` or their anchors render as literal text.
 - Every func-map entry is wrapped by `markupAware` (src/template/markup.go): Markup arguments
-  feed `string` parameters as text, a string result becomes Markup when any argument was Markup,
-  and the plain-string arguments of such a call are escaped first. Common signatures have
-  reflection-free fast paths (`markupAwareTyped`); the reflect path costs a few allocations
-  per call, so add a typed case there before optimizing anything else when a function shows
-  up hot. `print`/`printf`/`println` are overridden in the local map for the same reason.
+  feed `string` parameters as text; a string result becomes Markup only when the call had a
+  Markup argument and every other argument was a string, number or bool (a slice, struct,
+  error or pointer may hide data the wrapper cannot escape, so such calls stay plain). Plain
+  strings, printf formats included, are escaped when promoting. Functions whose output is not
+  their input (`readFile`, `cmd`, `b64dec`, `env`, ...) sit in `noPromote`. Common signatures
+  have reflection-free fast paths (`markupAwareTyped`); add a typed case there before optimizing
+  anything else when a function shows up hot. `print`/`printf`/`println` are overridden in the
+  local map. Sprig functions with attacker-chosen counts (`repeat`, `seq`, `until`, `rand*`)
+  are in `dangerousFuncs`, trusted templates only.
 - `terminal.write`'s `isHyperlink` branch (OSC 8 URI region) applies shell escaping
   (`formats.EscapeSequences`) since 2026-09-05 - bash `@P` would otherwise re-interpret a URI
   backslash as a prompt escape. Never bypass it there.

--- a/.agents/skills/project-knowledge/references/codebase.md
+++ b/.agents/skills/project-knowledge/references/codebase.md
@@ -91,8 +91,10 @@
 - Untrusted templates (`RenderUntrusted`, used for the path segment where folder names are
   template source) bind the output escape to `escapeUntrustedActionValue`, which escapes Markup
   results too: `{{ url ... }}` or `{{ date "<red>" }}` in a folder name must not forge anchors.
-  The path segment escapes folder names on every branch of `replaceMappedLocations` (no mapped
-  locations, regex mappings, prefix mappings); a new early return there needs its own escape.
+  The path segment escapes folder names with `template.EscapeSource` on every branch of
+  `replaceMappedLocations` (no mapped locations, regex mappings, prefix mappings): chevrons
+  become literal and `{{` becomes an action that prints `{{`, so a folder name can no longer
+  call any template function. A new early return there needs its own escape.
 - `template.Markup` (src/template/markup.go) is the bypass type: a named string, never a
   struct (text/template treats every struct as true, which broke the `{{ if .BranchStatus }}`
   guards in 60 shipped themes, and `eq` cannot compare a struct to a string). Constructors:

--- a/.agents/skills/project-knowledge/references/codebase.md
+++ b/.agents/skills/project-knowledge/references/codebase.md
@@ -134,6 +134,19 @@
 
 ## Streaming and serve daemon
 
+- CONFIRMED data race (CI race detector, 2026-09-07): a segment that times out under streaming keeps
+  running in a background goroutine and can outlive its render cycle. When it publishes via
+  `template.Cache.AddSegmentData` in `config/segment.go` (the deferred publish in `Execute`, and also
+  `restoreCache`/`restoreData` on that same background path), it reads the package-level
+  `template.Cache` - which the serve daemon RESETS per cycle and the streaming tests reassign in
+  `setupStreamingTestEnv`. That read races the reset/reassignment. Fix pattern: capture
+  `renderCache := template.Cache` at the top of `Execute` and publish through the captured pointer,
+  never the global, on any code path that can run after the cycle ends. The `Execute` deferred site
+  is fixed; `restoreCache` (line ~636) and `restoreData` (line ~705) still read the global and need
+  the same capture if a cached/recorded segment ever times out. `-race` is unavailable on
+  windows/arm64, so this class only shows up on CI (amd64) - run the streaming tests there after any
+  change to the background-goroutine cache path.
+
 - Streaming is enabled by the top-level `"streaming": <ms>` config key. That value is ALSO each
   segment's pending-timeout and overwrites segment-level `timeout`.
 - `stream` always emits the transient prompt as a `\x1e`-prefixed NUL record (initial + refreshed

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -41,3 +41,6 @@ jobs:
         modernize "./..."
     - name: Unit Tests
       run: go test "./..."
+    - name: Race Detector
+      if: matrix.os == 'ubuntu-latest'
+      run: go test -race -count=1 ./prompt/... ./config/... ./cli/... ./template/... ./cache/... ./gitstatus/...

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This repo was made with love using GitKraken.
           <img alt="CodeRabbit" height="44" src="https://victorious-bubble-f69a016683.media.strapiapp.com/Orange_Typemark_43bf516c9d.svg" />
     </picture>
 </a>
-<!-- markdownlint-enable no-inline-html line-length -->J
+<!-- markdownlint-enable no-inline-html line-length -->
 
 [Want to become a sponsor?][sponsor-link]
 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ This repo was made with love using GitKraken.
 
 ## Join the community
 
-![Mastodon badge](https://img.shields.io/mastodon/follow/110275292073181892?domain=https%3A%2F%2Fhachyderm.io&label=Mastodon&style=social)
+[![Mastodon badge](https://img.shields.io/mastodon/follow/110275292073181892?domain=hachyderm.io&style=social&label=Mastodon)](https://hachyderm.io/@jandedobbeleer)
 
-![Discord badge](https://img.shields.io/discord/1023597603331526656)
+[![Discord badge](https://img.shields.io/discord/1023597603331526656?logo=discord&logoColor=white)](https://discord.com/invite/n7E3DkXssv)
 
 What started as the offspring of [oh-my-posh2](https://github.com/JanDeDobbeleer/oh-my-posh2) for PowerShell
 resulted in a cross platform, highly customizable and extensible prompt theme engine. After 4 years of working

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ This repo was made with love using GitKraken.
 <!-- markdownlint-disable no-inline-html line-length -->
 <a href="https://coderabbit.link/posh">
     <picture>
-          <source media="(prefers-color-scheme: dark)" srcset="https://victorious-bubble-f69a016683.media.strapiapp.com/White_Typemark_79b9189d19.svg">
-          <source media="(prefers-color-scheme: light)" srcset="https://victorious-bubble-f69a016683.media.strapiapp.com/Orange_Typemark_43bf516c9d.svg">
-          <img alt="CodeRabbit" height="44" src="https://victorious-bubble-f69a016683.media.strapiapp.com/Orange_Typemark_43bf516c9d.svg" />
+          <source media="(prefers-color-scheme: dark)" srcset="https://www.coderabbit.ai/press-kit/coderabbit-reverse-white.svg">
+          <source media="(prefers-color-scheme: light)" srcset="https://www.coderabbit.ai/press-kit/coderabbit-primary-black.svg">
+          <img alt="CodeRabbit" height="44" src="https://www.coderabbit.ai/press-kit/coderabbit-primary-black.svg" />
     </picture>
 </a>
 <!-- markdownlint-enable no-inline-html line-length -->

--- a/src/config/segment.go
+++ b/src/config/segment.go
@@ -712,7 +712,9 @@ func (segment *Segment) restoreInto(raw, methods json.RawMessage) error {
 		MergeRecordedMethods(data, overlay)
 	}
 
-	segment.data = normalizeNumbers(data).(map[string]any)
+	// Markup fields were recorded tagged (see template.Markup's JSON form);
+	// revive them or every recorded anchor renders escaped on this path.
+	segment.data = template.ReviveMarkup(normalizeNumbers(data)).(map[string]any)
 
 	return nil
 }

--- a/src/config/segment.go
+++ b/src/config/segment.go
@@ -204,6 +204,13 @@ func (segment *Segment) Name() string {
 }
 
 func (segment *Segment) Execute(env runtime.Environment) {
+	// Capture the template cache once: a timed-out segment keeps running in a
+	// background goroutine and publishes below after its cycle is gone, when
+	// the serve daemon has reset the package-level cache for the next cycle.
+	// Reading the global there would race that reset (verified by the CI race
+	// detector on the streaming tests).
+	renderCache := template.Cache
+
 	// segment timings for debug purposes
 	var start time.Time
 	if env.Flags().Debug {
@@ -269,7 +276,7 @@ func (segment *Segment) Execute(env runtime.Environment) {
 
 	defer func() {
 		if segment.Enabled {
-			template.Cache.AddSegmentData(segment.Name(), segment.templateContext())
+			renderCache.AddSegmentData(segment.Name(), segment.templateContext())
 		}
 	}()
 

--- a/src/config/segment.go
+++ b/src/config/segment.go
@@ -48,7 +48,11 @@ type Segment struct {
 	data map[string]any
 	// text is where the rendered text lives when there is no writer to hold it: the writer
 	// normally stores it (SegmentWriter.SetText/Text), which a build with no writers cannot do.
-	text                   string
+	text string
+	// cache is the template cache Execute publishes into, taken when Execute
+	// starts: in the serve daemon an aborted cycle's Execute can outlive the
+	// cycle, and the package-level cache belongs to the next one by then.
+	cache                  *cache.Template
 	env                    runtime.Environment
 	Options                options.Map `json:"options,omitempty" toml:"options,omitempty" yaml:"options,omitempty"`
 	Properties             options.Map `json:"-" toml:"properties,omitempty" yaml:"-"`
@@ -201,7 +205,19 @@ func (segment *Segment) Name() string {
 	return name
 }
 
+// templateCache is the cache Execute took at its start, or the current one
+// for the restore paths tests drive directly.
+func (segment *Segment) templateCache() *cache.Template {
+	if segment.cache != nil {
+		return segment.cache
+	}
+
+	return template.Cache
+}
+
 func (segment *Segment) Execute(env runtime.Environment) {
+	segment.cache = template.Cache
+
 	// segment timings for debug purposes
 	var start time.Time
 	if env.Flags().Debug {
@@ -267,7 +283,7 @@ func (segment *Segment) Execute(env runtime.Environment) {
 
 	defer func() {
 		if segment.Enabled {
-			template.Cache.AddSegmentData(segment.Name(), segment.templateContext())
+			segment.templateCache().AddSegmentData(segment.Name(), segment.templateContext())
 		}
 	}()
 
@@ -372,14 +388,20 @@ func (segment *Segment) Render(index int, force bool) bool {
 	segment.foregroundResolved = false
 	segment.backgroundResolved = false
 
+	// A killed segment's Execute is still running, so none of its other
+	// flags may be read.
+	if segment.Killed {
+		return false
+	}
+
 	// Allow pending segments to render (they'll show "..." text)
 	if !segment.Pending && !segment.Enabled && !force {
 		return segment.renderFallback(index)
 	}
 
-	if force {
-		segment.Force = true
-	}
+	// Force stays local: Execute may still be reading the field on its own
+	// goroutine for a pending segment.
+	forced := force || segment.Force
 
 	segment.setIndex(index)
 
@@ -387,7 +409,7 @@ func (segment *Segment) Render(index int, force bool) bool {
 
 	// Only update Enabled if segment is NOT pending (avoid race with Execute goroutine)
 	if !segment.Pending {
-		segment.Enabled = segment.Force || strings.ContainsFunc(rendered, func(r rune) bool { return r != ' ' })
+		segment.Enabled = forced || strings.ContainsFunc(rendered, func(r rune) bool { return r != ' ' })
 
 		if !segment.Enabled {
 			template.Cache.RemoveSegmentData(segment.Name())
@@ -396,9 +418,15 @@ func (segment *Segment) Render(index int, force bool) bool {
 	}
 
 	segment.SetText(rendered)
-	segment.setCache()
 
-	// We do this to make `.Text` available for a cross-segment reference in an extra prompt.
+	// A pending segment's writer is still being filled in by Execute; the
+	// resolved render caches it and publishes it for cross-segment
+	// references (`.Segments.X.Segment.Text` in an extra prompt).
+	if segment.Pending {
+		return true
+	}
+
+	segment.setCache()
 	template.Cache.AddSegmentData(segment.Name(), segment.templateContext())
 
 	return true
@@ -413,7 +441,7 @@ func (segment *Segment) Render(index int, force bool) bool {
 // than evaluated, because their Execute goroutine keeps running after the
 // kill and may still complete the evaluation before rendering starts.
 func (segment *Segment) renderFallback(index int) bool {
-	if segment.FallbackTemplate == "" || !segment.evaluated || segment.Killed {
+	if segment.FallbackTemplate == "" || segment.Killed || !segment.evaluated {
 		return false
 	}
 
@@ -608,7 +636,7 @@ func (segment *Segment) restoreCache() bool {
 	}
 
 	segment.Enabled = true
-	template.Cache.AddSegmentData(segment.Name(), segment.templateContext())
+	segment.templateCache().AddSegmentData(segment.Name(), segment.templateContext())
 
 	log.Debug("restored segment from cache: ", segment.Name())
 
@@ -677,7 +705,7 @@ func (segment *Segment) restoreData() bool {
 	segment.Enabled = true
 	segment.restored = true
 
-	template.Cache.AddSegmentData(segment.Name(), segment.templateContext())
+	segment.templateCache().AddSegmentData(segment.Name(), segment.templateContext())
 
 	log.Debug("restored segment from data: ", segment.Name())
 

--- a/src/config/segment.go
+++ b/src/config/segment.go
@@ -40,24 +40,20 @@ func (s *SegmentStyle) resolve(context any) SegmentStyle {
 
 type Segment struct {
 	writer SegmentWriter
+	env    runtime.Environment
 	// data is what templates evaluate against when there is no writer to evaluate against: a
 	// build with no segment packages linked restores recorded data into a plain map instead of
 	// into a writer struct. Nil everywhere else, and templateContext picks whichever of the two is
 	// present. Go templates resolve a name against a map key exactly as they resolve it against a
 	// field or a method, so a recorded value reads the same either way.
-	data map[string]any
+	data          map[string]any
+	Options       options.Map `json:"options,omitempty" toml:"options,omitempty" yaml:"options,omitempty"`
+	Properties    options.Map `json:"-" toml:"properties,omitempty" yaml:"-"`
+	Cache         *Cache      `json:"cache,omitempty" toml:"cache,omitempty" yaml:"cache,omitempty"`
+	presentFields map[string]bool
 	// text is where the rendered text lives when there is no writer to hold it: the writer
 	// normally stores it (SegmentWriter.SetText/Text), which a build with no writers cannot do.
-	text string
-	// cache is the template cache Execute publishes into, taken when Execute
-	// starts: in the serve daemon an aborted cycle's Execute can outlive the
-	// cycle, and the package-level cache belongs to the next one by then.
-	cache                  *cache.Template
-	env                    runtime.Environment
-	Options                options.Map `json:"options,omitempty" toml:"options,omitempty" yaml:"options,omitempty"`
-	Properties             options.Map `json:"-" toml:"properties,omitempty" yaml:"-"`
-	Cache                  *Cache      `json:"cache,omitempty" toml:"cache,omitempty" yaml:"cache,omitempty"`
-	presentFields          map[string]bool
+	text                   string
 	Alias                  string `json:"alias,omitempty" toml:"alias,omitempty" yaml:"alias,omitempty"`
 	styleCache             SegmentStyle
 	foregroundCache        color.Ansi
@@ -98,23 +94,25 @@ type Segment struct {
 	// live outside this segment, in texts the segment cannot reconstruct
 	// from its own fields. Nil for analyzable segments and for configs that
 	// never went through ResolveFieldSets.
-	HeuristicSources    []string      `json:"-" toml:"-" yaml:"-"`
-	Index               int           `json:"index,omitempty" toml:"index,omitempty" yaml:"index,omitempty"`
-	MinWidth            int           `json:"min_width,omitempty" toml:"min_width,omitempty" yaml:"min_width,omitempty"`
-	Duration            time.Duration `json:"-" toml:"-" yaml:"-"`
-	NameLength          int           `json:"-" toml:"-" yaml:"-"`
-	MaxWidth            int           `json:"max_width,omitempty" toml:"max_width,omitempty" yaml:"max_width,omitempty"`
-	Timeout             int           `json:"timeout,omitempty" toml:"timeout,omitempty" yaml:"timeout,omitempty"`
-	Newline             bool          `json:"newline,omitempty" toml:"newline,omitempty" yaml:"newline,omitempty"`
-	Enabled             bool          `json:"-" toml:"-" yaml:"-"`
-	InvertPowerline     bool          `json:"invert_powerline,omitempty" toml:"invert_powerline,omitempty" yaml:"invert_powerline,omitempty"`
-	Force               bool          `json:"force,omitempty" toml:"force,omitempty" yaml:"force,omitempty"`
-	restored            bool          `json:"-" toml:"-" yaml:"-"`
-	Toggled             bool          `json:"toggled,omitempty" toml:"toggled,omitempty" yaml:"toggled,omitempty"`
-	Pending             bool          `json:"-" toml:"-" yaml:"-"`
-	Killed              bool          `json:"-" toml:"-" yaml:"-"`
-	Interactive         bool          `json:"interactive,omitempty" toml:"interactive,omitempty" yaml:"interactive,omitempty"`
-	MultilineKeepPrompt bool          `json:"multiline_keepprompt,omitempty" toml:"multiline_keepprompt,omitempty" yaml:"multiline_keepprompt,omitempty"`
+	HeuristicSources []string      `json:"-" toml:"-" yaml:"-"`
+	Index            int           `json:"index,omitempty" toml:"index,omitempty" yaml:"index,omitempty"`
+	MinWidth         int           `json:"min_width,omitempty" toml:"min_width,omitempty" yaml:"min_width,omitempty"`
+	Duration         time.Duration `json:"-" toml:"-" yaml:"-"`
+	NameLength       int           `json:"-" toml:"-" yaml:"-"`
+	MaxWidth         int           `json:"max_width,omitempty" toml:"max_width,omitempty" yaml:"max_width,omitempty"`
+	Timeout          int           `json:"timeout,omitempty" toml:"timeout,omitempty" yaml:"timeout,omitempty"`
+	// placeholder is set while the segment shows its streaming placeholder; the writer is off
+	// limits until the segment completes, so Text serves text instead.
+	placeholder         bool
+	Newline             bool `json:"newline,omitempty" toml:"newline,omitempty" yaml:"newline,omitempty"`
+	Enabled             bool `json:"-" toml:"-" yaml:"-"`
+	InvertPowerline     bool `json:"invert_powerline,omitempty" toml:"invert_powerline,omitempty" yaml:"invert_powerline,omitempty"`
+	Force               bool `json:"force,omitempty" toml:"force,omitempty" yaml:"force,omitempty"`
+	restored            bool `json:"-" toml:"-" yaml:"-"`
+	Toggled             bool `json:"toggled,omitempty" toml:"toggled,omitempty" yaml:"toggled,omitempty"`
+	Killed              bool `json:"-" toml:"-" yaml:"-"`
+	Interactive         bool `json:"interactive,omitempty" toml:"interactive,omitempty" yaml:"interactive,omitempty"`
+	MultilineKeepPrompt bool `json:"multiline_keepprompt,omitempty" toml:"multiline_keepprompt,omitempty" yaml:"multiline_keepprompt,omitempty"`
 	foregroundResolved  bool
 	backgroundResolved  bool
 	needsEvaluated      bool
@@ -205,19 +203,7 @@ func (segment *Segment) Name() string {
 	return name
 }
 
-// templateCache is the cache Execute took at its start, or the current one
-// for the restore paths tests drive directly.
-func (segment *Segment) templateCache() *cache.Template {
-	if segment.cache != nil {
-		return segment.cache
-	}
-
-	return template.Cache
-}
-
 func (segment *Segment) Execute(env runtime.Environment) {
-	segment.cache = template.Cache
-
 	// segment timings for debug purposes
 	var start time.Time
 	if env.Flags().Debug {
@@ -283,7 +269,7 @@ func (segment *Segment) Execute(env runtime.Environment) {
 
 	defer func() {
 		if segment.Enabled {
-			segment.templateCache().AddSegmentData(segment.Name(), segment.templateContext())
+			template.Cache.AddSegmentData(segment.Name(), segment.templateContext())
 		}
 	}()
 
@@ -380,6 +366,13 @@ func (segment *Segment) overlayData() {
 }
 
 func (segment *Segment) Render(index int, force bool) bool {
+	// Leaving the placeholder behind: the style cached while pending was resolved without the
+	// writer (see RenderPlaceholder) and must not survive into the resolved render.
+	if segment.placeholder {
+		segment.placeholder = false
+		segment.styleCache = ""
+	}
+
 	// Foreground/background may be overridden directly (e.g. color cycling) between
 	// render passes, so the memoized values must not survive across calls to Render.
 	// This reset must precede the early return below: a disabled segment without a
@@ -388,48 +381,48 @@ func (segment *Segment) Render(index int, force bool) bool {
 	segment.foregroundResolved = false
 	segment.backgroundResolved = false
 
-	// A killed segment's Execute is still running, so none of its other
-	// flags may be read.
-	if segment.Killed {
-		return false
-	}
-
-	// Allow pending segments to render (they'll show "..." text)
-	if !segment.Pending && !segment.Enabled && !force {
+	if !segment.Enabled && !force {
 		return segment.renderFallback(index)
 	}
 
-	// Force stays local: Execute may still be reading the field on its own
-	// goroutine for a pending segment.
-	forced := force || segment.Force
+	if force {
+		segment.Force = true
+	}
 
 	segment.setIndex(index)
 
 	rendered := segment.string()
 
-	// Only update Enabled if segment is NOT pending (avoid race with Execute goroutine)
-	if !segment.Pending {
-		segment.Enabled = forced || strings.ContainsFunc(rendered, func(r rune) bool { return r != ' ' })
+	segment.Enabled = segment.Force || strings.ContainsFunc(rendered, func(r rune) bool { return r != ' ' })
 
-		if !segment.Enabled {
-			template.Cache.RemoveSegmentData(segment.Name())
-			return false
-		}
+	if !segment.Enabled {
+		template.Cache.RemoveSegmentData(segment.Name())
+		return false
 	}
 
 	segment.SetText(rendered)
-
-	// A pending segment's writer is still being filled in by Execute; the
-	// resolved render caches it and publishes it for cross-segment
-	// references (`.Segments.X.Segment.Text` in an extra prompt).
-	if segment.Pending {
-		return true
-	}
 
 	segment.setCache()
 	template.Cache.AddSegmentData(segment.Name(), segment.templateContext())
 
 	return true
+}
+
+// RenderPlaceholder renders the streaming placeholder for a segment whose Execute goroutine is
+// still running. It reads configuration fields only: the writer is being written by that
+// goroutine, so SetText, SetIndex, the color templates and the style template are all data races
+// here. Colors are the raw Foreground/Background, and a style template that needs writer data
+// falls back to Plain until the segment resolves.
+func (segment *Segment) RenderPlaceholder() {
+	segment.placeholder = true
+	segment.text = segment.Placeholder
+	if segment.text == "" {
+		segment.text = "..."
+	}
+
+	segment.CollapseForeground(segment.Foreground)
+	segment.CollapseBackground(segment.Background)
+	segment.styleCache = segment.Style.resolve(nil)
 }
 
 // renderFallback attempts to render FallbackTemplate when a segment would
@@ -441,7 +434,7 @@ func (segment *Segment) Render(index int, force bool) bool {
 // than evaluated, because their Execute goroutine keeps running after the
 // kill and may still complete the evaluation before rendering starts.
 func (segment *Segment) renderFallback(index int) bool {
-	if segment.FallbackTemplate == "" || segment.Killed || !segment.evaluated {
+	if segment.FallbackTemplate == "" || !segment.evaluated || segment.Killed {
 		return false
 	}
 
@@ -473,6 +466,10 @@ func (segment *Segment) renderFallback(index int) bool {
 }
 
 func (segment *Segment) Text() string {
+	if segment.placeholder {
+		return segment.text
+	}
+
 	if segment.writer == nil {
 		return segment.text
 	}
@@ -636,7 +633,7 @@ func (segment *Segment) restoreCache() bool {
 	}
 
 	segment.Enabled = true
-	segment.templateCache().AddSegmentData(segment.Name(), segment.templateContext())
+	template.Cache.AddSegmentData(segment.Name(), segment.templateContext())
 
 	log.Debug("restored segment from cache: ", segment.Name())
 
@@ -705,7 +702,7 @@ func (segment *Segment) restoreData() bool {
 	segment.Enabled = true
 	segment.restored = true
 
-	segment.templateCache().AddSegmentData(segment.Name(), segment.templateContext())
+	template.Cache.AddSegmentData(segment.Name(), segment.templateContext())
 
 	log.Debug("restored segment from data: ", segment.Name())
 
@@ -740,8 +737,6 @@ func (segment *Segment) restoreInto(raw, methods json.RawMessage) error {
 		MergeRecordedMethods(data, overlay)
 	}
 
-	// Markup fields were recorded tagged (see template.Markup's JSON form);
-	// revive them or every recorded anchor renders escaped on this path.
 	segment.data = template.ReviveMarkup(normalizeNumbers(data)).(map[string]any)
 
 	return nil
@@ -820,11 +815,6 @@ func decodeRecordedSegment(raw json.RawMessage) (RecordedSegment, bool) {
 
 func (segment *Segment) setCache() {
 	if segment.restored || !segment.hasCache() {
-		return
-	}
-
-	// Never cache pending state to avoid polluting cache with incomplete data
-	if segment.Pending {
 		return
 	}
 
@@ -921,15 +911,6 @@ func (segment *Segment) templateContext() any {
 }
 
 func (segment *Segment) string() string {
-	// Use simple pending text if segment is still pending
-	if segment.Pending {
-		if segment.Placeholder != "" {
-			return segment.Placeholder
-		}
-
-		return "..."
-	}
-
 	context := segment.templateContext()
 
 	result := segment.Templates.Resolve(context, "", segment.TemplatesLogic)

--- a/src/config/segment_test.go
+++ b/src/config/segment_test.go
@@ -832,3 +832,19 @@ func TestSegment_FallbackTemplate(t *testing.T) {
 		assert.False(t, found, tc.Case)
 	}
 }
+
+// Without a writer (the website build) recorded data lands in a map; the
+// tagged markup it carries must come back as Markup so the anchors render.
+func TestRestoreIntoRevivesMarkupWithoutWriter(t *testing.T) {
+	segment := &Segment{}
+
+	raw := json.RawMessage(`{"HEAD":{"$markup":"<red>main</>"},"Ref":"<b>","Total":2}`)
+	methods := json.RawMessage(`{"Working":{"String":{"$markup":"<b>~1</>"}}}`)
+
+	require.NoError(t, segment.restoreInto(raw, methods))
+
+	assert.Equal(t, template.RawMarkup("<red>main</>"), segment.data["HEAD"])
+	assert.Equal(t, "<b>", segment.data["Ref"])
+	assert.Equal(t, 2, segment.data["Total"])
+	assert.Equal(t, template.RawMarkup("<b>~1</>"), segment.data["Working"].(map[string]any)["String"])
+}

--- a/src/config/segment_test.go
+++ b/src/config/segment_test.go
@@ -319,41 +319,6 @@ func TestEvaluateNeeds(t *testing.T) {
 	}
 }
 
-func TestSegment_NoCachingWhenPending(t *testing.T) {
-	env := new(mock.Environment)
-	env.On("Shell").Return("pwsh")
-	env.On("Flags").Return(&runtime.Flags{})
-	env.On("Pwd").Return("/test")
-	env.On("Home").Return("/home")
-
-	segment := &Segment{
-		Type:     SESSION,
-		Pending:  true,
-		Template: "test",
-	}
-
-	err := segment.MapSegmentWithWriter(env)
-	assert.NoError(t, err)
-
-	// When Pending=true, setCache should return early without caching
-	// We can't easily mock cache.Set, but we can verify the method doesn't panic
-	// and that the behavior differs between Pending=true and Pending=false
-
-	// With Pending=true, setCache returns early
-	segment.Cache = &Cache{Duration: "5h"}
-	segment.setCache() // Should return early, not attempt to cache
-
-	// Verify this doesn't panic and segment still works
-	assert.True(t, segment.Pending, "Segment should still be pending")
-
-	// Now with Pending=false, setCache will attempt to cache
-	segment.Pending = false
-	segment.restored = false
-	segment.setCache() // Should attempt to cache (may fail but shouldn't panic)
-
-	assert.False(t, segment.Pending, "Segment should not be pending")
-}
-
 func TestSegment_DataKey(t *testing.T) {
 	aliased := &Segment{Type: SESSION, Alias: "work"}
 	assert.Equal(t, "work", aliased.DataKey())
@@ -833,8 +798,9 @@ func TestSegment_FallbackTemplate(t *testing.T) {
 	}
 }
 
-// Without a writer (the website build) recorded data lands in a map; the
-// tagged markup it carries must come back as Markup so the anchors render.
+// Without a writer (the website build) recorded data lands in a map. The
+// tagged markup in it must come back as Markup, or its anchors render as
+// literal text.
 func TestRestoreIntoRevivesMarkupWithoutWriter(t *testing.T) {
 	segment := &Segment{}
 

--- a/src/prompt/engine.go
+++ b/src/prompt/engine.go
@@ -3,7 +3,6 @@ package prompt
 import (
 	"slices"
 	"strings"
-	"sync"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/cache"
 	"github.com/jandedobbeleer/oh-my-posh/src/color"
@@ -26,53 +25,23 @@ const DefaultRPromptBreathingRoom = 30
 type Engine struct {
 	Env                   runtime.Environment
 	activeSegment         *config.Segment
-	done                  chan struct{}
 	Config                *config.Config
-	streamingResults      chan *config.Segment
-	abort                 chan struct{}
+	stream                *streamCycle
 	previousActiveSegment *config.Segment
-	pendingSegments       sync.Map
 	Overflow              config.Overflow
 	rprompt               string
 	prompt                strings.Builder
-	// blockTailColors is a snapshot of terminal.ParentColors captured just
-	// before previousActiveSegment resets to nil at the end of a block. A
-	// block's own Filler (see shouldFill) renders after terminal.String()
-	// has already cleared the parent stack for the next block, so a filler
-	// template using <parentBackground>/<parentForeground> needs this to
-	// resolve against the block it is padding rather than an empty stack.
-	// A full copy, not just the tail entry: the tail segment's own stored
-	// color can itself be an unresolved parentBackground/parentForeground
-	// keyword, and resolving that requires walking the rest of the chain
-	// the same way the block's own last segment did.
-	blockTailColors []*color.Set
-	// capturedRows/rpromptRuns are the Run stream's engine-side counterpart to
-	// prompt/rprompt above, populated only when terminal.CaptureRuns is set
-	// (see runs.go). rpromptRuns persists on the Engine, mirroring e.rprompt,
-	// because writeBlock's RPrompt case stores it for a later CapturedRuns
-	// consumer to read back; the block/filler runs a single writeBlock call
-	// consumes immediately (formerly pendingBlockRuns/pendingFillerRuns) now
-	// flow as return values instead, the same way blockText/length already do
-	// (renderBlockSegments/captureBlockRuns -> renderLaunchedBlock -> writeBlock,
-	// and shouldFill's own expanded filler runs).
-	capturedRows [][]terminal.Run
-	allBlocks    []*config.Block
-	rpromptRuns  []terminal.Run
-	// RPromptBreathingRoom overrides how many cells canWriteRightBlock insists on leaving free
-	// between the prompt and an rprompt. Zero keeps the interactive default. An export has no
-	// one typing into it, which is the only thing that margin protects, so a renderer can ask
-	// for a smaller one - see render.Config.
-	RPromptBreathingRoom int
-	rpromptLength        int
-	Padding              int
-	currentLineLength    int
-	// cursorRow/cursorRun locate the end of the primary prompt's own output
-	// within capturedRows — where the shell leaves the cursor. -1 means
-	// unset; see markCursorAnchor/CursorAnchor.
-	cursorRow   int
-	cursorRun   int
-	Plain       bool
-	forceRender bool
+	blockTailColors       []*color.Set
+	capturedRows          [][]terminal.Run
+	rpromptRuns           []terminal.Run
+	RPromptBreathingRoom  int
+	rpromptLength         int
+	Padding               int
+	currentLineLength     int
+	cursorRow             int
+	cursorRun             int
+	Plain                 bool
+	forceRender           bool
 }
 
 const (
@@ -372,30 +341,17 @@ func (e *Engine) renderBlockFromCache(block *config.Block, cancelNewline bool) b
 		cycle = &e.Config.Cycle
 	}
 
-	// Re-render all segments in the block
-	for segmentIndex, segment := range block.Segments {
-		// Allow pending segments to render (they show "..." text)
-		if !segment.Pending && !segment.Enabled && segment.ResolveStyle() != config.Accordion {
-			continue
+	// Two intentional behavior alignments with the first-pass path: the index passed to Render
+	// counts enabled segments instead of the position in the block, so index-dependent templates
+	// no longer jump between the first render and a streamed refresh; and a disabled accordion
+	// segment renders collapsed on refresh exactly as writeSegment renders it on the first pass.
+	// The color cycle / leading diamond lines that used to live in this loop now live inside
+	// writeSegment, shared with the first-pass path via renderSegment.
+	segmentIndex := 0
+	for _, segment := range block.Segments {
+		if e.renderSegment(block, segment, segmentIndex) {
+			segmentIndex++
 		}
-
-		// Render segment text (will use pending state if still pending)
-		if !segment.Render(segmentIndex, e.forceRender) {
-			continue
-		}
-
-		if colors, newCycle := cycle.Loop(); colors != nil {
-			cycle = &newCycle
-			segment.Foreground = colors.Foreground
-			segment.Background = colors.Background
-		}
-
-		if terminal.Len() == 0 && len(block.LeadingDiamond) > 0 {
-			segment.LeadingDiamond = block.LeadingDiamond
-		}
-
-		e.setActiveSegment(segment)
-		e.renderActiveSegment()
 	}
 
 	if e.activeSegment != nil && len(block.TrailingDiamond) > 0 {
@@ -445,7 +401,7 @@ func (e *Engine) applyPowerShellBleedPatch() {
 // whole channel with the gradient's last stop.
 const minGradientCellsPerStop = 2
 
-func (e *Engine) setActiveSegment(segment *config.Segment) {
+func (e *Engine) setActiveSegment(segment *config.Segment, pending bool) {
 	e.activeSegment = segment
 	terminal.Interactive = segment.Interactive
 
@@ -468,7 +424,7 @@ func (e *Engine) setActiveSegment(segment *config.Segment) {
 	// parent color references) agrees on the same solid color; see collapseGradient.
 	// Pending placeholders are exempt: they are transient and should preview the
 	// segment's gradient rather than flash a collapsed solid color mid-stream.
-	if !segment.Pending && (background.IsGradient() || foreground.IsGradient()) {
+	if !pending && (background.IsGradient() || foreground.IsGradient()) {
 		cells := terminal.VisibleCells(segment.Text())
 
 		if collapsed, ok := collapseGradient(background, cells); ok {
@@ -668,7 +624,7 @@ func (e *Engine) resolveLeadingDiamond() string {
 	return resolveBackgroundKeyword(diamond, edge)
 }
 
-func (e *Engine) renderActiveSegment() {
+func (e *Engine) renderActiveSegment(enabled bool) {
 	e.writeSeparator(false)
 
 	switch e.activeSegment.ResolveStyle() {
@@ -685,8 +641,7 @@ func (e *Engine) renderActiveSegment() {
 		terminal.Write(background, color.Background, e.resolveLeadingDiamond())
 		terminal.Write(color.Background, color.Foreground, e.activeSegment.Text())
 	case config.Accordion:
-		// Render accordion segments if enabled OR pending (pending shows "..." text)
-		if e.activeSegment.Enabled || e.activeSegment.Pending {
+		if enabled {
 			terminal.Write(color.Background, color.Foreground, e.activeSegment.Text())
 		}
 	}

--- a/src/prompt/gradient_collapse_test.go
+++ b/src/prompt/gradient_collapse_test.go
@@ -37,8 +37,8 @@ func renderPowerlineSegment(t *testing.T, background color.Ansi, template string
 	assert.NoError(t, segment.MapSegmentWithWriter(engine.Env))
 	segment.Render(0, true)
 
-	engine.setActiveSegment(segment)
-	engine.renderActiveSegment()
+	engine.setActiveSegment(segment, false)
+	engine.renderActiveSegment(true)
 
 	out, _ := terminal.String()
 	return out
@@ -113,11 +113,10 @@ func TestPendingSegmentKeepsGradientPlaceholder(t *testing.T) {
 		Background: gradientStops,
 	}
 	assert.NoError(t, pending.MapSegmentWithWriter(engine.Env))
-	pending.Pending = true
-	pending.Render(0, false)
+	pending.RenderPlaceholder()
 
-	engine.setActiveSegment(pending)
-	engine.renderActiveSegment()
+	engine.setActiveSegment(pending, true)
+	engine.renderActiveSegment(true)
 
 	out, _ := terminal.String()
 
@@ -151,8 +150,8 @@ func TestPaletteReferencedGradientCollapses(t *testing.T) {
 	assert.NoError(t, segment.MapSegmentWithWriter(engine.Env))
 	segment.Render(0, true)
 
-	engine.setActiveSegment(segment)
-	engine.renderActiveSegment()
+	engine.setActiveSegment(segment, false)
+	engine.renderActiveSegment(true)
 
 	out, _ := terminal.String()
 

--- a/src/prompt/gradient_test.go
+++ b/src/prompt/gradient_test.go
@@ -128,7 +128,7 @@ func TestWriteSeparatorTrailingDiamondGradient(t *testing.T) {
 		assert.NoError(t, segment.MapSegmentWithWriter(engine.Env))
 		segment.Render(0, true)
 
-		engine.setActiveSegment(segment)
+		engine.setActiveSegment(segment, false)
 		engine.writeSeparator(true)
 
 		out, _ := terminal.String()
@@ -174,8 +174,8 @@ func TestRenderActiveSegmentDiamondPreviousGradient(t *testing.T) {
 		assert.NoError(t, previous.MapSegmentWithWriter(engine.Env))
 		previous.Render(0, true)
 
-		engine.setActiveSegment(previous)
-		engine.renderActiveSegment()
+		engine.setActiveSegment(previous, false)
+		engine.renderActiveSegment(true)
 		terminal.String() // drain the previous segment's own output
 
 		next := &config.Segment{
@@ -189,8 +189,8 @@ func TestRenderActiveSegmentDiamondPreviousGradient(t *testing.T) {
 		assert.NoError(t, next.MapSegmentWithWriter(engine.Env))
 		next.Render(1, true)
 
-		engine.setActiveSegment(next)
-		engine.renderActiveSegment()
+		engine.setActiveSegment(next, false)
+		engine.renderActiveSegment(true)
 
 		out, _ := terminal.String()
 
@@ -231,8 +231,8 @@ func TestParentBackgroundKeywordCollapsesGradientLastStop(t *testing.T) {
 		assert.NoError(t, previous.MapSegmentWithWriter(engine.Env))
 		previous.Render(0, true)
 
-		engine.setActiveSegment(previous)
-		engine.renderActiveSegment()
+		engine.setActiveSegment(previous, false)
+		engine.renderActiveSegment(true)
 		terminal.String()
 
 		next := &config.Segment{
@@ -245,8 +245,8 @@ func TestParentBackgroundKeywordCollapsesGradientLastStop(t *testing.T) {
 		assert.NoError(t, next.MapSegmentWithWriter(engine.Env))
 		next.Render(1, true)
 
-		engine.setActiveSegment(next)
-		engine.renderActiveSegment()
+		engine.setActiveSegment(next, false)
+		engine.renderActiveSegment(true)
 
 		out, _ := terminal.String()
 		return out

--- a/src/prompt/primary.go
+++ b/src/prompt/primary.go
@@ -66,11 +66,7 @@ func (e *Engine) writePrimaryPromptInternal(needsPrimaryRPrompt, fromCache bool)
 	cycle = &e.Config.Cycle
 	var cancelNewline, didRender bool
 
-	// Choose block source based on whether we're rendering from cache
 	blocks := e.Config.Blocks
-	if fromCache {
-		blocks = e.allBlocks
-	}
 
 	// Launch execution for every segment of every block up front so they all
 	// run concurrently; blocks are still rendered sequentially afterward, in
@@ -104,6 +100,13 @@ func (e *Engine) writePrimaryPromptInternal(needsPrimaryRPrompt, fromCache bool)
 
 			allResults[i] = drainBlockResults(launched[i], len(block.Segments), executed)
 		}
+	}
+
+	// Every segment that timed out queued its event before its block result was delivered
+	// (see executeSegmentWithTimeout), so absorbing the queue here, after the drain, yields the
+	// exact pending set for this pass.
+	if e.stream != nil {
+		e.stream.absorb()
 	}
 
 	for i, block := range blocks {

--- a/src/prompt/segments.go
+++ b/src/prompt/segments.go
@@ -1,6 +1,7 @@
 package prompt
 
 import (
+	"runtime/debug"
 	"time"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/config"
@@ -93,42 +94,57 @@ func (e *Engine) renderBlockSegments(results []*config.Segment, block *config.Bl
 
 func (e *Engine) writeSegmentsConcurrently(segments []*config.Segment, out chan result) {
 	for i, segment := range segments {
-		// In streaming mode, pre-register all segments as pending
-		// This ensures countPendingSegments() sees them before timeout occurs.
-		// Without a positive streaming timeout no segment can ever time out
-		// into the pending state, so pre-registering would leak entries (the
-		// cleanup below only runs for segment.Timeout > 0) and keep the
-		// StreamPrimary producer waiting forever.
 		if e.Env.Flags().Streaming && e.Config.Streaming > 0 {
 			segment.Timeout = e.Config.Streaming
-			e.pendingSegments.Store(segment.Name(), true)
 		}
 
+		// Name memoizes on first call. Resolve it before the goroutine starts so the render and
+		// Execute goroutines never both write it.
+		_ = segment.Name()
+
 		go func(segment *config.Segment, index int) {
-			if segment.Timeout > 0 {
-				e.executeSegmentWithTimeout(segment)
-			} else {
-				segment.Execute(e.Env)
-			}
-
+			e.runSegment(segment)
 			out <- result{segment, index}
-
-			// In streaming mode, clean up pre-registered segments that completed before timeout
-			if e.Env.Flags().Streaming && segment.Timeout > 0 && !segment.Pending {
-				e.pendingSegments.Delete(segment.Name())
-			}
 		}(segment, i)
 	}
 }
 
+// runSegment dispatches to the timeout-aware path when the segment has a deadline, and to a
+// direct execution otherwise.
+func (e *Engine) runSegment(segment *config.Segment) {
+	if segment.Timeout > 0 {
+		e.executeSegmentWithTimeout(segment)
+		return
+	}
+
+	e.executeSegment(segment)
+}
+
+// executeSegment runs Execute and turns a panic into a disabled segment. Without this a
+// panicking segment kills the whole process, which for the serve daemon means a dead prompt
+// with no error anywhere.
+func (e *Engine) executeSegment(segment *config.Segment) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			return
+		}
+
+		log.Errorf("segment %s panicked: %v\n%s", segment.Name(), r, debug.Stack())
+		segment.Enabled = false
+	}()
+
+	segment.Execute(e.Env)
+}
+
 func (e *Engine) executeSegmentWithTimeout(segment *config.Segment) {
-	done := make(chan bool)
+	done := make(chan struct{})
 	gidChan := make(chan uint64, 1)
 
 	go func() {
 		gidChan <- runjobs.CurrentGID()
-		segment.Execute(e.Env)
-		close(done)
+		defer close(done)
+		e.executeSegment(segment)
 	}()
 
 	gid := <-gidChan
@@ -138,27 +154,66 @@ func (e *Engine) executeSegmentWithTimeout(segment *config.Segment) {
 
 	select {
 	case <-done:
-		// Completed before timeout - nothing extra to do
+		return
 	case <-timer.C:
-		log.Errorf("timeout after %dms for segment: %s", segment.Timeout, segment.Name())
+	}
 
-		// When streaming is enabled, don't kill goroutines - let them continue executing
-		if e.Env.Flags().Streaming {
-			segment.Pending = true
-			// Note: Do NOT set segment.Enabled here - that would race with Execute()
-			// Rendering logic handles Pending state to display "..." text
+	log.Errorf("timeout after %dms for segment: %s", segment.Timeout, segment.Name())
 
-			// Track this segment as pending and continue execution in background
-			e.trackPendingSegment(segment, done)
-			return
-		}
-
-		// For non-streaming mode, kill the goroutine
+	if e.stream == nil {
 		segment.Killed = true
 		if err := runjobs.KillGoroutineChildren(gid); err != nil {
 			log.Errorf("failed to kill child processes for goroutine %d (segment: %s): %v", gid, segment.Name(), err)
 		}
+
+		return
 	}
+
+	// The timed-out event is queued before this function returns and the block result is sent,
+	// so the producer's absorb after drainBlockResults always sees it.
+	e.stream.timedOut(segment)
+
+	go e.awaitPendingSegment(segment, done, gid)
+}
+
+// awaitPendingSegment reports a pending segment's completion to the producer, or abandons it
+// once pendingSegmentLimit passes so a hung segment cannot pin the cycle forever.
+func (e *Engine) awaitPendingSegment(segment *config.Segment, done <-chan struct{}, gid uint64) {
+	timer := time.NewTimer(pendingSegmentLimit)
+	defer timer.Stop()
+
+	select {
+	case <-done:
+		e.stream.completed(segment)
+	case <-timer.C:
+		log.Errorf("abandoning segment %s: still running after %s", segment.Name(), pendingSegmentLimit)
+		if err := runjobs.KillGoroutineChildren(gid); err != nil {
+			log.Errorf("failed to kill child processes for goroutine %d (segment: %s): %v", gid, segment.Name(), err)
+		}
+
+		e.stream.abandon(segment)
+	}
+}
+
+// renderSegment renders one segment for the current pass and reports whether it occupied an
+// index slot. A pending segment renders its placeholder from configuration only; an abandoned
+// one is skipped entirely. Neither may touch the writer: it belongs to the Execute goroutine
+// until the completed event arrives.
+func (e *Engine) renderSegment(block *config.Block, segment *config.Segment, index int) bool {
+	if e.segmentAbandoned(segment) {
+		return false
+	}
+
+	if e.segmentPending(segment) {
+		segment.RenderPlaceholder()
+		e.writeSegment(block, segment, true, true)
+		return true
+	}
+
+	enabled := segment.Render(index, e.forceRender)
+	e.writeSegment(block, segment, false, enabled)
+
+	return enabled
 }
 
 func (e *Engine) writeSegments(results []*config.Segment, block *config.Block, executed map[string]bool) {
@@ -169,30 +224,26 @@ func (e *Engine) writeSegments(results []*config.Segment, block *config.Block, e
 	// Render segments in index order while their dependencies are satisfied.
 	// executed is fully pre-populated before rendering begins (via drainBlockResults),
 	// so all resolvable cross-block and same-block dependencies are already available.
-	for current < count && e.canRenderSegment(results[current], executed) {
-		segment := results[current]
-		if segment.Render(segmentIndex, e.forceRender) {
+	// A pending segment's Needs must never be read here: Execute's deferred evaluateNeeds
+	// may still be appending to it concurrently.
+	for current < count && (e.segmentPending(results[current]) || e.canRenderSegment(results[current], executed)) {
+		if e.renderSegment(block, results[current], segmentIndex) {
 			segmentIndex++
 		}
 
-		e.writeSegment(block, segment)
 		current++
 	}
 
 	// Render remaining segments whose Needs could not be resolved
 	for ; current < count; current++ {
-		segment := results[current]
-		if segment.Render(segmentIndex, e.forceRender) {
+		if e.renderSegment(block, results[current], segmentIndex) {
 			segmentIndex++
 		}
-
-		e.writeSegment(block, segment)
 	}
 }
 
-func (e *Engine) writeSegment(block *config.Block, segment *config.Segment) {
-	// Allow pending segments to render (they show "..." text)
-	if !segment.Pending && !segment.Enabled && segment.ResolveStyle() != config.Accordion {
+func (e *Engine) writeSegment(block *config.Block, segment *config.Segment, pending, enabled bool) {
+	if !enabled && segment.ResolveStyle() != config.Accordion {
 		return
 	}
 
@@ -200,14 +251,22 @@ func (e *Engine) writeSegment(block *config.Block, segment *config.Segment) {
 		cycle = &newCycle
 		segment.Foreground = colors.Foreground
 		segment.Background = colors.Background
+
+		// A resolved segment picks these up lazily through its color templates; the
+		// placeholder already collapsed its colors in RenderPlaceholder, so re-seed them
+		// or the cycle would be skipped while the segment is pending.
+		if pending {
+			segment.CollapseForeground(colors.Foreground)
+			segment.CollapseBackground(colors.Background)
+		}
 	}
 
 	if terminal.Len() == 0 && len(block.LeadingDiamond) > 0 {
 		segment.LeadingDiamond = block.LeadingDiamond
 	}
 
-	e.setActiveSegment(segment)
-	e.renderActiveSegment()
+	e.setActiveSegment(segment, pending)
+	e.renderActiveSegment(enabled)
 }
 
 func (e *Engine) canRenderSegment(segment *config.Segment, executed map[string]bool) bool {

--- a/src/prompt/segments_test.go
+++ b/src/prompt/segments_test.go
@@ -2,7 +2,6 @@ package prompt
 
 import (
 	"testing"
-	"time"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/cache"
 	"github.com/jandedobbeleer/oh-my-posh/src/color"
@@ -145,85 +144,10 @@ func TestCanRenderSegment(t *testing.T) {
 	}
 }
 
-func TestExecuteSegmentWithTimeout_Streaming(t *testing.T) {
-	// This test verifies that when streaming is enabled and a timeout occurs,
-	// the segment is marked as pending and tracked for later completion
-	env := new(mock.Environment)
-	env.On("Flags").Return(&runtime.Flags{Streaming: true})
-
-	segment := &config.Segment{
-		Type:    "text",
-		Timeout: 1, // Very short timeout to ensure it triggers
-	}
-
-	engine := &Engine{
-		Env:              env,
-		streamingResults: make(chan *config.Segment, 10),
-	}
-
-	// Create a mock segment that will definitely timeout
-	// We'll use the actual timeout mechanism by making the execution slow
-	done := make(chan bool)
-	go func() {
-		time.Sleep(100 * time.Millisecond) // Longer than timeout
-		close(done)
-	}()
-
-	// Pre-register segment as pending (this happens in writeSegmentsConcurrently)
-	engine.pendingSegments.Store(segment.Name(), true)
-
-	// Mark as pending and track (simulating what executeSegmentWithTimeout does)
-	segment.Pending = true
-	engine.trackPendingSegment(segment, done)
-
-	// Verify it was tracked as pending
-	_, exists := engine.pendingSegments.Load(segment.Name())
-	assert.True(t, exists, "Segment should be tracked as pending")
-
-	// Wait for completion notification
-	select {
-	case completed := <-engine.streamingResults:
-		assert.Equal(t, segment, completed)
-		assert.False(t, completed.Pending, "Segment should no longer be pending after completion")
-	case <-time.After(200 * time.Millisecond):
-		t.Error("Expected segment completion notification")
-	}
-}
-
-func TestExecuteSegmentWithTimeout_NonStreaming(t *testing.T) {
-	// This test verifies that when streaming is disabled,
-	// trackPendingSegment returns early without tracking when streamingResults is nil
-	segment := &config.Segment{
-		Type:    "text",
-		Timeout: 10,
-	}
-
-	engine := &Engine{
-		// streamingResults is nil (non-streaming mode)
-	}
-
-	done := make(chan bool)
-
-	// Pre-register segment (simulating what happens in concurrent execution)
-	engine.pendingSegments.Store(segment.Name(), true)
-
-	// trackPendingSegment should not track when streamingResults is nil
-	engine.trackPendingSegment(segment, done)
-
-	// Signal completion
-	close(done)
-
-	// Give time for any goroutine to run (shouldn't be one)
-	time.Sleep(50 * time.Millisecond)
-
-	// Segment should still be in pendingSegments because notifySegmentCompletion
-	// was never called (trackPendingSegment returns early when streamingResults is nil)
-	_, exists := engine.pendingSegments.Load(segment.Name())
-	assert.True(t, exists, "Segment should remain in pendingSegments when streaming is disabled")
-}
-
-func TestExecuteSegmentWithTimeout_CachedValueFallback(t *testing.T) {
-	// This test verifies that a pending segment's Text() returns "..." placeholder
+// TestRenderPlaceholder_ThenRenderShowsRealText covers the streaming placeholder contract: a
+// pending segment's Text() serves the "..." placeholder without touching the writer, and once
+// the segment completes, Render replaces it with the segment's real, template-derived text.
+func TestRenderPlaceholder_ThenRenderShowsRealText(t *testing.T) {
 	env := new(mock.Environment)
 	env.On("Flags").Return(&runtime.Flags{})
 	env.On("Shell").Return(shell.GENERIC)
@@ -237,22 +161,15 @@ func TestExecuteSegmentWithTimeout_CachedValueFallback(t *testing.T) {
 
 	segment := &config.Segment{
 		Type:     "text",
-		Pending:  true,
 		Template: "actual content",
 	}
 
-	// Initialize the segment writer
 	err := segment.MapSegmentWithWriter(env)
 	assert.NoError(t, err)
 
-	// Render with pending state - should show "..."
-	segment.Render(0, true)
-	text := segment.Text()
-	assert.Equal(t, "...", text, "Pending segment should show ...")
+	segment.RenderPlaceholder()
+	assert.Equal(t, "...", segment.Text(), "a pending segment should show the placeholder text")
 
-	// After completion, render again with actual content
-	segment.Pending = false
 	segment.Render(0, true)
-	text = segment.Text()
-	assert.NotEqual(t, "...", text, "Non-pending segment should show actual content")
+	assert.Equal(t, "actual content", segment.Text(), "a completed segment should show its real text")
 }

--- a/src/prompt/streaming.go
+++ b/src/prompt/streaming.go
@@ -1,7 +1,11 @@
 package prompt
 
 import (
+	"runtime/debug"
+	"time"
+
 	"github.com/jandedobbeleer/oh-my-posh/src/config"
+	"github.com/jandedobbeleer/oh-my-posh/src/log"
 	"github.com/jandedobbeleer/oh-my-posh/src/shell"
 )
 
@@ -10,6 +14,100 @@ import (
 // the transient prompt on Enter needs no additional CLI call.
 const TransientMarker = "\x1e"
 
+// pendingSegmentLimit bounds how long a timed-out segment may stay pending before the cycle
+// abandons it and renders without it. A package variable so tests can shorten it.
+var pendingSegmentLimit = 30 * time.Second
+
+type segmentEventKind uint8
+
+const (
+	segmentTimedOut segmentEventKind = iota
+	segmentCompleted
+	segmentAbandoned
+)
+
+type segmentEvent struct {
+	segment *config.Segment
+	kind    segmentEventKind
+}
+
+// streamCycle holds the state of one StreamPrimary run. events is the only channel between
+// segment goroutines and the producer goroutine. pending and abandoned are owned by the producer
+// goroutine: nothing else reads or writes them, so they need no lock.
+type streamCycle struct {
+	events    chan segmentEvent
+	pending   map[*config.Segment]struct{}
+	abandoned map[*config.Segment]struct{}
+	abort     chan struct{}
+	done      chan struct{}
+}
+
+// newStreamCycle creates the event queue for one StreamPrimary run. events is sized to
+// 2*segmentCount + 1: every segment emits at most two events (timedOut, then exactly one of
+// completed/abandoned), so a send can never block and is never dropped. Every send on this
+// channel is a plain send, never a select/default, because the buffer is provably big enough.
+func newStreamCycle(segmentCount int) *streamCycle {
+	return &streamCycle{
+		events:    make(chan segmentEvent, 2*segmentCount+1),
+		pending:   make(map[*config.Segment]struct{}),
+		abandoned: make(map[*config.Segment]struct{}),
+		abort:     make(chan struct{}),
+		done:      make(chan struct{}),
+	}
+}
+
+func (c *streamCycle) timedOut(segment *config.Segment) {
+	c.events <- segmentEvent{segment: segment, kind: segmentTimedOut}
+}
+
+func (c *streamCycle) completed(segment *config.Segment) {
+	c.events <- segmentEvent{segment: segment, kind: segmentCompleted}
+}
+
+// abandon queues a segmentAbandoned event. Named to avoid colliding with the abandoned field.
+func (c *streamCycle) abandon(segment *config.Segment) {
+	c.events <- segmentEvent{segment: segment, kind: segmentAbandoned}
+}
+
+// apply folds one event into the pending/abandoned sets. Producer goroutine only.
+func (c *streamCycle) apply(ev segmentEvent) {
+	switch ev.kind {
+	case segmentTimedOut:
+		if _, ok := c.abandoned[ev.segment]; ok {
+			return
+		}
+
+		c.pending[ev.segment] = struct{}{}
+	case segmentCompleted:
+		delete(c.pending, ev.segment)
+	case segmentAbandoned:
+		delete(c.pending, ev.segment)
+		c.abandoned[ev.segment] = struct{}{}
+	}
+}
+
+// absorb drains every event already queued without blocking. Producer goroutine only.
+func (c *streamCycle) absorb() {
+	for {
+		select {
+		case ev := <-c.events:
+			c.apply(ev)
+		default:
+			return
+		}
+	}
+}
+
+func (c *streamCycle) isPending(segment *config.Segment) bool {
+	_, ok := c.pending[segment]
+	return ok
+}
+
+func (c *streamCycle) isAbandoned(segment *config.Segment) bool {
+	_, ok := c.abandoned[segment]
+	return ok
+}
+
 // The engine + terminal package globals are not thread-safe, so at most one
 // StreamPrimary producer goroutine may be rendering at any given time. Callers
 // that need to interrupt an in-flight cycle (e.g. a long-lived server handling
@@ -17,13 +115,7 @@ const TransientMarker = "\x1e"
 // wait for it to return before starting a new cycle - Abort blocks until the
 // producer goroutine has fully exited.
 func (e *Engine) StreamPrimary() <-chan string {
-	// Initialize streaming infrastructure BEFORE launching goroutine
-	// This ensures the channel exists when segments start timing out
-	e.streamingResults = make(chan *config.Segment, 100)
-	e.allBlocks = e.Config.Blocks
-	e.abort = make(chan struct{})
-	e.done = make(chan struct{})
-
+	e.stream = newStreamCycle(e.segmentCount())
 	out := make(chan string, 10)
 
 	// sendRecord delivers a record unless the cycle gets aborted. A plain
@@ -35,7 +127,7 @@ func (e *Engine) StreamPrimary() <-chan string {
 		select {
 		case out <- record:
 			return true
-		case <-e.abort:
+		case <-e.stream.abort:
 			return false
 		}
 	}
@@ -45,7 +137,7 @@ func (e *Engine) StreamPrimary() <-chan string {
 	// terminal package globals again - those are shared with the next cycle.
 	aborted := func() bool {
 		select {
-		case <-e.abort:
+		case <-e.stream.abort:
 			return true
 		default:
 			return false
@@ -80,69 +172,55 @@ func (e *Engine) StreamPrimary() <-chan string {
 	}
 
 	go func() {
-		defer close(e.done)
+		defer close(e.stream.done)
 		defer close(out)
 		// Registered last so it runs first during unwinding: a panic in
 		// segment/render code then costs this one cycle instead of the whole
 		// process - which matters for the long-lived serve daemon. The closes
 		// above still run afterwards, so Abort() and the record consumer both
-		// observe a normally-ended cycle.
+		// observe a normally-ended cycle. The recover MUST log; a silent
+		// recover previously hid the very bug this rewrite fixes.
 		defer func() {
-			_ = recover()
+			r := recover()
+			if r == nil {
+				return
+			}
+
+			log.Errorf("streaming: render cycle panicked: %v\n%s", r, debug.Stack())
 		}()
 
 		if aborted() {
 			return
 		}
 
-		// Render and send initial prompt with pending segments
 		if !sendRecord(e.Primary()) {
 			return
 		}
 
 		sendTransient()
 
-		if e.countPendingSegments() == 0 {
-			// No segment is executing in the background, so nothing can send
-			// on streamingResults after this point - safe to close.
-			close(e.streamingResults)
-			return
+		refreshed := false
+
+		for len(e.stream.pending) > 0 {
+			select {
+			case <-e.stream.abort:
+				return
+			case ev := <-e.stream.events:
+				e.stream.apply(ev)
+			}
+
+			// Coalesce whatever else already queued so simultaneous completions cost one render.
+			e.stream.absorb()
+
+			if !sendRecord(e.renderFromBlocks()) {
+				return
+			}
+
+			refreshed = true
 		}
 
-		// Listen for segment completions. A segment that timed out keeps
-		// executing in the background (trackPendingSegment) even after this
-		// loop returns; notifySegmentCompletion sends via select/default so
-		// it never blocks such a goroutine, but that also means
-		// streamingResults must NOT be closed here on the abort path - a
-		// stray late send on a closed channel would panic. Only close it once
-		// every pending segment has actually reported in (countPendingSegments
-		// reaches 0), which is the one path guaranteed to have no further
-		// senders. On abort, leave the channel open and let it be garbage
-		// collected once the last stray sender (and this Engine) is dropped.
-		for {
-			select {
-			case <-e.abort:
-				return
-			case _, ok := <-e.streamingResults:
-				if !ok {
-					return
-				}
-
-				if aborted() {
-					continue
-				}
-
-				if !sendRecord(e.renderFromBlocks()) {
-					return
-				}
-
-				if e.countPendingSegments() == 0 {
-					// refresh the transient prompt now the context is fully resolved
-					sendTransient()
-					close(e.streamingResults)
-					return
-				}
-			}
+		if refreshed {
+			sendTransient()
 		}
 	}()
 
@@ -156,37 +234,25 @@ func (e *Engine) StreamPrimary() <-chan string {
 // or the cycle has already finished on its own.
 //
 // Abort does not wait for segments still executing in the background after a
-// per-segment timeout (see trackPendingSegment) - those belong to this
-// Engine instance only and are expected to be abandoned along with it; they
-// will report to a now-unread streamingResults channel (via
-// notifySegmentCompletion's non-blocking send) until they finish on their own
-// and get garbage collected with this Engine.
+// per-segment timeout (see awaitPendingSegment) - those belong to this Engine
+// instance only and are expected to be abandoned along with it.
 func (e *Engine) Abort() {
-	if e.abort == nil {
+	if e.stream == nil {
 		return
 	}
 
 	select {
-	case <-e.abort:
+	case <-e.stream.abort:
 		// already aborted
 	default:
-		close(e.abort)
+		close(e.stream.abort)
 	}
 
-	if e.done != nil {
-		<-e.done
-	}
+	<-e.stream.done
 }
 
-func (e *Engine) countPendingSegments() int {
-	count := 0
-	e.pendingSegments.Range(func(_, _ any) bool {
-		count++
-		return true
-	})
-	return count
-}
-
+// renderFromBlocks resets the prompt builder state a fresh render pass needs and re-renders
+// the primary prompt from the segments' already-executed state (the cache path).
 func (e *Engine) renderFromBlocks() string {
 	// Reset prompt builder
 	e.prompt.Reset()
@@ -199,31 +265,19 @@ func (e *Engine) renderFromBlocks() string {
 	return e.primaryInternal(true)
 }
 
-func (e *Engine) trackPendingSegment(segment *config.Segment, done chan bool) {
-	if e.streamingResults == nil {
-		return
-	}
-
-	// Segment is already pre-registered in pendingSegments map
-	go func() {
-		<-done
-		segment.Pending = false
-		e.notifySegmentCompletion(segment)
-	}()
+func (e *Engine) segmentPending(segment *config.Segment) bool {
+	return e.stream != nil && e.stream.isPending(segment)
 }
 
-func (e *Engine) notifySegmentCompletion(segment *config.Segment) {
-	if e.streamingResults == nil {
-		return
+func (e *Engine) segmentAbandoned(segment *config.Segment) bool {
+	return e.stream != nil && e.stream.isAbandoned(segment)
+}
+
+func (e *Engine) segmentCount() int {
+	count := 0
+	for _, block := range e.Config.Blocks {
+		count += len(block.Segments)
 	}
 
-	if _, ok := e.pendingSegments.LoadAndDelete(segment.Name()); ok {
-		select {
-		case e.streamingResults <- segment:
-			// Successfully notified consumer
-		default:
-			// Consumer not ready or already exited
-			// This can happen if segment completes after consumer finishes
-		}
-	}
+	return count
 }

--- a/src/prompt/streaming_test.go
+++ b/src/prompt/streaming_test.go
@@ -2,7 +2,9 @@ package prompt
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -29,6 +31,7 @@ func TestStreamPrimary_NoSegments(t *testing.T) {
 	env.On("Flags").Return(&runtime.Flags{Streaming: true})
 	env.On("CursorPosition").Return(1, 1)
 	env.On("StatusCodes").Return(0, "0")
+	env.On("DirMatchesOneOf", testifymock.Anything, testifymock.Anything).Return(false)
 	// Mock accent color retrieval for both Windows and macOS. The mock
 	// forwards RunCommand as Called(command, args), so the expectation
 	// takes two arguments: the command and the args slice.
@@ -76,15 +79,23 @@ func TestStreamPrimary_TransientRecord(t *testing.T) {
 	assert.NotEmpty(t, strings.TrimPrefix(prompts[1], TransientMarker), "Transient record should contain the rendered prompt")
 }
 
+// mockSlowSession configures env's Session-segment dependencies (SSH_CONNECTION,
+// SSH_CLIENT, Platform) so a config.SESSION segment's real Execute genuinely blocks for
+// delay before completing - driving the real timeout/completion machinery instead of
+// poking streamCycle internals directly.
+func mockSlowSession(env *mock.Environment, delay time.Duration) {
+	env.On("Getenv", "SSH_CONNECTION").Return("").After(delay)
+	env.On("Getenv", "SSH_CLIENT").Return("")
+	env.On("Platform").Return(runtime.WINDOWS)
+}
+
 func TestStreamPrimary_TransientRecord_RefreshedAfterCompletion(t *testing.T) {
 	env := setupStreamingTestEnv()
+	mockSlowSession(env, 50*time.Millisecond)
 
 	slowSegment := &config.Segment{
-		Type:       "text",
-		Template:   "SLOW",
-		Pending:    true,
-		Foreground: "#ffffff",
-		Background: "#000000",
+		Type:    config.SESSION,
+		Timeout: 5,
 	}
 
 	engine := &Engine{
@@ -97,24 +108,11 @@ func TestStreamPrimary_TransientRecord_RefreshedAfterCompletion(t *testing.T) {
 				},
 			},
 		},
-		Env:              env,
-		streamingResults: make(chan *config.Segment, 10),
+		Env: env,
 	}
 
-	err := slowSegment.MapSegmentWithWriter(env)
-	require.NoError(t, err)
-
-	engine.pendingSegments.Store(slowSegment.Name(), true)
-
 	out := engine.StreamPrimary()
-
-	go func() {
-		time.Sleep(50 * time.Millisecond)
-		slowSegment.Pending = false
-		engine.notifySegmentCompletion(slowSegment)
-	}()
-
-	prompts := collectChannelOutput(out, 200*time.Millisecond)
+	prompts := collectChannelOutput(out, 300*time.Millisecond)
 
 	// initial prompt, initial transient, primary update, refreshed transient
 	assert.Len(t, prompts, 4)
@@ -156,39 +154,42 @@ func TestStreamPrimary_RecoversFromRenderPanic(t *testing.T) {
 // Guards against the abort deadlock: when the record channel fills against a
 // stalled consumer, the producer blocks in a send; Abort() must still unblock
 // it (via the abort-aware send) instead of waiting forever for the goroutine
-// to exit.
+// to exit. Fifteen segments complete at staggered real times (an incrementing
+// sleep per call to the mocked Getenv), so their completions cannot all
+// coalesce into a single render; with nothing draining out (buffer 10), the
+// producer is driven into a blocked send well before all of them land.
 func TestStreamPrimary_AbortUnblocksSaturatedProducer(t *testing.T) {
 	env := setupStreamingTestEnv()
+	env.On("Getenv", "SSH_CLIENT").Return("")
+	env.On("Platform").Return(runtime.WINDOWS)
+
+	var calls atomic.Int64
+	env.On("Getenv", "SSH_CONNECTION").Return("").Run(func(_ testifymock.Arguments) {
+		n := calls.Add(1)
+		time.Sleep(time.Duration(n) * 8 * time.Millisecond)
+	})
+
+	const segmentCount = 15
+
+	segments := make([]*config.Segment, segmentCount)
+	for i := range segments {
+		segments[i] = &config.Segment{Type: config.SESSION, Timeout: 1}
+	}
 
 	engine := &Engine{
 		Config: &config.Config{
-			Blocks: []*config.Block{},
+			Blocks: []*config.Block{
+				{Type: config.Prompt, Alignment: config.Left, Segments: segments},
+			},
 		},
-		Env:              env,
-		streamingResults: make(chan *config.Segment, 100),
+		Env: env,
 	}
 
-	// Pre-register pending segments that never get removed, so the producer
-	// keeps looping over completions instead of finishing the cycle.
-	segments := make([]*config.Segment, 20)
-	for i := range segments {
-		segments[i] = &config.Segment{Type: config.SegmentType(fmt.Sprintf("test-%d", i)), Pending: true}
-		engine.pendingSegments.Store(segments[i].Name(), true)
-	}
-
-	// Nothing reads from the channel: the producer will saturate the record
-	// buffer and block in a send while processing the completions. Feed them
-	// directly (bypassing notifySegmentCompletion, which would drain
-	// pendingSegments and end the cycle early).
+	// Nothing reads from the output channel.
 	_ = engine.StreamPrimary()
 
-	for _, segment := range segments {
-		segment.Pending = false
-		engine.streamingResults <- segment
-	}
-
-	// Give the producer time to fill the record buffer and block.
-	time.Sleep(100 * time.Millisecond)
+	// Give every staggered completion time to fire for real before checking Abort.
+	time.Sleep(time.Duration(segmentCount+2) * 8 * time.Millisecond)
 
 	done := make(chan struct{})
 	go func() {
@@ -201,290 +202,6 @@ func TestStreamPrimary_AbortUnblocksSaturatedProducer(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("Abort must unblock a producer stuck in a record send")
 	}
-}
-
-func TestStreamPrimary_WithPendingSegments(t *testing.T) {
-	engine := &Engine{
-		streamingResults: make(chan *config.Segment, 10),
-	}
-
-	segment := &config.Segment{
-		Type:    "text",
-		Pending: true,
-	}
-
-	// Track as pending
-	engine.pendingSegments.Store(segment.Name(), true)
-
-	// Simulate segment completion in background
-	go func() {
-		time.Sleep(50 * time.Millisecond)
-		segment.Pending = false
-		engine.notifySegmentCompletion(segment)
-	}()
-
-	// Verify notification is received
-	select {
-	case completed := <-engine.streamingResults:
-		assert.Equal(t, segment, completed)
-		assert.False(t, completed.Pending)
-	case <-time.After(200 * time.Millisecond):
-		t.Error("Expected segment completion notification")
-	}
-}
-
-func TestCountPendingSegments(t *testing.T) {
-	cases := []struct {
-		Case     string
-		Segments []string
-		Count    int
-	}{
-		{Case: "No pending segments", Count: 0, Segments: []string{}},
-		{Case: "One pending segment", Count: 1, Segments: []string{"segment1"}},
-		{Case: "Multiple pending segments", Count: 3, Segments: []string{"segment1", "segment2", "segment3"}},
-	}
-
-	for _, tc := range cases {
-		engine := &Engine{}
-
-		for _, name := range tc.Segments {
-			engine.pendingSegments.Store(name, true)
-		}
-
-		count := engine.countPendingSegments()
-		assert.Equal(t, tc.Count, count, tc.Case)
-	}
-}
-
-func TestNotifySegmentCompletion(t *testing.T) {
-	cases := []struct {
-		Case           string
-		StreamingSetup bool
-		SegmentPending bool
-		ExpectNotify   bool
-	}{
-		{Case: "No streaming channel", StreamingSetup: false, SegmentPending: true, ExpectNotify: false},
-		{Case: "Segment not pending", StreamingSetup: true, SegmentPending: false, ExpectNotify: false},
-		{Case: "Valid notification", StreamingSetup: true, SegmentPending: true, ExpectNotify: true},
-	}
-
-	for _, tc := range cases {
-		engine := &Engine{}
-		segment := &config.Segment{Type: "test"}
-
-		if tc.StreamingSetup {
-			engine.streamingResults = make(chan *config.Segment, 10)
-		}
-
-		if tc.SegmentPending {
-			engine.pendingSegments.Store(segment.Name(), true)
-		}
-
-		engine.notifySegmentCompletion(segment)
-
-		if tc.ExpectNotify {
-			select {
-			case received := <-engine.streamingResults:
-				assert.Equal(t, segment, received, tc.Case)
-			case <-time.After(100 * time.Millisecond):
-				t.Errorf("%s: Expected notification but got timeout", tc.Case)
-			}
-		} else if tc.StreamingSetup {
-			select {
-			case <-engine.streamingResults:
-				t.Errorf("%s: Unexpected notification received", tc.Case)
-			case <-time.After(50 * time.Millisecond):
-				// Expected - no notification
-			}
-		}
-	}
-}
-
-func TestTrackPendingSegment(t *testing.T) {
-	engine := &Engine{
-		streamingResults: make(chan *config.Segment, 10),
-	}
-
-	segment := &config.Segment{
-		Type:    "test",
-		Pending: true,
-	}
-
-	done := make(chan bool)
-
-	// Pre-register segment as pending (this happens in writeSegmentsConcurrently in real code)
-	engine.pendingSegments.Store(segment.Name(), true)
-
-	// Start tracking
-	engine.trackPendingSegment(segment, done)
-
-	// Verify segment is tracked
-	_, ok := engine.pendingSegments.Load(segment.Name())
-	assert.True(t, ok, "Segment should be tracked")
-
-	// Simulate completion
-	close(done)
-
-	// Wait for goroutine to process
-	select {
-	case completed := <-engine.streamingResults:
-		assert.Equal(t, segment, completed)
-		assert.False(t, segment.Pending, "Segment should no longer be pending")
-	case <-time.After(100 * time.Millisecond):
-		t.Error("Expected segment completion notification")
-	}
-
-	// Verify segment is no longer tracked
-	_, ok = engine.pendingSegments.Load(segment.Name())
-	assert.False(t, ok, "Segment should no longer be tracked")
-}
-
-func TestRenderFromBlocks(_ *testing.T) {
-	env := new(mock.Environment)
-	env.On("Shell").Return(shell.PWSH)
-	env.On("Flags").Return(&runtime.Flags{})
-
-	// This test validates that renderFromBlocks properly delegates to primaryInternal
-	engine := &Engine{
-		Config: &config.Config{
-			Blocks: []*config.Block{},
-		},
-		Env:       env,
-		allBlocks: []*config.Block{},
-	}
-
-	// Just verify it doesn't panic - full integration tested elsewhere
-	_ = engine.renderFromBlocks()
-}
-
-func TestPrimaryInternal_FromCache(_ *testing.T) {
-	env := new(mock.Environment)
-	env.On("Shell").Return(shell.PWSH)
-	env.On("Flags").Return(&runtime.Flags{})
-
-	// This test validates the fromCache parameter is handled correctly
-	engine := &Engine{
-		Config: &config.Config{
-			Blocks: []*config.Block{},
-		},
-		Env:       env,
-		allBlocks: []*config.Block{},
-	}
-
-	// Just verify it doesn't panic - full integration tested elsewhere
-	_ = engine.primaryInternal(true)
-}
-
-func TestRenderBlockFromCache(t *testing.T) {
-	// This test validates renderBlockFromCache handles segments correctly
-	segment := &config.Segment{
-		Type:    "text",
-		Enabled: false,
-	}
-
-	block := &config.Block{
-		Type:      config.Prompt,
-		Alignment: config.Left,
-		Segments:  []*config.Segment{segment},
-	}
-
-	engine := &Engine{
-		Config: &config.Config{},
-	}
-
-	terminal.Init(shell.PWSH)
-
-	// Should not render when segment is disabled and not forced
-	result := engine.renderBlockFromCache(block, false)
-	assert.False(t, result, "Block should not render with disabled segment")
-}
-
-func TestSegmentPendingState(t *testing.T) {
-	env := new(mock.Environment)
-	env.On("Shell").Return(shell.PWSH)
-	env.On("Flags").Return(&runtime.Flags{})
-
-	template.Cache = &cache.Template{
-		Segments: maps.NewConcurrent[any](),
-	}
-	template.Init(env, nil, nil)
-
-	segment := &config.Segment{
-		Type:     "text",
-		Pending:  true,
-		Template: "test template",
-	}
-	err := segment.MapSegmentWithWriter(env)
-	require.NoError(t, err)
-
-	// Render with pending state - should show "..."
-	segment.Render(0, true)
-	text := segment.Text()
-	assert.Equal(t, "...", text, "Pending segment should show ...")
-
-	// After completion
-	segment.Pending = false
-	segment.Render(0, true)
-	text = segment.Text()
-	assert.NotEqual(t, "...", text, "Non-pending segment should show actual content")
-}
-
-func collectChannelOutput(ch <-chan string, timeout time.Duration) []string {
-	var results []string
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
-
-	for {
-		select {
-		case result, ok := <-ch:
-			if !ok {
-				return results
-			}
-			results = append(results, result)
-		case <-timer.C:
-			return results
-		}
-	}
-}
-
-func TestStreamingWithTimeout(t *testing.T) {
-	engine := &Engine{
-		streamingResults: make(chan *config.Segment, 10),
-	}
-
-	segment := &config.Segment{
-		Type:    "test",
-		Timeout: 10,
-	}
-
-	// Pre-register segment as pending (this happens in writeSegmentsConcurrently in real code)
-	engine.pendingSegments.Store(segment.Name(), true)
-
-	// Test that timeout with streaming enabled marks segment as pending
-	done := make(chan bool)
-
-	go func() {
-		time.Sleep(50 * time.Millisecond)
-		close(done)
-	}()
-
-	engine.trackPendingSegment(segment, done)
-
-	// Verify pending state
-	_, isPending := engine.pendingSegments.Load(segment.Name())
-	require.True(t, isPending, "Segment should be pending")
-
-	// Wait for completion
-	select {
-	case <-engine.streamingResults:
-		// Success
-	case <-time.After(200 * time.Millisecond):
-		t.Error("Timeout waiting for segment completion")
-	}
-
-	// Verify no longer pending
-	_, isPending = engine.pendingSegments.Load(segment.Name())
-	assert.False(t, isPending, "Segment should no longer be pending")
 }
 
 func setupStreamingTestEnv() *mock.Environment {
@@ -512,8 +229,27 @@ func setupStreamingTestEnv() *mock.Environment {
 	return env
 }
 
+func collectChannelOutput(ch <-chan string, timeout time.Duration) []string {
+	var results []string
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	for {
+		select {
+		case result, ok := <-ch:
+			if !ok {
+				return results
+			}
+			results = append(results, result)
+		case <-timer.C:
+			return results
+		}
+	}
+}
+
 func TestStreamPrimary_FullFlow_WithRendering(t *testing.T) {
 	env := setupStreamingTestEnv()
+	mockSlowSession(env, 50*time.Millisecond)
 
 	// Create segments with different speeds
 	fastSegment := &config.Segment{
@@ -524,11 +260,8 @@ func TestStreamPrimary_FullFlow_WithRendering(t *testing.T) {
 	}
 
 	slowSegment := &config.Segment{
-		Type:       "text",
-		Template:   "SLOW",
-		Pending:    true, // Initially pending
-		Foreground: "#ffffff",
-		Background: "#000000",
+		Type:    config.SESSION,
+		Timeout: 5,
 	}
 
 	engine := &Engine{
@@ -541,36 +274,19 @@ func TestStreamPrimary_FullFlow_WithRendering(t *testing.T) {
 				},
 			},
 		},
-		Env:              env,
-		streamingResults: make(chan *config.Segment, 10),
+		Env: env,
 	}
-
-	// Map segment writers
-	err := fastSegment.MapSegmentWithWriter(env)
-	require.NoError(t, err)
-	err = slowSegment.MapSegmentWithWriter(env)
-	require.NoError(t, err)
-
-	// Track slow segment as pending
-	engine.pendingSegments.Store(slowSegment.Name(), true)
 
 	// Start streaming
 	out := engine.StreamPrimary()
 
-	// Simulate slow segment completion after delay
-	go func() {
-		time.Sleep(50 * time.Millisecond)
-		slowSegment.Pending = false
-		engine.notifySegmentCompletion(slowSegment)
-	}()
-
 	// Collect all prompts
-	prompts := collectChannelOutput(out, 200*time.Millisecond)
+	prompts := collectChannelOutput(out, 300*time.Millisecond)
 
-	// Should have at least 2 prompts: initial (with "...") and final (with "SLOW")
+	// Should have at least 2 prompts: initial (with "...") and final (with the resolved segment)
 	assert.GreaterOrEqual(t, len(prompts), 1, "Should have at least initial prompt")
 
-	// First prompt should contain "..." for pending segment
+	// First prompt should contain "..." for the pending segment
 	if len(prompts) > 0 {
 		assert.Contains(t, prompts[0], "...", "Initial prompt should show pending text")
 	}
@@ -583,6 +299,7 @@ func TestStreamPrimary_FullFlow_WithRendering(t *testing.T) {
 
 func TestStreamPrimary_MultipleBlocks_MixedSpeed(t *testing.T) {
 	env := setupStreamingTestEnv()
+	mockSlowSession(env, 50*time.Millisecond)
 
 	// Block 1: Fast segment
 	fast1 := &config.Segment{
@@ -592,9 +309,8 @@ func TestStreamPrimary_MultipleBlocks_MixedSpeed(t *testing.T) {
 
 	// Block 2: Slow segment
 	slow1 := &config.Segment{
-		Type:     "text",
-		Template: "SLOW1",
-		Pending:  true,
+		Type:    config.SESSION,
+		Timeout: 5,
 	}
 
 	// Block 3: Another fast segment
@@ -611,29 +327,13 @@ func TestStreamPrimary_MultipleBlocks_MixedSpeed(t *testing.T) {
 				{Type: config.Prompt, Alignment: config.Left, Segments: []*config.Segment{fast2}},
 			},
 		},
-		Env:              env,
-		streamingResults: make(chan *config.Segment, 10),
+		Env: env,
 	}
-
-	// Map segments
-	require.NoError(t, fast1.MapSegmentWithWriter(env))
-	require.NoError(t, slow1.MapSegmentWithWriter(env))
-	require.NoError(t, fast2.MapSegmentWithWriter(env))
-
-	// Track slow segment
-	engine.pendingSegments.Store(slow1.Name(), true)
 
 	// Start streaming
 	out := engine.StreamPrimary()
 
-	// Simulate completion
-	go func() {
-		time.Sleep(50 * time.Millisecond)
-		slow1.Pending = false
-		engine.notifySegmentCompletion(slow1)
-	}()
-
-	prompts := collectChannelOutput(out, 200*time.Millisecond)
+	prompts := collectChannelOutput(out, 300*time.Millisecond)
 
 	// Should receive prompts
 	assert.NotEmpty(t, prompts, "Should receive streaming prompts")
@@ -647,6 +347,7 @@ func setupBasicStreamingTestEnv() *Engine {
 	env.On("Flags").Return(&runtime.Flags{Streaming: true})
 	env.On("CursorPosition").Return(1, 1)
 	env.On("StatusCodes").Return(0, "0")
+	env.On("DirMatchesOneOf", testifymock.Anything, testifymock.Anything).Return(false)
 	// MakeColors resolves the accent color, which reads the registry on Windows
 	// and shells out on macOS. Without these the helper panics on those hosts.
 	env.On("RunCommand", testifymock.Anything, testifymock.Anything).Return("4", nil)
@@ -683,122 +384,17 @@ func TestStreamPrimary_EarlyChannelClosure(t *testing.T) {
 	assert.Len(t, prompts, 2, "Should receive initial prompt and transient record")
 }
 
-func TestStreamPrimary_NoStreamingResults_Channel(t *testing.T) {
-	engine := setupBasicStreamingTestEnv()
-
-	// Engine without streamingResults channel (edge case)
-	// No streamingResults channel set
-
-	// Should not panic
-	out := engine.StreamPrimary()
-	prompts := collectChannelOutput(out, 100*time.Millisecond)
-
-	assert.Len(t, prompts, 2, "Should get the initial prompt and transient record with no pending segments")
-}
-
-// Validates that the streaming loop correctly handles segments that complete
-// after Primary() but before/during the counting phase - the fix for the race
-// where pendingCount could get out of sync with actual pending segments.
-func TestStreamPrimary_RaceConditionFix(t *testing.T) {
-	env := new(mock.Environment)
-	env.On("Pwd").Return("/test")
-	env.On("Home").Return("/home")
-	env.On("Shell").Return(shell.PWSH)
-	env.On("Flags").Return(&runtime.Flags{Streaming: true})
-	env.On("CursorPosition").Return(1, 1)
-	env.On("StatusCodes").Return(0, "0")
-	// MakeColors resolves the accent color, which reads the registry on Windows
-	// and shells out on macOS. Without these the setup panics on those hosts.
-	env.On("RunCommand", testifymock.Anything, testifymock.Anything).Return("4", nil)
-	env.On("WindowsRegistryKeyValue", testifymock.Anything).Return(&runtime.WindowsRegistryValue{ValueType: runtime.DWORD, DWord: 0xFF0078D7}, nil)
-
-	template.Cache = &cache.Template{
-		Segments: maps.NewConcurrent[any](),
-	}
-	template.Init(env, nil, nil)
-	terminal.Init(shell.PWSH)
-	terminal.Colors = color.MakeColors(nil, false, "", env)
-
-	engine := &Engine{
-		Config: &config.Config{
-			Blocks: []*config.Block{},
-		},
-		Env:              env,
-		streamingResults: make(chan *config.Segment, 10),
-	}
-
-	// Create three segments, simulating the race scenario:
-	// - segmentA: Completes quickly after Primary()
-	// - segmentB: Completes during loop
-	// - segmentC: Completes last
-	segmentA := &config.Segment{Type: "test-a", Pending: true}
-	segmentB := &config.Segment{Type: "test-b", Pending: true}
-	segmentC := &config.Segment{Type: "test-c", Pending: true}
-
-	// Pre-register all three as pending (simulates timeout during Primary())
-	engine.pendingSegments.Store(segmentA.Name(), true)
-	engine.pendingSegments.Store(segmentB.Name(), true)
-	engine.pendingSegments.Store(segmentC.Name(), true)
-
-	// Simulate segmentA completing immediately after Primary() but before countPendingSegments()
-	// This is the race condition - notification sent but segment removed from map
-	go func() {
-		// Small delay to ensure StreamPrimary has been called but before counting
-		time.Sleep(5 * time.Millisecond)
-		segmentA.Pending = false
-		engine.notifySegmentCompletion(segmentA)
-	}()
-
-	// Simulate segmentB and segmentC completing during the loop
-	go func() {
-		time.Sleep(30 * time.Millisecond)
-		segmentB.Pending = false
-		engine.notifySegmentCompletion(segmentB)
-	}()
-
-	go func() {
-		time.Sleep(50 * time.Millisecond)
-		segmentC.Pending = false
-		engine.notifySegmentCompletion(segmentC)
-	}()
-
-	// Start streaming
-	out := engine.StreamPrimary()
-
-	// Collect all prompts with sufficient timeout
-	prompts := collectChannelOutput(out, 200*time.Millisecond)
-
-	// Only count primary prompt records, transient records don't reflect segment updates
-	var primaryPrompts []string
-	for _, record := range prompts {
-		if !strings.HasPrefix(record, TransientMarker) {
-			primaryPrompts = append(primaryPrompts, record)
-		}
-	}
-
-	// With the fix, we should receive updates for all three segments
-	// Initial prompt + 3 updates (A, B, C) = 4 total
-	// Without the fix, we might only get Initial + 2 updates and exit early
-	assert.GreaterOrEqual(t, len(primaryPrompts), 3, "Should receive updates for all pending segments")
-
-	// Verify all segments were properly cleaned up
-	count := engine.countPendingSegments()
-	assert.Equal(t, 0, count, "All pending segments should be cleared")
-}
-
 // Validates that Abort() stops the producer from emitting further records and
 // blocks until the producer goroutine has fully exited, even when a segment
 // completes (and tries to notify) after the abort was issued - that late
 // notification must not panic or deadlock.
 func TestStreamPrimary_Abort_StopsRenderingAndDrains(t *testing.T) {
 	env := setupStreamingTestEnv()
+	mockSlowSession(env, 40*time.Millisecond)
 
 	slowSegment := &config.Segment{
-		Type:       "text",
-		Template:   "SLOW",
-		Pending:    true,
-		Foreground: "#ffffff",
-		Background: "#000000",
+		Type:    config.SESSION,
+		Timeout: 5,
 	}
 
 	engine := &Engine{
@@ -814,28 +410,21 @@ func TestStreamPrimary_Abort_StopsRenderingAndDrains(t *testing.T) {
 		Env: env,
 	}
 
-	require.NoError(t, slowSegment.MapSegmentWithWriter(env))
-	engine.pendingSegments.Store(slowSegment.Name(), true)
-
 	out := engine.StreamPrimary()
 
 	// Consume the initial prompt + transient record before aborting, mirroring
-	// how a server would start draining a cycle immediately.
+	// how a server would start draining a cycle immediately. By this point the
+	// segment's real 5ms timeout has already fired, so it is pending.
 	<-out
 	<-out
 
-	// Complete the segment AFTER abort is issued: the drain loop must consume
-	// this notification without rendering (and without blocking the sender).
-	go func() {
-		time.Sleep(20 * time.Millisecond)
-		slowSegment.Pending = false
-		engine.notifySegmentCompletion(slowSegment)
-	}()
-
+	// The segment's real completion (its mocked Getenv unblocks after 40ms) lands
+	// AFTER Abort is issued below; the producer must consume that late event
+	// without rendering it (and without the sender blocking).
 	engine.Abort()
 
 	// Abort must not return until the producer has exited, which implies out
-	// and streamingResults are both closed.
+	// and the stream's internal channels are both closed.
 	select {
 	case _, ok := <-out:
 		assert.False(t, ok, "out channel should be closed after Abort returns")
@@ -849,15 +438,13 @@ func TestStreamPrimary_Abort_StopsRenderingAndDrains(t *testing.T) {
 	// Give the delayed segment-completion goroutine time to fire its late,
 	// post-abort notification; it must not panic (send on closed channel)
 	// or otherwise crash the test binary.
-	time.Sleep(40 * time.Millisecond)
+	time.Sleep(80 * time.Millisecond)
 }
 
-// Guards against the pending-segment leak: with the Streaming flag set but no
-// top-level "streaming" timeout in the config (Config.Streaming == 0), every
-// segment used to be pre-registered in pendingSegments and never cleaned up
-// (the cleanup in writeSegmentsConcurrently only ran for Timeout > 0), so
-// countPendingSegments never reached 0, the producer goroutine waited on
-// streamingResults forever, and the stream CLI command never exited.
+// Guards a class of pending-segment leak: a segment with no explicit Timeout, under a
+// config with no global per-segment timeout either (Config.Streaming == 0), must never
+// enter the pending path at all - it runs (and reports) through the plain executeSegment
+// path - so the producer's pending set never grows and the cycle always closes on its own.
 func TestStreamPrimary_NoStreamingTimeout_ChannelCloses(t *testing.T) {
 	env := setupStreamingTestEnv()
 
@@ -870,7 +457,7 @@ func TestStreamPrimary_NoStreamingTimeout_ChannelCloses(t *testing.T) {
 
 	engine := &Engine{
 		Config: &config.Config{
-			// Streaming (the global segment timeout) deliberately left at 0
+			// Streaming (the global per-segment timeout) deliberately left at 0
 			Blocks: []*config.Block{
 				{
 					Type:      config.Prompt,
@@ -881,8 +468,6 @@ func TestStreamPrimary_NoStreamingTimeout_ChannelCloses(t *testing.T) {
 		},
 		Env: env,
 	}
-
-	require.NoError(t, segment.MapSegmentWithWriter(env))
 
 	out := engine.StreamPrimary()
 
@@ -897,13 +482,12 @@ func TestStreamPrimary_NoStreamingTimeout_ChannelCloses(t *testing.T) {
 			if !ok {
 				// Initial prompt + transient record, then a clean close.
 				assert.Len(t, prompts, 2)
-				assert.Equal(t, 0, engine.countPendingSegments(), "no segment may stay pending without a streaming timeout")
 				return
 			}
 
 			prompts = append(prompts, record)
 		case <-deadline:
-			t.Fatal("output channel never closed: segments leaked into pendingSegments without a streaming timeout")
+			t.Fatal("output channel never closed: a segment without a timeout must never become pending")
 		}
 	}
 }
@@ -931,4 +515,408 @@ func TestStreamPrimary_Abort_ThenNewCycleWorks(t *testing.T) {
 	prompts := collectChannelOutput(secondOut, 100*time.Millisecond)
 
 	assert.Len(t, prompts, 2, "A new cycle after abort should render normally")
+}
+
+// collectRecords reads every record from ch until it closes. bound is a hang guard only: reaching
+// it before the channel closes is always a test failure, never a signal that the cycle is done -
+// a producer that is merely slow must still be given the chance to finish and close the channel.
+func collectRecords(t *testing.T, ch <-chan string, bound time.Duration) []string {
+	t.Helper()
+
+	var records []string
+	timer := time.NewTimer(bound)
+	defer timer.Stop()
+
+	for {
+		select {
+		case record, ok := <-ch:
+			if !ok {
+				return records
+			}
+
+			records = append(records, record)
+		case <-timer.C:
+			require.Fail(t, "streaming channel did not close within the hang bound",
+				"bound: %s, records collected so far: %d", bound, len(records))
+			return records
+		}
+	}
+}
+
+// splitRecords separates primary prompt records from transient records, which are identified by
+// the TransientMarker prefix.
+func splitRecords(records []string) (primaries, transients []string) {
+	for _, record := range records {
+		if strings.HasPrefix(record, TransientMarker) {
+			transients = append(transients, record)
+			continue
+		}
+
+		primaries = append(primaries, record)
+	}
+
+	return primaries, transients
+}
+
+// streamTestCase describes one segment inside a TestStreamPrimary_Lifecycle case: how its fake
+// writer behaves, and whether the test needs to release it explicitly after the first record.
+type streamTestCase struct {
+	ID                      string
+	Delay                   time.Duration
+	ReleaseAfterFirstRecord bool
+	Panics                  bool
+	NeverCompletes          bool
+}
+
+// lifecycleCase is one row of the TestStreamPrimary_Lifecycle table.
+type lifecycleCase struct {
+	ExpectCountInLast  map[string]int
+	Case               string
+	Segments           []streamTestCase
+	ExpectInLast       []string
+	ExpectNotInLast    []string
+	PendingLimit       time.Duration
+	Streaming          int
+	ExpectTransients   int
+	ExpectPrimariesMin int
+	ExpectPrimariesMax int
+	ReleaseTogether    bool
+}
+
+// TestStreamPrimary_Lifecycle drives the streaming producer through the timedOut/completed/
+// abandoned event machinery via one or more fake segments, and checks the record sequence it
+// produces. The core invariant every case shares: once any primary record still shows a
+// PENDING- placeholder, the very last primary record produced for that cycle must show none.
+func TestStreamPrimary_Lifecycle(t *testing.T) {
+	cases := []lifecycleCase{
+		{
+			Case: "resolves before timeout",
+			Segments: []streamTestCase{
+				{ID: "resolves-before-timeout"},
+			},
+			// A larger window than the spec's 5ms: nothing here is meant to race the timeout at
+			// all, and 5ms is tight enough to flake under a loaded test binary (see the Streaming
+			// field doc comment).
+			Streaming:          250,
+			ExpectTransients:   1,
+			ExpectPrimariesMin: 1,
+			ExpectPrimariesMax: 1,
+			ExpectInLast:       []string{"resolved/42"},
+			ExpectNotInLast:    []string{"PENDING"},
+		},
+		{
+			Case: "resolves after timeout",
+			Segments: []streamTestCase{
+				{ID: "resolves-after-timeout", ReleaseAfterFirstRecord: true},
+			},
+			ExpectTransients:   2,
+			ExpectPrimariesMin: 2,
+			ExpectPrimariesMax: 2,
+			ExpectInLast:       []string{"resolved/42"},
+		},
+		{
+			Case: "two segments released one after another",
+			Segments: []streamTestCase{
+				{ID: "one-after-another-a", ReleaseAfterFirstRecord: true},
+				{ID: "one-after-another-b", ReleaseAfterFirstRecord: true},
+			},
+			ExpectTransients:   2,
+			ExpectPrimariesMin: 2,
+			ExpectPrimariesMax: 3,
+			ExpectCountInLast:  map[string]int{"resolved/42": 2},
+			ExpectNotInLast:    []string{"PENDING"},
+		},
+		{
+			Case: "two segments released together",
+			Segments: []streamTestCase{
+				{ID: "together-a", ReleaseAfterFirstRecord: true},
+				{ID: "together-b", ReleaseAfterFirstRecord: true},
+			},
+			ReleaseTogether:    true,
+			ExpectTransients:   2,
+			ExpectPrimariesMin: 2,
+			ExpectPrimariesMax: 3,
+			ExpectCountInLast:  map[string]int{"resolved/42": 2},
+			ExpectNotInLast:    []string{"PENDING"},
+		},
+		{
+			Case: "mixed: one fast one slow",
+			Segments: []streamTestCase{
+				{ID: "mixed-fast"},
+				{ID: "mixed-slow", ReleaseAfterFirstRecord: true},
+			},
+			// The fast segment must not itself race the timeout; see the Streaming field doc
+			// comment. The slow segment is gated on its release channel regardless of this value.
+			Streaming:          250,
+			ExpectTransients:   2,
+			ExpectPrimariesMin: 2,
+			ExpectPrimariesMax: 2,
+			ExpectCountInLast:  map[string]int{"resolved/42": 2},
+			ExpectNotInLast:    []string{"PENDING"},
+		},
+		{
+			Case: "panic before timeout",
+			Segments: []streamTestCase{
+				{ID: "panic-before-timeout", Panics: true},
+			},
+			// See the Streaming field doc comment: this panic must not itself race the timeout.
+			Streaming:          250,
+			ExpectTransients:   1,
+			ExpectPrimariesMin: 1,
+			ExpectPrimariesMax: 1,
+			ExpectNotInLast:    []string{"PENDING", "resolved"},
+		},
+		{
+			Case: "panic after timeout",
+			Segments: []streamTestCase{
+				{ID: "panic-after-timeout", ReleaseAfterFirstRecord: true, Panics: true},
+			},
+			ExpectTransients:   2,
+			ExpectPrimariesMin: 2,
+			ExpectPrimariesMax: 2,
+			ExpectNotInLast:    []string{"PENDING", "resolved"},
+		},
+		{
+			Case: "never completes is abandoned",
+			Segments: []streamTestCase{
+				{ID: "never-completes", NeverCompletes: true},
+			},
+			PendingLimit:       50 * time.Millisecond,
+			ExpectTransients:   2,
+			ExpectPrimariesMin: 2,
+			ExpectPrimariesMax: 2,
+			ExpectNotInLast:    []string{"PENDING", "resolved"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Case, func(t *testing.T) {
+			runLifecycleCase(t, &tc)
+		})
+	}
+}
+
+// runLifecycleCase installs one fake writer control per segment, starts the cycle, drives any
+// release channels the case calls for, then collects and asserts on the resulting record stream.
+func runLifecycleCase(t *testing.T, tc *lifecycleCase) {
+	t.Helper()
+
+	if tc.PendingLimit != 0 {
+		original := pendingSegmentLimit
+		pendingSegmentLimit = tc.PendingLimit
+		t.Cleanup(func() { pendingSegmentLimit = original })
+	}
+
+	env := setupStreamingTestEnv()
+
+	streaming := tc.Streaming
+	if streaming == 0 {
+		streaming = 5
+	}
+
+	segs := make([]*config.Segment, len(tc.Segments))
+	var releaseControls []*streamTestControl
+
+	for i, sc := range tc.Segments {
+		control := &streamTestControl{delay: sc.Delay, panics: sc.Panics}
+		if sc.ReleaseAfterFirstRecord || sc.NeverCompletes {
+			control.release = make(chan struct{})
+		}
+
+		streamTestControls.Store(sc.ID, control)
+		t.Cleanup(func() { streamTestControls.Delete(sc.ID) })
+
+		segs[i] = streamTestSegment(sc.ID)
+
+		if sc.ReleaseAfterFirstRecord {
+			releaseControls = append(releaseControls, control)
+		}
+	}
+
+	engine := &Engine{
+		Config: &config.Config{
+			Streaming: streaming,
+			Blocks: []*config.Block{
+				{Type: config.Prompt, Alignment: config.Left, Segments: segs},
+			},
+		},
+		Env: env,
+	}
+
+	out := engine.StreamPrimary()
+
+	var records []string
+
+	if len(releaseControls) > 0 {
+		first, ok := <-out
+		require.True(t, ok, "case %s: streaming channel closed before the first record", tc.Case)
+		records = append(records, first)
+
+		for i, control := range releaseControls {
+			close(control.release)
+
+			last := i == len(releaseControls)-1
+			if tc.ReleaseTogether || last {
+				continue
+			}
+
+			// Wait for the record reflecting this segment's own completion before releasing the
+			// next one, so the two completions land as separate, serialized events rather than
+			// racing to be absorbed together.
+			record, ok := <-out
+			require.True(t, ok, "case %s: streaming channel closed while awaiting an intermediate record", tc.Case)
+			records = append(records, record)
+		}
+	}
+
+	records = append(records, collectRecords(t, out, 5*time.Second)...)
+
+	primaries, transients := splitRecords(records)
+
+	assert.Len(t, transients, tc.ExpectTransients, "case %s: transient record count", tc.Case)
+	assert.GreaterOrEqual(t, len(primaries), tc.ExpectPrimariesMin, "case %s: primary record count (min)", tc.Case)
+	assert.LessOrEqual(t, len(primaries), tc.ExpectPrimariesMax, "case %s: primary record count (max)", tc.Case)
+
+	require.NotEmpty(t, primaries, "case %s: expected at least one primary record", tc.Case)
+	last := primaries[len(primaries)-1]
+
+	for _, substr := range tc.ExpectInLast {
+		assert.Contains(t, last, substr, "case %s: last primary missing %q", tc.Case, substr)
+	}
+
+	for _, substr := range tc.ExpectNotInLast {
+		assert.NotContains(t, last, substr, "case %s: last primary should not contain %q", tc.Case, substr)
+	}
+
+	for substr, count := range tc.ExpectCountInLast {
+		assert.Equal(t, count, strings.Count(last, substr), "case %s: last primary %q occurrence count", tc.Case, substr)
+	}
+
+	hadPending := false
+	for _, primary := range primaries {
+		if strings.Contains(primary, "PENDING-") {
+			hadPending = true
+			break
+		}
+	}
+
+	if !hadPending {
+		return
+	}
+
+	assert.NotContains(t, last, "PENDING-", "case %s: the last primary must never still show a placeholder", tc.Case)
+}
+
+// TestStreamPrimary_StraddlingTimeoutNeverSticks is a regression fuzz test for the bug this
+// rewrite fixes: a segment resolving within a few milliseconds of the streaming timeout used to
+// race the render against the writer, and could leave a placeholder in the last primary record.
+// It runs many iterations with a randomized delay straddling the 5ms timeout so the race window
+// gets exercised at many different offsets instead of just one fixed one.
+func TestStreamPrimary_StraddlingTimeoutNeverSticks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping the straddling-timeout fuzz loop in short mode")
+	}
+
+	const iterations = 200
+
+	for i := range iterations {
+		delay := time.Duration(2+rand.IntN(7)) * time.Millisecond
+		id := fmt.Sprintf("straddle-%d", i)
+
+		streamTestControls.Store(id, &streamTestControl{delay: delay})
+
+		runStraddlingIteration(t, i, id)
+
+		streamTestControls.Delete(id)
+	}
+}
+
+// runStraddlingIteration runs one iteration of the straddling-timeout fuzz loop against the
+// segment already installed under id.
+func runStraddlingIteration(t *testing.T, iteration int, id string) {
+	t.Helper()
+
+	env := setupStreamingTestEnv()
+
+	engine := &Engine{
+		Config: &config.Config{
+			Streaming: 5,
+			Blocks: []*config.Block{
+				{Type: config.Prompt, Alignment: config.Left, Segments: []*config.Segment{streamTestSegment(id)}},
+			},
+		},
+		Env: env,
+	}
+
+	out := engine.StreamPrimary()
+	records := collectRecords(t, out, 5*time.Second)
+	primaries, transients := splitRecords(records)
+
+	require.NotEmpty(t, primaries, "iteration %d: no primary records produced; records: %v", iteration, records)
+
+	last := primaries[len(primaries)-1]
+	assert.Contains(t, last, "resolved/42", "iteration %d: last primary missing resolved/42; records: %v", iteration, records)
+	assert.NotContains(t, last, "PENDING-", "iteration %d: last primary still shows a placeholder; records: %v", iteration, records)
+
+	transientCount := len(transients)
+	assert.True(t, transientCount == 1 || transientCount == 2,
+		"iteration %d: unexpected transient count %d; records: %v", iteration, transientCount, records)
+
+	hadPending := false
+	for _, primary := range primaries {
+		if strings.Contains(primary, "PENDING-") {
+			hadPending = true
+			break
+		}
+	}
+
+	if !hadPending {
+		return
+	}
+
+	assert.Equal(t, 2, transientCount,
+		"iteration %d: a primary that was ever pending must produce a refreshed transient; records: %v", iteration, records)
+}
+
+// TestStreamPrimary_PlaceholderUsesConfiguredColors checks that a pending segment's placeholder
+// renders with the segment's raw configured colors, never with a color that would require reading
+// the writer - which is off limits while the segment is still pending (see RenderPlaceholder).
+func TestStreamPrimary_PlaceholderUsesConfiguredColors(t *testing.T) {
+	env := setupStreamingTestEnv()
+
+	id := "placeholder-colors"
+	control := &streamTestControl{release: make(chan struct{})}
+	streamTestControls.Store(id, control)
+	t.Cleanup(func() { streamTestControls.Delete(id) })
+
+	engine := &Engine{
+		Config: &config.Config{
+			Streaming: 5,
+			Blocks: []*config.Block{
+				{Type: config.Prompt, Alignment: config.Left, Segments: []*config.Segment{streamTestSegment(id)}},
+			},
+		},
+		Env: env,
+	}
+
+	out := engine.StreamPrimary()
+
+	first, ok := <-out
+	require.True(t, ok, "streaming channel closed before the first record")
+
+	close(control.release)
+
+	rest := collectRecords(t, out, 2*time.Second)
+	primaries, _ := splitRecords(append([]string{first}, rest...))
+
+	require.Len(t, primaries, 2, "expected an initial pending primary and a resolved primary")
+
+	defaults := &color.Defaults{}
+	whiteForeground := "\x1b[" + defaults.ToAnsi(color.Ansi("#ffffff"), false).String() + "m"
+	greenForeground := "\x1b[" + defaults.ToAnsi(color.Ansi("#00ff00"), false).String() + "m"
+
+	assert.Contains(t, primaries[0], whiteForeground, "the placeholder should use the segment's raw configured foreground")
+	assert.NotContains(t, primaries[0], greenForeground, "the placeholder must not resolve a foreground template against the writer")
+
+	assert.Contains(t, primaries[1], greenForeground, "the resolved segment should use its matched foreground template")
 }

--- a/src/prompt/streaming_writer_test.go
+++ b/src/prompt/streaming_writer_test.go
@@ -1,0 +1,98 @@
+package prompt
+
+import (
+	"sync"
+	"time"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/config"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments"
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+)
+
+// streamTestType is a test-only segment type that drives the streaming machinery through a
+// controllable fake writer instead of a real segment's Enabled() implementation.
+const streamTestType config.SegmentType = "streamtest"
+
+// streamTestControl steers one fake writer instance, looked up by the segment's "id" option.
+type streamTestControl struct {
+	release chan struct{} // Enabled blocks on this until closed; nil means no wait.
+	delay   time.Duration // Sleep after release, before writing fields.
+	panics  bool          // Panic instead of returning, after release and delay.
+}
+
+// streamTestControls maps a segment's "id" option to the control steering its writer instance.
+// It has to be a package-level map: writer instances are constructed by the config package's
+// registry (config.Segments), which has no way to thread per-test state through a constructor.
+var streamTestControls sync.Map
+
+// streamTestWriter is a fake SegmentWriter whose Enabled() can be told to block, sleep, or panic,
+// so a test can drive the exact timing the streaming producer must handle correctly.
+type streamTestWriter struct {
+	segments.Base
+	control *streamTestControl
+	Ref     string
+	Items   []string
+	Count   int
+}
+
+func init() {
+	// Test-only writer type; registered for the whole test binary, never removed.
+	config.Segments[streamTestType] = func() config.SegmentWriter { return &streamTestWriter{} }
+}
+
+func (w *streamTestWriter) Init(props options.Provider, env runtime.Environment) {
+	w.Base.Init(props, env)
+
+	control, ok := streamTestControls.Load(props.String("id", ""))
+	if !ok {
+		return
+	}
+
+	w.control = control.(*streamTestControl)
+}
+
+func (w *streamTestWriter) Template() string {
+	return "{{ .Ref }}/{{ .Count }}"
+}
+
+func (w *streamTestWriter) Enabled() bool {
+	if w.control != nil {
+		if w.control.release != nil {
+			<-w.control.release
+		}
+
+		time.Sleep(w.control.delay)
+
+		if w.control.panics {
+			panic("streamtest: enabled panicked")
+		}
+	}
+
+	// Multi-word fields on purpose: a string and a slice are what a concurrent reader would
+	// tear, so these writes are what the race detector must see against a pending render.
+	w.Ref = "resolved"
+	w.Items = []string{"a", "b", "c"}
+	w.Count = 42
+
+	return true
+}
+
+// streamTestSegment builds a config.Segment wired to the streamTestType writer identified by id.
+// Its two foreground templates read writer fields the fake writer writes late (Ref, then Items),
+// so a render that touches the writer while the segment is pending is exactly what the race
+// detector needs to see.
+func streamTestSegment(id string) *config.Segment {
+	return &config.Segment{
+		Type:        streamTestType,
+		Options:     options.Map{"id": id},
+		Style:       config.Powerline,
+		Placeholder: "PENDING-" + id,
+		Foreground:  "#ffffff",
+		Background:  "#000000",
+		ForegroundTemplates: []string{
+			"{{ if .Ref }}#00ff00{{ end }}",
+			"{{ if gt (len .Items) 0 }}#ff0000{{ end }}",
+		},
+	}
+}

--- a/src/segments/base.go
+++ b/src/segments/base.go
@@ -3,6 +3,7 @@ package segments
 import (
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
 	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+	"github.com/jandedobbeleer/oh-my-posh/src/template"
 )
 
 type Base struct {
@@ -13,16 +14,20 @@ type Base struct {
 }
 
 type Segment struct {
-	Text  string
+	// Text is the fully rendered markup (anchors intact), stored for
+	// cross-segment references like {{ .Segments.Git.Segment.Text }} in
+	// transient and tooltip templates. It must be Markup or a re-render
+	// escapes its anchors back into literal text.
+	Text  template.Markup
 	Index int
 }
 
 func (b *Base) Text() string {
-	return b.Segment.Text
+	return b.Segment.Text.String()
 }
 
 func (b *Base) SetText(text string) {
-	b.Segment.Text = text
+	b.Segment.Text = template.RawMarkup(text)
 }
 
 func (b *Base) SetIndex(index int) {

--- a/src/segments/battery.go
+++ b/src/segments/battery.go
@@ -3,12 +3,13 @@ package segments
 import (
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime/battery"
 	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+	"github.com/jandedobbeleer/oh-my-posh/src/template"
 )
 
 type Battery struct {
 	Base
 	Error string
-	Icon  string
+	Icon  template.Markup
 	battery.Info
 }
 
@@ -41,13 +42,13 @@ func (b *Battery) Enabled() bool {
 
 	switch b.State {
 	case battery.Discharging:
-		b.Icon = b.options.String(DischargingIcon, "")
+		b.Icon = b.options.Markup(DischargingIcon, "")
 	case battery.NotCharging:
-		b.Icon = b.options.String(NotChargingIcon, "")
+		b.Icon = b.options.Markup(NotChargingIcon, "")
 	case battery.Charging:
-		b.Icon = b.options.String(ChargingIcon, "")
+		b.Icon = b.options.Markup(ChargingIcon, "")
 	case battery.Full:
-		b.Icon = b.options.String(ChargedIcon, "")
+		b.Icon = b.options.Markup(ChargedIcon, "")
 	case battery.Empty, battery.Unknown:
 		return true
 	}

--- a/src/segments/bazel.go
+++ b/src/segments/bazel.go
@@ -1,9 +1,12 @@
 package segments
 
-import "github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+import (
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+	"github.com/jandedobbeleer/oh-my-posh/src/template"
+)
 
 type Bazel struct {
-	Icon string
+	Icon template.Markup
 	Language
 }
 
@@ -49,5 +52,5 @@ func (b *Bazel) loadSpec() {
 	// Use the correct URL for Bazel >5.4.1, since they do not have the docs subdomain.
 	b.versionURLTemplate = "https://{{ if lt .Major 6 }}docs.{{ end }}bazel.build/versions/{{ .Major }}.{{ .Minor }}.{{ .Patch }}"
 
-	b.Icon = b.options.String(Icon, "\ue63a")
+	b.Icon = b.options.Markup(Icon, "\ue63a")
 }

--- a/src/segments/brewfather.go
+++ b/src/segments/brewfather.go
@@ -11,15 +11,16 @@ import (
 	"time"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+	"github.com/jandedobbeleer/oh-my-posh/src/template"
 )
 
 type Brewfather struct {
 	Base
 
 	DaysBottledOrFermented *uint
-	TemperatureTrendIcon   string
-	StatusIcon             string
-	DayIcon                string
+	TemperatureTrendIcon   template.Markup
+	StatusIcon             template.Markup
+	DayIcon                template.Markup
 	URL                    string
 	Batch
 	ReadingAge     int
@@ -129,58 +130,58 @@ func (bf *Brewfather) Enabled() bool {
 		bf.URL = fmt.Sprintf("https://web.brewfather.app/tabs/batches/batch/%s", batchID)
 	}
 
-	bf.DayIcon = bf.options.String(BFDayIcon, "d")
+	bf.DayIcon = bf.options.Markup(BFDayIcon, "d")
 
 	return true
 }
 
-func (bf *Brewfather) getTrendIcon(trend float64) string {
+func (bf *Brewfather) getTrendIcon(trend float64) template.Markup {
 	// Not a fan of this logic - wondering if Go lets us do something cleaner...
 	if trend >= 0 {
 		if trend > 4 {
-			return bf.options.String(BFDoubleUpIcon, "↑↑")
+			return bf.options.Markup(BFDoubleUpIcon, "↑↑")
 		}
 
 		if trend > 2 {
-			return bf.options.String(BFSingleUpIcon, "↑")
+			return bf.options.Markup(BFSingleUpIcon, "↑")
 		}
 
 		if trend > 0.5 {
-			return bf.options.String(BFFortyFiveUpIcon, "↗")
+			return bf.options.Markup(BFFortyFiveUpIcon, "↗")
 		}
 
-		return bf.options.String(BFFlatIcon, "→")
+		return bf.options.Markup(BFFlatIcon, "→")
 	}
 
 	if trend < -4 {
-		return bf.options.String(BFDoubleDownIcon, "↓↓")
+		return bf.options.Markup(BFDoubleDownIcon, "↓↓")
 	}
 
 	if trend < -2 {
-		return bf.options.String(BFSingleDownIcon, "↓")
+		return bf.options.Markup(BFSingleDownIcon, "↓")
 	}
 
 	if trend < -0.5 {
-		return bf.options.String(BFFortyFiveDownIcon, "↘")
+		return bf.options.Markup(BFFortyFiveDownIcon, "↘")
 	}
 
-	return bf.options.String(BFFlatIcon, "→")
+	return bf.options.Markup(BFFlatIcon, "→")
 }
 
-func (bf *Brewfather) getBatchStatusIcon(batchStatus string) string {
+func (bf *Brewfather) getBatchStatusIcon(batchStatus string) template.Markup {
 	switch batchStatus {
 	case BFStatusPlanning:
-		return bf.options.String(BFPlanningStatusIcon, "\uF8EA")
+		return bf.options.Markup(BFPlanningStatusIcon, "\uF8EA")
 	case BFStatusBrewing:
-		return bf.options.String(BFBrewingStatusIcon, "\uF7DE")
+		return bf.options.Markup(BFBrewingStatusIcon, "\uF7DE")
 	case BFStatusFermenting:
-		return bf.options.String(BFFermentingStatusIcon, "\uF499")
+		return bf.options.Markup(BFFermentingStatusIcon, "\uF499")
 	case BFStatusConditioning:
-		return bf.options.String(BFConditioningStatusIcon, "\uE372")
+		return bf.options.Markup(BFConditioningStatusIcon, "\uE372")
 	case BFStatusCompleted:
-		return bf.options.String(BFCompletedStatusIcon, "\uF7A5")
+		return bf.options.Markup(BFCompletedStatusIcon, "\uF7A5")
 	case BFStatusArchived:
-		return bf.options.String(BFArchivedStatusIcon, "\uF187")
+		return bf.options.Markup(BFArchivedStatusIcon, "\uF187")
 	default:
 		return ""
 	}

--- a/src/segments/dvc_test.go
+++ b/src/segments/dvc_test.go
@@ -125,6 +125,6 @@ func TestDvcStatus(t *testing.T) {
 			continue
 		}
 
-		assert.Equal(t, tc.ExpectedStatus, d.Status.String(), tc.Case)
+		assert.Equal(t, tc.ExpectedStatus, d.Status.String().String(), tc.Case)
 	}
 }

--- a/src/segments/fossil_test.go
+++ b/src/segments/fossil_test.go
@@ -77,7 +77,7 @@ func TestFossilStatus(t *testing.T) {
 		if tc.ExpectedDisabled {
 			continue
 		}
-		assert.Equal(t, tc.ExpectedStatus, f.Status.String(), tc.Case)
+		assert.Equal(t, tc.ExpectedStatus, f.Status.String().String(), tc.Case)
 		assert.Equal(t, tc.ExpectedBranch, f.Branch, tc.Case)
 	}
 }

--- a/src/segments/git.go
+++ b/src/segments/git.go
@@ -17,6 +17,7 @@ import (
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime/path"
 	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+	"github.com/jandedobbeleer/oh-my-posh/src/template"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/ini"
 )
@@ -104,8 +105,8 @@ const (
 )
 
 type Rebase struct {
-	HEAD    string
-	Onto    string
+	HEAD    template.Markup
+	Onto    template.Markup
 	Current int
 	Total   int
 }
@@ -142,9 +143,9 @@ type Git struct {
 	User           *User
 	ShortHash      string
 	Hash           string
-	BranchStatus   string
-	HEAD           string
-	UpstreamIcon   string
+	BranchStatus   template.Markup
+	HEAD           template.Markup
+	UpstreamIcon   template.Markup
 	UpstreamURL    string
 	Ref            string
 	RawUpstreamURL string
@@ -514,9 +515,9 @@ func (g *Git) isBareRepo(gitDir *runtime.FileInfo) bool {
 
 func (g *Git) getBareRepoInfo() {
 	head := g.fileContent(g.mainSCMDir, "HEAD")
-	branchIcon := g.options.String(BranchIcon, "\uE0A0")
+	branchIcon := g.options.Markup(BranchIcon, "\uE0A0")
 	g.Ref = strings.Replace(head, "ref: refs/heads/", "", 1)
-	g.HEAD = fmt.Sprintf("%s%s", branchIcon, g.formatBranch(g.Ref))
+	g.HEAD = template.JoinMarkup(branchIcon, g.formatBranch(g.Ref))
 	if !g.fetchUnit(gitUpstreamIconFields...) {
 		return
 	}
@@ -639,7 +640,7 @@ func (g *Git) setBranchStatus() {
 		}
 		return ""
 	}
-	g.BranchStatus = getBranchStatus()
+	g.BranchStatus = template.RawMarkup(getBranchStatus())
 }
 
 func (g *Git) setPushStatus() {
@@ -813,8 +814,8 @@ func (g *Git) cleanUpstreamURL(url string) string {
 	return fmt.Sprintf("https://%s/%s", match["URL"], strings.TrimSuffix(match["PATH"], ".git"))
 }
 
-func (g *Git) getUpstreamIcon() string {
-	fallback := g.options.String(GitIcon, "\uE5FB ")
+func (g *Git) getUpstreamIcon() template.Markup {
+	fallback := g.options.Markup(GitIcon, "\uE5FB ")
 
 	g.RawUpstreamURL = g.getRemoteURL()
 	if g.RawUpstreamURL == "" {
@@ -827,7 +828,7 @@ func (g *Git) getUpstreamIcon() string {
 	custom := g.options.KeyValueMap(UpstreamIcons, map[string]string{})
 	for key, value := range custom {
 		if strings.Contains(g.UpstreamURL, key) {
-			return value
+			return template.RawMarkup(value)
 		}
 	}
 
@@ -846,7 +847,7 @@ func (g *Git) getUpstreamIcon() string {
 
 	for key, value := range defaults {
 		if strings.Contains(g.UpstreamURL, key) {
-			return g.options.String(value.Icon, value.Default)
+			return g.options.Markup(value.Icon, value.Default)
 		}
 	}
 
@@ -1007,30 +1008,30 @@ func (g *Git) getGitCommandOutput(args ...string) string {
 }
 
 func (g *Git) setHEADStatus() {
-	branchIcon := g.options.String(BranchIcon, "\uE0A0")
+	branchIcon := g.options.Markup(BranchIcon, "\uE0A0")
 	if g.Ref == DETACHED {
 		g.Detached = true
 		g.resolveDetachedHEAD()
 	} else {
 		head := g.formatBranch(g.Ref)
-		g.HEAD = fmt.Sprintf("%s%s", branchIcon, head)
+		g.HEAD = template.JoinMarkup(branchIcon, head)
 	}
 
-	formatDetached := func() string {
+	formatDetached := func() template.Markup {
 		if g.Detached {
-			return fmt.Sprintf("%sdetached at %s", branchIcon, g.HEAD)
+			return template.JoinMarkup(branchIcon, template.RawMarkup("detached at "), g.HEAD)
 		}
 		return g.HEAD
 	}
 
-	getPrettyNameOrigin := func(file string) string {
-		var origin string
+	getPrettyNameOrigin := func(file string) template.Markup {
+		var origin template.Markup
 		head := g.fileContent(g.mainSCMDir, file)
 		if head == "detached HEAD" {
 			origin = formatDetached()
 		} else {
 			head = strings.Replace(head, "refs/heads/", "", 1)
-			origin = branchIcon + g.formatBranch(head)
+			origin = template.JoinMarkup(branchIcon, g.formatBranch(head))
 		}
 		return origin
 	}
@@ -1043,19 +1044,20 @@ func (g *Git) setHEADStatus() {
 	if g.env.HasFolder(g.mainSCMDir + "/rebase-merge") {
 		head := getPrettyNameOrigin("rebase-merge/head-name")
 		onto := g.getGitRefFileSymbolicName("rebase-merge/onto")
-		onto = g.formatBranch(onto)
+		ontoMarkup := g.formatBranch(onto)
 		current := parseInt("rebase-merge/msgnum")
 		total := parseInt("rebase-merge/end")
-		icon := g.options.String(RebaseIcon, "\uE728 ")
+		icon := g.options.Markup(RebaseIcon, "\uE728 ")
 
 		g.Rebase = &Rebase{
 			HEAD:    head,
-			Onto:    onto,
+			Onto:    ontoMarkup,
 			Current: current,
 			Total:   total,
 		}
 
-		g.HEAD = fmt.Sprintf("%s%s onto %s%s (%d/%d) at %s", icon, head, branchIcon, onto, current, total, g.HEAD)
+		progress := template.RawMarkup(fmt.Sprintf(" (%d/%d) at ", current, total))
+		g.HEAD = template.JoinMarkup(icon, head, template.RawMarkup(" onto "), branchIcon, ontoMarkup, progress, g.HEAD)
 		return
 	}
 
@@ -1063,7 +1065,7 @@ func (g *Git) setHEADStatus() {
 		head := getPrettyNameOrigin("rebase-apply/head-name")
 		current := parseInt("rebase-apply/next")
 		total := parseInt("rebase-apply/last")
-		icon := g.options.String(RebaseIcon, "\uE728 ")
+		icon := g.options.Markup(RebaseIcon, "\uE728 ")
 
 		g.Rebase = &Rebase{
 			HEAD:    head,
@@ -1071,33 +1073,33 @@ func (g *Git) setHEADStatus() {
 			Total:   total,
 		}
 
-		g.HEAD = fmt.Sprintf("%s%s (%d/%d) at %s", icon, head, current, total, g.HEAD)
+		g.HEAD = template.JoinMarkup(icon, head, template.RawMarkup(fmt.Sprintf(" (%d/%d) at ", current, total)), g.HEAD)
 		return
 	}
 
 	// merge
-	commitIcon := g.options.String(CommitIcon, "\uF417")
+	commitIcon := g.options.Markup(CommitIcon, "\uF417")
 
 	if g.hasGitFile("MERGE_MSG") {
 		g.Merge = true
-		icon := g.options.String(MergeIcon, "\uE727 ")
+		icon := g.options.Markup(MergeIcon, "\uE727 ")
 		mergeContext := g.fileContent(g.mainSCMDir, "MERGE_MSG")
 		matches := regex.FindNamedRegexMatch(`Merge (remote-tracking )?(?P<type>branch|commit|tag) '(?P<theirs>.*)'`, mergeContext)
 		// head := g.getGitRefFileSymbolicName("ORIG_HEAD")
 		if matches != nil && matches["theirs"] != "" {
-			var headIcon, theirs string
+			var headIcon, theirs template.Markup
 			switch matches["type"] {
 			case "tag":
-				headIcon = g.options.String(TagIcon, "\uF412")
-				theirs = matches["theirs"]
+				headIcon = g.options.Markup(TagIcon, "\uF412")
+				theirs = template.EscapeMarkup(matches["theirs"])
 			case "commit":
 				headIcon = commitIcon
-				theirs = g.formatSHA(matches["theirs"])
+				theirs = template.EscapeMarkup(g.formatSHA(matches["theirs"]))
 			default:
 				headIcon = branchIcon
 				theirs = g.formatBranch(matches["theirs"])
 			}
-			g.HEAD = fmt.Sprintf("%s%s%s into %s", icon, headIcon, theirs, formatDetached())
+			g.HEAD = template.JoinMarkup(icon, headIcon, theirs, template.RawMarkup(" into "), formatDetached())
 			return
 		}
 	}
@@ -1110,16 +1112,16 @@ func (g *Git) setHEADStatus() {
 	if g.hasGitFile("CHERRY_PICK_HEAD") {
 		g.CherryPick = true
 		sha := g.fileContent(g.mainSCMDir, "CHERRY_PICK_HEAD")
-		cherry := g.options.String(CherryPickIcon, "\uE29B ")
-		g.HEAD = fmt.Sprintf("%s%s%s onto %s", cherry, commitIcon, g.formatSHA(sha), formatDetached())
+		cherry := g.options.Markup(CherryPickIcon, "\uE29B ")
+		g.HEAD = g.sequenceHEAD(cherry, commitIcon, sha, formatDetached())
 		return
 	}
 
 	if g.hasGitFile("REVERT_HEAD") {
 		g.Revert = true
 		sha := g.fileContent(g.mainSCMDir, "REVERT_HEAD")
-		revert := g.options.String(RevertIcon, "\uF0E2 ")
-		g.HEAD = fmt.Sprintf("%s%s%s onto %s", revert, commitIcon, g.formatSHA(sha), formatDetached())
+		revert := g.options.Markup(RevertIcon, "\uF0E2 ")
+		g.HEAD = g.sequenceHEAD(revert, commitIcon, sha, formatDetached())
 		return
 	}
 
@@ -1132,19 +1134,23 @@ func (g *Git) setHEADStatus() {
 			switch action {
 			case "p", "pick":
 				g.CherryPick = true
-				cherry := g.options.String(CherryPickIcon, "\uE29B ")
-				g.HEAD = fmt.Sprintf("%s%s%s onto %s", cherry, commitIcon, g.formatSHA(sha), formatDetached())
+				cherry := g.options.Markup(CherryPickIcon, "\uE29B ")
+				g.HEAD = g.sequenceHEAD(cherry, commitIcon, sha, formatDetached())
 				return
 			case "revert":
 				g.Revert = true
-				revert := g.options.String(RevertIcon, "\uF0E2 ")
-				g.HEAD = fmt.Sprintf("%s%s%s onto %s", revert, commitIcon, g.formatSHA(sha), formatDetached())
+				revert := g.options.Markup(RevertIcon, "\uF0E2 ")
+				g.HEAD = g.sequenceHEAD(revert, commitIcon, sha, formatDetached())
 				return
 			}
 		}
 	}
 
 	g.HEAD = formatDetached()
+}
+
+func (g *Git) sequenceHEAD(actionIcon, commitIcon template.Markup, sha string, detached template.Markup) template.Markup {
+	return template.JoinMarkup(actionIcon, commitIcon, template.EscapeMarkup(g.formatSHA(sha)), template.RawMarkup(" onto "), detached)
 }
 
 func (g *Git) formatSHA(sha string) string {
@@ -1193,7 +1199,7 @@ func (g *Git) updateHEADReference() {
 		log.Debug("current HEAD is a branch:", branchName)
 
 		g.Ref = branchName
-		g.HEAD = fmt.Sprintf("%s%s", g.options.String(BranchIcon, "\uE0A0"), g.formatBranch(branchName))
+		g.HEAD = template.JoinMarkup(g.options.Markup(BranchIcon, "\uE0A0"), g.formatBranch(branchName))
 
 		return
 	}
@@ -1203,7 +1209,7 @@ func (g *Git) updateHEADReference() {
 
 func (g *Git) resolveDetachedHEAD() {
 	if !g.resolveDetachedHash() {
-		g.HEAD = g.options.String(NoCommitsIcon, "\U000F0095 ")
+		g.HEAD = g.options.Markup(NoCommitsIcon, "\U000F0095 ")
 		return
 	}
 
@@ -1211,11 +1217,11 @@ func (g *Git) resolveDetachedHEAD() {
 
 	if tagName, found := g.resolveExactTag(); found {
 		g.Ref = tagName
-		g.HEAD = fmt.Sprintf("%s%s", g.options.String(TagIcon, "\uF412"), tagName)
+		g.HEAD = template.JoinMarkup(g.options.Markup(TagIcon, "\uF412"), template.EscapeMarkup(tagName))
 		return
 	}
 
-	g.HEAD = fmt.Sprintf("%s%s", g.options.String(CommitIcon, "\uF417"), g.ShortHash)
+	g.HEAD = template.JoinMarkup(g.options.Markup(CommitIcon, "\uF417"), template.EscapeMarkup(g.ShortHash))
 }
 
 // resolveDetachedHash fills g.Hash/g.ShortHash for a detached HEAD, reading

--- a/src/segments/git_test.go
+++ b/src/segments/git_test.go
@@ -862,7 +862,7 @@ func TestSetGitHEADContextClean(t *testing.T) {
 		g.mainSCMDir = ""
 
 		g.setHEADStatus()
-		assert.Equal(t, tc.Expected, g.HEAD, tc.Case)
+		assert.Equal(t, tc.Expected, g.HEAD.String(), tc.Case)
 	}
 }
 
@@ -912,7 +912,7 @@ func TestSetPrettyHEADName(t *testing.T) {
 		g.mainSCMDir = ""
 
 		g.updateHEADReference()
-		assert.Equal(t, tc.Expected, g.HEAD, tc.Case)
+		assert.Equal(t, tc.Expected, g.HEAD.String(), tc.Case)
 	}
 }
 
@@ -1206,7 +1206,7 @@ func TestGitUpstream(t *testing.T) {
 		})
 
 		upstreamIcon := g.getUpstreamIcon()
-		assert.Equal(t, tc.Expected, upstreamIcon, tc.Case)
+		assert.Equal(t, tc.Expected, upstreamIcon.String(), tc.Case)
 	}
 }
 
@@ -1245,7 +1245,7 @@ func TestGetBranchStatus(t *testing.T) {
 		g.Init(props, new(mock.Environment))
 
 		g.setBranchStatus()
-		assert.Equal(t, tc.Expected, g.BranchStatus, tc.Case)
+		assert.Equal(t, tc.Expected, g.BranchStatus.String(), tc.Case)
 	}
 }
 
@@ -1261,7 +1261,7 @@ func TestGitTemplateString(t *testing.T) {
 			Expected: branchName,
 			Template: "{{ .HEAD }}",
 			Git: &Git{
-				HEAD:   branchName,
+				HEAD:   template.RawMarkup(branchName),
 				Behind: 2,
 			},
 		},
@@ -1270,7 +1270,7 @@ func TestGitTemplateString(t *testing.T) {
 			Expected: "main \uF044 +2 ~3",
 			Template: "{{ .HEAD }}{{ if .Working.Changed }} \uF044 {{ .Working.String }}{{ end }}",
 			Git: &Git{
-				HEAD: branchName,
+				HEAD: template.RawMarkup(branchName),
 				Working: &GitStatus{
 					Added:    2,
 					Modified: 3,
@@ -1282,7 +1282,7 @@ func TestGitTemplateString(t *testing.T) {
 			Expected: branchName,
 			Template: "{{ .HEAD }}{{ if .Working.Changed }} \uF044 {{ .Working.String }}{{ end }}",
 			Git: &Git{
-				HEAD:    branchName,
+				HEAD:    template.RawMarkup(branchName),
 				Working: &GitStatus{},
 			},
 		},
@@ -1291,7 +1291,7 @@ func TestGitTemplateString(t *testing.T) {
 			Expected: "main \uF046 +5 ~1 \uF044 +2 ~3",
 			Template: "{{ .HEAD }}{{ if .Staging.Changed }} \uF046 {{ .Staging.String }}{{ end }}{{ if .Working.Changed }} \uF044 {{ .Working.String }}{{ end }}",
 			Git: &Git{
-				HEAD: branchName,
+				HEAD: template.RawMarkup(branchName),
 				Working: &GitStatus{
 					Added:    2,
 					Modified: 3,
@@ -1307,7 +1307,7 @@ func TestGitTemplateString(t *testing.T) {
 			Expected: "main \uF046 +5 ~1 | \uF044 +2 ~3",
 			Template: "{{ .HEAD }}{{ if .Staging.Changed }} \uF046 {{ .Staging.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Working.Changed }} \uF044 {{ .Working.String }}{{ end }}", //nolint:lll
 			Git: &Git{
-				HEAD: branchName,
+				HEAD: template.RawMarkup(branchName),
 				Working: &GitStatus{
 					Added:    2,
 					Modified: 3,
@@ -1323,7 +1323,7 @@ func TestGitTemplateString(t *testing.T) {
 			Expected: "main \uF046 +5 ~1 | \uF044 +2 ~3 \ueb4b 3",
 			Template: "{{ .HEAD }}{{ if .Staging.Changed }} \uF046 {{ .Staging.String }}{{ end }}{{ if and (.Working.Changed) (.Staging.Changed) }} |{{ end }}{{ if .Working.Changed }} \uF044 {{ .Working.String }}{{ end }}{{ if gt .StashCount 0 }} \ueb4b {{ .StashCount }}{{ end }}", //nolint:lll
 			Git: &Git{
-				HEAD: branchName,
+				HEAD: template.RawMarkup(branchName),
 				Working: &GitStatus{
 					Added:    2,
 					Modified: 3,
@@ -1341,7 +1341,7 @@ func TestGitTemplateString(t *testing.T) {
 			Expected: branchName,
 			Template: "{{ .HEAD }}{{ if .Staging.Changed }} \uF046{{ .Staging.String }}{{ end }}{{ if .Working.Changed }} \uF044{{ .Working.String }}{{ end }}",
 			Git: &Git{
-				HEAD:    branchName,
+				HEAD:    template.RawMarkup(branchName),
 				Staging: &GitStatus{},
 				Working: &GitStatus{},
 			},
@@ -1351,10 +1351,10 @@ func TestGitTemplateString(t *testing.T) {
 			Expected: "from GitHub on main",
 			Template: "from {{ .UpstreamIcon }} on {{ .HEAD }}",
 			Git: &Git{
-				HEAD:         branchName,
+				HEAD:         template.RawMarkup(branchName),
 				Staging:      &GitStatus{},
 				Working:      &GitStatus{},
-				UpstreamIcon: "GitHub",
+				UpstreamIcon: template.RawMarkup("GitHub"),
 			},
 		},
 	}

--- a/src/segments/http_test.go
+++ b/src/segments/http_test.go
@@ -9,6 +9,7 @@ import (
 	runtimehttp "github.com/jandedobbeleer/oh-my-posh/src/runtime/http"
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
 	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+	"github.com/jandedobbeleer/oh-my-posh/src/template"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -118,7 +119,7 @@ func TestHTTPSegmentCache(t *testing.T) {
 	// Create and populate HTTP segment
 	original := &HTTP{
 		Segment: &Segment{
-			Text:  " Electron: v39.2.6 ",
+			Text:  template.RawMarkup(" Electron: v39.2.6 "),
 			Index: 1,
 		},
 	}

--- a/src/segments/lastfm.go
+++ b/src/segments/lastfm.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jandedobbeleer/oh-my-posh/src/log"
 	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+	"github.com/jandedobbeleer/oh-my-posh/src/template"
 )
 
 type LastFM struct {
@@ -15,7 +16,7 @@ type LastFM struct {
 	Artist string
 	Track  string
 	Full   string
-	Icon   string
+	Icon   template.Markup
 	Status string
 }
 
@@ -106,10 +107,10 @@ func (d *LastFM) setStatus() error {
 	isPlaying := track.Info != nil && track.Info.IsPlaying != nil && *track.Info.IsPlaying == "true"
 
 	if isPlaying {
-		d.Icon = d.options.String(PlayingIcon, "\uE602 ")
+		d.Icon = d.options.Markup(PlayingIcon, "\uE602 ")
 		d.Status = "playing"
 	} else {
-		d.Icon = d.options.String(StoppedIcon, "\uF04D ")
+		d.Icon = d.options.Markup(StoppedIcon, "\uF04D ")
 		d.Status = "stopped"
 	}
 

--- a/src/segments/nightscout.go
+++ b/src/segments/nightscout.go
@@ -8,12 +8,13 @@ import (
 	"time"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+	"github.com/jandedobbeleer/oh-my-posh/src/template"
 )
 
 type Nightscout struct {
 	Base
 
-	TrendIcon string
+	TrendIcon template.Markup
 	NightscoutData
 }
 
@@ -91,22 +92,22 @@ func (ns *Nightscout) Enabled() bool {
 	return true
 }
 
-func (ns *Nightscout) getTrendIcon() string {
+func (ns *Nightscout) getTrendIcon() template.Markup {
 	switch ns.Direction {
 	case "DoubleUp":
-		return ns.options.String(DoubleUpIcon, "↑↑")
+		return ns.options.Markup(DoubleUpIcon, "↑↑")
 	case "SingleUp":
-		return ns.options.String(SingleUpIcon, "↑")
+		return ns.options.Markup(SingleUpIcon, "↑")
 	case "FortyFiveUp":
-		return ns.options.String(FortyFiveUpIcon, "↗")
+		return ns.options.Markup(FortyFiveUpIcon, "↗")
 	case "Flat":
-		return ns.options.String(FlatIcon, "→")
+		return ns.options.Markup(FlatIcon, "→")
 	case "FortyFiveDown":
-		return ns.options.String(FortyFiveDownIcon, "↘")
+		return ns.options.Markup(FortyFiveDownIcon, "↘")
 	case "SingleDown":
-		return ns.options.String(SingleDownIcon, "↓")
+		return ns.options.Markup(SingleDownIcon, "↓")
 	case "DoubleDown":
-		return ns.options.String(DoubleDownIcon, "↓↓")
+		return ns.options.Markup(DoubleDownIcon, "↓↓")
 	default:
 		return ""
 	}

--- a/src/segments/node.go
+++ b/src/segments/node.go
@@ -6,10 +6,11 @@ import (
 
 	"github.com/jandedobbeleer/oh-my-posh/src/regex"
 	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+	"github.com/jandedobbeleer/oh-my-posh/src/template"
 )
 
 type Node struct {
-	PackageManagerIcon string
+	PackageManagerIcon template.Markup
 	PackageManagerName string
 
 	Language
@@ -112,7 +113,7 @@ func (n *Node) loadContext() {
 	for _, pm := range packageManagerDefinitions {
 		if n.env.HasFiles(pm.fileName) {
 			n.PackageManagerName = pm.name
-			n.PackageManagerIcon = n.options.String(pm.iconProperty, pm.defaultIcon)
+			n.PackageManagerIcon = n.options.Markup(pm.iconProperty, pm.defaultIcon)
 			break
 		}
 	}

--- a/src/segments/node_test.go
+++ b/src/segments/node_test.go
@@ -96,6 +96,6 @@ func TestNodeInContext(t *testing.T) {
 		node.Init(props, env)
 
 		node.loadContext()
-		assert.Equal(t, tc.ExpectedString, node.PackageManagerIcon, tc.Case)
+		assert.Equal(t, tc.ExpectedString, node.PackageManagerIcon.String(), tc.Case)
 	}
 }

--- a/src/segments/options/map.go
+++ b/src/segments/options/map.go
@@ -32,6 +32,7 @@ type Provider interface {
 	Color(option Option, defaultValue color.Ansi) color.Ansi
 	Bool(option Option, defaultValue bool) bool
 	String(option Option, defaultValue string) string
+	Markup(option Option, defaultValue string) template.Markup
 	Template(option Option, defaultValue string, context any) string
 	Float64(option Option, defaultValue float64) float64
 	Int(option Option, defaultValue int) int
@@ -79,6 +80,13 @@ func (m Map) String(option Option, defaultValue string) string {
 	value := fmt.Sprint(val)
 	debugf("%s: %s", option, value)
 	return value
+}
+
+// Markup returns the option's value as trusted terminal markup: option values
+// are user configuration and may carry <...> anchors, unlike data a segment
+// reads from the filesystem, a VCS, or the network.
+func (m Map) Markup(option Option, defaultValue string) template.Markup {
+	return template.RawMarkup(m.String(option, defaultValue))
 }
 
 // Supports template syntax like {{ .Env.MY_API_KEY }} in configuration values; falls back to

--- a/src/segments/os.go
+++ b/src/segments/os.go
@@ -3,12 +3,13 @@ package segments
 import (
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime"
 	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+	"github.com/jandedobbeleer/oh-my-posh/src/template"
 )
 
 type Os struct {
 	Base
 
-	Icon string
+	Icon template.Markup
 }
 
 const (
@@ -27,26 +28,31 @@ func (oi *Os) Enabled() bool {
 	goos := oi.env.GOOS()
 	switch goos {
 	case runtime.WINDOWS:
-		oi.Icon = oi.options.String(Windows, "\uE62A")
+		oi.Icon = oi.options.Markup(Windows, "\uE62A")
 	case runtime.DARWIN:
-		oi.Icon = oi.options.String(MacOS, "\uF179")
+		oi.Icon = oi.options.Markup(MacOS, "\uF179")
 	case runtime.LINUX, runtime.FREEBSD:
 		pf := oi.env.Platform()
 		displayDistroName := oi.options.Bool(DisplayDistroName, false)
 		if displayDistroName {
-			oi.Icon = oi.options.String(options.Option(pf), pf)
+			icon := oi.options.String(options.Option(pf), "")
+			if icon == "" {
+				oi.Icon = template.EscapeMarkup(pf)
+				break
+			}
+			oi.Icon = template.RawMarkup(icon)
 			break
 		}
 		oi.Icon = oi.getDistroIcon(pf)
 	case runtime.ANDROID:
-		oi.Icon = oi.options.String(Android, "\ue70e")
+		oi.Icon = oi.options.Markup(Android, "\ue70e")
 	default:
-		oi.Icon = goos
+		oi.Icon = template.EscapeMarkup(goos)
 	}
 	return true
 }
 
-func (oi *Os) getDistroIcon(distro string) string {
+func (oi *Os) getDistroIcon(distro string) template.Markup {
 	iconMap := map[string]string{
 		"alma":                "\uf31d",
 		"almalinux":           "\uf31d",
@@ -85,13 +91,13 @@ func (oi *Os) getDistroIcon(distro string) string {
 	}
 
 	if icon, ok := iconMap[distro]; ok {
-		return oi.options.String(options.Option(distro), icon)
+		return oi.options.Markup(options.Option(distro), icon)
 	}
 
 	icon := oi.options.String(options.Option(distro), "")
 	if len(icon) > 0 {
-		return icon
+		return template.RawMarkup(icon)
 	}
 
-	return oi.options.String(Linux, "\uF17C")
+	return oi.options.Markup(Linux, "\uF17C")
 }

--- a/src/segments/path.go
+++ b/src/segments/path.go
@@ -53,7 +53,7 @@ type Path struct {
 	pwd             string
 	Location        string
 	pathSeparator   string
-	Path            string
+	Path            template.Markup
 	Folders         Folders
 	StackCount      int
 	windowsPath     bool
@@ -219,48 +219,53 @@ func (pt *Path) setStyle() {
 			root += pt.getFolderSeparator()
 		}
 
-		pt.Path = pt.colorizePath(root, nil)
+		pt.Path = template.RawMarkup(pt.colorizePath(root, nil))
 		return
 	}
+
+	var styled string
 
 	switch style := pt.options.String(options.Style, Agnoster); style {
 	case Agnoster:
 		maxWidth := pt.getMaxWidth()
-		pt.Path = pt.getAgnosterPath(maxWidth)
+		styled = pt.getAgnosterPath(maxWidth)
 	case AgnosterFull:
-		pt.Path = pt.getAgnosterFullPath()
+		styled = pt.getAgnosterFullPath()
 	case AgnosterShort:
-		pt.Path = pt.getAgnosterShortPath()
+		styled = pt.getAgnosterShortPath()
 	case Mixed:
-		pt.Path = pt.getMixedPath()
+		styled = pt.getMixedPath()
 	case Letter:
-		pt.Path = pt.getLetterPath()
+		styled = pt.getLetterPath()
 	case Unique:
-		pt.Path = pt.getUniqueLettersPath(0)
+		styled = pt.getUniqueLettersPath(0)
 	case AgnosterLeft:
-		pt.Path = pt.getAgnosterLeftPath()
+		styled = pt.getAgnosterLeftPath()
 	case Full, Short: // "short" is a duplicate of "full", just here for backwards compatibility
-		pt.Path = pt.getFullPath()
+		styled = pt.getFullPath()
 	case FolderType:
-		pt.Path = pt.getFolderPath()
+		styled = pt.getFolderPath()
 	case Powerlevel:
 		maxWidth := pt.getMaxWidth()
-		pt.Path = pt.getUniqueLettersPath(maxWidth)
+		styled = pt.getUniqueLettersPath(maxWidth)
 	case Fish:
-		pt.Path = pt.getFishPath()
+		styled = pt.getFishPath()
 	default:
-		pt.Path = fmt.Sprintf("Path style: %s is not available", style)
+		styled = fmt.Sprintf("Path style: %s is not available", style)
 	}
 
 	// make sure we resolve all templates
 	//
-	// pt.Path is composed from raw filesystem folder names (untrusted) plus
-	// already-rendered config templates, so it must never get the func map
-	// entries that touch the OS (cmd/readFile/stat/glob) — use the restricted
-	// renderer, not template.Render.
-	if txt, err := template.RenderUntrusted(pt.Path, pt); err == nil {
-		pt.Path = txt
+	// styled mixes raw folder names (chevrons already escaped by
+	// replaceMappedLocations) with rendered config templates, so it must not
+	// get the functions that touch the OS (cmd, readFile, stat, glob): use
+	// the restricted renderer. Literal text, including the config anchors,
+	// passes through unchanged; embedded actions render escaped.
+	if txt, err := template.RenderUntrusted(styled, pt); err == nil {
+		styled = txt
 	}
+
+	pt.Path = template.RawMarkup(styled)
 }
 
 func (pt *Path) getMaxWidth() int {
@@ -675,10 +680,9 @@ func (pt *Path) replaceMappedLocations(inputPath string) (string, string) {
 	rootN := pt.normalize(root)
 	relativeN := pt.normalize(relative)
 
-	escape := func(path string) string {
-		// Escape chevron characters to avoid applying unexpected text styles.
-		return strings.NewReplacer("<", "<<>", ">", "<>>").Replace(path)
-	}
+	// folder names are untrusted; the renderer would read their chevrons as
+	// anchors
+	escape := template.EscapeText
 
 	handleRegex := func(key string) (string, bool) {
 		if !strings.HasPrefix(key, regexPrefix) {

--- a/src/segments/path.go
+++ b/src/segments/path.go
@@ -663,9 +663,10 @@ func (pt *Path) replaceMappedLocations(inputPath string) (string, string) {
 		pt.RootDir = true
 	}
 
-	// folder names are untrusted; unescaped chevrons would reach the writer
-	// as anchors
-	escape := template.EscapeText
+	// folder names are untrusted and end up as template source (setStyle
+	// renders the styled path): chevrons would reach the writer as anchors and
+	// a template delimiter would run as an action
+	escape := template.EscapeSource
 
 	pt.setMappedLocations()
 	if len(pt.mappedLocations) == 0 {

--- a/src/segments/path.go
+++ b/src/segments/path.go
@@ -663,9 +663,13 @@ func (pt *Path) replaceMappedLocations(inputPath string) (string, string) {
 		pt.RootDir = true
 	}
 
+	// folder names are untrusted; unescaped chevrons would reach the writer
+	// as anchors
+	escape := template.EscapeText
+
 	pt.setMappedLocations()
 	if len(pt.mappedLocations) == 0 {
-		return root, relative
+		return escape(root), escape(relative)
 	}
 
 	// sort map keys in reverse order
@@ -679,10 +683,6 @@ func (pt *Path) replaceMappedLocations(inputPath string) (string, string) {
 
 	rootN := pt.normalize(root)
 	relativeN := pt.normalize(relative)
-
-	// folder names are untrusted; the renderer would read their chevrons as
-	// anchors
-	escape := template.EscapeText
 
 	handleRegex := func(key string) (string, bool) {
 		if !strings.HasPrefix(key, regexPrefix) {
@@ -723,7 +723,8 @@ func (pt *Path) replaceMappedLocations(inputPath string) (string, string) {
 
 	for _, key := range keys {
 		if input, OK := handleRegex(key); OK {
-			return pt.parsePath(input)
+			mappedRoot, mappedRelative := pt.parsePath(input)
+			return escape(mappedRoot), escape(mappedRelative)
 		}
 
 		keyRoot, keyRelative := pt.parsePath(key)

--- a/src/segments/path_unix_test.go
+++ b/src/segments/path_unix_test.go
@@ -574,6 +574,11 @@ var testFullAndFolderPathCases = []testFullAndFolderPathCase{
 	{Style: Full, Pwd: homeDir + abc, Expected: homeDir + abc, DisableMappedLocations: true},
 	{Style: Full, Pwd: abcd, Expected: abcd},
 
+	// folder names are template source in setStyle; delimiters must print, never run
+	{Style: Full, Pwd: homeDir + `/{{ url "click" "https://evil.example" }}`, Expected: `~/{{ url "click" "https:/evil.example" }}`}, // the path cleaner folds the double slash
+	{Style: FolderType, Pwd: homeDir + "/{{ upper .Path }}", Expected: "{{ upper .Path }}"},
+	{Style: Full, Pwd: homeDir + "/<red>{{ .Path }}</>", Expected: "~/<<>red<>>{{ .Path }}<<>/<>>"},
+
 	{Style: Full, FolderSeparatorIcon: "|", Pwd: homeDir, Expected: "~"},
 	{Style: Full, FolderSeparatorIcon: "|", Pwd: homeDir, Expected: "/home|someone", DisableMappedLocations: true},
 	{Style: Full, FolderSeparatorIcon: "|", Pwd: homeDir + abc, Expected: "~|abc"},

--- a/src/segments/path_windows_test.go
+++ b/src/segments/path_windows_test.go
@@ -422,13 +422,21 @@ var testFullAndFolderPathCases = []testFullAndFolderPathCase{
 	{Style: Full, FolderSeparatorIcon: `\`, Pwd: homeDirWindows + "\\abc", Expected: "~\\abc", PathSeparator: `\`, GOOS: runtime.WINDOWS},
 	{Style: Full, FolderSeparatorIcon: `\`, Pwd: "C:\\Users\\posh", Expected: "C:\\Users\\posh", PathSeparator: `\`, GOOS: runtime.WINDOWS},
 
-	// A folder name containing template syntax must never execute the `cmd` function
-	// once it is spliced into pt.Path and re-rendered in setStyle(): the render uses
-	// the restricted func map, so parsing fails and pt.Path keeps its raw, unexecuted
-	// text instead.
+	// A folder name containing template syntax is spliced into pt.Path and
+	// re-rendered in setStyle(); its delimiters must print, never run.
 	{
 		Style: FolderType, FolderSeparatorIcon: `\`,
 		Pwd: homeDirWindows + "\\{{ cmd `whoami` }}", Expected: "{{ cmd `whoami` }}",
+		PathSeparator: `\`, GOOS: runtime.WINDOWS,
+	},
+	{
+		Style: Full, FolderSeparatorIcon: `\`,
+		Pwd: homeDirWindows + "\\{{ upper .Path }}", Expected: "~\\{{ upper .Path }}",
+		PathSeparator: `\`, GOOS: runtime.WINDOWS,
+	},
+	{
+		Style: Full, FolderSeparatorIcon: `\`,
+		Pwd: homeDirWindows + "\\{{ printf `INJECTED-%s` `x` }}", Expected: "~\\{{ printf `INJECTED-%s` `x` }}",
 		PathSeparator: `\`, GOOS: runtime.WINDOWS,
 	},
 }

--- a/src/segments/plastic.go
+++ b/src/segments/plastic.go
@@ -1,11 +1,11 @@
 package segments
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/regex"
+	"github.com/jandedobbeleer/oh-my-posh/src/template"
 )
 
 type PlasticStatus struct {
@@ -31,7 +31,7 @@ var plasticStatusFields = []string{"Status", "Behind", "MergePending"}
 
 type Plastic struct {
 	Status                 *PlasticStatus
-	Selector               string
+	Selector               template.Markup
 	plasticWorkspaceFolder string
 	Scm
 	FieldRefs
@@ -150,24 +150,26 @@ func (p *Plastic) setSelector() {
 	// changeset
 	ref = p.parseChangesetSelector(selector)
 	if len(ref) > 0 {
-		p.Selector = fmt.Sprintf("%s%s", p.options.String(CommitIcon, "\uF417"), ref)
+		p.Selector = template.JoinMarkup(p.options.Markup(CommitIcon, "\uF417"), template.EscapeMarkup(ref))
 		return
 	}
 
 	// fallback to label
 	ref = p.parseLabelSelector(selector)
 	if len(ref) > 0 {
-		p.Selector = fmt.Sprintf("%s%s", p.options.String(TagIcon, "\uF412"), ref)
+		p.Selector = template.JoinMarkup(p.options.Markup(TagIcon, "\uF412"), template.EscapeMarkup(ref))
 		return
 	}
 
 	// fallback to branch/smartbranch
 	ref = p.parseBranchSelector(selector)
+
+	branch := template.EscapeMarkup(ref)
 	if len(ref) > 0 {
-		ref = p.formatBranch(ref)
+		branch = p.formatBranch(ref)
 	}
 
-	p.Selector = fmt.Sprintf("%s%s", p.options.String(BranchIcon, "\uE0A0"), ref)
+	p.Selector = template.JoinMarkup(p.options.Markup(BranchIcon, "\uE0A0"), branch)
 }
 
 func (p *Plastic) parseChangesetSelector(selector string) string {

--- a/src/segments/plastic_test.go
+++ b/src/segments/plastic_test.go
@@ -273,7 +273,7 @@ func TestPlasticStatus(t *testing.T) {
 			Unmerged: 5,
 		},
 	}
-	status := p.Status.String()
+	status := p.Status.String().String()
 	expected := "+1 ~2 -3 >4 x5"
 	assert.Equal(t, expected, status)
 }
@@ -290,7 +290,7 @@ func TestPlasticTemplateString(t *testing.T) {
 			Expected: "/main",
 			Template: "{{ .Selector }}",
 			Plastic: &Plastic{
-				Selector: "/main",
+				Selector: template.RawMarkup("/main"),
 				Behind:   false,
 			},
 		},
@@ -299,7 +299,7 @@ func TestPlasticTemplateString(t *testing.T) {
 			Expected: "/main \uF044 +2 ~3 -1 >4",
 			Template: "{{ .Selector }}{{ if .Status.Changed }} \uF044 {{ .Status.String }}{{ end }}",
 			Plastic: &Plastic{
-				Selector: "/main",
+				Selector: template.RawMarkup("/main"),
 				Status: &PlasticStatus{
 					Added:    2,
 					Modified: 3,
@@ -313,7 +313,7 @@ func TestPlasticTemplateString(t *testing.T) {
 			Expected: "/main",
 			Template: "{{ .Selector }}{{ if .Status.Changed }} \uF044 {{ .Status.String }}{{ end }}",
 			Plastic: &Plastic{
-				Selector: "/main",
+				Selector: template.RawMarkup("/main"),
 				Status:   &PlasticStatus{},
 			},
 		},

--- a/src/segments/posh_git.go
+++ b/src/segments/posh_git.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/log"
+	"github.com/jandedobbeleer/oh-my-posh/src/template"
 )
 
 const (
@@ -81,19 +82,19 @@ func (g *Git) hasPoshGitStatus() bool {
 	return true
 }
 
-func (g *Git) parsePoshGitHEAD(head string) string {
+func (g *Git) parsePoshGitHEAD(head string) template.Markup {
 	// commit
 	if strings.HasSuffix(head, "...)") {
 		head = strings.TrimLeft(head, "(")
 		head = strings.TrimRight(head, ".)")
-		return fmt.Sprintf("%s%s", g.options.String(CommitIcon, "\uF417"), head)
+		return template.JoinMarkup(g.options.Markup(CommitIcon, "\uF417"), template.EscapeMarkup(head))
 	}
 	// tag
 	if strings.HasPrefix(head, "(") {
 		head = strings.TrimLeft(head, "(")
 		head = strings.TrimRight(head, ")")
-		return fmt.Sprintf("%s%s", g.options.String(TagIcon, "\uF412"), head)
+		return template.JoinMarkup(g.options.Markup(TagIcon, "\uF412"), template.EscapeMarkup(head))
 	}
 	// regular branch
-	return fmt.Sprintf("%s%s", g.options.String(BranchIcon, "\uE0A0"), g.formatBranch(head))
+	return template.JoinMarkup(g.options.Markup(BranchIcon, "\uE0A0"), g.formatBranch(head))
 }

--- a/src/segments/posh_git_test.go
+++ b/src/segments/posh_git_test.go
@@ -245,6 +245,6 @@ func TestParsePoshGitHEAD(t *testing.T) {
 		g := &Git{}
 		g.Init(&options.Map{}, new(mock.Environment))
 
-		assert.Equal(t, tc.ExpectedString, g.parsePoshGitHEAD(tc.HEAD), tc.Case)
+		assert.Equal(t, tc.ExpectedString, g.parsePoshGitHEAD(tc.HEAD).String(), tc.Case)
 	}
 }

--- a/src/segments/sapling_test.go
+++ b/src/segments/sapling_test.go
@@ -222,7 +222,7 @@ func TestSetHeadContext(t *testing.T) {
 		}
 
 		sl.setHeadContext()
-		got := sl.Working.String()
+		got := sl.Working.String().String()
 		assert.Equal(t, tc.Expected, got, tc.Case)
 	}
 }

--- a/src/segments/scm.go
+++ b/src/segments/scm.go
@@ -130,9 +130,7 @@ func (s *Scm) RelativeDir() string {
 // formatBranch returns the branch name as markup: the branch itself is
 // untrusted VCS data (a repository controls it), so its chevrons are escaped,
 // while mapped_branches values and the branch_template render are user
-// configuration and keep their anchors. branchTemplate receives the mapped
-// branch as a plain string so trunc and friends keep working; anchors in a
-// mapped value only survive when no branch_template is set.
+// configuration and keep their anchors.
 func (s *Scm) formatBranch(branch string) template.Markup {
 	mappedBranches := s.options.KeyValueMap(MappedBranches, make(map[string]string))
 
@@ -145,15 +143,13 @@ func (s *Scm) formatBranch(branch string) template.Markup {
 
 	const wildcard = "*"
 
-	display := branch
-	displayMarkup := template.EscapeMarkup(branch)
+	display := template.EscapeMarkup(branch)
 
 	for _, key := range keys {
 		mappedBranch := mappedBranches[key]
 
 		if key == wildcard || branch == key {
-			display = mappedBranch
-			displayMarkup = template.RawMarkup(mappedBranch)
+			display = template.RawMarkup(mappedBranch)
 			break
 		}
 
@@ -162,20 +158,24 @@ func (s *Scm) formatBranch(branch string) template.Markup {
 
 		if matchSubFolders && strings.HasPrefix(branch, subfolderKey) {
 			remainder := strings.TrimPrefix(branch, subfolderKey)
-			display = mappedBranch + remainder
-			displayMarkup = template.JoinMarkup(template.RawMarkup(mappedBranch), template.EscapeMarkup(remainder))
+			display = template.JoinMarkup(template.RawMarkup(mappedBranch), template.EscapeMarkup(remainder))
 			break
 		}
 	}
 
 	branchTemplate := s.options.String(BranchTemplate, "")
 	if branchTemplate == "" {
-		return displayMarkup
+		return display
 	}
 
-	txt, err := template.RenderTrusted(branchTemplate, struct{ Branch, Upstream string }{Branch: display, Upstream: s.Upstream})
+	context := struct {
+		Branch   template.Markup
+		Upstream string
+	}{Branch: display, Upstream: s.Upstream}
+
+	txt, err := template.RenderTrusted(branchTemplate, context)
 	if err != nil {
-		return displayMarkup
+		return display
 	}
 
 	return template.RawMarkup(txt)

--- a/src/segments/scm.go
+++ b/src/segments/scm.go
@@ -49,7 +49,10 @@ func (s *ScmStatus) Changed() bool {
 		s.Ignored > 0
 }
 
-func (s *ScmStatus) String() string {
+// String composes the status from config formats (status_formats) and counts,
+// so the result is trusted markup: the `>` moved-prefix and any anchors in a
+// configured format must survive rendering.
+func (s *ScmStatus) String() template.Markup {
 	status := text.NewBuilder()
 
 	if s.Formats == nil {
@@ -81,7 +84,7 @@ func (s *ScmStatus) String() string {
 	stringIfValue(s.Clean, "Clean", "=")
 	stringIfValue(s.Ignored, "Ignored", "Ø")
 
-	return strings.TrimSpace(status.String())
+	return template.RawMarkup(strings.TrimSpace(status.String()))
 }
 
 type Scm struct {
@@ -124,7 +127,13 @@ func (s *Scm) RelativeDir() string {
 	return rel
 }
 
-func (s *Scm) formatBranch(branch string) string {
+// formatBranch returns the branch name as markup: the branch itself is
+// untrusted VCS data (a repository controls it), so its chevrons are escaped,
+// while mapped_branches values and the branch_template render are user
+// configuration and keep their anchors. branchTemplate receives the mapped
+// branch as a plain string so trunc and friends keep working; anchors in a
+// mapped value only survive when no branch_template is set.
+func (s *Scm) formatBranch(branch string) template.Markup {
 	mappedBranches := s.options.KeyValueMap(MappedBranches, make(map[string]string))
 
 	// sort the keys alphabetically
@@ -136,9 +145,15 @@ func (s *Scm) formatBranch(branch string) string {
 
 	const wildcard = "*"
 
+	display := branch
+	displayMarkup := template.EscapeMarkup(branch)
+
 	for _, key := range keys {
-		if key == wildcard {
-			branch = mappedBranches[key]
+		mappedBranch := mappedBranches[key]
+
+		if key == wildcard || branch == key {
+			display = mappedBranch
+			displayMarkup = template.RawMarkup(mappedBranch)
 			break
 		}
 
@@ -146,29 +161,24 @@ func (s *Scm) formatBranch(branch string) string {
 		subfolderKey := strings.TrimSuffix(key, wildcard)
 
 		if matchSubFolders && strings.HasPrefix(branch, subfolderKey) {
-			branch = strings.Replace(branch, subfolderKey, mappedBranches[key], 1)
+			remainder := strings.TrimPrefix(branch, subfolderKey)
+			display = mappedBranch + remainder
+			displayMarkup = template.JoinMarkup(template.RawMarkup(mappedBranch), template.EscapeMarkup(remainder))
 			break
 		}
-
-		if matchSubFolders || branch != key {
-			continue
-		}
-
-		branch = strings.Replace(branch, key, mappedBranches[key], 1)
-		break
 	}
 
 	branchTemplate := s.options.String(BranchTemplate, "")
 	if branchTemplate == "" {
-		return branch
+		return displayMarkup
 	}
 
-	txt, err := template.RenderTrusted(branchTemplate, struct{ Branch, Upstream string }{Branch: branch, Upstream: s.Upstream})
+	txt, err := template.RenderTrusted(branchTemplate, struct{ Branch, Upstream string }{Branch: display, Upstream: s.Upstream})
 	if err != nil {
-		return branch
+		return displayMarkup
 	}
 
-	return txt
+	return template.RawMarkup(txt)
 }
 
 func (s *Scm) fileContent(folder, file string) string {

--- a/src/segments/scm_test.go
+++ b/src/segments/scm_test.go
@@ -245,6 +245,24 @@ func TestFormatBranch(t *testing.T) {
 			Expected:       "<b><<>red<>>x</>",
 			BranchTemplate: "<b>{{ .Branch }}</>",
 		},
+		{
+			Case:           "Mapped branch keeps markup through the branch template",
+			Input:          "feat/x",
+			Expected:       "<#ff0000>feat</> x (mapped)",
+			BranchTemplate: "{{ .Branch }} (mapped)",
+			MappedBranches: map[string]string{
+				"feat/*": "<#ff0000>feat</> ",
+			},
+		},
+		{
+			Case:           "Mapped branch survives string functions in the branch template",
+			Input:          "feat/my-new-feature",
+			Expected:       "<#FF0000>FEAT</> MY-NEW",
+			BranchTemplate: "{{ .Branch | trimSuffix \"-feature\" | upper }}",
+			MappedBranches: map[string]string{
+				"feat/*": "<#ff0000>feat</> ",
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/src/segments/scm_test.go
+++ b/src/segments/scm_test.go
@@ -104,7 +104,7 @@ func TestScmStatusString(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		assert.Equal(t, tc.Expected, tc.Status.String(), tc.Case)
+		assert.Equal(t, tc.Expected, tc.Status.String().String(), tc.Case)
 	}
 }
 
@@ -216,6 +216,35 @@ func TestFormatBranch(t *testing.T) {
 			Upstream:       "origin",
 			BranchTemplate: "{{ .Branch }}{{ if .Upstream }}@{{ .Upstream }}{{ end }}",
 		},
+		{
+			// a branch name is repo-controlled: its chevrons must be escaped so
+			// the writer cannot parse them as anchors (the writer renders
+			// <<>red<>> as literal <red>)
+			Case:     "Branch name with anchor-shaped text is escaped",
+			Input:    "<red>pwned-branch",
+			Expected: "<<>red<>>pwned-branch",
+		},
+		{
+			Case:     "Branch name with hyperlink markup is escaped",
+			Input:    "<LINK>https://attacker.example<TEXT>x",
+			Expected: "<<>LINK<>>https://attacker.example<<>TEXT<>>x",
+		},
+		{
+			// the mapped value is user configuration and keeps its anchors
+			Case:     "Mapped branch value keeps markup",
+			Input:    "feat/x",
+			Expected: "<#ff0000>feat</> x",
+			MappedBranches: map[string]string{
+				"feat/*": "<#ff0000>feat</> ",
+			},
+		},
+		{
+			// data flows through branch_template escaped; config text keeps anchors
+			Case:           "Branch template escapes data, keeps config anchors",
+			Input:          "<red>x",
+			Expected:       "<b><<>red<>>x</>",
+			BranchTemplate: "<b>{{ .Branch }}</>",
+		},
 	}
 
 	for _, tc := range cases {
@@ -235,6 +264,6 @@ func TestFormatBranch(t *testing.T) {
 		template.Init(env, nil, nil)
 
 		got := s.formatBranch(tc.Input)
-		assert.Equal(t, tc.Expected, got, tc.Case)
+		assert.Equal(t, tc.Expected, got.String(), tc.Case)
 	}
 }

--- a/src/segments/spotify.go
+++ b/src/segments/spotify.go
@@ -1,6 +1,9 @@
 package segments
 
-import "github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+import (
+	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+	"github.com/jandedobbeleer/oh-my-posh/src/template"
+)
 
 type Spotify struct {
 	Base
@@ -12,7 +15,7 @@ type MusicPlayer struct {
 	Status string
 	Artist string
 	Track  string
-	Icon   string
+	Icon   template.Markup
 }
 
 const (
@@ -35,12 +38,12 @@ func (s *Spotify) resolveIcon() {
 	switch s.Status {
 	case stopped:
 		// in this case, no artist or track info
-		s.Icon = s.options.String(StoppedIcon, " ")
+		s.Icon = s.options.Markup(StoppedIcon, " ")
 	case paused:
-		s.Icon = s.options.String(PausedIcon, " ")
+		s.Icon = s.options.Markup(PausedIcon, " ")
 	case playing:
-		s.Icon = s.options.String(PlayingIcon, " ")
+		s.Icon = s.options.Markup(PlayingIcon, " ")
 	case ad:
-		s.Icon = s.options.String(AdIcon, " ")
+		s.Icon = s.options.Markup(AdIcon, " ")
 	}
 }

--- a/src/segments/spotify_test.go
+++ b/src/segments/spotify_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
 	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+	"github.com/jandedobbeleer/oh-my-posh/src/template"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -17,7 +18,7 @@ func TestSpotifyStringPlayingSong(t *testing.T) {
 		Artist: "Candlemass",
 		Track:  "Spellbreaker",
 		Status: "playing",
-		Icon:   "\ue602 ",
+		Icon:   template.RawMarkup("\ue602 "),
 	}
 	s.Init(options.Map{}, env)
 
@@ -32,7 +33,7 @@ func TestSpotifyStringStoppedSong(t *testing.T) {
 		Artist: "Candlemass",
 		Track:  "Spellbreaker",
 		Status: "stopped",
-		Icon:   "\uf04d ",
+		Icon:   template.RawMarkup("\uf04d "),
 	}
 	s.Init(options.Map{}, env)
 

--- a/src/segments/status.go
+++ b/src/segments/status.go
@@ -17,7 +17,7 @@ const (
 type Status struct {
 	Base
 
-	String  string
+	String  template.Markup
 	Meaning string
 	Error   bool
 }
@@ -29,7 +29,7 @@ func (s *Status) Template() string {
 func (s *Status) Enabled() bool {
 	status, pipeStatus := s.env.StatusCodes()
 
-	s.String = s.formatStatus(status, pipeStatus)
+	s.String = template.RawMarkup(s.formatStatus(status, pipeStatus))
 	// Deprecated: Use {{ reason .Code }} instead
 	s.Meaning = template.GetReasonFromStatus(status)
 

--- a/src/segments/strava.go
+++ b/src/segments/strava.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime/http"
 	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+	"github.com/jandedobbeleer/oh-my-posh/src/template"
 )
 
 type StravaAPI interface {
@@ -26,7 +27,7 @@ type Strava struct {
 	Base
 
 	api   StravaAPI
-	Icon  string
+	Icon  template.Markup
 	Ago   string
 	Error string
 	URL   string
@@ -123,22 +124,22 @@ func (s *Strava) getAgo() string {
 	return fmt.Sprintf("%d", s.Hours) + string("h")
 }
 
-func (s *Strava) getActivityIcon() string {
+func (s *Strava) getActivityIcon() template.Markup {
 	switch s.Type {
 	case "VirtualRide":
 		fallthrough
 	case "Ride":
-		return s.options.String(RideIcon, "\uf206")
+		return s.options.Markup(RideIcon, "\uf206")
 	case "Run":
-		return s.options.String(RunIcon, "\ue213")
+		return s.options.Markup(RunIcon, "\ue213")
 	case "NordicSki":
 	case "AlpineSki":
 	case "BackcountrySki":
-		return s.options.String(SkiingIcon, "\ue213")
+		return s.options.Markup(SkiingIcon, "\ue213")
 	case "WorkOut":
-		return s.options.String(WorkOutIcon, "\ue213")
+		return s.options.Markup(WorkOutIcon, "\ue213")
 	default:
-		return s.options.String(UnknownActivityIcon, "\ue213")
+		return s.options.Markup(UnknownActivityIcon, "\ue213")
 	}
-	return s.options.String(UnknownActivityIcon, "\ue213")
+	return s.options.Markup(UnknownActivityIcon, "\ue213")
 }

--- a/src/segments/terraform_test.go
+++ b/src/segments/terraform_test.go
@@ -57,8 +57,10 @@ func TestTerraform(t *testing.T) {
 			FetchVersion:   true,
 		},
 		{
-			Case:              "files",
-			ExpectedString:    ">= 1.0.10",
+			Case: "files",
+			// required_version is repo-controlled data: its chevrons are escaped
+			// by the renderer and resolved back to >= by the writer
+			ExpectedString:    "<>>= 1.0.10",
 			ExpectedEnabled:   true,
 			WorkspaceName:     "default",
 			Template:          "{{ .Version }}",

--- a/src/segments/ytm.go
+++ b/src/segments/ytm.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jandedobbeleer/oh-my-posh/src/cli/auth"
 	"github.com/jandedobbeleer/oh-my-posh/src/log"
 	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+	"github.com/jandedobbeleer/oh-my-posh/src/template"
 )
 
 const (
@@ -59,18 +60,18 @@ func (y *Ytm) setStatus() error {
 	switch status.Player.TrackState {
 	case 1, 2: // playing or buffering
 		y.Status = playing
-		y.Icon = y.options.String(PlayingIcon, "\uf04b ")
+		y.Icon = y.options.Markup(PlayingIcon, "\uf04b ")
 	case -1: // stopped
 		y.Status = stopped
-		y.Icon = y.options.String(StoppedIcon, "\uf04d ")
+		y.Icon = y.options.Markup(StoppedIcon, "\uf04d ")
 	default: // paused
 		y.Status = paused
-		y.Icon = y.options.String(PausedIcon, "\uf04c ")
+		y.Icon = y.options.Markup(PausedIcon, "\uf04c ")
 	}
 
 	if status.Player.AdPlaying {
-		ad := y.options.String(AdIcon, "\ueebb ")
-		y.Icon = ad + y.Icon
+		ad := y.options.Markup(AdIcon, "\ueebb ")
+		y.Icon = template.JoinMarkup(ad, y.Icon)
 	}
 
 	y.Artist = status.Video.Author

--- a/src/segments/ytm_test.go
+++ b/src/segments/ytm_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jandedobbeleer/oh-my-posh/src/cli/auth"
 	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
 	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+	"github.com/jandedobbeleer/oh-my-posh/src/template"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -88,10 +89,10 @@ func TestYTM(t *testing.T) {
 		}
 
 		props := options.Map{
-			StoppedIcon: "Stopped ",
-			PlayingIcon: "Playing ",
-			PausedIcon:  "Paused ",
-			AdIcon:      "Ad ",
+			StoppedIcon: template.RawMarkup("Stopped "),
+			PlayingIcon: template.RawMarkup("Playing "),
+			PausedIcon:  template.RawMarkup("Paused "),
+			AdIcon:      template.RawMarkup("Ad "),
 		}
 
 		ytm := new(Ytm)

--- a/src/segments/zvm.go
+++ b/src/segments/zvm.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/segments/options"
+	"github.com/jandedobbeleer/oh-my-posh/src/template"
 )
 
 const ZigIcon options.Option = "zigicon"
@@ -12,7 +13,7 @@ type Zvm struct {
 	Base
 
 	Version string
-	ZigIcon string
+	ZigIcon template.Markup
 }
 
 func (z *Zvm) Template() string {
@@ -24,7 +25,7 @@ func (z *Zvm) Enabled() bool {
 		return false
 	}
 
-	z.ZigIcon = z.options.String(ZigIcon, "ZVM")
+	z.ZigIcon = z.options.Markup(ZigIcon, "ZVM")
 
 	// Disable colors so the output has no ANSI escape codes to parse.
 	output, err := z.env.RunCommand("zvm", "--color=false", "list")

--- a/src/template/bench_test.go
+++ b/src/template/bench_test.go
@@ -86,3 +86,24 @@ func BenchmarkPatchTemplate(b *testing.B) {
 		t.patchTemplate()
 	}
 }
+
+// Models a segment template that leans on functions: every call crosses the
+// Markup-aware wrapper, so this is where its cost shows up.
+func BenchmarkRenderFunctions(b *testing.B) {
+	setupTemplateBench()
+	type ctx struct {
+		Folder  string
+		Branch  string
+		Version string
+	}
+	data := ctx{
+		Folder:  "oh-my-posh",
+		Branch:  "perf/rendering-engine",
+		Version: "23.4.1",
+	}
+	tmpl := `{{ .Folder | upper }} {{ trunc 5 .Branch }}{{ if contains "perf" .Branch }} perf{{ end }} {{ printf "v%s" .Version }} {{ .Branch | replace "/" " " }}`
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = RenderTrusted(tmpl, data)
+	}
+}

--- a/src/template/date.go
+++ b/src/template/date.go
@@ -7,9 +7,13 @@ import (
 
 // dateInZone is a replacement for sprig's dateInZone that adds support for string
 // epoch values. Sprig's unixEpoch returns a string, which sprig's own date functions
-// do not handle — they fall through to time.Now(). This wrapper parses numeric strings
+// do not handle: they fall through to time.Now(). This wrapper parses numeric strings
 // as Unix timestamps so that patterns like `{{ now | unixEpoch | date "..." }}` work.
-func dateInZone(fmt string, date any, zone string) string {
+//
+// The result is Markup: the layout is user configuration and may carry anchors
+// (e.g. a time_format of "Monday <#ffffff>at</> 15:04"), while the substituted
+// values are formatted time components and cannot contain chevrons.
+func dateInZone(fmt string, date any, zone string) Markup {
 	var t time.Time
 
 	switch v := date.(type) {
@@ -34,7 +38,7 @@ func dateInZone(fmt string, date any, zone string) string {
 		loc, _ = time.LoadLocation("UTC")
 	}
 
-	return t.In(loc).Format(fmt)
+	return RawMarkup(t.In(loc).Format(fmt))
 }
 
 // parseDateString reads the two shapes a date reaches a template as text in: a Unix epoch, which
@@ -54,18 +58,18 @@ func parseDateString(value string) time.Time {
 	return time.Now()
 }
 
-func ompDate(fmt string, date any) string {
+func ompDate(fmt string, date any) Markup {
 	return dateInZone(fmt, date, "Local")
 }
 
-func ompDateInZone(fmt string, date any, zone string) string {
+func ompDateInZone(fmt string, date any, zone string) Markup {
 	return dateInZone(fmt, date, zone)
 }
 
-func ompHTMLDate(date any) string {
+func ompHTMLDate(date any) Markup {
 	return dateInZone("2006-01-02", date, "Local")
 }
 
-func ompHTMLDateInZone(date any, zone string) string {
+func ompHTMLDateInZone(date any, zone string) Markup {
 	return dateInZone("2006-01-02", date, zone)
 }

--- a/src/template/func_map.go
+++ b/src/template/func_map.go
@@ -86,12 +86,18 @@ var restrictedAllowedSprigFuncs = map[string]bool{
 	"wrapWith": true,
 }
 
+// escapeFuncName is the internal function appended to every print action's
+// pipeline after parsing (see escapePrintActions). It must resolve in both
+// trust levels, so it lives in the shared local map.
+const escapeFuncName = "__esc"
+
 // localFuncMap holds oh-my-posh's own template functions, including ones
 // that intentionally override a sprig function of the same name (e.g. date,
 // to support string epoch values). These are unconditionally available in
 // both the trusted and restricted func maps.
 func localFuncMap() map[string]any {
-	return map[string]any{
+	fm := map[string]any{
+		escapeFuncName: escapeActionValue,
 		"secondsRound": secondsRound,
 		"url":          url,
 		"path":         filePath,
@@ -103,8 +109,6 @@ func localFuncMap() map[string]any {
 		"random":       random,
 		"reason":       GetReasonFromStatus,
 		"hresult":      hresult,
-		"trunc":        trunc,
-		"truncE":       TruncE,
 		"dir":          filepath.Dir,
 		"base":         filepath.Base,
 		// Locale-aware date/time formatting using OS regional settings.
@@ -117,6 +121,12 @@ func localFuncMap() map[string]any {
 		"htmlDate":       ompHTMLDate,
 		"htmlDateInZone": ompHTMLDateInZone,
 	}
+
+	for name, fn := range markupStringFuncs() {
+		fm[name] = fn
+	}
+
+	return fm
 }
 
 func baseFuncMap() map[string]any {

--- a/src/template/func_map.go
+++ b/src/template/func_map.go
@@ -1,6 +1,7 @@
 package template
 
 import (
+	"fmt"
 	"path/filepath"
 	"sync"
 	"text/template"
@@ -111,6 +112,14 @@ func localFuncMap() map[string]any {
 		"hresult":      hresult,
 		"dir":          filepath.Dir,
 		"base":         filepath.Base,
+		"trunc":        trunc,
+		"truncE":       TruncE,
+		// The print builtins format through fmt and return plain strings, so
+		// they would drop the trust of a Markup argument; these overrides go
+		// through markupAware like every other function.
+		"print":   fmt.Sprint,
+		"printf":  fmt.Sprintf,
+		"println": fmt.Sprintln,
 		// Locale-aware date/time formatting using OS regional settings.
 		"localeShortDate": localeShortDate,
 		"localeShortTime": localeShortTime,
@@ -122,11 +131,22 @@ func localFuncMap() map[string]any {
 		"htmlDateInZone": ompHTMLDateInZone,
 	}
 
-	for name, fn := range markupStringFuncs() {
-		fm[name] = fn
+	return fm
+}
+
+// wrapMarkupAware replaces every function in fm with its Markup-aware form
+// (see markupAware). The escape function is the one exception: it is the
+// boundary the wrapper protects, and must see the raw value.
+func wrapMarkupAware(fm map[string]any) template.FuncMap {
+	for name, fn := range fm {
+		if name == escapeFuncName {
+			continue
+		}
+
+		fm[name] = markupAware(name, fn)
 	}
 
-	return fm
+	return template.FuncMap(fm)
 }
 
 func baseFuncMap() map[string]any {
@@ -178,7 +198,7 @@ var sharedFuncMap = sync.OnceValue(func() template.FuncMap {
 		}
 	}
 
-	return template.FuncMap(fm)
+	return wrapMarkupAware(fm)
 })
 
 // Reused across all restricted template constructions (see RenderUntrusted).
@@ -203,7 +223,7 @@ var restrictedFuncMap = sync.OnceValue(func() template.FuncMap {
 		}
 	}
 
-	return template.FuncMap(fm)
+	return wrapMarkupAware(fm)
 })
 
 func funcMap(trusted bool) template.FuncMap {

--- a/src/template/func_map.go
+++ b/src/template/func_map.go
@@ -42,6 +42,17 @@ var dangerousFuncs = map[string]bool{
 	"encryptAES":               true,
 	"decryptAES":               true,
 	"randBytes":                true,
+
+	// Attacker-chosen counts: a crafted folder name can allocate gigabytes
+	// or spin for minutes with these.
+	"repeat":       true,
+	"seq":          true,
+	"until":        true,
+	"untilStep":    true,
+	"randAlpha":    true,
+	"randAlphaNum": true,
+	"randAscii":    true,
+	"randNumeric":  true,
 }
 
 // restrictedAllowedSprigFuncs is a frozen allowlist of sprig functions that
@@ -73,16 +84,16 @@ var restrictedAllowedSprigFuncs = map[string]bool{
 	"mustToRawJson": true, "mustUniq": true, "mustWithout": true, "must_date_modify": true, "nindent": true,
 	"nospace": true, "now": true, "omit": true, "osBase": true, "osClean": true, "osDir": true, "osExt": true,
 	"osIsAbs": true, "pick": true, "pluck": true, "plural": true, "prepend": true, "push": true, "quote": true,
-	"randAlpha": true, "randAlphaNum": true, "randAscii": true, "randInt": true, "randNumeric": true,
+	"randInt":   true,
 	"regexFind": true, "regexFindAll": true, "regexMatch": true, "regexQuoteMeta": true, "regexReplaceAll": true,
-	"regexReplaceAllLiteral": true, "regexSplit": true, "repeat": true, "replace": true, "rest": true,
-	"reverse": true, "round": true, "semver": true, "semverCompare": true, "seq": true, "set": true, "sha1sum": true,
+	"regexReplaceAllLiteral": true, "regexSplit": true, "replace": true, "rest": true,
+	"reverse": true, "round": true, "semver": true, "semverCompare": true, "set": true, "sha1sum": true,
 	"sha256sum": true, "sha512sum": true, "shuffle": true, "slice": true, "snakecase": true, "sortAlpha": true,
 	"split": true, "splitList": true, "splitn": true, "squote": true, "sub": true, "subf": true, "substr": true,
 	"swapcase": true, "ternary": true, "title": true, "toDate": true, "toDecimal": true, "toJson": true,
 	"toPrettyJson": true, "toRawJson": true, "toString": true, "toStrings": true, "trim": true, "trimAll": true,
 	"trimPrefix": true, "trimSuffix": true, "trimall": true, "tuple": true, "typeIs": true, "typeIsLike": true,
-	"typeOf": true, "uniq": true, "unixEpoch": true, "unset": true, "until": true, "untilStep": true, "untitle": true,
+	"typeOf": true, "uniq": true, "unixEpoch": true, "unset": true, "untitle": true,
 	"upper": true, "urlJoin": true, "urlParse": true, "uuidv4": true, "values": true, "without": true, "wrap": true,
 	"wrapWith": true,
 }
@@ -97,7 +108,7 @@ const escapeFuncName = "__esc"
 // to support string epoch values). These are unconditionally available in
 // both the trusted and restricted func maps.
 func localFuncMap() map[string]any {
-	fm := map[string]any{
+	return map[string]any{
 		escapeFuncName: escapeActionValue,
 		"secondsRound": secondsRound,
 		"url":          url,
@@ -123,15 +134,12 @@ func localFuncMap() map[string]any {
 		// Locale-aware date/time formatting using OS regional settings.
 		"localeShortDate": localeShortDate,
 		"localeShortTime": localeShortTime,
-		// Override sprig date functions to support string epoch values (e.g. output of unixEpoch).
-		"date":           ompDate,
-		"date_in_zone":   ompDateInZone,
-		"dateInZone":     ompDateInZone,
-		"htmlDate":       ompHTMLDate,
-		"htmlDateInZone": ompHTMLDateInZone,
+		"date":            ompDate,
+		"date_in_zone":    ompDateInZone,
+		"dateInZone":      ompDateInZone,
+		"htmlDate":        ompHTMLDate,
+		"htmlDateInZone":  ompHTMLDateInZone,
 	}
-
-	return fm
 }
 
 // wrapMarkupAware replaces every function in fm with its Markup-aware form
@@ -174,25 +182,7 @@ var sharedFuncMap = sync.OnceValue(func() template.FuncMap {
 	fm["glob"] = glob
 
 	sprigFuncs := sprig.TxtFuncMap()
-	for _, name := range []string{
-		"env",
-		"expandenv",
-		"getHostByName",
-		"genPrivateKey",
-		"genCA",
-		"genCAWithKey",
-		"genSelfSignedCert",
-		"genSelfSignedCertWithKey",
-		"genSignedCert",
-		"genSignedCertWithKey",
-		"buildCustomCert",
-		"bcrypt",
-		"htpasswd",
-		"derivePassword",
-		"encryptAES",
-		"decryptAES",
-		"randBytes",
-	} {
+	for name := range dangerousFuncs {
 		if fn, ok := sprigFuncs[name]; ok {
 			fm[name] = fn
 		}
@@ -208,12 +198,9 @@ var sharedFuncMap = sync.OnceValue(func() template.FuncMap {
 // reviewed change to that list.
 var restrictedFuncMap = sync.OnceValue(func() template.FuncMap {
 	fm := localFuncMap()
+	fm[escapeFuncName] = escapeUntrustedActionValue
 
 	for key, fun := range sprig.TxtFuncMap() {
-		if dangerousFuncs[key] {
-			continue
-		}
-
 		if !restrictedAllowedSprigFuncs[key] {
 			continue
 		}

--- a/src/template/func_map_test.go
+++ b/src/template/func_map_test.go
@@ -17,6 +17,10 @@ func TestRestrictedAllowedSprigFuncsCoversAllSprigFuncs(t *testing.T) {
 	localOverrides := localFuncMap()
 
 	for name := range sprig.TxtFuncMap() {
+		if dangerousFuncs[name] && restrictedAllowedSprigFuncs[name] {
+			t.Errorf("sprig function %q is in both lists", name)
+		}
+
 		if dangerousFuncs[name] || restrictedAllowedSprigFuncs[name] {
 			continue
 		}

--- a/src/template/init.go
+++ b/src/template/init.go
@@ -34,9 +34,12 @@ func Init(environment runtime.Environment, vars maps.Simple[any], aliases *maps.
 	env = environment
 	shell = env.Shell()
 
-	// Reset per-process caches so tests that call Init multiple times stay isolated.
-	knownFields = sync.Map{}
-	parsedTemplates = sync.Map{}
+	// Reset per-process caches so tests that call Init multiple times stay isolated. Clear, not
+	// a struct reassignment: the serve daemon calls Init once per prompt while segment goroutines
+	// abandoned by the previous cycle may still be mid-Load on these maps, and overwriting a live
+	// sync.Map is a data race that can end in a fatal runtime throw.
+	knownFields.Clear()
+	parsedTemplates.Clear()
 
 	renderPool = generics.NewPool(func() *renderer {
 		return &renderer{

--- a/src/template/link.go
+++ b/src/template/link.go
@@ -1,34 +1,67 @@
 package template
 
 import (
+	"errors"
 	"fmt"
 	link "net/url"
 	"slices"
+	"strings"
 )
 
-func url(text, url string) (string, error) {
+// labelMarkup keeps a Markup label's anchors intact (e.g. an icon field)
+// while escaping plain data strings.
+func labelMarkup(v any) Markup {
+	switch l := v.(type) {
+	case Markup:
+		return l
+	case string:
+		return EscapeMarkup(l)
+	default:
+		return EscapeMarkup(fmt.Sprint(v))
+	}
+}
+
+func textValue(v any) string {
+	switch s := v.(type) {
+	case Markup:
+		return string(s)
+	case string:
+		return s
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+func url(label, rawURL any) (Markup, error) {
 	unsupported := []string{elvish, xonsh}
 	if slices.Contains(unsupported, shell) {
-		return text, nil
+		return labelMarkup(label), nil
 	}
 
+	url := textValue(rawURL)
 	if url == "" {
-		return text, nil
+		return labelMarkup(label), nil
 	}
+
+	if strings.ContainsAny(url, "<>") {
+		return "", errors.New("url contains chevrons")
+	}
+
 	_, err := link.ParseRequestURI(url)
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("<LINK>%s<TEXT>%s</TEXT></LINK>", url, text), nil
+
+	return RawMarkup(fmt.Sprintf("<LINK>%s<TEXT>%s</TEXT></LINK>", url, labelMarkup(label))), nil
 }
 
-func filePath(text, path string) (string, error) {
+func filePath(label, path any) (Markup, error) {
 	unsupported := []string{elvish, xonsh}
 	if slices.Contains(unsupported, shell) {
-		return text, nil
+		return labelMarkup(label), nil
 	}
 
-	encodedPath := (&link.URL{Path: path}).EscapedPath()
+	encodedPath := (&link.URL{Path: textValue(path)}).EscapedPath()
 
-	return fmt.Sprintf("<LINK>file:%s<TEXT>%s</TEXT></LINK>", encodedPath, text), nil
+	return RawMarkup(fmt.Sprintf("<LINK>file:%s<TEXT>%s</TEXT></LINK>", encodedPath, labelMarkup(label))), nil
 }

--- a/src/template/link.go
+++ b/src/template/link.go
@@ -1,7 +1,6 @@
 package template
 
 import (
-	"errors"
 	"fmt"
 	link "net/url"
 	"slices"
@@ -22,14 +21,11 @@ func labelMarkup(v any) Markup {
 }
 
 func textValue(v any) string {
-	switch s := v.(type) {
-	case Markup:
-		return string(s)
-	case string:
+	if s, ok := v.(string); ok {
 		return s
-	default:
-		return fmt.Sprint(v)
 	}
+
+	return fmt.Sprint(v)
 }
 
 func url(label, rawURL any) (Markup, error) {
@@ -43,13 +39,14 @@ func url(label, rawURL any) (Markup, error) {
 		return labelMarkup(label), nil
 	}
 
+	// A URL a repository controls (a remote) can be anything; a bad one
+	// drops the link rather than the whole segment.
 	if strings.ContainsAny(url, "<>") {
-		return "", errors.New("url contains chevrons")
+		return labelMarkup(label), nil
 	}
 
-	_, err := link.ParseRequestURI(url)
-	if err != nil {
-		return "", err
+	if _, err := link.ParseRequestURI(url); err != nil {
+		return labelMarkup(label), nil
 	}
 
 	return RawMarkup(fmt.Sprintf("<LINK>%s<TEXT>%s</TEXT></LINK>", url, labelMarkup(label))), nil

--- a/src/template/link_test.go
+++ b/src/template/link_test.go
@@ -17,7 +17,7 @@ func TestUrl(t *testing.T) {
 		ShouldError bool
 	}{
 		{Case: "valid url", Expected: "<LINK>https://ohmyposh.dev<TEXT>link</TEXT></LINK>", Template: `{{ url "link" "https://ohmyposh.dev" }}`},
-		{Case: "invalid url", Expected: "", Template: `{{ url "link" "Foo" }}`, ShouldError: true},
+		{Case: "invalid url keeps the label", Expected: "link", Template: `{{ url "link" "Foo" }}`},
 	}
 
 	env := &mock.Environment{}

--- a/src/template/locale.go
+++ b/src/template/locale.go
@@ -84,7 +84,7 @@ func getLocaleLayouts() (string, string) {
 // Example:
 //
 //	{{ localeShortDate .SomeTime }}
-func localeShortDate(date any) string {
+func localeShortDate(date any) Markup {
 	layout, _ := getLocaleLayouts()
 	return dateInZone(layout, date, "Local")
 }
@@ -94,7 +94,7 @@ func localeShortDate(date any) string {
 // Example:
 //
 //	{{ localeShortTime .SomeTime }}
-func localeShortTime(date any) string {
+func localeShortTime(date any) Markup {
 	_, layout := getLocaleLayouts()
 	return dateInZone(layout, date, "Local")
 }

--- a/src/template/markup.go
+++ b/src/template/markup.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
-
-	"github.com/Masterminds/sprig/v3"
 )
 
 // Markup carries terminal markup that may reach the prompt writer verbatim:
@@ -72,60 +70,301 @@ func init() {
 
 const noValue = "<no value>"
 
-// markupStringFunc adapts a unary string-transforming template function so
-// Markup inputs stay Markup (their anchors survive the transformation) while
-// plain string inputs behave exactly as before.
-func markupStringFunc(fn func(string) string) func(any) (any, error) {
-	return func(v any) (any, error) {
-		switch s := v.(type) {
-		case Markup:
-			return Markup(fn(string(s))), nil
-		case string:
-			return fn(s), nil
-		default:
-			return nil, fmt.Errorf("expected string, got %T", v)
+var (
+	markupType = reflect.TypeFor[Markup]()
+	errorType  = reflect.TypeFor[error]()
+)
+
+// markupAware adapts a template function so Markup values can pass through it.
+// text/template refuses a Markup where a function expects a string, which
+// would make every string function (contains, replace, trimSuffix, ...) fail
+// on a field of that type. The wrapper feeds the string parameters the
+// markup's text instead. When the function returns a string and any argument
+// was Markup, the result is Markup again so the anchors survive; the plain
+// string arguments of such a call are escaped first, since they would
+// otherwise ride into the trusted result unchecked.
+//
+// Functions that neither take nor return strings are returned untouched.
+func markupAware(name string, fn any) any {
+	if fast, ok := markupAwareTyped(fn); ok {
+		return fast
+	}
+
+	fv := reflect.ValueOf(fn)
+	ft := fv.Type()
+
+	if ft.Kind() != reflect.Func || !touchesStrings(ft) {
+		return fn
+	}
+
+	numIn := ft.NumIn()
+	variadic := ft.IsVariadic()
+	returnsString := ft.NumOut() > 0 && ft.Out(0).Kind() == reflect.String && ft.Out(0) != markupType
+	returnsError := ft.NumOut() == 2 && ft.Out(1) == errorType
+
+	paramType := func(i int) reflect.Type {
+		if variadic && i >= numIn-1 {
+			return ft.In(numIn - 1).Elem()
 		}
+
+		return ft.In(i)
+	}
+
+	return func(args ...any) (any, error) {
+		if (variadic && len(args) < numIn-1) || (!variadic && len(args) != numIn) {
+			return nil, fmt.Errorf("wrong number of args for %s: want %d got %d", name, numIn, len(args))
+		}
+
+		fromMarkup := false
+		for _, arg := range args {
+			if _, ok := arg.(Markup); ok {
+				fromMarkup = true
+				break
+			}
+		}
+
+		escapeStrings := fromMarkup && returnsString
+
+		in := make([]reflect.Value, len(args))
+		for i, arg := range args {
+			param := paramType(i)
+
+			switch v := arg.(type) {
+			case Markup:
+				if param.Kind() == reflect.String && param != markupType {
+					arg = string(v)
+				}
+			case string:
+				if escapeStrings {
+					arg = EscapeText(v)
+				}
+			}
+
+			value, err := argValue(name, arg, param)
+			if err != nil {
+				return nil, err
+			}
+
+			in[i] = value
+		}
+
+		out := fv.Call(in)
+
+		if returnsError && !out[1].IsNil() {
+			return nil, out[1].Interface().(error)
+		}
+
+		if len(out) == 0 {
+			return nil, nil
+		}
+
+		if returnsString && fromMarkup {
+			return Markup(out[0].String()), nil
+		}
+
+		return out[0].Interface(), nil
 	}
 }
 
-// markupStringFuncs returns Markup-preserving overrides for the unary sprig
-// string functions that make sense on display text. Functions taking extra
-// arguments (indent, replace, trimall, quote, ...) are not adapted: applied
-// to a Markup value they error, which is visible rather than silently wrong.
-func markupStringFuncs() map[string]any {
-	wrapped := make(map[string]any)
+// markupAwareTyped covers the signatures most theme templates call (upper,
+// trunc, replace, contains, trimSuffix, ...) without reflection: reflect.Call
+// costs several allocations per invocation, which adds up in a prompt that
+// pipes every segment through a function or two. The semantics are those of
+// markupAware.
+func markupAwareTyped(fn any) (any, bool) {
+	switch f := fn.(type) {
+	case func(string) string:
+		return func(a any) (any, error) {
+			args, markup, err := textArgs(a)
+			if err != nil {
+				return nil, err
+			}
 
-	for _, name := range []string{
-		"lower", "upper", "title", "untitle", "swapcase", "trim",
-		"nospace", "snakecase", "kebabcase", "camelcase", "shuffle",
-	} {
-		fn, ok := sprig.TxtFuncMap()[name].(func(string) string)
-		if !ok {
-			continue
+			return markupResult(f(args[0]), markup), nil
+		}, true
+	case func(string, string) string:
+		return func(a, b any) (any, error) {
+			args, markup, err := textArgs(a, b)
+			if err != nil {
+				return nil, err
+			}
+
+			return markupResult(f(args[0], args[1]), markup), nil
+		}, true
+	case func(string, string, string) string:
+		return func(a, b, c any) (any, error) {
+			args, markup, err := textArgs(a, b, c)
+			if err != nil {
+				return nil, err
+			}
+
+			return markupResult(f(args[0], args[1], args[2]), markup), nil
+		}, true
+	case func(string, string) bool:
+		return func(a, b any) (any, error) {
+			args, _, err := textArgs(a, b)
+			if err != nil {
+				return nil, err
+			}
+
+			return f(args[0], args[1]), nil
+		}, true
+	case func(any, string) string:
+		return func(a, b any) (any, error) {
+			args, markup, err := textArgs(b)
+			if err != nil {
+				return nil, err
+			}
+
+			return markupResult(f(a, args[0]), markup), nil
+		}, true
+	case func(string, ...any) string:
+		return func(format any, values ...any) (any, error) {
+			args, markup, err := textArgs(format)
+			if err != nil {
+				return nil, err
+			}
+
+			markup = escapeMixedValues(values, markup)
+
+			return markupResult(f(args[0], values...), markup), nil
+		}, true
+	case func(...any) string:
+		return func(values ...any) (any, error) {
+			markup := escapeMixedValues(values, false)
+
+			return markupResult(f(values...), markup), nil
+		}, true
+	default:
+		return nil, false
+	}
+}
+
+// escapeMixedValues applies the markupAware rule to a print-style argument
+// list: when any value (or the seen flag) is Markup, the plain strings among
+// them are escaped in place. Markup values are left as they are, fmt prints
+// them through String.
+func escapeMixedValues(values []any, seen bool) bool {
+	markup := seen
+	for _, v := range values {
+		if _, ok := v.(Markup); ok {
+			markup = true
+			break
 		}
-
-		wrapped[name] = markupStringFunc(fn)
 	}
 
-	// trunc and TruncE are local (they take an any length); adapt them so a
-	// Markup branch name or path survives truncation with anchors intact.
-	wrapped["trunc"] = func(length any, v any) any {
-		if m, ok := v.(Markup); ok {
-			return Markup(trunc(length, string(m)))
-		}
-
-		return trunc(length, fmt.Sprint(v))
+	if !markup {
+		return false
 	}
 
-	wrapped["truncE"] = func(length any, v any) any {
-		if m, ok := v.(Markup); ok {
-			return Markup(TruncE(length, string(m)))
+	for i, v := range values {
+		if s, ok := v.(string); ok {
+			values[i] = EscapeText(s)
 		}
-
-		return TruncE(length, fmt.Sprint(v))
 	}
 
-	return wrapped
+	return true
+}
+
+// textArgs converts string parameters the way markupAware does: Markup
+// arguments become their text and, when any argument was Markup, the plain
+// ones are escaped. The returned flag reports whether a Markup was seen.
+func textArgs(values ...any) ([3]string, bool, error) {
+	var args [3]string
+	var isMarkup [3]bool
+
+	markup := false
+
+	for i, v := range values {
+		switch s := v.(type) {
+		case Markup:
+			args[i] = string(s)
+			isMarkup[i] = true
+			markup = true
+		case string:
+			args[i] = s
+		default:
+			return args, false, fmt.Errorf("expected string, got %T", v)
+		}
+	}
+
+	if !markup {
+		return args, false, nil
+	}
+
+	for i := range values {
+		if !isMarkup[i] {
+			args[i] = EscapeText(args[i])
+		}
+	}
+
+	return args, true, nil
+}
+
+func markupResult(s string, markup bool) any {
+	if markup {
+		return Markup(s)
+	}
+
+	return s
+}
+
+func touchesStrings(ft reflect.Type) bool {
+	if ft.NumOut() > 0 && ft.Out(0).Kind() == reflect.String {
+		return true
+	}
+
+	for i := range ft.NumIn() {
+		param := ft.In(i)
+		if ft.IsVariadic() && i == ft.NumIn()-1 {
+			param = param.Elem()
+		}
+
+		if param.Kind() == reflect.String {
+			return true
+		}
+	}
+
+	return false
+}
+
+// argValue mirrors the coercions text/template applies to a typed parameter
+// before the wrapper hid the real signature behind a variadic any one.
+func argValue(name string, arg any, param reflect.Type) (reflect.Value, error) {
+	if arg == nil {
+		switch param.Kind() {
+		case reflect.Interface, reflect.Pointer, reflect.Map, reflect.Slice, reflect.Func, reflect.Chan:
+			return reflect.Zero(param), nil
+		default:
+			return reflect.Value{}, fmt.Errorf("invalid value; expected %s for %s", param, name)
+		}
+	}
+
+	value := reflect.ValueOf(arg)
+
+	switch {
+	case value.Type().AssignableTo(param):
+		return value, nil
+	case value.Kind() == reflect.Pointer && value.Elem().Type().AssignableTo(param):
+		return value.Elem(), nil
+	case isNumber(value.Kind()) && isNumber(param.Kind()):
+		// a template literal reaches the wrapper as int or float64, whatever
+		// the parameter's exact numeric type
+		return value.Convert(param), nil
+	default:
+		return reflect.Value{}, fmt.Errorf("wrong type for value; expected %s; got %s for %s", param, value.Type(), name)
+	}
+}
+
+func isNumber(kind reflect.Kind) bool {
+	switch kind {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
+		return true
+	default:
+		return false
+	}
 }
 
 // escapeActionValue is appended to every print action's pipeline after parsing

--- a/src/template/markup.go
+++ b/src/template/markup.go
@@ -1,0 +1,168 @@
+package template
+
+import (
+	"encoding/gob"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/Masterminds/sprig/v3"
+)
+
+// Markup carries terminal markup that may reach the prompt writer verbatim:
+// the writer interprets <...> anchors (colors, styles, hyperlinks), so only
+// text originating from user configuration or an intentional markup
+// constructor may flow through this type. Everything a template action
+// evaluates to is escaped by the renderer unless it is a Markup.
+//
+// A string kind, not a struct: text/template treats every struct as true, so
+// a struct would break the `{{ if .Field }}` guards themes use on fields of
+// this type, and `eq`/`ne` compare string kinds by value.
+type Markup string
+
+func (m Markup) String() string {
+	return string(m)
+}
+
+// RawMarkup marks user-authored configuration text (a template render result,
+// an icon option, a mapped value) as trusted markup. Never call it with data
+// read from the filesystem, a VCS, or the network.
+func RawMarkup(s string) Markup {
+	return Markup(s)
+}
+
+// EscapeMarkup converts untrusted data into markup-safe text: chevrons are
+// replaced so the writer prints them literally instead of parsing an anchor.
+func EscapeMarkup(s string) Markup {
+	return Markup(EscapeText(s))
+}
+
+// JoinMarkup concatenates markup fragments, preserving each fragment's trust.
+func JoinMarkup(parts ...Markup) Markup {
+	size := 0
+	for _, part := range parts {
+		size += len(part)
+	}
+
+	var sb strings.Builder
+	sb.Grow(size)
+
+	for _, part := range parts {
+		sb.WriteString(string(part))
+	}
+
+	return Markup(sb.String())
+}
+
+// EscapeText replaces chevrons so the writer renders them literally. The
+// escape sequences (<<>, <>>) are the writer's own quoted form of < and >.
+func EscapeText(s string) string {
+	return chevronReplacer.Replace(s)
+}
+
+var chevronReplacer = strings.NewReplacer("<", "<<>", ">", "<>>")
+
+// The session cache stores segment data as map[string]any (interface values)
+// and gob-encodes it per process; an unregistered concrete type inside an
+// interface fails to encode and the whole segment entry is silently dropped.
+func init() {
+	gob.Register(Markup(""))
+}
+
+const noValue = "<no value>"
+
+// markupStringFunc adapts a unary string-transforming template function so
+// Markup inputs stay Markup (their anchors survive the transformation) while
+// plain string inputs behave exactly as before.
+func markupStringFunc(fn func(string) string) func(any) (any, error) {
+	return func(v any) (any, error) {
+		switch s := v.(type) {
+		case Markup:
+			return Markup(fn(string(s))), nil
+		case string:
+			return fn(s), nil
+		default:
+			return nil, fmt.Errorf("expected string, got %T", v)
+		}
+	}
+}
+
+// markupStringFuncs returns Markup-preserving overrides for the unary sprig
+// string functions that make sense on display text. Functions taking extra
+// arguments (indent, replace, trimall, quote, ...) are not adapted: applied
+// to a Markup value they error, which is visible rather than silently wrong.
+func markupStringFuncs() map[string]any {
+	wrapped := make(map[string]any)
+
+	for _, name := range []string{
+		"lower", "upper", "title", "untitle", "swapcase", "trim",
+		"nospace", "snakecase", "kebabcase", "camelcase", "shuffle",
+	} {
+		fn, ok := sprig.TxtFuncMap()[name].(func(string) string)
+		if !ok {
+			continue
+		}
+
+		wrapped[name] = markupStringFunc(fn)
+	}
+
+	// trunc and TruncE are local (they take an any length); adapt them so a
+	// Markup branch name or path survives truncation with anchors intact.
+	wrapped["trunc"] = func(length any, v any) any {
+		if m, ok := v.(Markup); ok {
+			return Markup(trunc(length, string(m)))
+		}
+
+		return trunc(length, fmt.Sprint(v))
+	}
+
+	wrapped["truncE"] = func(length any, v any) any {
+		if m, ok := v.(Markup); ok {
+			return Markup(TruncE(length, string(m)))
+		}
+
+		return TruncE(length, fmt.Sprint(v))
+	}
+
+	return wrapped
+}
+
+// escapeActionValue is appended to every print action's pipeline after parsing
+// (see parsedTemplate), making action output safe for the writer: literal
+// template text may carry markup, action results may not unless typed Markup.
+func escapeActionValue(v any) (string, error) {
+	// plain strings dominate segment output, so skip the reflection below
+	switch m := v.(type) {
+	case Markup:
+		return string(m), nil
+	case string:
+		return EscapeText(m), nil
+	case *Markup:
+		if m == nil {
+			return noValue, nil
+		}
+
+		return string(*m), nil
+	}
+
+	// text/template indirects pointers and interfaces before printing
+	rv := reflect.ValueOf(v)
+	for rv.Kind() == reflect.Pointer || rv.Kind() == reflect.Interface {
+		if rv.IsNil() {
+			return noValue, nil
+		}
+
+		rv = rv.Elem()
+	}
+
+	if !rv.IsValid() {
+		return noValue, nil
+	}
+
+	if rv.Kind() == reflect.Chan || rv.Kind() == reflect.Func {
+		return "", errors.New("unprintable value")
+	}
+
+	return EscapeText(fmt.Sprint(rv.Interface())), nil
+}

--- a/src/template/markup.go
+++ b/src/template/markup.go
@@ -2,6 +2,7 @@ package template
 
 import (
 	"encoding/gob"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -68,6 +69,85 @@ func init() {
 	gob.Register(Markup(""))
 }
 
+// markupJSONKey tags a Markup in JSON: {"$markup": "<red>text</>"}. Recorded
+// as a bare string it would come back as plain data wherever a data file is
+// decoded into a map (the website build has no segment writers), and every
+// recorded anchor would render as literal text.
+const markupJSONKey = "$markup"
+
+func (m Markup) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]string{markupJSONKey: string(m)})
+}
+
+// UnmarshalJSON accepts the tagged form and, for hand-written data files and
+// fixtures recorded before the tag existed, a bare string.
+func (m *Markup) UnmarshalJSON(b []byte) error {
+	if len(b) > 0 && b[0] == '"' {
+		var s string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return err
+		}
+
+		*m = Markup(s)
+
+		return nil
+	}
+
+	var tagged map[string]string
+	if err := json.Unmarshal(b, &tagged); err != nil {
+		return err
+	}
+
+	text, ok := tagged[markupJSONKey]
+	if !ok {
+		return fmt.Errorf("markup JSON object is missing the %q key", markupJSONKey)
+	}
+
+	*m = Markup(text)
+
+	return nil
+}
+
+// ReviveMarkup walks a generically decoded JSON value and turns every tagged
+// markup object (see markupJSONKey) back into a Markup, in place for maps and
+// slices. It is what lets a map[string]any carry the same trust as the writer
+// struct it was recorded from.
+func ReviveMarkup(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		if text, ok := taggedMarkup(typed); ok {
+			return text
+		}
+
+		for key, nested := range typed {
+			typed[key] = ReviveMarkup(nested)
+		}
+
+		return typed
+	case []any:
+		for i, nested := range typed {
+			typed[i] = ReviveMarkup(nested)
+		}
+
+		return typed
+	default:
+		return value
+	}
+}
+
+func taggedMarkup(object map[string]any) (Markup, bool) {
+	if len(object) != 1 {
+		return "", false
+	}
+
+	text, ok := object[markupJSONKey].(string)
+	if !ok {
+		return "", false
+	}
+
+	return Markup(text), true
+}
+
 const noValue = "<no value>"
 
 var (
@@ -78,11 +158,11 @@ var (
 // markupAware adapts a template function so Markup values can pass through it.
 // text/template refuses a Markup where a function expects a string, which
 // would make every string function (contains, replace, trimSuffix, ...) fail
-// on a field of that type. The wrapper feeds the string parameters the
+// on a field of that type. The wrapper hands the string parameters the
 // markup's text instead. When the function returns a string and any argument
-// was Markup, the result is Markup again so the anchors survive; the plain
-// string arguments of such a call are escaped first, since they would
-// otherwise ride into the trusted result unchecked.
+// was Markup, the result is Markup again so the anchors survive. The plain
+// string arguments of such a call are escaped first; otherwise they would end
+// up inside the trusted result without ever being escaped.
 //
 // Functions that neither take nor return strings are returned untouched.
 func markupAware(name string, fn any) any {
@@ -328,8 +408,8 @@ func touchesStrings(ft reflect.Type) bool {
 	return false
 }
 
-// argValue mirrors the coercions text/template applies to a typed parameter
-// before the wrapper hid the real signature behind a variadic any one.
+// argValue applies the checks text/template would have done against the real
+// parameter types; the wrapper accepts any arguments, so they happen here.
 func argValue(name string, arg any, param reflect.Type) (reflect.Value, error) {
 	if arg == nil {
 		switch param.Kind() {

--- a/src/template/markup.go
+++ b/src/template/markup.go
@@ -62,6 +62,17 @@ func EscapeText(s string) string {
 
 var chevronReplacer = strings.NewReplacer("<", "<<>", ">", "<>>")
 
+// EscapeSource prepares data that becomes template source (a folder name
+// inside the path segment's styled path) so the renderer prints it as it
+// is: chevrons are escaped like any data, and a template delimiter becomes
+// an action that prints the delimiter, so the data can never open an
+// action of its own.
+func EscapeSource(s string) string {
+	return delimiterReplacer.Replace(EscapeText(s))
+}
+
+var delimiterReplacer = strings.NewReplacer("{{", `{{"{{"}}`)
+
 // The session cache stores segment data as map[string]any (interface values)
 // and gob-encodes it per process; an unregistered concrete type inside an
 // interface fails to encode and the whole segment entry is silently dropped.

--- a/src/template/markup.go
+++ b/src/template/markup.go
@@ -69,10 +69,10 @@ func init() {
 	gob.Register(Markup(""))
 }
 
-// markupJSONKey tags a Markup in JSON: {"$markup": "<red>text</>"}. Recorded
-// as a bare string it would come back as plain data wherever a data file is
-// decoded into a map (the website build has no segment writers), and every
-// recorded anchor would render as literal text.
+// markupJSONKey tags a Markup in JSON: {"$markup": "<red>text</>"}. A bare
+// string would decode as plain data when a data file lands in a map (the
+// website build has no segment writers), and every recorded anchor would
+// render as literal text.
 const markupJSONKey = "$markup"
 
 func (m Markup) MarshalJSON() ([]byte, error) {
@@ -82,6 +82,10 @@ func (m Markup) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON accepts the tagged form and, for hand-written data files and
 // fixtures recorded before the tag existed, a bare string.
 func (m *Markup) UnmarshalJSON(b []byte) error {
+	if string(b) == "null" {
+		return nil
+	}
+
 	if len(b) > 0 && b[0] == '"' {
 		var s string
 		if err := json.Unmarshal(b, &s); err != nil {
@@ -99,8 +103,8 @@ func (m *Markup) UnmarshalJSON(b []byte) error {
 	}
 
 	text, ok := tagged[markupJSONKey]
-	if !ok {
-		return fmt.Errorf("markup JSON object is missing the %q key", markupJSONKey)
+	if !ok || len(tagged) != 1 {
+		return fmt.Errorf("markup JSON must be an object with only the %q key", markupJSONKey)
 	}
 
 	*m = Markup(text)
@@ -150,37 +154,52 @@ func taggedMarkup(object map[string]any) (Markup, bool) {
 
 const noValue = "<no value>"
 
-var (
-	markupType = reflect.TypeFor[Markup]()
-	errorType  = reflect.TypeFor[error]()
-)
+var markupType = reflect.TypeFor[Markup]()
+
+// noPromote lists the functions whose output does not come from their text
+// arguments (file contents, command output, decoded bytes, the environment).
+// A Markup argument must not turn that output into trusted markup.
+var noPromote = map[string]bool{
+	"cmd":           true,
+	"readFile":      true,
+	"stat":          true,
+	"glob":          true,
+	"env":           true,
+	"expandenv":     true,
+	"getHostByName": true,
+	"b64dec":        true,
+	"b32dec":        true,
+}
 
 // markupAware adapts a template function so Markup values can pass through it.
 // text/template refuses a Markup where a function expects a string, which
 // would make every string function (contains, replace, trimSuffix, ...) fail
-// on a field of that type. The wrapper hands the string parameters the
-// markup's text instead. When the function returns a string and any argument
-// was Markup, the result is Markup again so the anchors survive. The plain
-// string arguments of such a call are escaped first; otherwise they would end
-// up inside the trusted result without ever being escaped.
+// on a field of that type. The wrapper hands string parameters the markup's
+// text instead.
 //
-// Functions that neither take nor return strings are returned untouched.
+// A string result is promoted back to Markup when the call had a Markup
+// argument and every other argument was a plain string, number or bool. The
+// plain strings are escaped first, so no data can end up inside the trusted
+// result unescaped; a template literal such as a printf format counts as a
+// plain string here. Any other argument (a slice, a struct, an error) may hold
+// data the wrapper cannot escape, so such a call keeps a plain result, which
+// the renderer escapes on output.
 func markupAware(name string, fn any) any {
-	if fast, ok := markupAwareTyped(fn); ok {
+	if fast, ok := markupAwareTyped(name, fn); ok {
 		return fast
 	}
 
 	fv := reflect.ValueOf(fn)
 	ft := fv.Type()
 
-	if ft.Kind() != reflect.Func || !touchesStrings(ft) {
+	if ft.Kind() != reflect.Func || !acceptsMarkup(ft) {
 		return fn
 	}
 
 	numIn := ft.NumIn()
 	variadic := ft.IsVariadic()
-	returnsString := ft.NumOut() > 0 && ft.Out(0).Kind() == reflect.String && ft.Out(0) != markupType
-	returnsError := ft.NumOut() == 2 && ft.Out(1) == errorType
+	mayPromote := ft.Out(0).Kind() == reflect.String && ft.Out(0) != markupType && !noPromote[name]
+	returnsError := ft.NumOut() == 2
 
 	paramType := func(i int) reflect.Type {
 		if variadic && i >= numIn-1 {
@@ -190,39 +209,26 @@ func markupAware(name string, fn any) any {
 		return ft.In(i)
 	}
 
+	stringParam := func(i int) bool {
+		param := paramType(i)
+		return param.Kind() == reflect.String && param != markupType
+	}
+
 	return func(args ...any) (any, error) {
 		if (variadic && len(args) < numIn-1) || (!variadic && len(args) != numIn) {
-			return nil, fmt.Errorf("wrong number of args for %s: want %d got %d", name, numIn, len(args))
+			return nil, fmt.Errorf("wrong number of args for %s: got %d", name, len(args))
 		}
 
-		fromMarkup := false
-		for _, arg := range args {
-			if _, ok := arg.(Markup); ok {
-				fromMarkup = true
-				break
-			}
+		promote, err := markupArgs(args, stringParam, mayPromote)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", name, err)
 		}
-
-		escapeStrings := fromMarkup && returnsString
 
 		in := make([]reflect.Value, len(args))
 		for i, arg := range args {
-			param := paramType(i)
-
-			switch v := arg.(type) {
-			case Markup:
-				if param.Kind() == reflect.String && param != markupType {
-					arg = string(v)
-				}
-			case string:
-				if escapeStrings {
-					arg = EscapeText(v)
-				}
-			}
-
-			value, err := argValue(name, arg, param)
+			value, err := argValue(arg, paramType(i))
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("%s: %w", name, err)
 			}
 
 			in[i] = value
@@ -234,11 +240,7 @@ func markupAware(name string, fn any) any {
 			return nil, out[1].Interface().(error)
 		}
 
-		if len(out) == 0 {
-			return nil, nil
-		}
-
-		if returnsString && fromMarkup {
+		if promote {
 			return Markup(out[0].String()), nil
 		}
 
@@ -246,161 +248,151 @@ func markupAware(name string, fn any) any {
 	}
 }
 
-// markupAwareTyped covers the signatures most theme templates call (upper,
-// trunc, replace, contains, trimSuffix, ...) without reflection: reflect.Call
-// costs several allocations per invocation, which adds up in a prompt that
-// pipes every segment through a function or two. The semantics are those of
+// markupAwareTyped covers the signatures theme templates call most (upper,
+// trunc, replace, contains, trimSuffix, printf, date) without reflection,
+// which costs several allocations per call. The rules are those of
 // markupAware.
-func markupAwareTyped(fn any) (any, bool) {
+func markupAwareTyped(name string, fn any) (any, bool) {
+	allStrings := func(int) bool { return true }
+	promotes := !noPromote[name]
+
 	switch f := fn.(type) {
 	case func(string) string:
 		return func(a any) (any, error) {
-			args, markup, err := textArgs(a)
+			args := [1]any{a}
+
+			promote, err := markupArgs(args[:], allStrings, promotes)
 			if err != nil {
 				return nil, err
 			}
 
-			return markupResult(f(args[0]), markup), nil
+			strs, err := stringArgs(args[:])
+			if err != nil {
+				return nil, err
+			}
+
+			return markupResult(f(strs[0]), promote), nil
 		}, true
 	case func(string, string) string:
 		return func(a, b any) (any, error) {
-			args, markup, err := textArgs(a, b)
+			args := [2]any{a, b}
+
+			promote, err := markupArgs(args[:], allStrings, promotes)
 			if err != nil {
 				return nil, err
 			}
 
-			return markupResult(f(args[0], args[1]), markup), nil
+			strs, err := stringArgs(args[:])
+			if err != nil {
+				return nil, err
+			}
+
+			return markupResult(f(strs[0], strs[1]), promote), nil
 		}, true
 	case func(string, string, string) string:
 		return func(a, b, c any) (any, error) {
-			args, markup, err := textArgs(a, b, c)
+			args := [3]any{a, b, c}
+
+			promote, err := markupArgs(args[:], allStrings, promotes)
 			if err != nil {
 				return nil, err
 			}
 
-			return markupResult(f(args[0], args[1], args[2]), markup), nil
+			strs, err := stringArgs(args[:])
+			if err != nil {
+				return nil, err
+			}
+
+			return markupResult(f(strs[0], strs[1], strs[2]), promote), nil
 		}, true
 	case func(string, string) bool:
 		return func(a, b any) (any, error) {
-			args, _, err := textArgs(a, b)
+			args := [2]any{a, b}
+
+			if _, err := markupArgs(args[:], allStrings, false); err != nil {
+				return nil, err
+			}
+
+			strs, err := stringArgs(args[:])
 			if err != nil {
 				return nil, err
 			}
 
-			return f(args[0], args[1]), nil
+			return f(strs[0], strs[1]), nil
 		}, true
 	case func(any, string) string:
 		return func(a, b any) (any, error) {
-			args, markup, err := textArgs(b)
+			args := [2]any{a, b}
+
+			promote, err := markupArgs(args[:], func(i int) bool { return i == 1 }, promotes)
 			if err != nil {
 				return nil, err
 			}
 
-			return markupResult(f(a, args[0]), markup), nil
+			s, err := stringArg(args[1])
+			if err != nil {
+				return nil, err
+			}
+
+			return markupResult(f(args[0], s), promote), nil
+		}, true
+	case func(string, any) Markup:
+		return func(a, b any) (any, error) {
+			args := [1]any{a}
+
+			if _, err := markupArgs(args[:], allStrings, false); err != nil {
+				return nil, err
+			}
+
+			s, err := stringArg(args[0])
+			if err != nil {
+				return nil, err
+			}
+
+			return f(s, b), nil
 		}, true
 	case func(string, ...any) string:
 		return func(format any, values ...any) (any, error) {
-			args, markup, err := textArgs(format)
+			args := make([]any, 0, len(values)+1)
+			args = append(args, format)
+			args = append(args, values...)
+
+			promote, err := markupArgs(args, func(i int) bool { return i == 0 }, promotes)
 			if err != nil {
 				return nil, err
 			}
 
-			markup = escapeMixedValues(values, markup)
+			s, err := stringArg(args[0])
+			if err != nil {
+				return nil, err
+			}
 
-			return markupResult(f(args[0], values...), markup), nil
+			return markupResult(f(s, args[1:]...), promote), nil
 		}, true
 	case func(...any) string:
 		return func(values ...any) (any, error) {
-			markup := escapeMixedValues(values, false)
+			promote, err := markupArgs(values, func(int) bool { return false }, promotes)
+			if err != nil {
+				return nil, err
+			}
 
-			return markupResult(f(values...), markup), nil
+			return markupResult(f(values...), promote), nil
 		}, true
 	default:
 		return nil, false
 	}
 }
 
-// escapeMixedValues applies the markupAware rule to a print-style argument
-// list: when any value (or the seen flag) is Markup, the plain strings among
-// them are escaped in place. Markup values are left as they are, fmt prints
-// them through String.
-func escapeMixedValues(values []any, seen bool) bool {
-	markup := seen
-	for _, v := range values {
-		if _, ok := v.(Markup); ok {
-			markup = true
-			break
-		}
-	}
-
-	if !markup {
-		return false
-	}
-
-	for i, v := range values {
-		if s, ok := v.(string); ok {
-			values[i] = EscapeText(s)
-		}
-	}
-
-	return true
-}
-
-// textArgs converts string parameters the way markupAware does: Markup
-// arguments become their text and, when any argument was Markup, the plain
-// ones are escaped. The returned flag reports whether a Markup was seen.
-func textArgs(values ...any) ([3]string, bool, error) {
-	var args [3]string
-	var isMarkup [3]bool
-
-	markup := false
-
-	for i, v := range values {
-		switch s := v.(type) {
-		case Markup:
-			args[i] = string(s)
-			isMarkup[i] = true
-			markup = true
-		case string:
-			args[i] = s
-		default:
-			return args, false, fmt.Errorf("expected string, got %T", v)
-		}
-	}
-
-	if !markup {
-		return args, false, nil
-	}
-
-	for i := range values {
-		if !isMarkup[i] {
-			args[i] = EscapeText(args[i])
-		}
-	}
-
-	return args, true, nil
-}
-
-func markupResult(s string, markup bool) any {
-	if markup {
-		return Markup(s)
-	}
-
-	return s
-}
-
-func touchesStrings(ft reflect.Type) bool {
-	if ft.NumOut() > 0 && ft.Out(0).Kind() == reflect.String {
-		return true
-	}
-
+// acceptsMarkup reports whether a Markup could ever reach the function: only
+// string and interface parameters can carry one.
+func acceptsMarkup(ft reflect.Type) bool {
 	for i := range ft.NumIn() {
 		param := ft.In(i)
 		if ft.IsVariadic() && i == ft.NumIn()-1 {
 			param = param.Elem()
 		}
 
-		if param.Kind() == reflect.String {
+		if param.Kind() == reflect.Interface || (param.Kind() == reflect.String && param != markupType) {
 			return true
 		}
 	}
@@ -408,15 +400,108 @@ func touchesStrings(ft reflect.Type) bool {
 	return false
 }
 
-// argValue applies the checks text/template would have done against the real
-// parameter types; the wrapper accepts any arguments, so they happen here.
-func argValue(name string, arg any, param reflect.Type) (reflect.Value, error) {
+// markupArgs rewrites the arguments of one call in place and reports whether
+// its result must become Markup. A Markup argument becomes its text where the
+// parameter is a string; a *string is dereferenced the way text/template
+// does. When the result is promoted, every plain string argument is escaped.
+func markupArgs(args []any, stringParam func(int) bool, mayPromote bool) (bool, error) {
+	markup, opaque := false, false
+
+	for i, arg := range args {
+		if p, ok := arg.(*string); ok {
+			if p == nil {
+				return false, errors.New("nil pointer evaluating string")
+			}
+
+			arg = *p
+			args[i] = arg
+		}
+
+		switch {
+		case isMarkup(arg):
+			markup = true
+		case !isScalar(arg):
+			opaque = true
+		}
+	}
+
+	promote := mayPromote && markup && !opaque
+
+	for i, arg := range args {
+		switch v := arg.(type) {
+		case Markup:
+			if stringParam(i) {
+				args[i] = string(v)
+			}
+		case string:
+			if promote {
+				args[i] = EscapeText(v)
+			}
+		}
+	}
+
+	return promote, nil
+}
+
+func isMarkup(v any) bool {
+	_, ok := v.(Markup)
+	return ok
+}
+
+func isScalar(v any) bool {
+	switch reflect.ValueOf(v).Kind() {
+	case reflect.String, reflect.Bool,
+		reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
+		reflect.Float32, reflect.Float64:
+		return true
+	default:
+		return false
+	}
+}
+
+func stringArg(v any) (string, error) {
+	s, ok := v.(string)
+	if !ok {
+		return "", fmt.Errorf("expected string, got %T", v)
+	}
+
+	return s, nil
+}
+
+func stringArgs(args []any) ([3]string, error) {
+	var strs [3]string
+
+	for i, arg := range args {
+		s, err := stringArg(arg)
+		if err != nil {
+			return strs, err
+		}
+
+		strs[i] = s
+	}
+
+	return strs, nil
+}
+
+func markupResult(s string, promote bool) any {
+	if promote {
+		return Markup(s)
+	}
+
+	return s
+}
+
+// argValue checks and converts an argument the way text/template would
+// against the real parameter type; the wrapper accepts anything, so that work
+// happens here.
+func argValue(arg any, param reflect.Type) (reflect.Value, error) {
 	if arg == nil {
 		switch param.Kind() {
 		case reflect.Interface, reflect.Pointer, reflect.Map, reflect.Slice, reflect.Func, reflect.Chan:
 			return reflect.Zero(param), nil
 		default:
-			return reflect.Value{}, fmt.Errorf("invalid value; expected %s for %s", param, name)
+			return reflect.Value{}, fmt.Errorf("invalid value; expected %s", param)
 		}
 	}
 
@@ -427,24 +512,33 @@ func argValue(name string, arg any, param reflect.Type) (reflect.Value, error) {
 		return value, nil
 	case value.Kind() == reflect.Pointer && value.Elem().Type().AssignableTo(param):
 		return value.Elem(), nil
-	case isNumber(value.Kind()) && isNumber(param.Kind()):
-		// a template literal reaches the wrapper as int or float64, whatever
-		// the parameter's exact numeric type
+	case value.CanInt() && isUint(param.Kind()):
+		if value.Int() < 0 {
+			return reflect.Value{}, fmt.Errorf("negative value for unsigned %s", param)
+		}
+
+		return value.Convert(param), nil
+	case value.CanInt() && (isInt(param.Kind()) || isFloat(param.Kind())):
+		// a template literal reaches the wrapper as int, whatever the
+		// parameter's exact numeric type
+		return value.Convert(param), nil
+	case value.CanFloat() && isFloat(param.Kind()):
 		return value.Convert(param), nil
 	default:
-		return reflect.Value{}, fmt.Errorf("wrong type for value; expected %s; got %s for %s", param, value.Type(), name)
+		return reflect.Value{}, fmt.Errorf("wrong type for value; expected %s; got %s", param, value.Type())
 	}
 }
 
-func isNumber(kind reflect.Kind) bool {
-	switch kind {
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
-		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64,
-		reflect.Float32, reflect.Float64:
-		return true
-	default:
-		return false
-	}
+func isInt(kind reflect.Kind) bool {
+	return kind >= reflect.Int && kind <= reflect.Int64
+}
+
+func isUint(kind reflect.Kind) bool {
+	return kind >= reflect.Uint && kind <= reflect.Uint64
+}
+
+func isFloat(kind reflect.Kind) bool {
+	return kind == reflect.Float32 || kind == reflect.Float64
 }
 
 // escapeActionValue is appended to every print action's pipeline after parsing
@@ -457,26 +551,24 @@ func escapeActionValue(v any) (string, error) {
 		return string(m), nil
 	case string:
 		return EscapeText(m), nil
-	case *Markup:
-		if m == nil {
-			return noValue, nil
-		}
-
-		return string(*m), nil
 	}
 
-	// text/template indirects pointers and interfaces before printing
 	rv := reflect.ValueOf(v)
-	for rv.Kind() == reflect.Pointer || rv.Kind() == reflect.Interface {
-		if rv.IsNil() {
-			return noValue, nil
-		}
-
-		rv = rv.Elem()
+	if !rv.IsValid() || (rv.Kind() == reflect.Pointer && rv.IsNil()) {
+		return noValue, nil
 	}
 
-	if !rv.IsValid() {
-		return noValue, nil
+	// text/template prints through String and Error when a value has them,
+	// including on pointer receivers, before it follows the pointer.
+	switch m := v.(type) {
+	case fmt.Stringer:
+		return EscapeText(m.String()), nil
+	case error:
+		return EscapeText(m.Error()), nil
+	}
+
+	for rv.Kind() == reflect.Pointer {
+		rv = rv.Elem()
 	}
 
 	if rv.Kind() == reflect.Chan || rv.Kind() == reflect.Func {
@@ -484,4 +576,15 @@ func escapeActionValue(v any) (string, error) {
 	}
 
 	return EscapeText(fmt.Sprint(rv.Interface())), nil
+}
+
+// escapeUntrustedActionValue is the untrusted renderer's output escape. An
+// untrusted template (folder names are one, see the path segment) must not be
+// able to produce trusted markup, so a Markup result is escaped like data.
+func escapeUntrustedActionValue(v any) (string, error) {
+	if m, ok := v.(Markup); ok {
+		return EscapeText(string(m)), nil
+	}
+
+	return escapeActionValue(v)
 }

--- a/src/template/markup_test.go
+++ b/src/template/markup_test.go
@@ -111,6 +111,45 @@ func TestRenderEscapesActionOutput(t *testing.T) {
 			Context:  struct{ HEAD Markup }{HEAD: RawMarkup("main")},
 			Expected: "yes",
 		},
+		{
+			Case:     "predicates accept markup",
+			Template: `{{ if contains "ma" .HEAD }}yes{{ end }}{{ if hasPrefix "x" .HEAD }}no{{ end }}`,
+			Context:  struct{ HEAD Markup }{HEAD: RawMarkup("<red>main</>")},
+			Expected: "yes",
+		},
+		{
+			Case:     "transforms keep markup anchors",
+			Template: `{{ .HEAD | trimSuffix "-wip" | upper }}{{ .HEAD | replace "main" "dev" }}`,
+			Context:  struct{ HEAD Markup }{HEAD: RawMarkup("<red>main</>-wip")},
+			Expected: "<RED>MAIN</><red>dev</>-wip",
+		},
+		{
+			Case:     "transforms on data stay escaped",
+			Template: `{{ .Branch | trimSuffix "-wip" }} {{ .Branch | upper }}`,
+			Context:  struct{ Branch string }{Branch: "<b>-wip"},
+			Expected: "<<>b<>> <<>B<>>-WIP",
+		},
+		{
+			Case:     "data mixed into a markup call is escaped",
+			Template: `{{ printf "%s%s" .Icon .Branch }}|{{ cat .Icon .Branch }}|{{ .Icon | replace "x" .Branch }}`,
+			Context: struct {
+				Icon   Markup
+				Branch string
+			}{Icon: RawMarkup("<red>x</>"), Branch: "<b>"},
+			Expected: "<red>x</><<>b<>>|<red>x</> <<>b<>>|<red><<>b<>></>",
+		},
+		{
+			Case:     "markup-free calls are unchanged",
+			Template: `{{ printf "<%s>" .Branch }}{{ trunc 2 .Branch }}{{ if contains "a" .Branch }}!{{ end }}`,
+			Context:  struct{ Branch string }{Branch: "main"},
+			Expected: "<<>main<>>ma!",
+		},
+		{
+			Case:     "numeric literals reach typed parameters",
+			Template: `{{ repeat 2 .HEAD }}{{ substr 0 3 .HEAD }}{{ add 1 2 }}`,
+			Context:  struct{ HEAD Markup }{HEAD: RawMarkup("<red>ab</>")},
+			Expected: "<red>ab</><red>ab</><re3",
+		},
 	}
 
 	origCache := Cache

--- a/src/template/markup_test.go
+++ b/src/template/markup_test.go
@@ -1,0 +1,213 @@
+package template
+
+import (
+	"bytes"
+	"encoding/gob"
+	"testing"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/cache"
+	"github.com/jandedobbeleer/oh-my-posh/src/runtime/mock"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderEscapesActionOutput(t *testing.T) {
+	type ctx struct {
+		Data   string
+		Markup Markup
+	}
+
+	cases := []struct {
+		Case     string
+		Template string
+		Context  any
+		Expected string
+	}{
+		{
+			Case:     "chevrons in data are neutralized",
+			Template: `{{ .Data }}`,
+			Context:  ctx{Data: "<red>pwned</>"},
+			Expected: "<<>red<>>pwned<<>/<>>",
+		},
+		{
+			Case:     "hyperlink injection from data is neutralized",
+			Template: `[{{ .Data }}] 100% done`,
+			Context:  ctx{Data: "<LINK>https://attacker.example/pwn<TEXT>label</TEXT>"},
+			Expected: "[<<>LINK<>>https://attacker.example/pwn<<>TEXT<>>label<<>/TEXT<>>] 100% done",
+		},
+		{
+			Case:     "literal anchors in template text pass through",
+			Template: `<red>{{ .Data }}</>`,
+			Context:  ctx{Data: "branch"},
+			Expected: "<red>branch</>",
+		},
+		{
+			Case:     "markup values pass through unescaped",
+			Template: `{{ .Markup }}`,
+			Context:  ctx{Markup: RawMarkup("<#ffffff>icon </>")},
+			Expected: "<#ffffff>icon </>",
+		},
+		{
+			Case:     "markup and data compose",
+			Template: `{{ .Markup }}{{ .Data }}`,
+			Context:  ctx{Markup: RawMarkup("<b>"), Data: "<red>x"},
+			Expected: "<b><<>red<>>x",
+		},
+		{
+			Case:     "assigned variables are escaped when printed",
+			Template: `{{ $x := .Data }}{{ $x }}`,
+			Context:  ctx{Data: "<red>"},
+			Expected: "<<>red<>>",
+		},
+		{
+			Case:     "actions inside if are escaped",
+			Template: `{{ if .Data }}{{ .Data }}{{ end }}`,
+			Context:  ctx{Data: "<red>"},
+			Expected: "<<>red<>>",
+		},
+		{
+			Case:     "actions inside range are escaped",
+			Template: `{{ range .Items }}{{ . }}{{ end }}`,
+			Context:  map[string]any{"Items": []string{"<a>", "<b>"}},
+			Expected: "<<>a<>><<>b<>>",
+		},
+		{
+			Case:     "actions inside with are escaped",
+			Template: `{{ with .Data }}{{ . }}{{ end }}`,
+			Context:  ctx{Data: "<red>"},
+			Expected: "<<>red<>>",
+		},
+		{
+			Case:     "pipelines through sprig functions are escaped",
+			Template: `{{ .Data | upper }}`,
+			Context:  ctx{Data: "<red>"},
+			Expected: "<<>RED<>>",
+		},
+		{
+			Case:     "present nil map values render empty",
+			Template: `[{{ .Data }}]`,
+			Context:  map[string]any{"Data": nil},
+			Expected: "[]",
+		},
+		{
+			Case:     "plain scalars are untouched",
+			Template: `{{ .Code }}`,
+			Context:  struct{ Code int }{Code: 42},
+			Expected: "42",
+		},
+		{
+			Case:     "empty markup is false, like an empty string",
+			Template: `{{ if .Icon }}[{{ .Icon }}]{{ end }}{{ if .Text }}[{{ .Text }}]{{ end }}`,
+			Context: struct {
+				Icon Markup
+				Text string
+			}{Icon: RawMarkup("")},
+			Expected: "",
+		},
+		{
+			Case:     "markup compares by value",
+			Template: `{{ if eq .HEAD "main" }}yes{{ end }}{{ if ne .HEAD "main" }}no{{ end }}`,
+			Context:  struct{ HEAD Markup }{HEAD: RawMarkup("main")},
+			Expected: "yes",
+		},
+	}
+
+	origCache := Cache
+	t.Cleanup(func() { Cache = origCache })
+
+	for _, tc := range cases {
+		env := new(mock.Environment)
+		env.On("Shell").Return("foo")
+		Cache = new(cache.Template)
+		Init(env, nil, nil)
+
+		text, err := RenderTrusted(tc.Template, tc.Context)
+		require.NoError(t, err, tc.Case)
+		assert.Equal(t, tc.Expected, text, tc.Case)
+	}
+}
+
+func TestRenderUntrustedEscapesActionOutput(t *testing.T) {
+	origCache := Cache
+	t.Cleanup(func() { Cache = origCache })
+
+	env := new(mock.Environment)
+	env.On("Shell").Return("foo")
+	Cache = new(cache.Template)
+	Init(env, nil, nil)
+
+	text, err := RenderUntrusted(`{{ .Data }}`, map[string]any{"Data": "<red>"})
+	require.NoError(t, err)
+	assert.Equal(t, "<<>red<>>", text)
+}
+
+func TestURLMarkup(t *testing.T) {
+	cases := []struct {
+		Case        string
+		Template    string
+		Expected    string
+		ShouldError bool
+	}{
+		{
+			Case:     "label is escaped, anchor structure intact",
+			Template: `{{ url "a<b" "https://ohmyposh.dev" }}`,
+			Expected: "<LINK>https://ohmyposh.dev<TEXT>a<<>b</TEXT></LINK>",
+		},
+		{
+			Case:        "chevrons in the URL are rejected",
+			Template:    `{{ url "link" "https://ohmyposh.dev/<TEXT>" }}`,
+			ShouldError: true,
+		},
+	}
+
+	for _, tc := range cases {
+		env := new(mock.Environment)
+		env.On("Shell").Return("foo")
+		Cache = new(cache.Template)
+		Init(env, nil, nil)
+
+		text, err := RenderTrusted(tc.Template, nil)
+		if tc.ShouldError {
+			assert.Error(t, err, tc.Case)
+			continue
+		}
+
+		require.NoError(t, err, tc.Case)
+		assert.Equal(t, tc.Expected, text, tc.Case)
+	}
+}
+
+func TestMarkupGobRoundtrip(t *testing.T) {
+	original := RawMarkup("<red>safe</>")
+
+	var buf bytes.Buffer
+	require.NoError(t, gob.NewEncoder(&buf).Encode(original))
+
+	var restored Markup
+	require.NoError(t, gob.NewDecoder(&buf).Decode(&restored))
+	assert.Equal(t, original.String(), restored.String())
+}
+
+// The session cache stores segment data as map[string]any and gob-encodes it
+// per process: an unregistered Markup inside an interface value fails the
+// whole encode (type not registered for interface), silently dropping the
+// segment's cache entry for the next render.
+func TestMarkupGobInterfaceRoundtrip(t *testing.T) {
+	m := map[string]any{"HEAD": RawMarkup("<red>safe</>")}
+
+	var buf bytes.Buffer
+	require.NoError(t, gob.NewEncoder(&buf).Encode(m))
+
+	var out map[string]any
+	require.NoError(t, gob.NewDecoder(&buf).Decode(&out))
+
+	got, ok := out["HEAD"].(Markup)
+	require.True(t, ok, "HEAD decoded as %T", out["HEAD"])
+	assert.Equal(t, "<red>safe</>", got.String())
+}
+
+func TestEscapeText(t *testing.T) {
+	assert.Equal(t, "<<>red<>>x<<>/<>>", EscapeText("<red>x</>"))
+	assert.Equal(t, "plain", EscapeText("plain"))
+}

--- a/src/template/markup_test.go
+++ b/src/template/markup_test.go
@@ -3,6 +3,7 @@ package template
 import (
 	"bytes"
 	"encoding/gob"
+	"encoding/json"
 	"testing"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/cache"
@@ -244,6 +245,68 @@ func TestMarkupGobInterfaceRoundtrip(t *testing.T) {
 	got, ok := out["HEAD"].(Markup)
 	require.True(t, ok, "HEAD decoded as %T", out["HEAD"])
 	assert.Equal(t, "<red>safe</>", got.String())
+}
+
+func TestMarkupJSON(t *testing.T) {
+	cases := []struct {
+		Case     string
+		JSON     string
+		Expected Markup
+		Error    bool
+	}{
+		{Case: "tagged form", JSON: `{"$markup":"<red>x</>"}`, Expected: RawMarkup("<red>x</>")},
+		{Case: "bare string from an older fixture", JSON: `"<red>x</>"`, Expected: RawMarkup("<red>x</>")},
+		{Case: "empty tagged form", JSON: `{"$markup":""}`, Expected: RawMarkup("")},
+		{Case: "object without the tag", JSON: `{"text":"x"}`, Error: true},
+	}
+
+	for _, tc := range cases {
+		var got Markup
+		err := json.Unmarshal([]byte(tc.JSON), &got)
+
+		if tc.Error {
+			assert.Error(t, err, tc.Case)
+			continue
+		}
+
+		require.NoError(t, err, tc.Case)
+		assert.Equal(t, tc.Expected, got, tc.Case)
+	}
+
+	encoded, err := json.Marshal(struct {
+		HEAD Markup
+		Ref  string
+	}{HEAD: RawMarkup("<red>x</>"), Ref: "<b>"})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"HEAD":{"$markup":"<red>x</>"},"Ref":"<b>"}`, string(encoded))
+}
+
+// A generically decoded document (the writer-less restore path) must carry
+// the same trust as the struct it was recorded from: tagged objects become
+// Markup, everything else stays data.
+func TestReviveMarkup(t *testing.T) {
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal([]byte(`{
+		"HEAD": {"$markup": "<red>main</>"},
+		"Ref": "<b>",
+		"Rebase": {"Onto": {"$markup": "<b>x</>"}, "Total": 2},
+		"Items": [{"$markup": "<i>y</>"}, "plain"],
+		"Shaped": {"$markup": "x", "extra": 1}
+	}`), &decoded))
+
+	got := ReviveMarkup(decoded).(map[string]any)
+
+	assert.Equal(t, RawMarkup("<red>main</>"), got["HEAD"])
+	assert.Equal(t, "<b>", got["Ref"])
+	assert.Equal(t, RawMarkup("<b>x</>"), got["Rebase"].(map[string]any)["Onto"])
+	assert.Equal(t, RawMarkup("<i>y</>"), got["Items"].([]any)[0])
+	assert.Equal(t, "plain", got["Items"].([]any)[1])
+	_, stillObject := got["Shaped"].(map[string]any)
+	assert.True(t, stillObject, "an object with more than the tag is not markup")
+
+	text, err := RenderTrusted(`{{ .HEAD }}|{{ .Ref }}`, got)
+	require.NoError(t, err)
+	assert.Equal(t, "<red>main</>|<<>b<>>", text)
 }
 
 func TestEscapeText(t *testing.T) {

--- a/src/template/markup_test.go
+++ b/src/template/markup_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/gob"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/cache"
@@ -24,6 +25,7 @@ func TestRenderEscapesActionOutput(t *testing.T) {
 		Template string
 		Context  any
 		Expected string
+		Error    bool
 	}{
 		{
 			Case:     "chevrons in data are neutralized",
@@ -146,6 +148,44 @@ func TestRenderEscapesActionOutput(t *testing.T) {
 			Expected: "<<>main<>>ma!",
 		},
 		{
+			Case:     "containers and errors keep the result plain",
+			Template: `{{ printf "%s %s" .Icon .Heads }}|{{ .Heads | join .Icon }}|{{ printf "%s %s" .Icon .Err }}|{{ cat .Icon (list .Branch) }}`,
+			Context: struct {
+				Err    error
+				Icon   Markup
+				Branch string
+				Heads  []string
+			}{Icon: RawMarkup("<red>x</>"), Heads: []string{"<b>"}, Err: errors.New("<i>"), Branch: "<b>"},
+			Expected: "<<>red<>>x<<>/<>> [<<>b<>>]|<<>b<>>|<<>red<>>x<<>/<>> <<>i<>>|<<>red<>>x<<>/<>> [<<>b<>>]",
+		},
+		{
+			Case:     "string pointers are followed",
+			Template: `{{ trimPrefix "v" .Ptr }} {{ .Ptr | upper }} {{ printf "%s%s" .Icon .Ptr }}`,
+			Context: struct {
+				Ptr  *string
+				Icon Markup
+			}{Ptr: new("v<1>"), Icon: RawMarkup("<red>x</>")},
+			Expected: "<<>1<>> V<<>1<>> <red>x</>v<<>1<>>",
+		},
+		{
+			Case:     "decoders never produce markup",
+			Template: `{{ b64dec .Enc }}`,
+			Context:  struct{ Enc Markup }{Enc: RawMarkup("PGI+")},
+			Expected: "<<>b<>>",
+		},
+		{
+			Case:     "a fraction is not an integer argument",
+			Template: `{{ repeat 2.5 .Icon }}`,
+			Context:  struct{ Icon Markup }{Icon: RawMarkup("x")},
+			Error:    true,
+		},
+		{
+			Case:     "errors print through Error",
+			Template: `{{ .Err }}`,
+			Context:  struct{ Err error }{Err: errors.New("<b>oom")},
+			Expected: "<<>b<>>oom",
+		},
+		{
 			Case:     "numeric literals reach typed parameters",
 			Template: `{{ repeat 2 .HEAD }}{{ substr 0 3 .HEAD }}{{ add 1 2 }}`,
 			Context:  struct{ HEAD Markup }{HEAD: RawMarkup("<red>ab</>")},
@@ -163,10 +203,17 @@ func TestRenderEscapesActionOutput(t *testing.T) {
 		Init(env, nil, nil)
 
 		text, err := RenderTrusted(tc.Template, tc.Context)
+		if tc.Error {
+			assert.Error(t, err, tc.Case)
+			continue
+		}
+
 		require.NoError(t, err, tc.Case)
 		assert.Equal(t, tc.Expected, text, tc.Case)
 	}
 }
+
+//go:fix inline
 
 func TestRenderUntrustedEscapesActionOutput(t *testing.T) {
 	origCache := Cache
@@ -195,9 +242,9 @@ func TestURLMarkup(t *testing.T) {
 			Expected: "<LINK>https://ohmyposh.dev<TEXT>a<<>b</TEXT></LINK>",
 		},
 		{
-			Case:        "chevrons in the URL are rejected",
-			Template:    `{{ url "link" "https://ohmyposh.dev/<TEXT>" }}`,
-			ShouldError: true,
+			Case:     "chevrons in the URL drop the link, keep the label",
+			Template: `{{ url "link" "https://ohmyposh.dev/<TEXT>" }}`,
+			Expected: "link",
 		},
 	}
 
@@ -258,6 +305,8 @@ func TestMarkupJSON(t *testing.T) {
 		{Case: "bare string from an older fixture", JSON: `"<red>x</>"`, Expected: RawMarkup("<red>x</>")},
 		{Case: "empty tagged form", JSON: `{"$markup":""}`, Expected: RawMarkup("")},
 		{Case: "object without the tag", JSON: `{"text":"x"}`, Error: true},
+		{Case: "object with more than the tag", JSON: `{"$markup":"x","extra":"y"}`, Error: true},
+		{Case: "null leaves the value alone", JSON: `null`, Expected: RawMarkup("")},
 	}
 
 	for _, tc := range cases {
@@ -307,6 +356,12 @@ func TestReviveMarkup(t *testing.T) {
 	text, err := RenderTrusted(`{{ .HEAD }}|{{ .Ref }}`, got)
 	require.NoError(t, err)
 	assert.Equal(t, "<red>main</>|<<>b<>>", text)
+
+	// data escaped at record time is not escaped a second time on replay
+	recorded := ReviveMarkup(map[string]any{"HEAD": map[string]any{"$markup": "<b><<>x<>></>"}})
+	text, err = RenderTrusted(`{{ .HEAD }}`, recorded)
+	require.NoError(t, err)
+	assert.Equal(t, "<b><<>x<>></>", text)
 }
 
 func TestEscapeText(t *testing.T) {

--- a/src/template/markup_test.go
+++ b/src/template/markup_test.go
@@ -364,6 +364,38 @@ func TestReviveMarkup(t *testing.T) {
 	assert.Equal(t, "<b><<>x<>></>", text)
 }
 
+// Data that becomes template source (folder names in the styled path) must
+// come out of the untrusted renderer exactly as it went in: no action may
+// run, and chevrons stay literal.
+func TestEscapeSource(t *testing.T) {
+	origCache := Cache
+	t.Cleanup(func() { Cache = origCache })
+
+	env := new(mock.Environment)
+	env.On("Shell").Return("foo")
+	Cache = new(cache.Template)
+	Init(env, nil, nil)
+
+	cases := []struct {
+		Case     string
+		Input    string
+		Expected string
+	}{
+		{Case: "plain", Input: "src", Expected: "src"},
+		{Case: "function call", Input: `{{ url "click" "https://evil.example" }}`, Expected: `{{ url "click" "https://evil.example" }}`},
+		{Case: "field access", Input: "{{ .Path }}Z", Expected: "{{ .Path }}Z"},
+		{Case: "chevrons and delimiters", Input: "<red>{{ upper .Path }}</>", Expected: "<<>red<>>{{ upper .Path }}<<>/<>>"},
+		{Case: "doubled delimiters", Input: "{{{{ x }}}}", Expected: "{{{{ x }}}}"},
+		{Case: "closing delimiter alone", Input: "a }} b", Expected: "a }} b"},
+	}
+
+	for _, tc := range cases {
+		text, err := RenderUntrusted("~/"+EscapeSource(tc.Input), nil)
+		require.NoError(t, err, tc.Case)
+		assert.Equal(t, "~/"+tc.Expected, text, tc.Case)
+	}
+}
+
 func TestEscapeText(t *testing.T) {
 	assert.Equal(t, "<<>red<>>x<<>/<>>", EscapeText("<red>x</>"))
 	assert.Equal(t, "plain", EscapeText("plain"))

--- a/src/template/render.go
+++ b/src/template/render.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+	"text/template/parse"
 	"unicode"
 	"unicode/utf8"
 
@@ -105,15 +106,76 @@ func parsedTemplate(text *Text) (*template.Template, error) {
 	// Cache miss: patch the raw template into its executable form.
 	text.patchTemplate()
 
-	// Parse into a fresh template with the func map matching this render's trust level.
-	tmpl, err := template.New("cache").Funcs(funcMap(text.trusted)).Parse(text.template)
+	// Parse into a fresh template with the func map matching this render's trust
+	// level. missingkey=zero makes a missing map key a typed nil, which
+	// escapeActionValue renders as <no value> instead of failing on an invalid
+	// reflect.Value. The visible output matches the default option.
+	tmpl, err := template.New("cache").Funcs(funcMap(text.trusted)).Option("missingkey=zero").Parse(text.template)
 	if err != nil {
 		return nil, err
 	}
 
+	escapePrintActions(tmpl)
+
 	// Store; if another goroutine already stored an equivalent template, use theirs.
 	actual, _ := parsedTemplates.LoadOrStore(key, tmpl)
 	return actual.(*template.Template), nil
+}
+
+// escapePrintActions appends escapeActionValue to every print action's
+// pipeline, so interpolated values get their chevrons neutralized (unless the
+// value is Markup) while literal template text keeps its anchors. This is the
+// boundary between user-authored markup and attacker-influenceable data
+// (branch names, manifest fields, folder names): without it both land in the
+// writer as indistinguishable text and data can forge anchors.
+func escapePrintActions(tmpl *template.Template) {
+	for _, t := range tmpl.Templates() {
+		if t.Tree == nil {
+			continue
+		}
+
+		escapeListActions(t.Tree, t.Root)
+	}
+}
+
+func escapeListActions(tree *parse.Tree, list *parse.ListNode) {
+	if list == nil {
+		return
+	}
+
+	for _, node := range list.Nodes {
+		switch n := node.(type) {
+		case *parse.ActionNode:
+			escapePipe(tree, n.Pipe)
+		case *parse.IfNode:
+			escapeBranchActions(tree, &n.BranchNode)
+		case *parse.RangeNode:
+			escapeBranchActions(tree, &n.BranchNode)
+		case *parse.WithNode:
+			escapeBranchActions(tree, &n.BranchNode)
+		}
+	}
+}
+
+func escapeBranchActions(tree *parse.Tree, branch *parse.BranchNode) {
+	escapeListActions(tree, branch.List)
+	escapeListActions(tree, branch.ElseList)
+}
+
+func escapePipe(tree *parse.Tree, pipe *parse.PipeNode) {
+	// assignments and declarations produce no output
+	if pipe == nil || len(pipe.Decl) != 0 || len(pipe.Cmds) == 0 {
+		return
+	}
+
+	pos := pipe.Cmds[len(pipe.Cmds)-1].Position()
+	ident := parse.NewIdentifier(escapeFuncName).SetTree(tree).SetPos(pos)
+	cmd := &parse.CommandNode{
+		NodeType: parse.NodeCommand,
+		Pos:      pos,
+		Args:     []parse.Node{ident},
+	}
+	pipe.Cmds = append(pipe.Cmds, cmd)
 }
 
 func (t *renderer) execute(text *Text) (string, error) {
@@ -135,7 +197,7 @@ func (t *renderer) execute(text *Text) (string, error) {
 
 	// issue with missingkey=zero ignored for map[string]any
 	// https://github.com/golang/go/issues/24963
-	output = strings.ReplaceAll(output, "<no value>", "")
+	output = strings.ReplaceAll(output, noValue, "")
 
 	return output, nil
 }

--- a/src/terminal/writer.go
+++ b/src/terminal/writer.go
@@ -944,7 +944,15 @@ func write(s rune, isInvisible bool) {
 			return
 		}
 
-		
+		// the OSC 8 URI region must survive the shell's prompt expansion
+		// intact, so apply the same shell escaping as visible runes; a URI
+		// backslash reaching bash's @P unescaped would be re-interpreted
+		if !Interactive {
+			if escaped, shouldEscape := formats.EscapeSequences[s]; shouldEscape {
+				builder.WriteString(escaped)
+				return
+			}
+		}
 
 		builder.WriteRune(s)
 

--- a/src/terminal/writer.go
+++ b/src/terminal/writer.go
@@ -427,13 +427,15 @@ func ClearAfter() string {
 }
 
 func FormatTitle(title string) string {
+	// The title bypasses write()'s per-rune control filter, and trimAnsi's regex
+	// doesn't cover every escape form (a bare BEL, CSI ! p, APC, SOS, ST).
+	title = stripControlRunes(trimAnsi(title))
+
 	switch Shell {
 	// These shells don't support setting the console title.
 	case shell.ELVISH, shell.XONSH:
 		return ""
 	case shell.BASH, shell.ZSH, shell.YASH:
-		title = trimAnsi(title)
-
 		sb := text.NewBuilder()
 
 		// We have to do this to prevent the shell from misidentifying escape sequences.
@@ -449,7 +451,7 @@ func FormatTitle(title string) string {
 
 		return fmt.Sprintf(formats.Title, sb.String())
 	default:
-		return fmt.Sprintf(formats.Title, trimAnsi(title))
+		return fmt.Sprintf(formats.Title, title)
 	}
 }
 
@@ -941,6 +943,8 @@ func write(s rune, isInvisible bool) {
 		if Plain {
 			return
 		}
+
+		
 
 		builder.WriteRune(s)
 

--- a/src/terminal/writer.go
+++ b/src/terminal/writer.go
@@ -427,8 +427,7 @@ func ClearAfter() string {
 }
 
 func FormatTitle(title string) string {
-	// The title bypasses write()'s per-rune control filter, and trimAnsi's regex
-	// doesn't cover every escape form (a bare BEL, CSI ! p, APC, SOS, ST).
+	// The title bypasses write()'s per-rune control filter.
 	title = stripControlRunes(trimAnsi(title))
 
 	switch Shell {
@@ -1021,7 +1020,10 @@ func isOSCPayloadControlRune(s rune) bool {
 // Kept separate from write/isControlRune, which guard the streaming render
 // path instead.
 func stripControlRunes(s string) string {
-	if !strings.ContainsFunc(s, isOSCPayloadControlRune) {
+	// An invalid byte decodes as U+FFFD, which is not a control rune, so
+	// a raw C1 byte such as 0x9b would slip through the fast path; the
+	// loop below rewrites it to U+FFFD.
+	if utf8.ValidString(s) && !strings.ContainsFunc(s, isOSCPayloadControlRune) {
 		return s
 	}
 
@@ -1637,7 +1639,7 @@ func asAnsiColorsWithSource(background, foreground color.Ansi) (bg, fg, bgSource
 }
 
 func trimAnsi(txt string) string {
-	if txt == "" || !strings.Contains(txt, "\x1b") {
+	if txt == "" || !strings.ContainsAny(txt, "\x1b\u009b") {
 		return txt
 	}
 	return regex.ReplaceAllString(AnsiRegex, txt, "")

--- a/src/terminal/writer_hyperlink_test.go
+++ b/src/terminal/writer_hyperlink_test.go
@@ -98,6 +98,21 @@ func TestGenerateHyperlinkWithUrl(t *testing.T) {
 			ShellName: shell.FISH,
 			Expected:  "\x1b[47m\x1b[30m\x1b]8;;http://evil]0;HACKED.com\x1b\\google\x1b]8;;\x1b\\\x1b[0m",
 		},
+		{
+			// a backslash in the OSC 8 URI is doubled for bash so @P prompt
+			// expansion hands the terminal exactly one backslash; undoubled it
+			// would be re-interpreted as a prompt escape (\e -> ESC)
+			Text:      `<LINK>C:\temp<TEXT>x</TEXT></LINK>`,
+			ShellName: shell.BASH,
+			Expected:  "\\[\x1b[47m\\]\\[\x1b[30m\\]\\[\x1b]8;;C:\\\\temp\x1b\\\\\\]x\\[\x1b]8;;\x1b\\\\\\]\\[\x1b[0m\\]",
+		},
+		{
+			// same for zsh: a % in the URI is doubled so prompt expansion
+			// does not treat it as a prompt escape
+			Text:      `<LINK>http://example.com/100%<TEXT>x</TEXT></LINK>`,
+			ShellName: shell.ZSH,
+			Expected:  "%{\x1b[47m%}%{\x1b[30m%}%{\x1b]8;;http://example.com/100%%\x1b\\%}x%{\x1b]8;;\x1b\\%}%{\x1b[0m%}",
+		},
 	}
 	for _, tc := range cases {
 		Init(tc.ShellName)

--- a/src/terminal/writer_test.go
+++ b/src/terminal/writer_test.go
@@ -735,6 +735,11 @@ func TestStripControlRunes(t *testing.T) {
 			Expected: "jan @ 世界 café",
 		},
 		{
+			Case:     "raw C1 byte in invalid UTF-8 cannot start a sequence",
+			Input:    "x\x9b2J",
+			Expected: "x\uFFFD2J",
+		},
+		{
 			Case:     "C0 and C1 control runes removed",
 			Input:    "evil\x1b\\\x1b]0;PWNED\x07rest",
 			Expected: "evil\\]0;PWNEDrest",

--- a/src/terminal/writer_test.go
+++ b/src/terminal/writer_test.go
@@ -1,6 +1,7 @@
 package terminal
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/color"
@@ -559,6 +560,87 @@ func TestPwd(t *testing.T) {
 
 			assert.Equal(t, tc.Expected, got, tc.Case)
 			assert.NotContains(t, got, "\x1b]0;PWNED\x07", tc.Case)
+		})
+	}
+}
+
+func TestFormatTitle(t *testing.T) {
+	cases := []struct {
+		Case     string
+		Shell    string
+		Title    string
+		Expected string
+	}{
+		{
+			Case:     "clean title, bash",
+			Shell:    shell.BASH,
+			Title:    "zsh in /home/user/omp",
+			Expected: "\\[\x1b]0;zsh in /home/user/omp\a\\]",
+		},
+		{
+			Case:     "bare BEL cannot terminate the OSC 0 sequence early, bash",
+			Shell:    shell.BASH,
+			Title:    "x\a[user@host ~]$ ",
+			Expected: "\\[\x1b]0;x[user@host ~]$ \a\\]",
+		},
+		{
+			Case:     "DECSTR in the title cannot reset the terminal, bash",
+			Shell:    shell.BASH,
+			Title:    "x\x1b[!p",
+			Expected: "\\[\x1b]0;x[!p\a\\]",
+		},
+		{
+			Case:     "APC payload in the title is inert, bash",
+			Shell:    shell.BASH,
+			Title:    "x\x1b_Gf=100,a=T;PAYLOAD\x1b\\",
+			Expected: "\\[\x1b]0;x_Gf=100,a=T;PAYLOAD\\\\\a\\]",
+		},
+		{
+			Case:     "SOS payload in the title is inert, bash",
+			Shell:    shell.BASH,
+			Title:    "x\x1bX swallowed \x1b\\",
+			Expected: "\\[\x1b]0;xX swallowed \\\\\a\\]",
+		},
+		{
+			Case:     "well-formed OSC is removed whole and % is escaped, zsh",
+			Shell:    shell.ZSH,
+			Title:    "100% \x1b]0;PWNED\a done",
+			Expected: "%{\x1b]0;100%%  done\a%}",
+		},
+		{
+			Case:     "generic shell strips control runes",
+			Shell:    shell.GENERIC,
+			Title:    "x\a\x1b[!p",
+			Expected: "\x1b]0;x[!p\a",
+		},
+		{
+			Case:     "elvish renders nothing",
+			Shell:    shell.ELVISH,
+			Title:    "x\a\x1b[!p",
+			Expected: "",
+		},
+		{
+			Case:     "xonsh renders nothing",
+			Shell:    shell.XONSH,
+			Title:    "x\a\x1b[!p",
+			Expected: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Case, func(t *testing.T) {
+			Init(tc.Shell)
+
+			got := FormatTitle(tc.Title)
+
+			assert.Equal(t, tc.Expected, got, tc.Case)
+
+			// the exact residue is cosmetic; what must hold is that no control
+			// rune remains inside the OSC body
+			if _, body, ok := strings.Cut(got, "]0;"); ok {
+				body, _, _ = strings.Cut(body, "\a")
+				assert.False(t, strings.ContainsFunc(body, isOSCPayloadControlRune), tc.Case)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary

The terminal writer parses `<...>` anchors (color/style overrides and OSC 8 hyperlinks) from the final rendered segment text, with no way to distinguish anchors authored by the user's template from chevrons inside attacker-controlled data. A repository the victim clones — or a package.json it contains — could therefore inject markup into every prompt draw:

- **Color anchors** via branch names (e.g. branch `<red>pwned`) — works with the default config, no user configuration needed.
- **Forged OSC 8 hyperlinks** via project-segment fields (`package.json` name/version) — attacker-chosen target under an attacker-chosen label.
- **Arbitrary terminal escape injection on bash/yash**: an unbalanced `<LINK>` in data left `isHyperlink` set for the rest of the segment, disabling shell escaping (`\` doubling for bash, `%` for zsh). Bash's `${prompt@P}` then manufactures real control bytes from a literal `\e` in the data — demonstrated as a title hijack, screen clear, and OSC 52 clipboard write. This was a full bypass of the GHSA-fwjx-9p69-h25h control-rune filter, which has nothing to strip because the bytes are born in the shell after oh-my-posh exits.

Reproduced all three at main before the fix; all three neutralized after.

## Fix

Two commits:

**`fix(terminal): strip control runes from console titles`** (prior work, same class) — console titles bypass `terminal.write`'s control filter; `trimAnsi` alone misses bare BEL, CSI `! p`, APC, SOS and ST payloads.

**`fix(template): escape chevrons in rendered action output`** — the renderer now appends an escaping step (`__esc`) to every print action's pipeline after parsing: literal template text keeps its anchors, while interpolated values are chevron-escaped unless typed as the new opaque `template.Markup`. `Markup` is reserved for user configuration and produced via `options.Markup` (new accessor on the options provider), `template.RawMarkup` on trusted composition results, or the `url`/`filePath` constructors, which validate their dynamic parts. The writer's OSC 8 URI region now applies shell escaping as defense in depth, so even a future regression in the render boundary cannot re-enable the bash `@P` byte manufacture.

New segments and future fields are safe by default: anything printed from a plain string is escaped; only an explicit `Markup`-typed field can carry anchors, which makes the trust decision visible at review time.

## Verification

- `go test ./...` green, `golangci-lint` 0 issues.
- All 125 shipped theme goldens render **byte-identical** to main (`TestGoldenThemes`) — themes using anchors in `branch_icon`, `folder_separator_*`, language icons, `status_formats`, and `time_format` are unaffected.
- New regression tests: `template/markup_test.go` (14 cases incl. assignment/if/range/with pipelines), `TestFormatBranch` injection cases, bash/zsh hyperlink-URI escaping cases.
- End-to-end PoC rerun post-fix: injected branch name prints literally (no `ESC[31m`); the `<LINK>` + `\e]0;HIJACKED\a` package.json payload produces zero ESC bytes after `${prompt@P}`.

## Notes

- `ScmStatus.String()` now returns `template.Markup` (composes `status_formats` config; its default moved-prefix is `>`).
- **Known limitation:** anchors in a `mapped_branches` value survive only when no `branch_template` is set — the sub-template receives `.Branch` as a plain string so `trunc` and friends keep working. No shipped theme combines the two.