### PR TITLE
fix(upgrade): stop spinner while progress bar owns the line

### DIFF
--- a/src/cli/upgrade/tui/tui.go
+++ b/src/cli/upgrade/tui/tui.go
@@ -10,6 +10,7 @@ package tui
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/jandedobbeleer/oh-my-posh/src/build"
@@ -17,6 +18,8 @@ import (
 	"github.com/jandedobbeleer/oh-my-posh/src/cli/upgrade"
 	"github.com/jandedobbeleer/oh-my-posh/src/log"
 )
+
+const barLabel = "  Downloading"
 
 func stageMessage(cfg *upgrade.Config, stage upgrade.Stage) string {
 	switch stage {
@@ -34,48 +37,27 @@ func stageMessage(cfg *upgrade.Config, stage upgrade.Stage) string {
 }
 
 func Run(cfg *upgrade.Config) error {
-	status := ui.NewStatus(os.Stdout)
-	bar := ui.NewProgress(os.Stdout, "  Downloading")
+	reporter := &reporter{
+		cfg:    cfg,
+		writer: os.Stdout,
+		status: ui.NewStatus(os.Stdout),
+		bar:    ui.NewProgress(os.Stdout, barLabel),
+	}
 
 	// cli/upgrade reports through plain callbacks precisely so it never has to know what is
 	// drawing - see its own report.go. This subscribes for the duration of the run and hands them
 	// back afterwards, so nothing keeps writing to a terminal after the command returns.
-	downloading := false
-
-	upgrade.SetStageReporter(func(stage upgrade.Stage) {
-		// The bar and the status line both own the same line, so only one may paint at a time.
-		// Downloading is the only stage with a bar, and reaching any other stage ends it.
-		if downloading && stage != upgrade.StageDownloading {
-			downloading = false
-
-			bar.Done()
-		}
-
-		if stage == upgrade.StageDownloading {
-			downloading = true
-
-			status.Set(stageMessage(cfg, stage))
-
-			return
-		}
-
-		status.Set(stageMessage(cfg, stage))
-	})
-
-	upgrade.SetProgressReporter(func(percent float64) {
-		if downloading {
-			bar.Set(percent)
-		}
-	})
+	upgrade.SetStageReporter(reporter.stage)
+	upgrade.SetProgressReporter(reporter.progress)
 
 	defer upgrade.SetStageReporter(nil)
 	defer upgrade.SetProgressReporter(nil)
 
-	status.Start(stageMessage(cfg, upgrade.StageValidating))
+	reporter.status.Start(stageMessage(cfg, upgrade.StageValidating))
 
 	if err := upgrade.Install(cfg); err != nil {
 		log.Debug("failed to install")
-		status.Stop(fmt.Sprintf(" ❌ upgrade failed: %v", err))
+		reporter.fail(err)
 
 		return err
 	}
@@ -88,7 +70,61 @@ func Run(cfg *upgrade.Config) error {
 		message += ", restart your shell to take full advantage of the new functionality"
 	}
 
-	status.Stop(message)
+	reporter.status.Stop(message)
 
 	return nil
+}
+
+// reporter owns the single line the upgrade draws on. The status spinner and the progress bar
+// both repaint that line, so only one may paint at a time: the spinner runs for every stage
+// except the download, which hands the line to the bar. Painting both at once is what made the
+// bar and the status text flicker over each other.
+type reporter struct {
+	status      *ui.Status
+	bar         *ui.Progress
+	writer      io.Writer
+	cfg         *upgrade.Config
+	downloading bool
+}
+
+func (r *reporter) stage(stage upgrade.Stage) {
+	if stage == upgrade.StageDownloading {
+		r.downloading = true
+		r.status.Stop("")
+
+		return
+	}
+
+	if r.downloading {
+		r.downloading = false
+		r.bar.Done()
+		r.status.Start(stageMessage(r.cfg, stage))
+
+		return
+	}
+
+	r.status.Set(stageMessage(r.cfg, stage))
+}
+
+func (r *reporter) progress(fraction float64) {
+	if !r.downloading {
+		return
+	}
+
+	r.bar.Set(fraction)
+}
+
+func (r *reporter) fail(err error) {
+	message := fmt.Sprintf(" ❌ upgrade failed: %v", err)
+
+	// Mid-download the status line is stopped, where Stop is a no-op that would swallow the
+	// message - so the bar is cleared and the failure printed plainly instead.
+	if r.downloading {
+		r.bar.Done()
+		fmt.Fprintln(r.writer, message)
+
+		return
+	}
+
+	r.status.Stop(message)
 }

--- a/src/cli/upgrade/tui/tui_test.go
+++ b/src/cli/upgrade/tui/tui_test.go
@@ -1,0 +1,109 @@
+package tui
+
+import (
+	"bytes"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jandedobbeleer/oh-my-posh/src/cli/ui"
+	"github.com/jandedobbeleer/oh-my-posh/src/cli/upgrade"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// lockedBuffer serializes the spinner goroutine's writes with the test's reads - a plain
+// bytes.Buffer races the moment a running spinner repaints while the test inspects the output.
+type lockedBuffer struct {
+	bytes.Buffer
+	mutex sync.Mutex
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	return b.Buffer.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	return b.Buffer.String()
+}
+
+func (b *lockedBuffer) Reset() {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+
+	b.Buffer.Reset()
+}
+
+func newReporter(out *lockedBuffer) *reporter {
+	return &reporter{
+		cfg:    &upgrade.Config{},
+		writer: out,
+		status: ui.NewStatus(out),
+		bar:    ui.NewProgress(out, barLabel),
+	}
+}
+
+// TestReporterHandsTheLineToTheBar pins the fix for the flicker between the status text and the
+// progress bar: while the download runs, the spinner is stopped and only the bar may repaint the
+// line, so without bar activity nothing gets written at all.
+func TestReporterHandsTheLineToTheBar(t *testing.T) {
+	var out lockedBuffer
+
+	r := newReporter(&out)
+	r.status.Start("Validating current installation")
+
+	r.stage(upgrade.StageDownloading)
+
+	out.Reset()
+	r.progress(0.4)
+	painted := out.String()
+
+	// Outlives several spinner ticks: a running spinner would have repainted by now.
+	time.Sleep(250 * time.Millisecond)
+
+	assert.Contains(t, painted, "40%")
+	assert.Equal(t, painted, out.String(), "the spinner must stay silent while the bar owns the line")
+}
+
+// TestReporterResumesTheSpinnerAfterDownloading covers the end of the download: the bar is done
+// and the status line spins again for the stages that follow.
+func TestReporterResumesTheSpinnerAfterDownloading(t *testing.T) {
+	var out lockedBuffer
+
+	r := newReporter(&out)
+	r.status.Start("Validating current installation")
+	defer r.status.Stop("")
+
+	r.stage(upgrade.StageDownloading)
+	r.stage(upgrade.StageInstalling)
+
+	out.Reset()
+
+	// A running spinner repaints every 100ms; poll rather than sleep so a loaded runner
+	// decides how long that takes.
+	assert.Eventually(t, func() bool {
+		return out.String() != ""
+	}, time.Second, 10*time.Millisecond, "the spinner must repaint again once the bar is done")
+}
+
+// TestReporterFailWhileDownloading pins that an error mid-download is still shown: the status
+// line is stopped then, so stopping it with a final message would print nothing.
+func TestReporterFailWhileDownloading(t *testing.T) {
+	var out lockedBuffer
+
+	r := newReporter(&out)
+	r.status.Start("Validating current installation")
+
+	r.stage(upgrade.StageDownloading)
+	r.progress(0.4)
+	r.fail(errors.New("boom"))
+
+	assert.Contains(t, out.String(), "upgrade failed: boom")
+}


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

During `oh-my-posh upgrade`, the upgrade text and the download progress bar flickered over each other (#7856). Both the status spinner (repainting every 100ms) and the progress bar (repainting on every progress tick) were writing to the same terminal line at the same time, so each repaint erased the other.

The callback wiring in `cli/upgrade/tui` is now a `reporter` that enforces single ownership of the line:

- Entering the download stage stops the spinner and hands the line to the bar.
- Leaving the download stage calls `bar.Done()` and resumes the spinner for the remaining stages.
- A failure mid-download is printed plainly instead of through the status line, whose `Stop` is a no-op once stopped and would have swallowed the error.

This matches the pattern `font install` already uses. Added tests pin that the spinner stays silent while the bar owns the line, resumes afterwards, and that mid-download errors still surface.

Fixes: #7856

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary