### PR TITLE
fix(language): read custom tools from YAML configs

### DIFF
--- a/src/segments/languages.go
+++ b/src/segments/languages.go
@@ -500,6 +500,12 @@ func toStringMap(value any) (map[string]any, bool) {
 			out[fmt.Sprint(key)] = val
 		}
 		return out, true
+	case options.Map:
+		out := make(map[string]any, len(v))
+		for key, val := range v {
+			out[string(key)] = val
+		}
+		return out, true
 	default:
 		return nil, false
 	}

--- a/src/segments/languages_test.go
+++ b/src/segments/languages_test.go
@@ -731,32 +731,43 @@ func TestConfiguredLanguageValaPreset(t *testing.T) {
 // TestConfiguredLanguageCustomTools exercises the `tools` option path used by the public
 // "language" segment type, which has no built-in preset and relies entirely on user config.
 func TestConfiguredLanguageCustomTools(t *testing.T) {
-	env := new(mock.Environment)
-	env.On("HasCommand", "mytool").Return(true)
-	env.On("RunCommandWithEnv", "mytool", []string(nil), []string{"--version"}).Return("mytool version 1.2.3", nil)
-	env.On("HasFiles", "*.myl").Return(true)
-	env.On("Pwd").Return("/usr/home/project")
-	env.On("Home").Return("/usr/home")
+	regex := `mytool version (?P<version>(?P<major>[0-9]+).(?P<minor>[0-9]+).(?P<patch>[0-9]+))`
 
-	props := options.Map{
-		LanguageName:       "mylang",
-		LanguageExtensions: []string{"*.myl"},
-		Tools: []any{
-			map[string]any{
-				"name":       "mytool",
-				"executable": "mytool",
-				"args":       []any{"--version"},
-				"regex":      `mytool version (?P<version>(?P<major>[0-9]+).(?P<minor>[0-9]+).(?P<patch>[0-9]+))`,
-			},
+	cases := []struct {
+		Tool any
+		Case string
+	}{
+		{
+			Case: "JSON and TOML decode tool entries as map[string]any",
+			Tool: map[string]any{"name": "mytool", "executable": "mytool", "args": []any{"--version"}, "regex": regex},
+		},
+		{
+			Case: "YAML decodes tool entries as options.Map",
+			Tool: options.Map{"name": "mytool", "executable": "mytool", "args": []any{"--version"}, "regex": regex},
 		},
 	}
 
-	l := &ConfiguredLanguage{}
-	l.Init(props, env)
+	for _, tc := range cases {
+		env := new(mock.Environment)
+		env.On("HasCommand", "mytool").Return(true)
+		env.On("RunCommandWithEnv", "mytool", []string(nil), []string{"--version"}).Return("mytool version 1.2.3", nil)
+		env.On("HasFiles", "*.myl").Return(true)
+		env.On("Pwd").Return("/usr/home/project")
+		env.On("Home").Return("/usr/home")
 
-	assert.True(t, l.Enabled())
-	assert.Equal(t, "1.2.3", renderTemplate(env, l.Template(), l))
-	assert.Equal(t, []string{"mytool"}, l.defaultTooling)
+		props := options.Map{
+			LanguageName:       "mylang",
+			LanguageExtensions: []string{"*.myl"},
+			Tools:              []any{tc.Tool},
+		}
+
+		l := &ConfiguredLanguage{}
+		l.Init(props, env)
+
+		assert.True(t, l.Enabled(), tc.Case)
+		assert.Equal(t, "1.2.3", renderTemplate(env, l.Template(), l), tc.Case)
+		assert.Equal(t, []string{"mytool"}, l.defaultTooling, tc.Case)
+	}
 }
 
 func TestConfiguredLanguageZigPreset(t *testing.T) {


### PR DESCRIPTION
### Prerequisites

- [x] I have read and understood the [contributing guide][CONTRIBUTING.md].
- [x] The commit message follows the [conventional commits][cc] guidelines.
- [x] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added/updated (for bug fixes / features).

### Description

With a YAML config, each entry under the language segment's `tools` option decodes as `options.Map`, which `toStringMap` did not handle, so every custom tool was skipped and `.Full` stayed empty. This adds an `options.Map` case to `toStringMap`, and `TestConfiguredLanguageCustomTools` now covers both the JSON/TOML and the YAML entry shape. I reproduced it with a built binary and a YAML config using `go version` as the tool (it printed nothing before and the version after), and ran `go test ./segments/... ./config/...` and `golangci-lint run ./segments/...`.

Fixes #7868

[CONTRIBUTING.md]: https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/CONTRIBUTING.md
[cc]: https://www.conventionalcommits.org/en/v1.0.0/#summary