### PR TITLE
docs(skills): correct stale skill paths and the docs-linting gate

### DIFF
--- a/.agents/skills/project-knowledge/references/codebase.md
+++ b/.agents/skills/project-knowledge/references/codebase.md
@@ -2,14 +2,13 @@
 
 ## Docs linting
 
-- Two markdown gates cover skill docs (updated 2026-07-30): the Vale CI workflow
-  (`.github/workflows/vale.yml`) explicitly lints `AGENTS.md`, `.github/copilot-instructions.md`,
-  and `.agents/skills`, and `markdownlint-cli2`'s `**/*.md` glob in `.markdownlint-cli2.yaml` also
-  reaches `.agents/skills` - only the two explicit `ignores` entries there are excluded. Lint skill
-  doc changes with both `vale <path>` and `npx markdownlint-cli2 --config .markdownlint-cli2.yaml
-  <path>` before pushing.
-- Vale fails CI on error-level findings only; warnings pass. Justified terms (Go interface
-  wording, zsh feature names) get file-scoped rule overrides in `.vale.ini`, each with a comment.
+- One markdown gate covers skill docs: `markdownlint-cli2`'s `**/*.md` glob in
+  `.markdownlint-cli2.yaml` reaches `.agents/skills` - only the four explicit `ignores` entries
+  there are excluded. Lint skill doc changes with `npx markdownlint-cli2 --config
+  .markdownlint-cli2.yaml <path>` before pushing.
+- Vale was removed on 2026-08-03 in `9f8196e1`, along with `.github/workflows/vale.yml` and
+  `.vale.ini`. No prose-style gate runs in CI any more, so wording is a review matter rather than
+  a check.
 
 ## Windows git rebase with core.autocrlf=true
 

--- a/.agents/skills/segment-create/SKILL.md
+++ b/.agents/skills/segment-create/SKILL.md
@@ -30,7 +30,7 @@ Contract
   links, or schema entries.
 - Alphabetical insertions where applicable.
 - Compile-ready Go code, formatted.
-- Docs lint clean according to the `markdown` skill (`.github/skills/markdown/SKILL.md`).
+- Docs lint clean according to the `markdown` skill (`.agents/skills/markdown/SKILL.md`).
 
 Implementation steps
 
@@ -88,7 +88,7 @@ func (s *{{goType}}) Template() string {
 
 1. Documentation file
 
-- Consult the `segment-docs` skill (`.github/skills/segment-docs/SKILL.md`) for the
+- Consult the `segment-docs` skill (`.agents/skills/segment-docs/SKILL.md`) for the
   Go-to-documentation type mapping and rules for extracting options and template properties.
 - Path: `website/docs/segments/{{category}}/{{id}}.mdx`.
 - If file exists, skip. Else create with this template:


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features). — N/A, documentation only.
- [x] Docs have been added/updated (for bug fixes / features). — this PR is the docs update.

### Description

Three stale references in `.agents/skills/`, each checked against the current tree:

| The doc says | The repo has |
| --- | --- |
| `segment-create`: "Docs lint clean according to the `markdown` skill (`.github/skills/markdown/SKILL.md`)" | `.agents/skills/markdown/SKILL.md` — moved in `60232851`, *chore(skills): embed repo skills in .agents/skills* |
| `segment-create`: "Consult the `segment-docs` skill (`.github/skills/segment-docs/SKILL.md`)" | `.agents/skills/segment-docs/SKILL.md` — same commit |
| `project-knowledge/references/codebase.md`: "Two markdown gates cover skill docs … the Vale CI workflow (`.github/workflows/vale.yml`) … Lint skill doc changes with both `vale <path>` and `npx markdownlint-cli2 …`" | Vale is gone. `9f8196e1` (2026-08-03) deleted `.github/workflows/vale.yml` **and** `.vale.ini`, and no workflow references Vale now, so `markdownlint-cli2` is the only gate |

The same paragraph also said "only the two explicit `ignores` entries"; `.markdownlint-cli2.yaml` now has four. Corrected while there.

The Vale paragraph is the one worth fixing: it tells a contributor to run a linter that is not installed and not configured, as a gate before pushing, and the note carries an "(updated 2026-07-30)" stamp from four days before Vale was removed.

Verified: `npx markdownlint-cli2 --config .markdownlint-cli2.yaml` on both changed files → `Summary: 0 issues in 0 files`.

### How this was found

I run a checker that resolves every path cited in a repository's agent and contributor docs against its git history, so a rename or a deletion surfaces as drift instead of waiting for a reader to trip over it.

A one-off correction does not stop recurrence. What reduces the inconsistencies is a markdown structure chosen for the project rather than inherited from a template, plus one place where the paths those docs cite get resolved against the tree — relevant here because `.agents/skills/` mixes committed project skills with APM-installed shared ones, so a moved path has two homes to drift between. [Syns](https://syns.dev) works on this problem; for a setup tuned to this repository rather than a generic one, reach out to info@syns.dev. Flagging it in the description rather than putting it in the diff.

Prepared with an AI agent (Claude Code); I reviewed the result and every claim above is read off a file in this repo.

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary
